### PR TITLE
fix: duplicate label and field IDs

### DIFF
--- a/packages/forms/resources/views/components/checkbox.blade.php
+++ b/packages/forms/resources/views/components/checkbox.blade.php
@@ -1,7 +1,7 @@
 <x-forms::field-group
     :column-span="$formComponent->columnSpan"
     :error-key="$formComponent->name"
-    :for="$formComponent->id"
+    :for="$formComponent->getId()"
     :help-message="__($formComponent->helpMessage)"
     :hint="__($formComponent->hint)"
     :label="__($formComponent->label)"
@@ -11,7 +11,7 @@
         <input
             {!! $formComponent->autofocus ? 'autofocus' : null !!}
             {!! $formComponent->disabled ? 'disabled' : null !!}
-            {!! $formComponent->id ? "id=\"{$formComponent->id}\"" : null !!}
+            {!! $formComponent->getId() ? "id=\"{$formComponent->getId()}\"" : null !!}
             {!! $formComponent->name ? "{$formComponent->nameAttribute}=\"{$formComponent->name}\"" : null !!}
             type="checkbox"
             {!! $formComponent->required ? 'required' : null !!}

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -314,7 +314,7 @@
 <x-forms::field-group
     :column-span="$formComponent->columnSpan"
     :error-key="$formComponent->name"
-    :for="$formComponent->id"
+    :for="$formComponent->getId()"
     :help-message="__($formComponent->helpMessage)"
     :hint="__($formComponent->hint)"
     :label="__($formComponent->label)"
@@ -338,7 +338,7 @@
         })"
         x-init="init()"
         x-on:click.away="closePicker()"
-        {!! $formComponent->id ? "id=\"{$formComponent->id}\"" : null !!}
+        {!! $formComponent->getId() ? "id=\"{$formComponent->getId()}\"" : null !!}
         class="relative"
         {!! Filament\format_attributes($formComponent->extraAttributes) !!}
     >

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -44,7 +44,7 @@
 <x-forms::field-group
     :column-span="$formComponent->columnSpan"
     :error-key="$formComponent->name"
-    :for="$formComponent->id"
+    :for="$formComponent->getId()"
     :help-message="__($formComponent->helpMessage)"
     :hint="__($formComponent->hint)"
     :label="__($formComponent->label)"

--- a/packages/forms/resources/views/components/multi-select.blade.php
+++ b/packages/forms/resources/views/components/multi-select.blade.php
@@ -185,7 +185,7 @@
 <x-forms::field-group
     :column-span="$formComponent->columnSpan"
     :error-key="$formComponent->name"
-    :for="$formComponent->id"
+    :for="$formComponent->getId()"
     :help-message="__($formComponent->helpMessage)"
     :hint="__($formComponent->hint)"
     :label="__($formComponent->label)"
@@ -206,7 +206,7 @@
         x-init="init()"
         x-on:click.away="closeListbox()"
         x-on:keydown.escape.stop="closeListbox()"
-        {!! $formComponent->id ? "id=\"{$formComponent->id}\"" : null !!}
+        {!! $formComponent->getId() ? "id=\"{$formComponent->getId()}\"" : null !!}
         class="relative"
         {!! Filament\format_attributes($formComponent->extraAttributes) !!}
     >

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -31,7 +31,7 @@
 <x-forms::field-group
     :column-span="$formComponent->columnSpan"
     :error-key="$formComponent->name"
-    :for="$formComponent->id"
+    :for="$formComponent->getId()"
     :help-message="__($formComponent->helpMessage)"
     :hint="__($formComponent->hint)"
     :label="__($formComponent->label)"
@@ -83,9 +83,9 @@
         wire:ignore
     >
         @unless ($formComponent->disabled)
-            <input id="trix-value-{{ $formComponent->id }}" type="hidden" />
+            <input id="trix-value-{{ $formComponent->getId() }}" type="hidden" />
 
-            <trix-toolbar id="trix-toolbar-{{ $formComponent->id }}">
+            <trix-toolbar id="trix-toolbar-{{ $formComponent->getId() }}">
                 <div class="trix-button-row">
                     @if ($formComponent->hasToolbarButton(['bold', 'italic', 'strike', 'link']))
                         <span class="trix-button-group trix-button-group--text-tools"
@@ -215,10 +215,10 @@
 
             <trix-editor
                 {{ $formComponent->autofocus ? 'autofocus' : null }}
-                id="{{ $formComponent->id }}"
-                input="trix-value-{{ $formComponent->id }}"
+                id="{{ $formComponent->getId() }}"
+                input="trix-value-{{ $formComponent->getId() }}"
                 placeholder="{{ __($formComponent->placeholder) }}"
-                toolbar="trix-toolbar-{{ $formComponent->id }}"
+                toolbar="trix-toolbar-{{ $formComponent->getId() }}"
                 x-ref="trix"
                 class="block w-full prose placeholder-gray-400 placeholder-opacity-100 bg-white border-gray-300 rounded shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50 max-w-none"
                 {!! Filament\format_attributes($formComponent->extraAttributes) !!}

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -184,7 +184,7 @@
 <x-forms::field-group
     :column-span="$formComponent->columnSpan"
     :error-key="$formComponent->name"
-    :for="$formComponent->id"
+    :for="$formComponent->getId()"
     :help-message="__($formComponent->helpMessage)"
     :hint="__($formComponent->hint)"
     :label="__($formComponent->label)"
@@ -206,7 +206,7 @@
         x-init="init()"
         x-on:click.away="closeListbox()"
         x-on:keydown.escape.stop="closeListbox()"
-        {!! $formComponent->id ? "id=\"{$formComponent->id}\"" : null !!}
+        {!! $formComponent->getId() ? "id=\"{$formComponent->getId()}\"" : null !!}
         class="relative"
         {!! Filament\format_attributes($formComponent->extraAttributes) !!}
     >

--- a/packages/forms/resources/views/components/tab.blade.php
+++ b/packages/forms/resources/views/components/tab.blade.php
@@ -1,9 +1,9 @@
 <div
-    aria-labelledby="{{ "{$formComponent->parent->id}.{$formComponent->id}" }}"
-    id="{{ "{$formComponent->parent->id}.{$formComponent->id}-tab" }}"
+    aria-labelledby="{{ "{$formComponent->parent->id}.{$formComponent->getId()}" }}"
+    id="{{ "{$formComponent->parent->id}.{$formComponent->getId()}-tab" }}"
     role="tabpanel"
     tabindex="0"
-    x-show="tab === '{{ "{$formComponent->parent->id}.{$formComponent->id}" }}'"
+    x-show="tab === '{{ "{$formComponent->parent->id}.{$formComponent->getId()}" }}'"
     class="p-4 md:p-6"
 >
     <x-forms::layout :schema="$formComponent->schema" :columns="$formComponent->columns" />

--- a/packages/forms/resources/views/components/tabs.blade.php
+++ b/packages/forms/resources/views/components/tabs.blade.php
@@ -20,7 +20,7 @@
     x-data="{ tab: '{{ count($formComponent->getTabsConfig()) ? array_key_first($formComponent->getTabsConfig()) : null }}', tabs: {{ json_encode($formComponent->getTabsConfig()) }} }"
     x-on:switch-tab.window="if ($event.detail in tabs) tab = $event.detail"
     x-cloak
-    {!! $formComponent->id ? "id=\"{$formComponent->id}\"" : null !!}
+    {!! $formComponent->getId() ? "id=\"{$formComponent->getId()}\"" : null !!}
     class="{{ $columnSpanClass }} bg-white border border-gray-200 rounded p-4 md:p-6"
 >
     <div class="-m-4 md:-m-6">

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -62,7 +62,7 @@
 <x-forms::field-group
     :column-span="$formComponent->columnSpan"
     :error-key="$formComponent->name"
-    :for="$formComponent->id"
+    :for="$formComponent->getId()"
     :help-message="__($formComponent->helpMessage)"
     :hint="__($formComponent->hint)"
     :label="__($formComponent->label)"
@@ -76,7 +76,7 @@
             @endif
         })"
         x-init="init()"
-        {!! $formComponent->id ? "id=\"{$formComponent->id}\"" : null !!}
+        {!! $formComponent->getId() ? "id=\"{$formComponent->getId()}\"" : null !!}
         {!! Filament\format_attributes($formComponent->extraAttributes) !!}
     >
         @unless (Str::of($formComponent->nameAttribute)->startsWith(['wire:model', 'x-model']))

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -1,7 +1,7 @@
 <x-forms::field-group
     :column-span="$formComponent->columnSpan"
     :error-key="$formComponent->name"
-    :for="$formComponent->id"
+    :for="$formComponent->getId()"
     :help-message="__($formComponent->helpMessage)"
     :hint="__($formComponent->hint)"
     :label="__($formComponent->label)"
@@ -18,7 +18,7 @@
             {!! $formComponent->autocomplete ? "autocomplete=\"{$formComponent->autocomplete}\"" : null !!}
             {!! $formComponent->autofocus ? 'autofocus' : null !!}
             {!! $formComponent->disabled ? 'disabled' : null !!}
-            {!! $formComponent->id ? "id=\"{$formComponent->id}\"" : null !!}
+            {!! $formComponent->getId() ? "id=\"{$formComponent->getId()}\"" : null !!}
             {!! $formComponent->name ? "{$formComponent->nameAttribute}=\"{$formComponent->name}\"" : null !!}
             {!! $formComponent->maxLength ? "maxlength=\"{$formComponent->maxLength}\"" : null !!}
             {!! $formComponent->minLength ? "minlength=\"{$formComponent->minLength}\"" : null !!}

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -1,7 +1,7 @@
 <x-forms::field-group
     :column-span="$formComponent->columnSpan"
     :error-key="$formComponent->name"
-    :for="$formComponent->id"
+    :for="$formComponent->getId()"
     :help-message="__($formComponent->helpMessage)"
     :hint="__($formComponent->hint)"
     :label="__($formComponent->label)"
@@ -12,7 +12,7 @@
         {!! $formComponent->autofocus ? 'autofocus' : null !!}
         {!! $formComponent->cols ? "cols=\"{$formComponent->cols}\"" : null !!}
         {!! $formComponent->disabled ? 'disabled' : null !!}
-        {!! $formComponent->id ? "id=\"{$formComponent->id}\"" : null !!}
+        {!! $formComponent->getId() ? "id=\"{$formComponent->getId()}\"" : null !!}
         {!! $formComponent->maxLength ? "maxlength=\"{$formComponent->maxLength}\"" : null !!}
         {!! $formComponent->minLength ? "minlength=\"{$formComponent->minLength}\"" : null !!}
         {!! $formComponent->name ? "{$formComponent->nameAttribute}=\"{$formComponent->name}\"" : null !!}

--- a/packages/forms/src/Components/Component.php
+++ b/packages/forms/src/Components/Component.php
@@ -140,7 +140,11 @@ class Component
 
     public function getId()
     {
-        return (string) Str::of($this->context)->replace('\\', '_')->lower()->append('_'.$this->id);
+        return (string) Str::of($this->context)
+            ->replace('\\', '-')
+            ->lower()
+            ->append('-')
+            ->append($this->id);
     }
 
     public function getSubform()

--- a/packages/forms/src/Components/Component.php
+++ b/packages/forms/src/Components/Component.php
@@ -140,7 +140,7 @@ class Component
 
     public function getId()
     {
-        return $this->context.$this->id;
+        return (string) Str::of($this->context)->replace('\\', '_')->lower()->append('_'.$this->id);
     }
 
     public function getSubform()

--- a/packages/forms/src/Components/Component.php
+++ b/packages/forms/src/Components/Component.php
@@ -138,6 +138,11 @@ class Component
         return $defaults;
     }
 
+    public function getId()
+    {
+        return $this->context.$this->id;
+    }
+
     public function getSubform()
     {
         $form = Form::make()->schema($this->schema);

--- a/stubs/FieldView.stub
+++ b/stubs/FieldView.stub
@@ -1,7 +1,7 @@
 <x-forms::field-group
     :column-span="$formComponent->columnSpan"
     :error-key="$formComponent->name"
-    :for="$formComponent->id"
+    :for="$formComponent->getId()"
     :help-message="__($formComponent->helpMessage)"
     :hint="__($formComponent->hint)"
     :label="__($formComponent->label)"
@@ -11,7 +11,7 @@
         x-data="{
             value: @entangle($formComponent->name){{ Str::of($formComponent->nameAttribute)->after('wire:model') }},
         }"
-        id="{{ $formComponent->id }}"
+        id="{{ $formComponent->getId() }}"
     >
         {{-- Field content --}}
     </div>


### PR DESCRIPTION
Closes #120.

This pull request refactors the `$formComponent->id` logic into a new `getId()` method that will prefix a slightly formatted version of the `$context` to the form's ID.