### PR TITLE
feature: allow customising (primary) record actions

### DIFF
--- a/src/Resources/RelationManager.php
+++ b/src/Resources/RelationManager.php
@@ -161,22 +161,32 @@ class RelationManager extends Component
         $this->selected = [];
     }
 
+    public function getPrimaryRecordAction($record)
+    {
+        if (! Filament::can('update', $record)) return;
+
+        return 'openEdit';
+    }
+
+    public function getRecordActions()
+    {
+        return [
+            RecordActions\Link::make('edit')
+                ->label(static::$editRecordActionLabel)
+                ->action('openEdit')
+                ->when(fn ($record) => Filament::can('update', $record)),
+        ];
+    }
+
     public function getTable()
     {
         return static::table(Table::make())
             ->filterable($this->filterable)
             ->pagination(false)
             ->primaryRecordAction(function ($record) {
-                if (! Filament::can('update', $record)) return;
-
-                return 'openEdit';
+                return $this->getPrimaryRecordAction($record);
             })
-            ->recordActions([
-                RecordActions\Link::make('edit')
-                    ->label(static::$editRecordActionLabel)
-                    ->action('openEdit')
-                    ->when(fn ($record) => Filament::can('update', $record)),
-            ])
+            ->recordActions($this->getRecordActions())
             ->searchable($this->searchable)
             ->sortable($this->sortable);
     }


### PR DESCRIPTION
This is in response to #166. It introduces 2 new methods on the `RelationManager`: `getPrimaryRecordAction` and `getRecordActions`.

These new methods will allow you to customise the table actions without overwriting the entire `getTable` method, as well remove the default actions by overwriting and returning an empty array (`getRecordActions`) or returning `null` from `getPrimaryRecordAction`.