### PR TITLE
feature: add DocBlocks to Filament facade

### DIFF
--- a/src/Filament.php
+++ b/src/Filament.php
@@ -5,6 +5,10 @@ namespace Filament;
 use Illuminate\Support\Facades\Facade;
 
 /**
+ * @method static array getPages()
+ * @method static array getResources() 
+ * @method static array getRoles()
+ * @method static array getWidgets()
  * @method static void registerPage(string $page)
  * @method static void registerResource(string $resource) 
  * @method static void registerRole(string $role)

--- a/src/Filament.php
+++ b/src/Filament.php
@@ -4,6 +4,14 @@ namespace Filament;
 
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * @method static void registerPage(string $page)
+ * @method static void registerResource(string $resource) 
+ * @method static void registerRole(string $role)
+ * @method static void registerWidget(string $widget)
+ *
+ * @see \Filament\FilamentManager
+ */
 class Filament extends Facade
 {
     protected static function getFacadeAccessor()


### PR DESCRIPTION
This pull request adds some DocBlock comments to the `Filament` facade so that IDEs and language servers can provide some decent autocomplete.

I've only added the `register*` methods for now, since they're more likely to be used than the `get*` methods.