### PR TITLE
fix: allow passing title to page layout

### DIFF
--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -1,4 +1,4 @@
-<x-filament::layouts.base>
+<x-filament::layouts.base :title="__($title)">
     <a href="#content" class="sr-only">Skip to content</a>
 
     <div class="relative overflow-hidden"

--- a/src/Pages/Page.php
+++ b/src/Pages/Page.php
@@ -76,6 +76,13 @@ class Page extends Component
             ->title();
     }
 
+    public static function getPageTitle()
+    {
+        if (property_exists(static::class, 'pageTitle')) return static::$pageTitle;
+
+        return static::getTitle();
+    }
+
     public static function navigationItems()
     {
         return [
@@ -110,7 +117,9 @@ class Page extends Component
     public function render()
     {
         return view(static::$view, $this->getViewParameters())
-            ->layout('filament::components.layouts.app');
+            ->layout('filament::components.layouts.app', [
+                'title' => static::getPageTitle(),
+            ]);
     }
 
     public function getViewParameters()


### PR DESCRIPTION
This pull request fixes an issue where the title wasn't being passed up to the base layout.

The solution here is to pass in an array of arguments to `view()->layout()`. Livewire will automatically pass these to the layout when rendering the component.

Also needed to bind the `$title` variable to the base layout so that it actually gets rendered.

By default, it will use the static `getTitle` method as the page title, but it can also be customised using the `$pageTitle` property on the `Page` class or by completely overriding the `getPageTitle()` method on the `Page` class.

This fixes #100.