### PR TITLE
Added trim functionality to Text Column

### DIFF
--- a/packages/tables/src/Columns/Text.php
+++ b/packages/tables/src/Columns/Text.php
@@ -90,9 +90,7 @@ class Text extends Column
     public function limit($length = -1)
     {
         $this->formatUsing = function ($value) use ($length) {
-            $value = Str::of($value)->limit($length);
-
-            return $value;
+            return Str::limit($value, $length);
         };
 
         return $this;

--- a/packages/tables/src/Columns/Text.php
+++ b/packages/tables/src/Columns/Text.php
@@ -14,10 +14,6 @@ class Text extends Column
 
     public $formatUsing;
 
-    public $trimLength = -1;
-
-    public $trimmable = false;
-
     public function currency($symbol = '$', $decimalSeparator = '.', $thousandsSeparator = ',')
     {
         $this->formatUsing = function ($value) use ($decimalSeparator, $symbol, $thousandsSeparator) {
@@ -75,10 +71,7 @@ class Text extends Column
             $value = $callback($value);
         }
 
-        if (! $this->trimmable) return $value;
-        if (! is_int($this->trimLength)) return $value;
-
-        return Str::of($value)->limit($this->trimLength);
+        return $value;
     }
 
     public function options($options)
@@ -94,10 +87,13 @@ class Text extends Column
         return $this;
     }
 
-    public function trim($trimLength = -1)
+    public function limit($length = -1)
     {
-        $this->trimLength = $trimLength;
-        $this->trimmable = true;
+        $this->formatUsing = function ($value) use ($length) {
+            $value = Str::of($value)->limit($length);
+
+            return $value;
+        };
 
         return $this;
     }

--- a/packages/tables/src/Columns/Text.php
+++ b/packages/tables/src/Columns/Text.php
@@ -3,6 +3,7 @@
 namespace Filament\Tables\Columns;
 
 use Carbon\Carbon;
+use Illuminate\Support\Str;
 
 class Text extends Column
 {
@@ -12,6 +13,10 @@ class Text extends Column
     public $default;
 
     public $formatUsing;
+
+    public $trimLength = -1;
+
+    public $trimmable = false;
 
     public function currency($symbol = '$', $decimalSeparator = '.', $thousandsSeparator = ',')
     {
@@ -70,7 +75,10 @@ class Text extends Column
             $value = $callback($value);
         }
 
-        return $value;
+        if (! $this->trimmable) return $value;
+        if (! is_int($this->trimLength)) return $value;
+
+        return Str::of($value)->limit($this->trimLength);
     }
 
     public function options($options)
@@ -82,6 +90,14 @@ class Text extends Column
 
             return $value;
         };
+
+        return $this;
+    }
+
+    public function trim($trimLength = -1)
+    {
+        $this->trimLength = $trimLength;
+        $this->trimmable = true;
 
         return $this;
     }


### PR DESCRIPTION
Morning folks,

TLDR: Added trim functionality to Text Column

I found that I was using the getValueUsing callback a lot of the time just to trim the length of the content but if I did this I lost the ability to search or sort on that field.

I've added a trim helper to the Text column that takes a trim length and then trims the value after it's been taken from the record.

Example usage:

```php
Columns\Text::make('reference')->primary()->searchable()->sortable()->trim(6),
```

This allows me to only show the first six characters of the reference in the table but retain search and sort functionality.

Cheers!