### PR TITLE
feature: generate resourceUrls in columns

### DIFF
--- a/src/Resources/Tables/Columns/Boolean.php
+++ b/src/Resources/Tables/Columns/Boolean.php
@@ -4,5 +4,5 @@ namespace Filament\Resources\Tables\Columns;
 
 class Boolean extends \Filament\Tables\Columns\Boolean
 {
-    //
+    use Concerns\InteractsWithResource;
 }

--- a/src/Resources/Tables/Columns/Column.php
+++ b/src/Resources/Tables/Columns/Column.php
@@ -4,5 +4,5 @@ namespace Filament\Resources\Tables\Columns;
 
 class Column extends \Filament\Tables\Columns\Column
 {
-    //
+    use Concerns\InteractsWithResource;
 }

--- a/src/Resources/Tables/Columns/Concerns/InteractsWithResource.php
+++ b/src/Resources/Tables/Columns/Concerns/InteractsWithResource.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Filament\Resources\Tables\Columns\Concerns;
+
+trait InteractsWithResource
+{
+    public function resourceUrl($resource, $route = 'edit', $shouldOpenInNewTab = false)
+    {
+        $this->url(function ($record) use ($resource, $route) {
+            return $resource::generateUrl($route, ['record' => $record]);
+        }, $shouldOpenInNewTab);
+
+        return $this;
+    }
+}

--- a/src/Resources/Tables/Columns/Icon.php
+++ b/src/Resources/Tables/Columns/Icon.php
@@ -4,5 +4,5 @@ namespace Filament\Resources\Tables\Columns;
 
 class Icon extends \Filament\Tables\Columns\Icon
 {
-    //
+    use Concerns\InteractsWithResource;
 }

--- a/src/Resources/Tables/Columns/Image.php
+++ b/src/Resources/Tables/Columns/Image.php
@@ -4,5 +4,5 @@ namespace Filament\Resources\Tables\Columns;
 
 class Image extends \Filament\Tables\Columns\Image
 {
-    //
+    use Concerns\InteractsWithResource;
 }

--- a/src/Resources/Tables/Columns/Text.php
+++ b/src/Resources/Tables/Columns/Text.php
@@ -4,5 +4,5 @@ namespace Filament\Resources\Tables\Columns;
 
 class Text extends \Filament\Tables\Columns\Text
 {
-    //
+    use Concerns\InteractsWithResource;
 }


### PR DESCRIPTION
This pull request introduces a new convenience method for resource-based table columns called `resourceUrl`.

It can be used like so:

```php
Columns\Text::make('name')
    ->resourceUrl(resource: OrderResource::class, route: 'edit', shouldOpenInNewTab: false)
```

/cc @edgrosvenor