### PR TITLE
fix: auto register widget component

### DIFF
--- a/src/PluginServiceProvider.php
+++ b/src/PluginServiceProvider.php
@@ -67,6 +67,10 @@ abstract class PluginServiceProvider extends ServiceProvider
                     Livewire::component($route->page::getName(), $route->page);
                 }
             }
+
+            foreach ($this->widgets() as $widget) {
+                Livewire::component($widget::getName(), $widget);
+            }
         });
 
         $this->pluginRegistered();


### PR DESCRIPTION
Fixes an issue where `Widget` classes registered in packages, etc could not load correctly as the classes themselves weren't registered with Livewire.

Logic is the same as pages and resources.