### PR TITLE
feature: new `RichEditor::disableAllToolbarButtons` method

### DIFF
--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -65,8 +65,6 @@ class RichEditor extends Field
     {
         if (! is_array($buttonsToDisable)) $buttonsToDisable = [$buttonsToDisable];
 
-        $this->toolbarButtons = array_merge($this->toolbarButtons, $buttonsToDisable);
-
         $this->toolbarButtons = collect($this->toolbarButtons)
             ->filter(fn ($button) => ! in_array($button, $buttonsToDisable))
             ->toArray();

--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -54,6 +54,13 @@ class RichEditor extends Field
         return $this;
     }
 
+    public function disableAllToolbarButtons()
+    {
+        $this->toolbarButtons = [];
+
+        return $this;
+    }
+
     public function disableToolbarButtons($buttonsToDisable)
     {
         if (! is_array($buttonsToDisable)) $buttonsToDisable = [$buttonsToDisable];


### PR DESCRIPTION
This PR is in response to my discussion #36.

It introduces a new `disableAllToolbarButtons` method that will reset the `$toolbarButtons` property to an empty array.

The benefit here is that you won't need to specify lots of buttons that need to be disabled if you only want **bold** or _italic_.