### PR TITLE
feature: alias `make:` commands

### DIFF
--- a/src/Commands/Aliases/MakeFieldCommand.php
+++ b/src/Commands/Aliases/MakeFieldCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Filament\Commands\Aliases;
+
+use Filament\Commands;
+
+class MakeFieldCommand extends Commands\MakeFieldCommand
+{
+    protected $signature = 'filament:field {name} {--R|resource}';
+
+    protected $hidden = true;
+}

--- a/src/Commands/Aliases/MakePageCommand.php
+++ b/src/Commands/Aliases/MakePageCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Filament\Commands\Aliases;
+
+use Filament\Commands;
+
+class MakePageCommand extends Commands\MakePageCommand
+{
+    protected $signature = 'filament:page {name} {--R|resource=}';
+
+    protected $hidden = true;
+}

--- a/src/Commands/Aliases/MakeRelationManagerCommand.php
+++ b/src/Commands/Aliases/MakeRelationManagerCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Filament\Commands\Aliases;
+
+use Filament\Commands;
+
+class MakeRelationManagerCommand extends Commands\MakeRelationManagerCommand
+{
+    protected $signature = 'filament:relation-manager {resource} {relationship}';
+
+    protected $hidden = true;
+}

--- a/src/Commands/Aliases/MakeResourceCommand.php
+++ b/src/Commands/Aliases/MakeResourceCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Filament\Commands\Aliases;
+
+use Filament\Commands;
+
+class MakeResourceCommand extends Commands\MakeResourceCommand
+{
+    protected $signature = 'filament:resource {name}';
+
+    protected $hidden = true;
+}

--- a/src/Commands/Aliases/MakeRoleCommand.php
+++ b/src/Commands/Aliases/MakeRoleCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Filament\Commands\Aliases;
+
+use Filament\Commands;
+
+class MakeRoleCommand extends Commands\MakeRoleCommand
+{
+    protected $signature = 'filament:role {name}';
+
+    protected $hidden = true;
+}

--- a/src/Commands/Aliases/MakeUserCommand.php
+++ b/src/Commands/Aliases/MakeUserCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Filament\Commands\Aliases;
+
+use Filament\Commands;
+
+class MakeUserCommand extends Commands\MakeUserCommand
+{
+    protected $signature = 'filament:user';
+
+    protected $hidden = true;
+}

--- a/src/Commands/Aliases/MakeWidgetCommand.php
+++ b/src/Commands/Aliases/MakeWidgetCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Filament\Commands\Aliases;
+
+use Filament\Commands;
+
+class MakeWidgetCommand extends Commands\MakeWidgetCommand
+{
+    protected $signature = 'filament:widget {name}';
+
+    protected $hidden = true;
+}

--- a/src/FilamentServiceProvider.php
+++ b/src/FilamentServiceProvider.php
@@ -70,6 +70,8 @@ class FilamentServiceProvider extends ServiceProvider
             Commands\MakeUserCommand::class,
             Commands\MakeWidgetCommand::class,
             Commands\MakeFieldCommand::class,
+            Commands\Aliases\MakePageCommand::class,
+            Commands\Aliases\MakeRelationManagerCommand::class,
         ]);
     }
 

--- a/src/FilamentServiceProvider.php
+++ b/src/FilamentServiceProvider.php
@@ -72,6 +72,11 @@ class FilamentServiceProvider extends ServiceProvider
             Commands\MakeFieldCommand::class,
             Commands\Aliases\MakePageCommand::class,
             Commands\Aliases\MakeRelationManagerCommand::class,
+            Commands\Aliases\MakeResourceCommand::class,
+            Commands\Aliases\MakeRoleCommand::class,
+            Commands\Aliases\MakeUserCommand::class,
+            Commands\Aliases\MakeWidgetCommand::class,
+            Commands\Aliases\MakeFieldCommand::class,
         ]);
     }
 

--- a/src/FilamentServiceProvider.php
+++ b/src/FilamentServiceProvider.php
@@ -75,7 +75,7 @@ class FilamentServiceProvider extends ServiceProvider
         $aliases = [];
 
         foreach ($commands as $command) {
-            $class = 'Filament\\Commands\\Aliases\\'.class_basename($command);
+            $class = 'Filament\\Commands\\Aliases\\' . class_basename($command);
 
             if (! class_exists($class)) {
                 continue;

--- a/src/FilamentServiceProvider.php
+++ b/src/FilamentServiceProvider.php
@@ -62,7 +62,7 @@ class FilamentServiceProvider extends ServiceProvider
             return;
         }
 
-        $this->commands([
+        $this->commands($commands = [
             Commands\MakeRelationManagerCommand::class,
             Commands\MakeResourceCommand::class,
             Commands\MakeRoleCommand::class,
@@ -70,14 +70,21 @@ class FilamentServiceProvider extends ServiceProvider
             Commands\MakeUserCommand::class,
             Commands\MakeWidgetCommand::class,
             Commands\MakeFieldCommand::class,
-            Commands\Aliases\MakePageCommand::class,
-            Commands\Aliases\MakeRelationManagerCommand::class,
-            Commands\Aliases\MakeResourceCommand::class,
-            Commands\Aliases\MakeRoleCommand::class,
-            Commands\Aliases\MakeUserCommand::class,
-            Commands\Aliases\MakeWidgetCommand::class,
-            Commands\Aliases\MakeFieldCommand::class,
         ]);
+
+        $aliases = [];
+
+        foreach ($commands as $command) {
+            $class = 'Filament\\Commands\\Aliases\\'.class_basename($command);
+
+            if (! class_exists($class)) {
+                continue;
+            }
+
+            $aliases[] = $class;
+        }
+
+        $this->commands($aliases);
     }
 
     protected function bootDirectives()


### PR DESCRIPTION
This PR introduces new aliases for all of the `make:filament-*` commands.

The transform from the original is simply removing the `make:filament-` prefix and using `filament:*` instead.

In terms of how it works, each command is extended and the signature is overwritten. The `$hidden` property is set to true as well so that the aliases don't show up in `artisan list`.

I placed them all in an `Aliases` namespace so that they're out of the way, but happy to move them out.

The command registration in the service provider is a bit messy. There might be a nicer way of doing it though, so that if an alias exists in the `Filament\Commands\Aliases` namespace, it's automatically registered. Although this would introduce a small overhead because each alias registration would be an additional `Artisan::starting` event listeners and therefore another `Closure` that needs to be invoked.

Let me know what you think!