### PR TITLE
chore: php-cs-fixer workflow

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -7,7 +7,7 @@ on:
     types: [closed]
 
 jobs:
-  phpcs-fixer:
+  php-cs-fixer:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
     steps:

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,4 +1,4 @@
-name: phpcs-fixer
+name: php-cs-fixer
 
 on:
   pull_request:

--- a/.github/workflows/phpcs-fixer.yml
+++ b/.github/workflows/phpcs-fixer.yml
@@ -1,0 +1,30 @@
+name: phpcs-fixer
+
+on:
+  pull_request:
+    branches:
+      - develop
+    types: [closed]
+
+jobs:
+  phpcs-fixer:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: develop
+
+      - name: Run PHP CS Fixer
+        uses: docker://oskarstark/php-cs-fixer-ga
+        with:
+          args: --config=.php_cs.dist --allow-risky=yes
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: >
+            chore: styling
+
+

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,43 @@
+<?php
+
+$finder = Symfony\Component\Finder\Finder::create()
+    ->notPath('bootstrap/*')
+    ->notPath('storage/*')
+    ->notPath('resources/view/mail/*')
+    ->in([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->name('*.php')
+    ->notName('*.blade.php')
+    ->ignoreDotFiles(true)
+    ->ignoreVCS(true);
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@PSR2' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'ordered_imports' => ['sortAlgorithm' => 'alpha'],
+        'no_unused_imports' => true,
+        'not_operator_with_successor_space' => true,
+        'trailing_comma_in_multiline_array' => true,
+        'phpdoc_scalar' => true,
+        'unary_operator_spaces' => true,
+        'binary_operator_spaces' => true,
+        'blank_line_before_statement' => [
+            'statements' => ['break', 'continue', 'declare', 'return', 'throw', 'try'],
+        ],
+        'phpdoc_single_line_var_spacing' => true,
+        'phpdoc_var_without_name' => true,
+        'class_attributes_separation' => [
+            'elements' => [
+                'method',
+            ],
+        ],
+        'method_argument_space' => [
+            'on_multiline' => 'ensure_fully_multiline',
+            'keep_multiple_spaces_after_comma' => true,
+        ],
+        'single_trait_insert_per_statement' => true,
+    ])
+    ->setFinder($finder);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -2,6 +2,9 @@
 
 $finder = Symfony\Component\Finder\Finder::create()
     ->in([
+        __DIR__ . '/config',
+        __DIR__ . '/packages',
+        __DIR__ . '/routes',
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ])

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -14,7 +14,10 @@ return PhpCsFixer\Config::create()
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
-        'ordered_imports' => ['sortAlgorithm' => 'alpha'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'orderered_class_elements' => [
+            'sort_algorithm' => 'alpha',
+        ],
         'no_unused_imports' => true,
         'not_operator_with_successor_space' => true,
         'trailing_comma_in_multiline_array' => true,

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,8 +1,6 @@
 <?php
 
 $finder = Symfony\Component\Finder\Finder::create()
-    ->notPath('bootstrap/*')
-    ->notPath('storage/*')
     ->in([
         __DIR__ . '/src',
         __DIR__ . '/tests',

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -3,7 +3,6 @@
 $finder = Symfony\Component\Finder\Finder::create()
     ->notPath('bootstrap/*')
     ->notPath('storage/*')
-    ->notPath('resources/view/mail/*')
     ->in([
         __DIR__ . '/src',
         __DIR__ . '/tests',


### PR DESCRIPTION
Closes #207. Went with the "after merge into develop" approach, so this workflow should run when any pull request is closed **and** merged into develop.

The rules are very basic and can be expanded upon in the future, full credit to Spatie for providing a great default in their package skeleton.