### PR TITLE
fix: add view prop to resource page stub

### DIFF
--- a/stubs/ResourcePage.stub
+++ b/stubs/ResourcePage.stub
@@ -8,4 +8,6 @@ use {{ baseResourcePage }};
 class {{ resourcePageClass }} extends {{ baseResourcePageClass }}
 {
     public static $resource = {{ resourceClass }}::class;
+
+    public static $view = '{{ view }}';
 }


### PR DESCRIPTION
Fixes an issue where the `ResourcePage` stub didn't have the view property, causing errors after creating a new page.