### PR TITLE
feature: add new Field::setup method

### DIFF
--- a/packages/forms/src/Components/Checkbox.php
+++ b/packages/forms/src/Components/Checkbox.php
@@ -6,10 +6,8 @@ class Checkbox extends Field
 {
     use Concerns\CanBeAutofocused;
 
-    public function __construct($name)
+    protected function setup()
     {
-        parent::__construct($name);
-
         $this->default(false);
     }
 }

--- a/packages/forms/src/Components/Checkbox.php
+++ b/packages/forms/src/Components/Checkbox.php
@@ -6,7 +6,7 @@ class Checkbox extends Field
 {
     use Concerns\CanBeAutofocused;
 
-    protected function setup()
+    protected function setUp()
     {
         $this->default(false);
     }

--- a/packages/forms/src/Components/Component.php
+++ b/packages/forms/src/Components/Component.php
@@ -36,6 +36,11 @@ class Component
 
     protected $pendingModelModifications = [];
 
+    protected function setUp()
+    {
+        //
+    }
+
     public function context($context)
     {
         $this->context = $context;

--- a/packages/forms/src/Components/DatePicker.php
+++ b/packages/forms/src/Components/DatePicker.php
@@ -23,7 +23,7 @@ class DatePicker extends Field
 
     public $view = 'forms::components.date-time-picker';
 
-    protected function setup()
+    protected function setUp()
     {
         $this->displayFormat('F j, Y');
         $this->format('Y-m-d');

--- a/packages/forms/src/Components/DatePicker.php
+++ b/packages/forms/src/Components/DatePicker.php
@@ -23,10 +23,8 @@ class DatePicker extends Field
 
     public $view = 'forms::components.date-time-picker';
 
-    public function __construct($name)
+    protected function setup()
     {
-        parent::__construct($name);
-
         $this->displayFormat('F j, Y');
         $this->format('Y-m-d');
     }

--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -16,7 +16,7 @@ class DateTimePicker extends DatePicker
 
     public $view = 'forms::components.date-time-picker';
 
-    protected function setup()
+    protected function setUp()
     {
         $this->displayFormat($this->defaultDisplayFormat);
         $this->format($this->defaultFormat);

--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -16,10 +16,8 @@ class DateTimePicker extends DatePicker
 
     public $view = 'forms::components.date-time-picker';
 
-    public function __construct($name)
+    protected function setup()
     {
-        parent::__construct($name);
-
         $this->displayFormat($this->defaultDisplayFormat);
         $this->format($this->defaultFormat);
     }

--- a/packages/forms/src/Components/Field.php
+++ b/packages/forms/src/Components/Field.php
@@ -29,11 +29,17 @@ class Field extends Component
     public function __construct($name)
     {
         $this->name($name);
+        $this->setup();
     }
 
     public static function make($name)
     {
         return new static($name);
+    }
+
+    protected function setup()
+    {
+        //
     }
 
     public function disabled()

--- a/packages/forms/src/Components/Field.php
+++ b/packages/forms/src/Components/Field.php
@@ -29,6 +29,7 @@ class Field extends Component
     public function __construct($name)
     {
         $this->name($name);
+        
         $this->setup();
     }
 

--- a/packages/forms/src/Components/Field.php
+++ b/packages/forms/src/Components/Field.php
@@ -29,17 +29,13 @@ class Field extends Component
     public function __construct($name)
     {
         $this->name($name);
-        $this->setup();
+
+        parent::setUp();
     }
 
     public static function make($name)
     {
         return new static($name);
-    }
-
-    protected function setup()
-    {
-        //
     }
 
     public function disabled()

--- a/packages/forms/src/Components/Field.php
+++ b/packages/forms/src/Components/Field.php
@@ -29,7 +29,6 @@ class Field extends Component
     public function __construct($name)
     {
         $this->name($name);
-        
         $this->setup();
     }
 

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -40,10 +40,8 @@ class FileUpload extends Field
 
     public $visibility = 'public';
 
-    public function __construct($name)
+    protected function setup()
     {
-        parent::__construct($name);
-
         $this->addRules([$this->getTemporaryUploadedFilePropertyName() => ['nullable', 'file']]);
         $this->disk(config('forms.default_filesystem_disk'));
     }

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -40,7 +40,7 @@ class FileUpload extends Field
 
     public $visibility = 'public';
 
-    protected function setup()
+    protected function setUp()
     {
         $this->addRules([$this->getTemporaryUploadedFilePropertyName() => ['nullable', 'file']]);
         $this->disk(config('forms.default_filesystem_disk'));

--- a/packages/forms/src/Components/MultiSelect.php
+++ b/packages/forms/src/Components/MultiSelect.php
@@ -13,10 +13,8 @@ class MultiSelect extends Field
 
     public $options = [];
 
-    public function __construct($name)
+    protected function setup()
     {
-        parent::__construct($name);
-
         $this->placeholder('forms::fields.multiSelect.placeholder');
     }
 

--- a/packages/forms/src/Components/MultiSelect.php
+++ b/packages/forms/src/Components/MultiSelect.php
@@ -13,7 +13,7 @@ class MultiSelect extends Field
 
     public $options = [];
 
-    protected function setup()
+    protected function setUp()
     {
         $this->placeholder('forms::fields.multiSelect.placeholder');
     }

--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -30,7 +30,7 @@ class RichEditor extends Field
         'undo',
     ];
 
-    protected function setup()
+    protected function setUp()
     {
         $this->attachmentDisk(config('forms.default_filesystem_disk'));
 

--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -30,10 +30,8 @@ class RichEditor extends Field
         'undo',
     ];
 
-    public function __construct($name)
+    protected function setup()
     {
-        parent::__construct($name);
-
         $this->attachmentDisk(config('forms.default_filesystem_disk'));
 
         $attachmentUploadUrl = config('forms.rich_editor.default_attachment_upload_url');

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -21,7 +21,7 @@ class Select extends Field
 
     public $options = [];
 
-    protected function setup()
+    protected function setUp()
     {
         $this->placeholder('forms::fields.select.placeholder');
 

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -21,10 +21,8 @@ class Select extends Field
 
     public $options = [];
 
-    public function __construct($name)
+    protected function setup()
     {
-        parent::__construct($name);
-
         $this->placeholder('forms::fields.select.placeholder');
 
         $this->getDisplayValueUsing(function ($value) {

--- a/packages/forms/src/Components/TagsInput.php
+++ b/packages/forms/src/Components/TagsInput.php
@@ -12,7 +12,7 @@ class TagsInput extends Field
 
     public $separator = ',';
 
-    protected function setup()
+    protected function setUp()
     {
         $this->placeholder('forms::fields.tags.placeholder');
     }

--- a/packages/forms/src/Components/TagsInput.php
+++ b/packages/forms/src/Components/TagsInput.php
@@ -12,10 +12,8 @@ class TagsInput extends Field
 
     public $separator = ',';
 
-    public function __construct($name)
+    protected function setup()
     {
-        parent::__construct($name);
-
         $this->placeholder('forms::fields.tags.placeholder');
     }
 

--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -37,7 +37,6 @@ class Column
     public function __construct($name)
     {
         $this->name($name);
-
         $this->setup();
     }
 

--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -37,6 +37,7 @@ class Column
     public function __construct($name)
     {
         $this->name($name);
+
         $this->setup();
     }
 

--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -37,11 +37,18 @@ class Column
     public function __construct($name)
     {
         $this->name($name);
+
+        $this->setup();
     }
 
     public static function make($name)
     {
         return new static($name);
+    }
+
+    protected function setup()
+    {
+        //
     }
 
     public function context($context)


### PR DESCRIPTION
This pull requests add a new `setup` method to the `Field` class.

The idea of this method is that it can be used to set default arguments, values, etc on the field without overwriting the constructor.

The method is protected since it shouldn't be called on an instance, just internally as part of the instantiation.

It's called **after** the call to `Field::name` in the constructor so that base defaults can also be overwritten, e.g. name, label, default rules.

E.g.

```php
class Checkbox extends Field
{
    protected function setup()
    {
        $this->default(false);
    }
}
```