### PR TITLE
feature: allow showing user resource in main nav

### DIFF
--- a/config/filament.php
+++ b/config/filament.php
@@ -76,6 +76,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Show User Resource In Navigation
+    |--------------------------------------------------------------------------
+    |
+    | Determines whether the default `User` resource should appear in
+    | the sidebar navigation or not.
+    |
+    */
+
+    'show_user_resource_in_navigation' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Default Filesystem Disk
     |--------------------------------------------------------------------------
     |
@@ -83,6 +95,7 @@ return [
     | of the disks defined in the `config/filesystems.php`.
     |
     */
+
     'default_filesystem_disk' => env('FILAMENT_FILESYSTEM_DRIVER', 'public'),
 
     /*

--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -8,24 +8,24 @@
          @keydown.escape.window="headerIsOpen = false"
          x-on:resize.window="if (window.outerWidth > 768) headerIsOpen = false"
     >
-        <div class="w-56 fixed z-20 h-screen transform transition-transform duration-200 md:translate-x-0 flex"
+        <div class="fixed z-20 flex w-56 h-screen transition-transform duration-200 transform md:translate-x-0"
              :class="headerIsOpen ? 'translate-x-0' : '-translate-x-full'">
             <header role="banner"
                     tabindex="-1"
                     id="banner"
-                    class="flex-grow overflow-y-auto bg-gray-900 text-gray-500 flex flex-col space-y-10 shadow-lg md:shadow-none">
+                    class="flex flex-col flex-grow space-y-10 overflow-y-auto text-gray-500 bg-gray-900 shadow-lg md:shadow-none">
                 <x-filament::branding.app />
 
                 <x-filament-nav class="flex-grow px-4 overflow-y-auto" />
                 <x-filament::dropdown
-                    class="w-full text-left flex-grow flex items-center p-4 space-x-3 transition-colors duration-200 hover:text-white hover:bg-gray-800">
+                    class="flex items-center flex-grow w-full p-4 space-x-3 text-left transition-colors duration-200 hover:text-white hover:bg-gray-800">
                     <x-slot name="button">
                         <x-filament-avatar :user="Auth::guard('filament')->user()" :size="32" class="flex-shrink-0 w-8 h-8 rounded-full" />
 
-                        <span class="flex-grow text-sm leading-tight font-medium">{{ Auth::guard('filament')->user()->name }}</span>
+                        <span class="flex-grow text-sm font-medium leading-tight">{{ Auth::guard('filament')->user()->name }}</span>
                     </x-slot>
 
-                    @if (Auth::guard('filament')->user()->is_admin)
+                    @if (Auth::guard('filament')->user()->is_admin && ! \Filament\Filament::showUserResourceInNavigation())
                         <x-filament::dropdown-link href="{{ route('filament.users.index') }}">
                             Users
                         </x-filament::dropdown-link>
@@ -35,7 +35,7 @@
                         {{ __('filament::edit-account.edit') }}
                     </x-filament::dropdown-link>
 
-                    <livewire:filament.auth.logout class="w-full py-2 px-4 transition-colors duration-200 text-gray-600 hover:bg-gray-200" />
+                    <livewire:filament.auth.logout class="w-full px-4 py-2 text-gray-600 transition-colors duration-200 hover:bg-gray-200" />
                 </x-filament::dropdown>
             </header>
 
@@ -46,20 +46,20 @@
                 :aria-expanded="headerIsOpen"
                 x-cloak
                 x-show.opacity="headerIsOpen"
-                class="md:hidden absolute top-2 right-0 transform translate-x-full p-3 text-gray-200 hover:text-white transition-colors duration-200">
+                class="absolute right-0 p-3 text-gray-200 transition-colors duration-200 transform translate-x-full md:hidden top-2 hover:text-white">
                 <x-heroicon-o-x class="w-6 h-6" />
             </button>
         </div>
 
-        <span class="absolute z-10 inset-0 bg-gray-800 bg-opacity-50 md:hidden" x-cloak x-show="headerIsOpen"
+        <span class="absolute inset-0 z-10 bg-gray-800 bg-opacity-50 md:hidden" x-cloak x-show="headerIsOpen"
               @click="headerIsOpen = false"></span>
 
-        <div class="min-h-screen w-full md:pl-56 flex flex-col">
+        <div class="flex flex-col w-full min-h-screen md:pl-56">
             <div class="flex-grow">
                 {{ $slot }}
             </div>
 
-            <footer rel="contentinfo" class="p-4 md:px-6 text-center">
+            <footer rel="contentinfo" class="p-4 text-center md:px-6">
                 <x-filament::branding.footer />
             </footer>
         </div>

--- a/src/FilamentManager.php
+++ b/src/FilamentManager.php
@@ -51,4 +51,9 @@ class FilamentManager
     {
         $this->widgets = array_merge($this->widgets, [$widget]);
     }
+
+    public function showUserResourceInNavigation()
+    {
+        return (bool) config('filament.show_user_resource_in_navigation');
+    }
 }

--- a/src/Resources/UserResource.php
+++ b/src/Resources/UserResource.php
@@ -80,7 +80,11 @@ class UserResource extends Resource
 
     public static function navigationItems()
     {
-        return [];
+        if (! Filament::showUserResourceInNavigation()) {
+            return [];
+        }
+
+        return parent::navigationItems();
     }
 
     public static function table(Table $table)

--- a/src/View/Components/Nav.php
+++ b/src/View/Components/Nav.php
@@ -4,6 +4,8 @@ namespace Filament\View\Components;
 
 use Filament\Filament;
 use Filament\NavigationItem;
+use Filament\Resources\UserResource;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\View\Component;
 
 class Nav extends Component
@@ -25,6 +27,10 @@ class Nav extends Component
             if ($resource::authorizationManager()->can()) {
                 $this->items->push(...$resource::navigationItems());
             }
+        }
+
+        if (Auth::guard('filament')->user()->is_admin) {
+            $this->items->push(...UserResource::navigationItems());
         }
 
         foreach (Filament::getPages() as $page) {


### PR DESCRIPTION
This PR introduces a new config option, `show_user_resource_in_navigation` (if you can think of a better name, please tell me).

When `true`, it will show the `Users` resource in the navigation just like the other resources and remove the dropdown option from the profile/user dropdown at the bottom of the navigation.

It's false by default so that the current behaviour is preserved.

Any thoughts @danharrin @ryanscherler?