### PR TITLE
feature: add new create another button

### DIFF
--- a/resources/lang/en/resources/relation-manager.php
+++ b/resources/lang/en/resources/relation-manager.php
@@ -66,6 +66,10 @@ return [
                     'label' => 'Create',
                 ],
 
+                'create_another' => [
+                    'label' => 'Create & Create Another',
+                ],
+
             ],
 
             'heading' => 'Create',

--- a/resources/lang/en/resources/relation-manager.php
+++ b/resources/lang/en/resources/relation-manager.php
@@ -66,7 +66,7 @@ return [
                     'label' => 'Create',
                 ],
 
-                'create_another' => [
+                'createAnother' => [
                     'label' => 'Create & Create Another',
                 ],
 

--- a/resources/views/relation-manager.blade.php
+++ b/resources/views/relation-manager.blade.php
@@ -46,6 +46,7 @@
 
             @livewire(\Livewire\Livewire::getAlias(Filament\Resources\RelationManager\CreateRecord::class), [
                 'cancelButtonLabel' => __(static::$createModalCancelButtonLabel),
+                'createAnotherButtonLabel' => __(static::$createModalCreateAnotherButtonLabel),
                 'createButtonLabel' => __(static::$createModalCreateButtonLabel),
                 'createdMessage' => __(static::$createModalCreatedMessage),
                 'manager' => static::class,

--- a/resources/views/resources/relation-manager/create-record.blade.php
+++ b/resources/views/resources/relation-manager/create-record.blade.php
@@ -8,6 +8,14 @@
                 {{ $createButtonLabel }}
             </x-filament::button>
 
+            <x-filament::button
+                type="button"
+                color="primary"
+                wire:click="create(true)"
+            >
+                {{ $createAnotherButtonLabel }}
+            </x-filament::button>
+
             <x-filament::button x-on:click="$dispatch('close', '{{ (string) Str::of($manager)->replace('\\', '\\\\') }}RelationManagerCreateModal')">
                 {{ $cancelButtonLabel }}
             </x-filament::button>

--- a/src/Resources/RelationManager.php
+++ b/src/Resources/RelationManager.php
@@ -28,7 +28,7 @@ class RelationManager extends Component
 
     public static $createModalCancelButtonLabel = 'filament::resources/relation-manager.modals.create.buttons.cancel.label';
 
-    public static $createModalCreateAnotherButtonLabel = 'filament::resources/relation-manager.modals.create.buttons.create_another.label';
+    public static $createModalCreateAnotherButtonLabel = 'filament::resources/relation-manager.modals.create.buttons.createAnother.label';
 
     public static $createModalCreateButtonLabel = 'filament::resources/relation-manager.modals.create.buttons.create.label';
 

--- a/src/Resources/RelationManager.php
+++ b/src/Resources/RelationManager.php
@@ -28,6 +28,8 @@ class RelationManager extends Component
 
     public static $createModalCancelButtonLabel = 'filament::resources/relation-manager.modals.create.buttons.cancel.label';
 
+    public static $createModalCreateAnotherButtonLabel = 'filament::resources/relation-manager.modals.create.buttons.create_another.label';
+
     public static $createModalCreateButtonLabel = 'filament::resources/relation-manager.modals.create.buttons.create.label';
 
     public static $createModalCreatedMessage = 'filament::resources/relation-manager.modals.create.messages.created';

--- a/src/Resources/RelationManager/CreateRecord.php
+++ b/src/Resources/RelationManager/CreateRecord.php
@@ -12,6 +12,8 @@ class CreateRecord extends Component
 
     public $cancelButtonLabel;
 
+    public $createAnotherButtonLabel;
+
     public $createButtonLabel;
 
     public $createdMessage;
@@ -22,7 +24,7 @@ class CreateRecord extends Component
 
     public $record = [];
 
-    public function create()
+    public function create($another = false)
     {
         $this->validateTemporaryUploadedFiles();
 
@@ -34,7 +36,10 @@ class CreateRecord extends Component
 
         $this->emit('refreshRelationManagerList', $this->manager);
 
-        $this->dispatchBrowserEvent('close', "{$this->manager}RelationManagerCreateModal");
+        if (! $another) {
+            $this->dispatchBrowserEvent('close', "{$this->manager}RelationManagerCreateModal");
+        }
+
         $this->dispatchBrowserEvent('notify', $this->createdMessage);
 
         $this->record = [];


### PR DESCRIPTION
This pull request adds a new "Create & Create Another" button to the relation manager's new / create modal. Here's what it looks like:

![image](https://user-images.githubusercontent.com/41837763/110209519-f835f280-7e84-11eb-8995-38f3204f21d3.png)
