### PR TITLE
fix: undefined method URL on view columns

### DIFF
--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -146,6 +146,10 @@ class Table
     {
         $this->columns = collect($this->columns)
             ->map(function ($column) use ($action) {
+                if (! method_exists($column, 'action')) {
+                    return $column;
+                }
+
                 return $column->action($action);
             })
             ->toArray();
@@ -157,6 +161,10 @@ class Table
     {
         $this->columns = collect($this->columns)
             ->map(function ($column) use ($url) {
+                if (! method_exists($column, 'url')) {
+                    return $column;
+                }
+
                 return $column->url($url);
             })
             ->toArray();


### PR DESCRIPTION
Closes #174.

Issue here is the `View` column doesn't support the `url()` or `action()` methods, which makes sense because you have full control over the view so you could wire all of that up inside.