### PR TITLE
Feature: Add external url capability for a text column URL

### DIFF
--- a/packages/tables/resources/views/cells/text.blade.php
+++ b/packages/tables/resources/views/cells/text.blade.php
@@ -15,7 +15,7 @@
         <a
             href="{{ $column->getUrl($record) }}"
             class="{{ $primaryClasses }} hover:underline hover:text-primary-600 transition-colors duration-200"
-            @if ($column->shouldOpenInNewTab)
+            @if ($column->openInNewTab)
                 target="_blank"
                 rel="noopener noreferrer"
             @endif

--- a/packages/tables/resources/views/cells/text.blade.php
+++ b/packages/tables/resources/views/cells/text.blade.php
@@ -15,6 +15,10 @@
         <a
             href="{{ $column->getUrl($record) }}"
             class="{{ $primaryClasses }} hover:underline hover:text-primary-600 transition-colors duration-200"
+            @if ($column->externalUrl)
+                target="_blank"
+                rel="noopener noreferrer"
+            @endif
         >
             {{ $column->getValue($record) }}
         </a>

--- a/packages/tables/resources/views/cells/text.blade.php
+++ b/packages/tables/resources/views/cells/text.blade.php
@@ -15,7 +15,7 @@
         <a
             href="{{ $column->getUrl($record) }}"
             class="{{ $primaryClasses }} hover:underline hover:text-primary-600 transition-colors duration-200"
-            @if ($column->externalUrl)
+            @if ($column->shouldOpenInNewTab)
                 target="_blank"
                 rel="noopener noreferrer"
             @endif

--- a/packages/tables/resources/views/cells/text.blade.php
+++ b/packages/tables/resources/views/cells/text.blade.php
@@ -15,7 +15,7 @@
         <a
             href="{{ $column->getUrl($record) }}"
             class="{{ $primaryClasses }} hover:underline hover:text-primary-600 transition-colors duration-200"
-            @if ($column->openInNewTab)
+            @if ($column->shouldOpenUrlInNewTab)
                 target="_blank"
                 rel="noopener noreferrer"
             @endif

--- a/packages/tables/src/Columns/Text.php
+++ b/packages/tables/src/Columns/Text.php
@@ -14,6 +14,8 @@ class Text extends Column
 
     public $url;
 
+    public $externalUrl;
+
     public function action($action)
     {
         $this->action = $action;
@@ -105,10 +107,17 @@ class Text extends Column
         return $this;
     }
 
-    public function url($url)
+    public function url($url, $external = false)
     {
         $this->url = $url;
+        $this->externalUrl = $external;
 
+        return $this;
+    }
+
+    public function externalUrl($url)
+    {
+        $this->url($url, true);
         return $this;
     }
 }

--- a/packages/tables/src/Columns/Text.php
+++ b/packages/tables/src/Columns/Text.php
@@ -12,9 +12,9 @@ class Text extends Column
 
     public $formatUsing;
 
-    public $url;
+    public $shouldOpenUrlInNewTab = false;
 
-    public $openInNewTab = false;
+    public $url;
 
     public function action($action)
     {
@@ -94,6 +94,13 @@ class Text extends Column
         return $value;
     }
 
+    public function openUrlInNewTab()
+    {
+        $this->shouldOpenUrlInNewTab = true;
+
+        return $this;
+    }
+
     public function options($options)
     {
         $this->formatUsing = function ($value) use ($options) {
@@ -107,17 +114,10 @@ class Text extends Column
         return $this;
     }
 
-    public function url($url, $openInNewTab = false)
+    public function url($url, $shouldOpenInNewTab = false)
     {
         $this->url = $url;
-        $this->openInNewTab = $openInNewTab;
-
-        return $this;
-    }
-    
-    public function openInNewTab()
-    {
-        $this->openInNewTab = true;
+        if ($shouldOpenInNewTab) $this->openUrlInNewTab();
 
         return $this;
     }

--- a/packages/tables/src/Columns/Text.php
+++ b/packages/tables/src/Columns/Text.php
@@ -14,7 +14,7 @@ class Text extends Column
 
     public $url;
 
-    public $shouldOpenInNewTab = false;
+    public $openInNewTab = false;
 
     public function action($action)
     {
@@ -107,16 +107,17 @@ class Text extends Column
         return $this;
     }
 
-    public function url($url)
+    public function url($url, $openInNewTab = false)
     {
         $this->url = $url;
+        $this->openInNewTab = $openInNewTab;
 
         return $this;
     }
     
-    public function shouldOpenInNewTab()
+    public function openInNewTab()
     {
-        $this->shouldOpenInNewTab = true;
+        $this->openInNewTab = true;
 
         return $this;
     }

--- a/packages/tables/src/Columns/Text.php
+++ b/packages/tables/src/Columns/Text.php
@@ -14,7 +14,7 @@ class Text extends Column
 
     public $url;
 
-    public $externalUrl;
+    public $shouldOpenInNewTab = false;
 
     public function action($action)
     {
@@ -107,17 +107,17 @@ class Text extends Column
         return $this;
     }
 
-    public function url($url, $external = false)
+    public function url($url)
     {
         $this->url = $url;
-        $this->externalUrl = $external;
 
         return $this;
     }
-
-    public function externalUrl($url)
+    
+    public function shouldOpenInNewTab()
     {
-        $this->url($url, true);
+        $this->shouldOpenInNewTab = true;
+
         return $this;
     }
 }


### PR DESCRIPTION
This PR allows for adding external URL's to the ->url() method of a text column.

Example for viewing an external `Page` resource from the table view:

```php
                Columns\Text::make('slug')
                    ->label('Visit')
                    ->url(function ($page) {
                        $path = $page->slug === 'home' ? '/' : $page->slug;
                        return url($path);
                    }, true),
                    
// or

                Columns\Text::make('slug')
                    ->label('Visit')
                    ->externalUrl(function ($page) {
                        $path = $page->slug === 'home' ? '/' : $page->slug;
                        return url($path);
                    }),
```