### PR TITLE
Updated Relationship Manager to include a check for Morph Many and stop the attach/detach panels showing if so.

### DIFF
--- a/resources/views/relation-manager.blade.php
+++ b/resources/views/relation-manager.blade.php
@@ -9,7 +9,7 @@
                 {{ __(static::$createButtonLabel) }}
             </x-filament::button>
 
-            @unless ($this->isHasMany())
+            @unless ($this->isHasMany() || $this->isMorphMany())
                 <x-filament::button wire:click="openAttach">
                     {{ __(static::$attachButtonLabel) }}
                 </x-filament::button>
@@ -72,7 +72,7 @@
         </x-filament::card>
     </x-filament::modal>
 
-    @unless ($this->isHasMany())
+    @unless ($this->isHasMany() || $this->isMorphMany())
         <x-filament::modal
             class="w-full max-w-lg"
             :name="static::class . 'RelationManagerAttachModal'"

--- a/resources/views/relation-manager.blade.php
+++ b/resources/views/relation-manager.blade.php
@@ -9,11 +9,13 @@
                 {{ __(static::$createButtonLabel) }}
             </x-filament::button>
 
-            @unless ($this->isHasMany() || $this->isMorphMany())
+            @if ($this->canAttach())
                 <x-filament::button wire:click="openAttach">
                     {{ __(static::$attachButtonLabel) }}
                 </x-filament::button>
+            @endif
 
+            @if ($this->canDetach())
                 <x-filament::button
                     wire:click="openDetach"
                     color="danger"
@@ -21,7 +23,7 @@
                 >
                     {{ __(static::$detachButtonLabel) }}
                 </x-filament::button>
-            @endunless
+            @endif
 
             <x-tables::delete-selected :selected="$selected" />
         </div>
@@ -72,7 +74,7 @@
         </x-filament::card>
     </x-filament::modal>
 
-    @unless ($this->isHasMany() || $this->isMorphMany())
+    @if ($this->canAttach())
         <x-filament::modal
             class="w-full max-w-lg"
             :name="static::class . 'RelationManagerAttachModal'"
@@ -90,7 +92,9 @@
                 ])
             </x-filament::card>
         </x-filament::modal>
+    @endif
 
+    @if ($this->canDetach())
         <x-filament::modal
             :name="static::class . 'RelationManagerDetachModal'"
         >
@@ -116,5 +120,5 @@
                 </div>
             </x-filament::card>
         </x-filament::modal>
-    @endunless
+    @endif
 </div>

--- a/src/Resources/RelationManager.php
+++ b/src/Resources/RelationManager.php
@@ -92,6 +92,18 @@ class RelationManager extends Component
             ->title();
     }
 
+    public function canAttach()
+    {
+        return !$this->owner->{$this->getRelationship()}() instanceof Relations\HasMany &&
+            !$this->owner->{$this->getRelationship()}() instanceof Relations\MorphMany;
+    }
+
+    public function canDetach()
+    {
+        return !$this->owner->{$this->getRelationship()}() instanceof Relations\HasMany &&
+            !$this->owner->{$this->getRelationship()}() instanceof Relations\MorphMany;
+    }
+
     public function detachSelected()
     {
         $relationship = $this->owner->{$this->getRelationship()}();
@@ -122,16 +134,6 @@ class RelationManager extends Component
     public function getQuery()
     {
         return $this->owner->{static::$relationship}();
-    }
-
-    public function isHasMany()
-    {
-        return $this->owner->{$this->getRelationship()}() instanceof Relations\HasMany;
-    }
-
-    public function isMorphMany()
-    {
-        return $this->owner->{$this->getRelationship()}() instanceof Relations\MorphMany;
     }
 
     public function openAttach()

--- a/src/Resources/RelationManager.php
+++ b/src/Resources/RelationManager.php
@@ -94,14 +94,22 @@ class RelationManager extends Component
 
     public function canAttach()
     {
-        return !$this->owner->{$this->getRelationship()}() instanceof Relations\HasMany &&
-            !$this->owner->{$this->getRelationship()}() instanceof Relations\MorphMany;
+        if (
+            $this->isType(Relations\HasMany::class) ||
+            $this->isType(Relations\MorphMany::class)
+        ) return false;
+
+        return true;
     }
 
     public function canDetach()
     {
-        return !$this->owner->{$this->getRelationship()}() instanceof Relations\HasMany &&
-            !$this->owner->{$this->getRelationship()}() instanceof Relations\MorphMany;
+        if (
+            $this->isType(Relations\HasMany::class) ||
+            $this->isType(Relations\MorphMany::class)
+        ) return false;
+
+        return true;
     }
 
     public function detachSelected()
@@ -134,6 +142,11 @@ class RelationManager extends Component
     public function getQuery()
     {
         return $this->owner->{static::$relationship}();
+    }
+
+    public function isType($type)
+    {
+        return $this->owner->{$this->getRelationship()}() instanceof $type;
     }
 
     public function openAttach()

--- a/src/Resources/RelationManager.php
+++ b/src/Resources/RelationManager.php
@@ -129,6 +129,11 @@ class RelationManager extends Component
         return $this->owner->{$this->getRelationship()}() instanceof Relations\HasMany;
     }
 
+    public function isMorphMany()
+    {
+        return $this->owner->{$this->getRelationship()}() instanceof Relations\MorphMany;
+    }
+
     public function openAttach()
     {
         $this->dispatchBrowserEvent('open', static::class . 'RelationManagerAttachModal');


### PR DESCRIPTION
Hey folks,

The attach/detach methods aren't available on a MorphMany relationship so I created a similar check for this relationship and stopped the buttons showing if the relationship was present.

There's a good chance I've misunderstood what you were going for in the other check so throw this in the sea if it's way off.

Love what you've all done with this - had a great weekend playing with it!