### PR TITLE
Allow additional recordActions

### DIFF
--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -2,6 +2,8 @@
 
 namespace Filament\Tables;
 
+use Illuminate\Support\Arr;
+
 class Table
 {
     public $columns = [];
@@ -166,7 +168,7 @@ class Table
 
     public function recordActions($actions)
     {
-        $this->recordActions = $actions;
+        $this->recordActions = Arr::collapse($this->recordActions, $actions);
 
         return $this;
     }

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -2,8 +2,6 @@
 
 namespace Filament\Tables;
 
-use Illuminate\Support\Arr;
-
 class Table
 {
     public $columns = [];
@@ -168,7 +166,7 @@ class Table
 
     public function recordActions($actions)
     {
-        $this->recordActions = Arr::collapse($this->recordActions, $actions);
+        $this->recordActions = array_merge($this->recordActions, $actions);
 
         return $this;
     }


### PR DESCRIPTION
Currently, if you set any `recordActions` on a table they are overwritten in ListRecords as `recordActions` just replaces the array instead of merging the arrays. 