### PR TITLE
fix: dont merge middleware config

### DIFF
--- a/src/FilamentServiceProvider.php
+++ b/src/FilamentServiceProvider.php
@@ -279,6 +279,10 @@ class FilamentServiceProvider extends ServiceProvider
                 continue;
             }
 
+            if ($key === 'middleware') {
+                continue;
+            }
+
             $array[$key] = $this->mergeConfig($value, $merging[$key]);
         }
 


### PR DESCRIPTION
This fixes an issue where the `middleware` config options were being deeply merged, so any custom middleware would still be applied alongside the original middleware, i.e. `Authenticate` from Filament would also be applied alongside any custom middleware in `middleware.auth`.