### PR TITLE
feature: add new View field type

### DIFF
--- a/packages/forms/src/Components/View.php
+++ b/packages/forms/src/Components/View.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Filament\Forms\Components;
+
+class View extends Component
+{
+    public static function make($view)
+    {
+        return (new static())
+            ->view($view);
+    }
+}

--- a/src/Resources/Forms/Components/View.php
+++ b/src/Resources/Forms/Components/View.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Filament\Resources\Forms\Components;
+
+class View extends \Filament\Forms\Components\View
+{
+    //
+}


### PR DESCRIPTION
This pull request introduces a new `View` field type.

It exposes a `View::make()` method. The only argument to this method is the name of the view you'd like to render and is really just a named wrapped for the base `Component` class (which already handles views, etc).

This field is clearly named and you can also access the resource being edited and the form component etc, so the world is your oyster!

The other benefit of having this field is that people won't need to completely override the resource page's view for a simple custom element, especially when the custom element you want to build doesn't make much sense as a custom field.

```php
public static function form(Form $form)
{
    return $form->schema([
        Components\View::make('custom.view-path'),
    ]);
}
```