### PR TITLE
Pluck id from record before passing to destroy

### DIFF
--- a/src/Resources/Pages/ListRecords.php
+++ b/src/Resources/Pages/ListRecords.php
@@ -68,6 +68,7 @@ class ListRecords extends Page
                 ->filter(function ($record) {
                     return Filament::can('delete', $record);
                 })
+                ->pluck('id')
                 ->toArray(),
         );
 

--- a/src/Resources/Pages/ListRecords.php
+++ b/src/Resources/Pages/ListRecords.php
@@ -68,7 +68,7 @@ class ListRecords extends Page
                 ->filter(function ($record) {
                     return Filament::can('delete', $record);
                 })
-                ->pluck('id')
+                ->map(fn ($record) => $record->getKey())
                 ->toArray(),
         );
 

--- a/src/Resources/RelationManager.php
+++ b/src/Resources/RelationManager.php
@@ -143,6 +143,7 @@ class RelationManager extends Component
                 ->filter(function ($record) {
                     return Filament::can('delete', $record);
                 })
+                ->map(fn ($record) => $record->getKey())
                 ->toArray(),
         );
 


### PR DESCRIPTION
Fixes #186 

Full record was being passed to destroy function, not the ID of the record