### PR TITLE
feature: implement new avatar providers

### DIFF
--- a/config/filament.php
+++ b/config/filament.php
@@ -1,5 +1,7 @@
 <?php
 
+use Filament\GravatarProvider;
+
 return [
 
     /*
@@ -38,6 +40,7 @@ return [
 
     'auth' => [
         'guard' => env('FILAMENT_AUTH_GUARD', 'filament'),
+        'avatar_provider' => GravatarProvider::class,
     ],
 
     /*

--- a/config/filament.php
+++ b/config/filament.php
@@ -1,7 +1,5 @@
 <?php
 
-use Filament\GravatarProvider;
-
 return [
 
     /*
@@ -40,7 +38,6 @@ return [
 
     'auth' => [
         'guard' => env('FILAMENT_AUTH_GUARD', 'filament'),
-        'avatar_provider' => GravatarProvider::class,
     ],
 
     /*
@@ -130,6 +127,18 @@ return [
     */
 
     'user_resource' => \Filament\Resources\UserResource::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Avatar Provider
+    |--------------------------------------------------------------------------
+    |
+    | This is the service that will be used to retrieve default avatars if one
+    | has not been uploaded.
+    |
+    */
+
+    'avatar_provider' => \Filament\AvatarProviders\GravatarProvider::class,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/AvatarProviders/Contracts/AvatarProvider.php
+++ b/src/AvatarProviders/Contracts/AvatarProvider.php
@@ -6,5 +6,5 @@ use Filament\Models\Contracts\FilamentUser;
 
 interface AvatarProvider
 {
-    public function get(FilamentUser $user);
+    public function get(FilamentUser $user, $size = 48, $dpr = 1);
 }

--- a/src/AvatarProviders/Contracts/AvatarProvider.php
+++ b/src/AvatarProviders/Contracts/AvatarProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Filament\AvatarProviders\Contracts;
+
+use Filament\Models\Contracts\FilamentUser;
+
+interface AvatarProvider
+{
+    public function get(FilamentUser $user);
+}

--- a/src/AvatarProviders/GravatarProvider.php
+++ b/src/AvatarProviders/GravatarProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Filament;
+namespace Filament\AvatarProviders;
 
 use Filament\Models\Contracts\FilamentUser;
 use Thomaswelton\LaravelGravatar\Facades\Gravatar;

--- a/src/AvatarProviders/GravatarProvider.php
+++ b/src/AvatarProviders/GravatarProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Filament;
+
+use Filament\Models\Contracts\FilamentUser;
+
+class GravatarProvider implements Contracts\AvatarProvider
+{
+    public function get(FilamentUser $user)
+    {
+
+    }
+}

--- a/src/AvatarProviders/GravatarProvider.php
+++ b/src/AvatarProviders/GravatarProvider.php
@@ -3,11 +3,12 @@
 namespace Filament;
 
 use Filament\Models\Contracts\FilamentUser;
+use Thomaswelton\LaravelGravatar\Facades\Gravatar;
 
 class GravatarProvider implements Contracts\AvatarProvider
 {
-    public function get(FilamentUser $user)
+    public function get(FilamentUser $user, $size = 48, $dpr = 1)
     {
-
+        return Gravatar::src($user->email, $size * $dpr);
     }
 }

--- a/src/AvatarProviders/UiAvatarProvider.php
+++ b/src/AvatarProviders/UiAvatarProvider.php
@@ -8,6 +8,6 @@ class UiAvatarProvider implements Contracts\AvatarProvider
 {
     public function get(FilamentUser $user, $size = 48, $dpr = 1)
     {
-        return 'https://ui-avatars.com/api/?name='.urlencode($user->name).'&color=7F9CF5&background=EBF4FF&size='.$size * $dpr;
+        return 'https://ui-avatars.com/api/?name='.urlencode($user->name).'&color=FFFFFF&background=0284c7&size='.$size * $dpr;
     }
 }

--- a/src/AvatarProviders/UiAvatarProvider.php
+++ b/src/AvatarProviders/UiAvatarProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Filament\AvatarProviders;
+
+use Filament\Models\Contracts\FilamentUser;
+
+class UiAvatarProvider implements Contracts\AvatarProvider
+{
+    public function get(FilamentUser $user, $size = 48, $dpr = 1)
+    {
+        return 'https://ui-avatars.com/api/?name='.urlencode($user->name).'&color=7F9CF5&background=EBF4FF&size='.$size * $dpr;
+    }
+}

--- a/src/AvatarProviders/UiAvatarProvider.php
+++ b/src/AvatarProviders/UiAvatarProvider.php
@@ -8,6 +8,6 @@ class UiAvatarProvider implements Contracts\AvatarProvider
 {
     public function get(FilamentUser $user, $size = 48, $dpr = 1)
     {
-        return 'https://ui-avatars.com/api/?name='.urlencode($user->name).'&color=FFFFFF&background=0284c7&size='.$size * $dpr;
+        return 'https://ui-avatars.com/api/?name=' . urlencode($user->name) . '&color=FFFFFF&background=0284c7&size=' . $size * $dpr;
     }
 }

--- a/src/Filament.php
+++ b/src/Filament.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static StatefulGuard auth()
+ * @method static \Filament\AvatarProviders\Contracts\AvatarProvider avatarProvider()
  * @method static bool can(string $action, object|string $target)
  * @method static array getAuthorizations()
  * @method static array getPages()

--- a/src/FilamentManager.php
+++ b/src/FilamentManager.php
@@ -3,6 +3,7 @@
 namespace Filament;
 
 use Composer\InstalledVersions;
+use Filament\AvatarProviders\GravatarProvider;
 use Filament\Events\ServingFilament;
 use Filament\Resources\UserResource;
 use Illuminate\Support\Facades\Auth;
@@ -36,7 +37,7 @@ class FilamentManager
 
     public function avatarProvider()
     {
-        $provider = config('filament.auth.avatar_provider', GravatarProvider::class);
+        $provider = config('filament.avatar_provider', GravatarProvider::class);
 
         return new $provider;
     }

--- a/src/FilamentManager.php
+++ b/src/FilamentManager.php
@@ -34,6 +34,13 @@ class FilamentManager
         return Auth::guard(config('filament.auth.guard', 'filament'));
     }
 
+    public function avatarProvider()
+    {
+        $provider = config('filament.auth.avatar_provider', GravatarProvider::class);
+
+        return new $provider;
+    }
+
     public function can($action, $target)
     {
         $user = $this->auth()->user();

--- a/src/FilamentServiceProvider.php
+++ b/src/FilamentServiceProvider.php
@@ -34,10 +34,7 @@ class FilamentServiceProvider extends ServiceProvider
         $this->bootLoaders();
         $this->bootLivewireComponents();
         $this->bootPublishing();
-
-        $this->app->booted(function () {
-            $this->configure();
-        });
+        $this->configure();
     }
 
     public function register()
@@ -158,30 +155,32 @@ class FilamentServiceProvider extends ServiceProvider
 
     protected function configure()
     {
-        $this->app['config']->set('auth.guards.filament', [
-            'driver' => 'session',
-            'provider' => 'filament_users',
-        ]);
+        $this->app->booting(function () {
+            $this->app['config']->set('auth.guards.filament', [
+                'driver' => 'session',
+                'provider' => 'filament_users',
+            ]);
 
-        $this->app['config']->set('auth.passwords.filament_users', [
-            'provider' => 'filament_users',
-            'table' => 'filament_password_resets',
-            'expire' => 60,
-            'throttle' => 60,
-        ]);
+            $this->app['config']->set('auth.passwords.filament_users', [
+                'provider' => 'filament_users',
+                'table' => 'filament_password_resets',
+                'expire' => 60,
+                'throttle' => 60,
+            ]);
 
-        $this->app['config']->set('auth.providers.filament_users', [
-            'driver' => 'eloquent',
-            'model' => User::class,
-        ]);
+            $this->app['config']->set('auth.providers.filament_users', [
+                'driver' => 'eloquent',
+                'model' => User::class,
+            ]);
 
-        $this->app['config']->set('forms', [
-            'default_filesystem_disk' => $this->app['config']->get('filament.default_filesystem_disk'),
-        ]);
+            $this->app['config']->set('forms', [
+                'default_filesystem_disk' => $this->app['config']->get('filament.default_filesystem_disk'),
+            ]);
 
-        $this->app['config']->set('forms.rich_editor', [
-            'default_attachment_upload_url' => route('filament.rich-editor-attachments.upload'),
-        ]);
+            $this->app['config']->set('forms.rich_editor', [
+                'default_attachment_upload_url' => route('filament.rich-editor-attachments.upload'),
+            ]);
+        });
     }
 
     protected function registerIcons()
@@ -196,7 +195,9 @@ class FilamentServiceProvider extends ServiceProvider
 
     protected function registerProviders()
     {
-        $this->app->register(RouteServiceProvider::class);
+        $this->app->booted(function () {
+            $this->app->register(RouteServiceProvider::class);
+        });
     }
 
     protected function mergeConfigFrom($path, $key)

--- a/src/FilamentServiceProvider.php
+++ b/src/FilamentServiceProvider.php
@@ -155,7 +155,7 @@ class FilamentServiceProvider extends ServiceProvider
 
     protected function configure()
     {
-        $this->app->booting(function () {
+        $this->app->booted(function () {
             $this->app['config']->set('auth.guards.filament', [
                 'driver' => 'session',
                 'provider' => 'filament_users',

--- a/src/View/Components/Avatar.php
+++ b/src/View/Components/Avatar.php
@@ -2,6 +2,7 @@
 
 namespace Filament\View\Components;
 
+use Filament\Filament;
 use Illuminate\View\Component;
 use Thomaswelton\LaravelGravatar\Facades\Gravatar;
 use function Filament\get_image_url;
@@ -26,7 +27,7 @@ class Avatar extends Component
         $avatar = $this->user->getFilamentAvatar();
 
         if ($avatar === null) {
-            return Gravatar::src($this->user->email, $this->size * $dpr);
+            return Filament::avatarProvider()->get($this->user, $this->size, $dpr);
         }
 
         return get_image_url(


### PR DESCRIPTION
This pull request adds support for custom implementations of `AvatarProvider`. The `AvatarProvider` is an object that is responsible for getting an avatar for a user.

By default, Filament will still use any uploaded avatars or avatars provided by `getFilamentAvatar`. If the avatar provided by these methods is `null`, it will fallback to the configured avatar provider.

Out of the box, Filament uses Gravatar as the default avatar provider but also provides one for ui-avatars.com (like Jetstream).

You can change the avatar provider used by modifying the `filament.auth.avatar_provider` configuration value.

### Gravatar

```php
'auth' => [
    'avatar_provider' => \Filament\AvatarProviders\GravatarProvider::class,
]
```

### UI Avatars

```php
'auth' => [
    'avatar_provider' => \Filament\AvatarProviders\UiAvatarProvider::class,
]
```