### PR TITLE
fix: add missing return in Text::getValue

### DIFF
--- a/packages/tables/src/Columns/Text.php
+++ b/packages/tables/src/Columns/Text.php
@@ -80,7 +80,7 @@ class Text extends Column
         $value = parent::getValue($record, $attribute);
 
         if ($value === null) {
-            $this->default;
+            return $this->default;
         }
 
         if ($this->formatUsing) {

--- a/packages/tables/src/Columns/Text.php
+++ b/packages/tables/src/Columns/Text.php
@@ -80,7 +80,7 @@ class Text extends Column
         $value = parent::getValue($record, $attribute);
 
         if ($value === null) {
-            return $this->default;
+            return value($this->default);
         }
 
         if ($this->formatUsing) {


### PR DESCRIPTION
This fixes an issue where the default value for a `Text` column wasn't being returned, purely a missing `return` statement.