### PR TITLE
Support Icons on RecordActions

### DIFF
--- a/packages/tables/resources/views/record-actions/link.blade.php
+++ b/packages/tables/resources/views/record-actions/link.blade.php
@@ -2,20 +2,32 @@
     <button
         wire:click="{{ $recordAction->action }}('{{ $record->getKey() }}')"
         type="button"
-        class="font-medium transition-colors duration-200 text-primary-600 hover:underline hover:text-primary-700"
+        title="{{$recordAction->label}}"
+        class="font-medium transition-colors duration-200 text-primary-600 hover:underline hover:text-primary-700 pr-2"
     >
+    @if ($recordAction->display != 'text')
+        <x-dynamic-component component="{{ $recordAction->icon}}" class="flex-shrink-0 h-5 w-5 inline" />
+    @endif
+    @if ($recordAction->display != 'icon')
         {{ __($recordAction->label) }}
+    @endif
     </button>
 @elseif ($recordAction->url)
     <a
         href="{{ $recordAction->getUrl($record) }}"
-        class="font-medium transition-colors duration-200 text-primary-600 hover:underline hover:text-primary-700"
+        class="font-medium transition-colors duration-200 text-primary-600 hover:underline hover:text-primary-700 pr-2"
+        title="{{$recordAction->label}}"
         @if ($recordAction->shouldOpenUrlInNewTab)
         target="_blank"
         rel="noopener noreferrer"
         @endif
     >
+        @if ($recordAction->display != 'text')
+        <x-dynamic-component component="{{ $recordAction->icon}}" class="flex-shrink-0 h-5 w-5 inline" />
+        @endif
+        @if ($recordAction->display != 'icon')
         {{ __($recordAction->label) }}
+        @endif
     </a>
 @else
     <span>{{ __($recordAction->label) }}</span>

--- a/packages/tables/src/RecordActions/Link.php
+++ b/packages/tables/src/RecordActions/Link.php
@@ -11,9 +11,34 @@ class Link extends Action
 
     public $label;
 
+    public $icon;
+
+    public $display = 'text';
+
     public function label($label)
     {
         $this->label = $label;
+
+        return $this;
+    }
+
+    public function displayIconOnly()
+    {
+        $this->display = 'icon';
+
+        return $this;
+    }
+
+    public function displayIconAndText()
+    {
+        $this->display = 'both';
+
+        return $this;
+    }
+
+    public function icon($icon)
+    {
+        $this->icon = $icon;
 
         return $this;
     }

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -174,7 +174,7 @@ class Table
 
     public function recordActions($actions)
     {
-        $this->recordActions = $this->recordActions ?? $actions;
+        $this->recordActions = $this->recordActions ?: $actions;
 
         return $this;
     }

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -174,7 +174,7 @@ class Table
 
     public function recordActions($actions)
     {
-        $this->recordActions = array_merge($this->recordActions, $actions);
+        $this->recordActions = $this->recordActions ?? $actions;
 
         return $this;
     }


### PR DESCRIPTION
This PR allows Icons to be added to RecordActions. 

There is a change in the logic of how RecordActions are displayed, previously any RecordActions added to a table would be displayed in addition to the default edit action. 

To allow the default edit action to be replaced it will now only be shown if no RecordActions are supplied. 