### PR TITLE
feature: add plugin service provider hooks for register

### DIFF
--- a/src/PluginServiceProvider.php
+++ b/src/PluginServiceProvider.php
@@ -20,6 +20,8 @@ abstract class PluginServiceProvider extends ServiceProvider
 
     public function register()
     {
+        $this->registeringPlugin();
+
         $this->app->booting(function () {
             foreach ($this->pages() as $page) {
                 Filament::registerPage($page);
@@ -49,11 +51,23 @@ abstract class PluginServiceProvider extends ServiceProvider
                 Filament::provideToScript($this->scriptData());
             });
         });
+
+        $this->pluginRegistered();
     }
 
     protected function pages()
     {
         return $this->pages;
+    }
+
+    protected function pluginRegistered()
+    {
+        //
+    }
+
+    protected function registeringPlugin()
+    {
+        //
     }
 
     protected function resources()


### PR DESCRIPTION
This pull request introduces 2 new methods to the `PluginServiceProvider` -- `registeringPlugin()` and `pluginRegistered()`.

These methods run at the start and end of `register()`, respectively. The main use case it to register some services for your plugin without having to override the parent's `register` method which is crucial to the plugin registration logic.