### PR TITLE
feature: class based filters

### DIFF
--- a/packages/tables/src/Filter.php
+++ b/packages/tables/src/Filter.php
@@ -23,10 +23,20 @@ class Filter
 
     protected $pendingIncludedContextModifications = [];
 
-    public function __construct($name, $callback = null)
+    public function __construct($name = null, $callback = null)
     {
-        $this->name($name);
+        if ($name) {
+            $this->name($name);
+        }
+
         $this->callback($callback);
+
+        $this->setUp();
+    }
+
+    protected function setUp()
+    {
+        //
     }
 
     public static function make($name, $callback = null)

--- a/packages/tables/src/Filter.php
+++ b/packages/tables/src/Filter.php
@@ -41,6 +41,13 @@ class Filter
         return $this;
     }
 
+    public function apply($query)
+    {
+        $callback = $this->callback;
+
+        return $callback($query);
+    }
+
     public function context($context)
     {
         $this->context = $context;

--- a/packages/tables/src/Filter.php
+++ b/packages/tables/src/Filter.php
@@ -39,7 +39,7 @@ class Filter
         //
     }
 
-    public static function make($name, $callback = null)
+    public static function make($name = null, $callback = null)
     {
         return new static($name, $callback);
     }

--- a/packages/tables/src/HasTable.php
+++ b/packages/tables/src/HasTable.php
@@ -118,9 +118,7 @@ trait HasTable
             collect($this->getTable()->filters)
                 ->filter(fn ($filter) => $filter->name === $this->filter)
                 ->each(function ($filter) use (&$query) {
-                    $callback = $filter->callback;
-
-                    $query = $callback($query);
+                    $query = $filter->apply($query);
                 });
         }
 

--- a/src/Commands/Aliases/MakeFilterCommand.php
+++ b/src/Commands/Aliases/MakeFilterCommand.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Filament\Commands\Aliases;
+
+class MakeFilterCommand extends \Filament\Commands\MakeFilterCommand
+{
+    protected $signature = 'filament:filter {name}';
+}

--- a/src/Commands/Aliases/MakeFilterCommand.php
+++ b/src/Commands/Aliases/MakeFilterCommand.php
@@ -4,5 +4,5 @@ namespace Filament\Commands\Aliases;
 
 class MakeFilterCommand extends \Filament\Commands\MakeFilterCommand
 {
-    protected $signature = 'filament:filter {name}';
+    protected $signature = 'filament:filter {name} {--R|resource=}';
 }

--- a/src/Commands/Aliases/MakeFilterCommand.php
+++ b/src/Commands/Aliases/MakeFilterCommand.php
@@ -4,5 +4,5 @@ namespace Filament\Commands\Aliases;
 
 class MakeFilterCommand extends \Filament\Commands\MakeFilterCommand
 {
-    protected $signature = 'filament:filter {name} {--R|resource=}';
+    protected $signature = 'filament:filter {name} {--R|resource}';
 }

--- a/src/Commands/MakeFieldCommand.php
+++ b/src/Commands/MakeFieldCommand.php
@@ -33,7 +33,7 @@ class MakeFieldCommand extends Command
 
         $path = app_path(
             (string) Str::of($field)
-                ->prepend($this->option('resource') ? 'Filament\\Resources\\Forms\\Components\\' : "Filament\\Forms\\Components\\")
+                ->prepend($this->option('resource') ? 'Filament\\Resources\\Forms\\Components\\' : 'Filament\\Forms\\Components\\')
                 ->replace('\\', '/')
                 ->append('.php'),
         );

--- a/src/Commands/MakeFilterCommand.php
+++ b/src/Commands/MakeFilterCommand.php
@@ -11,7 +11,7 @@ class MakeFilterCommand extends Command
 
     protected $description = 'Make a Filament filter class.';
 
-    protected $signature = 'make:filament-filter {name}';
+    protected $signature = 'make:filament-filter {name} {--R|resource=}';
 
     public function handle()
     {
@@ -20,11 +20,12 @@ class MakeFilterCommand extends Command
             ->trim('\\')
             ->trim(' ')
             ->replace('/', '\\');
-
         $filterClass = (string) Str::of($filter)->afterLast('\\');
         $filterNamespace = Str::of($filter)->contains('\\') ?
             (string) Str::of($filter)->beforeLast('\\') :
             '';
+
+        $resource = $this->option('resource');
 
         $path = app_path(
             (string) Str::of($filter)
@@ -37,11 +38,17 @@ class MakeFilterCommand extends Command
             $path,
         ])) return;
 
-        $this->copyStubToApp('Filter', $path, [
-            'class' => $filterClass,
-            'name' => $filter,
-            'namespace' => 'App\\Filament\\Filters' . ($filterNamespace !== '' ? "\\{$filterNamespace}" : ''),
-        ]);
+        if ($resource === null) {
+            $this->copyStubToApp('Filter', $path, [
+                'class' => $filterClass,
+                'namespace' => 'App\\Filament\\Filters',
+            ]);
+        } else {
+            $this->copyStubToApp('ResourceFilter', $path, [
+                'class' => $filterClass,
+                'namespace' => 'App\\Filament\\Filters',
+            ]);
+        }
 
         $this->info("Successfully created {$filter}!");
     }

--- a/src/Commands/MakeFilterCommand.php
+++ b/src/Commands/MakeFilterCommand.php
@@ -29,7 +29,7 @@ class MakeFilterCommand extends Command
 
         $path = app_path(
             (string) Str::of($filter)
-                ->prepend($resource === null ? 'Filament\\Filters\\' : "Filament\\Resources\\Filters\\")
+                ->prepend($resource === null ? 'Filament\\Tables\\Filters\\' : "Filament\\Resources\\Tables\\Filters\\")
                 ->replace('\\', '/')
                 ->append('.php'),
         );
@@ -41,12 +41,12 @@ class MakeFilterCommand extends Command
         if ($resource === false) {
             $this->copyStubToApp('Filter', $path, [
                 'class' => $filterClass,
-                'namespace' => 'App\\Filament\\Filters' . ($filterNamespace !== '' ? "\\{$filterNamespace}" : ''),
+                'namespace' => 'App\\Filament\\Tables\\Filters' . ($filterNamespace !== '' ? "\\{$filterNamespace}" : ''),
             ]);
         } else {
             $this->copyStubToApp('ResourceFilter', $path, [
                 'class' => $filterClass,
-                'namespace' => 'App\\Filament\\Resources\\Filters' . ($filterNamespace !== '' ? "\\{$filterNamespace}" : ''),
+                'namespace' => 'App\\Filament\\Resources\\Tables\\Filters' . ($filterNamespace !== '' ? "\\{$filterNamespace}" : ''),
             ]);
         }
 

--- a/src/Commands/MakeFilterCommand.php
+++ b/src/Commands/MakeFilterCommand.php
@@ -11,7 +11,7 @@ class MakeFilterCommand extends Command
 
     protected $description = 'Make a Filament filter class.';
 
-    protected $signature = 'make:filament-filter {name} {--R|resource=}';
+    protected $signature = 'make:filament-filter {name} {--R|resource}';
 
     public function handle()
     {
@@ -29,7 +29,7 @@ class MakeFilterCommand extends Command
 
         $path = app_path(
             (string) Str::of($filter)
-                ->prepend('Filament\\Filters\\')
+                ->prepend($resource === null ? 'Filament\\Filters\\' : "Filament\\Resources\\Filters\\")
                 ->replace('\\', '/')
                 ->append('.php'),
         );
@@ -38,15 +38,15 @@ class MakeFilterCommand extends Command
             $path,
         ])) return;
 
-        if ($resource === null) {
+        if ($resource === false) {
             $this->copyStubToApp('Filter', $path, [
                 'class' => $filterClass,
-                'namespace' => 'App\\Filament\\Filters',
+                'namespace' => 'App\\Filament\\Filters' . ($filterNamespace !== '' ? "\\{$filterNamespace}" : ''),
             ]);
         } else {
             $this->copyStubToApp('ResourceFilter', $path, [
                 'class' => $filterClass,
-                'namespace' => 'App\\Filament\\Filters',
+                'namespace' => 'App\\Filament\\Resources\\Filters' . ($filterNamespace !== '' ? "\\{$filterNamespace}" : ''),
             ]);
         }
 

--- a/src/Commands/MakeFilterCommand.php
+++ b/src/Commands/MakeFilterCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Filament\Commands;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\Command;
+
+class MakeFilterCommand extends Command
+{
+    use Concerns\CanManipulateFiles;
+
+    protected $description = 'Make a Filament filter class.';
+
+    protected $signature = 'make:filament-filter {name}';
+
+    public function handle()
+    {
+        $filter = (string) Str::of($this->argument('name'))
+            ->trim('/')
+            ->trim('\\')
+            ->trim(' ')
+            ->replace('/', '\\');
+
+        $filterClass = (string) Str::of($filter)->afterLast('\\');
+        $filterNamespace = Str::of($filter)->contains('\\') ?
+            (string) Str::of($filter)->beforeLast('\\') :
+            '';
+
+        $path = app_path(
+            (string) Str::of($filter)
+                ->prepend('Filament\\Filters\\')
+                ->replace('\\', '/')
+                ->append('.php'),
+        );
+
+        if ($this->checkForCollision([
+            $path,
+        ])) return;
+
+        $this->copyStubToApp('Filter', $path, [
+            'class' => $filterClass,
+            'name' => $filter,
+            'namespace' => 'App\\Filament\\Filters' . ($filterNamespace !== '' ? "\\{$filterNamespace}" : ''),
+        ]);
+
+        $this->info("Successfully created {$filter}!");
+    }
+}

--- a/src/Commands/MakeFilterCommand.php
+++ b/src/Commands/MakeFilterCommand.php
@@ -25,11 +25,9 @@ class MakeFilterCommand extends Command
             (string) Str::of($filter)->beforeLast('\\') :
             '';
 
-        $resource = $this->option('resource');
-
         $path = app_path(
             (string) Str::of($filter)
-                ->prepend($resource === null ? 'Filament\\Tables\\Filters\\' : "Filament\\Resources\\Tables\\Filters\\")
+                ->prepend($this->option('resource') ? 'Filament\\Resources\\Tables\\Filters\\' : 'Filament\\Tables\\Filters\\')
                 ->replace('\\', '/')
                 ->append('.php'),
         );
@@ -38,7 +36,7 @@ class MakeFilterCommand extends Command
             $path,
         ])) return;
 
-        if ($resource === false) {
+        if (! $this->option('resource')) {
             $this->copyStubToApp('Filter', $path, [
                 'class' => $filterClass,
                 'namespace' => 'App\\Filament\\Tables\\Filters' . ($filterNamespace !== '' ? "\\{$filterNamespace}" : ''),

--- a/src/FilamentServiceProvider.php
+++ b/src/FilamentServiceProvider.php
@@ -66,6 +66,7 @@ class FilamentServiceProvider extends ServiceProvider
             Commands\MakeWidgetCommand::class,
             Commands\MakeFieldCommand::class,
             Commands\MakeThemeCommand::class,
+            Commands\MakeFilterCommand::class,
         ]);
 
         $aliases = [];

--- a/stubs/Filter.stub
+++ b/stubs/Filter.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace {{ namespace }};
+
+use Filament\Resources\Tables\Filter;
+
+class {{ class }} extends Filter
+{
+    protected function setUp()
+    {
+        $this->name('{{ name }}');
+    }
+
+    public function apply($query)
+    {
+        return $query;
+    }
+}

--- a/stubs/ResourceFilter.stub
+++ b/stubs/ResourceFilter.stub
@@ -2,7 +2,7 @@
 
 namespace {{ namespace }};
 
-use Filament\Tables\Filter;
+use Filament\Resources\Tables\Filter;
 
 class {{ class }} extends Filter
 {


### PR DESCRIPTION
This pull request adds support for basic class based filters. This means you can extract a filter into a reusable class that could be applied to multiple resources.

Here's what the class looks like:

```php
class NameFilter extends Filter
{
    protected function setUp()
    {
        $this->name('Name Like a');
    }

    public function apply($query)
    {
        return $query->where('name', 'LIKE', 'a%');
    }
}
```

The `Filter` class now has a `setUp()` method that can be used by class-based filters to set some default arguments. The `$name` parameter for `::make()` and `__construct()` is also now nullable so class-based filters don't _need_ to provide it but they still can if they don't want to define the name as `$name` or using `$this->name()` in `setUp()`.

This pull request also opens up the scope for future enhancements, such as parameter based filters where you could define the fields for the filter / options inside of a class.

A good example of a reusable filter is a `ActiveFilter` where multiple resources have a common column and column values.