### PR TITLE
feature: View column

### DIFF
--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -30,6 +30,8 @@ class Column
 
     public $view;
 
+    public $viewData = [];
+
     protected $pendingExcludedContextModifications = [];
 
     protected $pendingIncludedContextModifications = [];
@@ -72,6 +74,13 @@ class Column
             });
 
         $this->pendingExcludedContextModifications = [];
+
+        return $this;
+    }
+
+    public function data($data = [])
+    {
+        $this->viewData = array_merge($this->viewData, $data);
 
         return $this;
     }
@@ -224,9 +233,11 @@ class Column
         return $this;
     }
 
-    public function view($view)
+    public function view($view, $data = [])
     {
         $this->view = $view;
+
+        $this->data($data);
 
         return $this;
     }
@@ -240,7 +251,7 @@ class Column
 
     protected function getViewData()
     {
-        return [];
+        return $this->viewData;
     }
 
     public function renderCell($record)

--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -238,15 +238,20 @@ class Column
         return $this;
     }
 
+    protected function getViewData()
+    {
+        return [];
+    }
+
     public function renderCell($record)
     {
         if ($this->hidden) return;
 
         $view = $this->view ?? 'tables::cells.'.Str::of(class_basename(static::class))->kebab();
 
-        return view($view, [
+        return view($view, array_merge($this->getViewData(), [
             'column' => $this,
             'record' => $record,
-        ]);
+        ]));
     }
 }

--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -40,7 +40,7 @@ class Column
     {
         $this->name($name);
 
-        $this->setup();
+        $this->setUp();
     }
 
     public static function make($name)
@@ -48,7 +48,7 @@ class Column
         return new static($name);
     }
 
-    protected function setup()
+    protected function setUp()
     {
         //
     }
@@ -74,13 +74,6 @@ class Column
             });
 
         $this->pendingExcludedContextModifications = [];
-
-        return $this;
-    }
-
-    public function data($data = [])
-    {
-        $this->viewData = array_merge($this->viewData, $data);
 
         return $this;
     }
@@ -233,11 +226,18 @@ class Column
         return $this;
     }
 
-    public function view($view, $data = [])
+    public function view($view, $viewData = [])
     {
         $this->view = $view;
 
-        $this->data($data);
+        $this->viewData($viewData);
+
+        return $this;
+    }
+
+    public function viewData($data = [])
+    {
+        $this->viewData = array_merge($this->viewData, $data);
 
         return $this;
     }
@@ -249,18 +249,13 @@ class Column
         return $this;
     }
 
-    protected function getViewData()
-    {
-        return $this->viewData;
-    }
-
     public function renderCell($record)
     {
         if ($this->hidden) return;
 
         $view = $this->view ?? 'tables::cells.'.Str::of(class_basename(static::class))->kebab();
 
-        return view($view, array_merge($this->getViewData(), [
+        return view($view, array_merge($this->viewData, [
             'column' => $this,
             'record' => $record,
         ]));

--- a/packages/tables/src/Columns/View.php
+++ b/packages/tables/src/Columns/View.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Filament\Tables\Columns;
+
+class View extends Column
+{
+    protected function setUp()
+    {
+        $this->view($this->name);
+    }
+}

--- a/packages/tables/src/Columns/View.php
+++ b/packages/tables/src/Columns/View.php
@@ -4,17 +4,5 @@ namespace Filament\Tables\Columns;
 
 class View extends Column
 {
-    public $viewData = [];
-
-    public function data($data)
-    {
-        $this->viewData = array_merge($this->viewData, $data);
-
-        return $this;
-    }
-
-    protected function getViewData()
-    {
-        return $this->viewData;
-    }
+    //
 }

--- a/packages/tables/src/Columns/View.php
+++ b/packages/tables/src/Columns/View.php
@@ -6,11 +6,6 @@ class View extends Column
 {
     public $viewData = [];
 
-    protected function setUp()
-    {
-        $this->view($this->name);
-    }
-
     public function data($data)
     {
         $this->viewData = array_merge($this->viewData, $data);

--- a/packages/tables/src/Columns/View.php
+++ b/packages/tables/src/Columns/View.php
@@ -4,8 +4,22 @@ namespace Filament\Tables\Columns;
 
 class View extends Column
 {
+    public $viewData = [];
+
     protected function setUp()
     {
         $this->view($this->name);
+    }
+
+    public function data($data)
+    {
+        $this->viewData = array_merge($this->viewData, $data);
+
+        return $this;
+    }
+
+    protected function getViewData()
+    {
+        return $this->viewData;
     }
 }

--- a/src/Resources/Tables/Columns/View.php
+++ b/src/Resources/Tables/Columns/View.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Filament\Resources\Tables\Columns;
+
+class View extends \Filament\Tables\Columns\View
+{
+    //
+}


### PR DESCRIPTION
This pull request introduces a new `View` column that can be used to render a custom view inside of a column cell.

It can be used like this:

```php
View::make('Custom Column')
    ->view('path.to.custom.view')
```

By default, the view you specify with have access to the current record in the table (`$record`) as well as the column class itself (`$column`).

You can also pass through additional data using the `data()` method, or pass an array of data as a second argument to `view()`:

```php
View::make('Custom Column')
    ->view('path.to.custom.view')
    ->data([
        'user' => Filament::auth()->user(),
    ])
```