### PR TITLE
Fix Bug: Multiple BelongsToSelect fields. When trying to change value of one will reset the value of the other one

### DIFF
--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -130,8 +130,6 @@
                     this.$watch('value', () => {
                         if (this.value in this.options) {
                             this.displayValue = this.options[this.value]
-                        } else {
-                            this.clearValue()
                         }
                     })
                 },

--- a/src/Commands/MakeResourceCommand.php
+++ b/src/Commands/MakeResourceCommand.php
@@ -61,7 +61,7 @@ class MakeResourceCommand extends Command
             'resourceClass' => $resourceClass,
         ]);
 
-        $this->copyStubToApp('ResourcePage', $indexResourcePagePath, [
+        $this->copyStubToApp('DefaultResourcePage', $indexResourcePagePath, [
             'baseResourcePage' => 'Filament\\Resources\\Pages\\ListRecords',
             'baseResourcePageClass' => 'ListRecords',
             'namespace' => "App\\Filament\\Resources\\{$resource}\\Pages",
@@ -70,7 +70,7 @@ class MakeResourceCommand extends Command
             'resourcePageClass' => $indexResourcePageClass,
         ]);
 
-        $this->copyStubToApp('ResourcePage', $createResourcePagePath, [
+        $this->copyStubToApp('DefaultResourcePage', $createResourcePagePath, [
             'baseResourcePage' => 'Filament\\Resources\\Pages\\CreateRecord',
             'baseResourcePageClass' => 'CreateRecord',
             'namespace' => "App\\Filament\\Resources\\{$resource}\\Pages",
@@ -79,7 +79,7 @@ class MakeResourceCommand extends Command
             'resourcePageClass' => $createResourcePageClass,
         ]);
 
-        $this->copyStubToApp('ResourcePage', $editResourcePagePath, [
+        $this->copyStubToApp('DefaultResourcePage', $editResourcePagePath, [
             'baseResourcePage' => 'Filament\\Resources\\Pages\\EditRecord',
             'baseResourcePageClass' => 'EditRecord',
             'namespace' => "App\\Filament\\Resources\\{$resource}\\Pages",

--- a/stubs/DefaultResourcePage.stub
+++ b/stubs/DefaultResourcePage.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace {{ namespace }};
+
+use App\Filament\Resources\{{ resource }};
+use {{ baseResourcePage }};
+
+class {{ resourcePageClass }} extends {{ baseResourcePageClass }}
+{
+    public static $resource = {{ resourceClass }}::class;
+}


### PR DESCRIPTION
**Describe the bug**
Having multiple BelongsToSelect fields with the default options without using ->preload() produce a strange behavior. Trying to change one field will reset the value of the other field.

**To reproduce**
Steps to reproduce the behavior:
1. Create a resource with 3 BelongsToSelect fields without ->preload() option
2. Search in the first select field and select a value from the list
3. Search in the second select field and select a value from the list
4. Search in the third select field will cause the first field to reset value.

The issue can also be reproduced using 2 select fields with ->dependable() option. Which will remove .defer option.

**Expected behavior**
Search in one of the select fields should not reset the value of the other fields.

**Code**
```php
    public static function form(Form $form)
    {
        return $form
            ->schema([
                BelongsToSelect::make('work_type_id')->relationship('workType', 'name')->required(),
                BelongsToSelect::make('work_priority_id')->relationship('workPriority', 'name')->required(),
                BelongsToSelect::make('asset_id')->relationship('asset', 'name')->required()
            ]);
    }
```

**Screenshots**
![issue](https://user-images.githubusercontent.com/3797475/110966622-823ef900-8366-11eb-8365-9110c83a2947.gif)


**Context**
- Package version: v1.5.5
- Livewire version: v2.4.0
- Laravel version: v8.32.1
- Browser: Chrome & firefox
- Server OS: macOS Big Sur 11.2.3 (Laravel Valet 2.13.19)
- PHP version: 8.0.2
- Database: MySQL 8.0

**Proposed fix**
change on value watcher
```js
this.$watch('value', () => {
	if (this.value in this.options) {
		this.displayValue = this.options[this.value]
	}
})
```