### PR TITLE
Fix/tabs styling

### DIFF
--- a/packages/forms/resources/views/components/tabs.blade.php
+++ b/packages/forms/resources/views/components/tabs.blade.php
@@ -21,11 +21,11 @@
     x-on:switch-tab.window="if ($event.detail in tabs) tab = $event.detail"
     x-cloak
     {!! $formComponent->id ? "id=\"{$formComponent->id}\"" : null !!}
-    class="{{ $columnSpanClass }} overflow-hidden bg-white shadow-xl rounded p-4 md:p-6"
+    class="{{ $columnSpanClass }} overflow-hidden bg-white border border-gray-200 rounded p-4 md:p-6"
 >
     <div class="-m-4 md:-m-6">
         <div {!! __($formComponent->label) ? 'aria-label="'.__($formComponent->label).'"' : null !!} role="tablist"
-             class="bg-gray-100 border-b border-gray-200 flex">
+             class="flex bg-gray-100 border-b border-gray-200">
             @foreach ($formComponent->getTabsConfig() as $tabId => $tabLabel)
                 <button type="button"
                         aria-controls="{{ $tabId }}-tab"
@@ -33,7 +33,7 @@
                         x-on:click="tab = '{{ $tabId }}'"
                         role="tab"
                         x-bind:tabindex="tab === '{{ $tabId }}' ? 0 : -1"
-                        class="text-sm leading-tight font-medium p-3 md:px-6 -mb-px border-r border-gray-200"
+                        class="p-3 -mb-px text-sm font-medium leading-tight border-r border-gray-200 md:px-6"
                         x-bind:class="{ 'bg-white': tab === '{{ $tabId }}' }"
                 >
                     {{ __($tabLabel) }}


### PR DESCRIPTION
Now that tabs are nested within cards, this fix's the visual regression by removing the inner tabs shadow and replacing with a border to better integrate with the form styling.