### PR TITLE
Allows a Column to have unescaped data

### DIFF
--- a/packages/tables/resources/views/cells/text.blade.php
+++ b/packages/tables/resources/views/cells/text.blade.php
@@ -18,5 +18,5 @@
         {{ $column->getValue($record) }}
     </a>
 @else
-    <span class="{{ $primaryClasses }}">{{ $column->getValue($record) }}</span>
+    <span class="{{ $primaryClasses }}">{!! $column->getValue($record) !!}</span>
 @endunless

--- a/packages/tables/resources/views/components/table.blade.php
+++ b/packages/tables/resources/views/components/table.blade.php
@@ -74,7 +74,7 @@
 
                     @foreach ($table->getVisibleColumns() as $column)
                         <td class="px-6 py-4 whitespace-nowrap">
-                            {{ $column->renderCell($record) }}
+                            {!! $column->renderCell($record) !!}
                         </td>
                     @endforeach
 

--- a/packages/tables/resources/views/components/table.blade.php
+++ b/packages/tables/resources/views/components/table.blade.php
@@ -74,7 +74,7 @@
 
                     @foreach ($table->getVisibleColumns() as $column)
                         <td class="px-6 py-4 whitespace-nowrap">
-                            {!! $column->renderCell($record) !!}
+                          {{ $column->renderCell($record) }}
                         </td>
                     @endforeach
 

--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -29,6 +29,8 @@ class Column
     public $sortable = false;
 
     public $view;
+    
+    public $escaped = true;
 
     protected $pendingExcludedContextModifications = [];
 
@@ -237,16 +239,34 @@ class Column
 
         return $this;
     }
-
+    
+    public function escaped()
+    {
+        $this->escaped = true;
+        
+        return $this;
+    }
+    
+    public function unescaped()
+    {
+        $this->escaped = false;
+        
+        return $this;
+    }
+    
     public function renderCell($record)
     {
         if ($this->hidden) return;
 
         $view = $this->view ?? 'tables::cells.'.Str::of(class_basename(static::class))->kebab();
-
+        
+        if($this->escaped) $record = htmlspecialchars($record, ENT_QUOTES,'UTF-8');
+        
         return view($view, [
             'column' => $this,
-            'record' => $record,
+            'record' =>  $record,
         ]);
     }
+    
+    
 }

--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -109,16 +109,22 @@ class Column
 
     public function getValue($record, $attribute = null)
     {
-        if ($this->getValueUsing) {
-            $callback = $this->getValueUsing;
-
-            return $callback($record);
-        }
-
         if ($attribute === null) {
             $attribute = $this->name;
         }
+    
+        
+        if ($this->getValueUsing) {
+            $callback = $this->getValueUsing;
 
+            $value = $callback($record);
+    
+            if($this->escaped) $value = htmlspecialchars($value, ENT_QUOTES,'UTF-8');
+    
+            return $value;
+        }
+
+        
         $value = $record->getAttribute(
             (string) Str::of($attribute)->before('.'),
         );
@@ -129,7 +135,9 @@ class Column
                 (string) Str::of($attribute)->after('.'),
             );
         }
-
+    
+        if($this->escaped) $value = htmlspecialchars($value, ENT_QUOTES,'UTF-8');
+    
         return $value;
     }
 
@@ -259,8 +267,6 @@ class Column
         if ($this->hidden) return;
 
         $view = $this->view ?? 'tables::cells.'.Str::of(class_basename(static::class))->kebab();
-        
-        if($this->escaped) $record = htmlspecialchars($record, ENT_QUOTES,'UTF-8');
         
         return view($view, [
             'column' => $this,


### PR DESCRIPTION
This is the first step in allowing custom data like svg or any data that can't be put through `htmlspecialchars` to appear in the table. It doesn't add any security overhead, all data is going through the {{ }} process, just in the render cell method instead of the blade template. This will now allow you to add chain ->unescaped() onto any declaration.

😎  This is a random emoji just for you.