### PR TITLE
Allow for restricted domains

### DIFF
--- a/config/filament.php
+++ b/config/filament.php
@@ -10,9 +10,14 @@ return [
     | The default is `admin` but you can change it to whatever works best and
     | doesn't conflict with the routing in your application.
     |
+    | You may also change the domain where Filament should be active. If the
+    | domain is empty, all domains will be valid.
+    |
     */
 
     'path' => 'admin',
+    
+    'domain' => '',
 
     /*
     |--------------------------------------------------------------------------

--- a/config/filament.php
+++ b/config/filament.php
@@ -10,14 +10,21 @@ return [
     | The default is `admin` but you can change it to whatever works best and
     | doesn't conflict with the routing in your application.
     |
-    | You may also change the domain where Filament should be active. If the
-    | domain is empty, all domains will be valid.
-    |
     */
 
     'path' => 'admin',
     
-    'domain' => '',
+    /*
+    |--------------------------------------------------------------------------
+    | Filament Domaın
+    |--------------------------------------------------------------------------
+    |
+    | You may change the domain where Filament should be active. If the domain 
+    | is empty, all domains will be valid.
+    |
+    */
+    
+    'domain' => env('FILAMENT_DOMAIN', ''),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/filament.php
+++ b/config/filament.php
@@ -24,7 +24,7 @@ return [
     |
     */
     
-    'domain' => env('FILAMENT_DOMAIN', ''),
+    'domain' => env('FILAMENT_DOMAIN', null),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/filament.php
+++ b/config/filament.php
@@ -16,7 +16,7 @@ return [
     
     /*
     |--------------------------------------------------------------------------
-    | Filament Domaın
+    | Filament Domain
     |--------------------------------------------------------------------------
     |
     | You may change the domain where Filament should be active. If the domain 

--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -26,6 +26,7 @@ class RouteServiceProvider extends ServiceProvider
                 VerifyCsrfToken::class,
                 SubstituteBindings::class,
             ])
+            ->domain(config('filament.domain'))
             ->prefix(config('filament.path'))
             ->group(__DIR__ . '/../../routes/web.php');
     }


### PR DESCRIPTION
Hi,

First of all, I have to say I absolutely love Filament! I really like the syntax and the ease of use.

I would like to use Filament only on a specific domain, so I created this PR.

This PR allows anyone to select a domain, and only from this domain Filament will be usable. All other domains will throw a 404 errorr.

If a user leaves the option empty, all domains will be allowed.

Thank you!
Jeroen