### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,36 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.0]
+        stability: [prefer-lowest, prefer-stable]
+
+    name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+
+      - name: Execute tests
+        run: vendor/bin/pest --verbose

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "watson/active": "^6.0"
     },
     "require-dev": {
-        "mockery/mockery": "^1.0",
+        "mockery/mockery": "^1.4.2",
         "orchestra/testbench": "^6.0",
         "pestphp/pest": "^0.3"
     },


### PR DESCRIPTION
This adds a Github Actions build to the project. I noticed your project doesn't specifies a minimum PHP version in the `composer.json` so I only added the PHP 8 matrix build. Feel free to adjust that as you wish.

I've bumped mockery because it failed on the lowest constraint matrix build.

Builds will only start running after merging this PR. You can see that it's passing atm on my fork here: https://github.com/driesvints/filament/runs/1519671693

Happy building!