### PR TITLE
Replace filament guard with dynamic from config (missing spots)

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -9,10 +9,10 @@
             @if (config('filament.widgets.default.account', true))
                 <x-filament::card class="flex">
                     <div class="flex items-center space-x-4">
-                        <x-filament-avatar :user="Auth::guard('filament')->user()" :size="160" class="flex-shrink-0 w-20 h-20 rounded-full" />
+                        <x-filament-avatar :user="\Filament\Filament::auth()->user()" :size="160" class="flex-shrink-0 w-20 h-20 rounded-full" />
 
                         <div class="space-y-1">
-                            <h2 class="text-2xl">{{ __('filament::dashboard.widgets.account.heading', ['name' => Auth::guard('filament')->user()->name]) }}</h2>
+                            <h2 class="text-2xl">{{ __('filament::dashboard.widgets.account.heading', ['name' => \Filament\Filament::auth()->user()->name]) }}</h2>
                             <p class="text-sm"><a href="{{ route('filament.account') }}" class="link">{{ __('filament::dashboard.widgets.account.links.account.label') }}</a></p>
                         </div>
                     </div>

--- a/src/Http/Livewire/EditAccount.php
+++ b/src/Http/Livewire/EditAccount.php
@@ -6,7 +6,6 @@ use Filament\Filament;
 use Filament\Forms\HasForm;
 use Filament\Resources\Forms\Form;
 use Filament\Resources\Pages\Page;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 
 class EditAccount extends Page
@@ -35,7 +34,7 @@ class EditAccount extends Page
 
     public function mount()
     {
-        $this->record = Auth::guard('filament')->user();
+        $this->record = Filament::auth()->user();
     }
 
     public function save()


### PR DESCRIPTION
Just replacing some missed spots where still there is the hardcoded `Auth::guard('filament')` with the new "custom guard" system implemented in https://github.com/laravel-filament/filament/pull/72