### PR TITLE
feature: add new Hidden field

### DIFF
--- a/packages/forms/resources/views/components/hidden.blade.php
+++ b/packages/forms/resources/views/components/hidden.blade.php
@@ -1,0 +1,7 @@
+<input
+    type="hidden"
+    {!! $formComponent->getId() ? "id=\"{$formComponent->getId()}\"" : null !!}
+    {!! $formComponent->getName() ? "{$formComponent->getBindingAttribute()}=\"{$formComponent->getName()}\"" : null !!}
+    {!! $formComponent->isRequired() ? 'required' : null !!}
+    {!! Filament\format_attributes($formComponent->getExtraAttributes()) !!}
+/>

--- a/packages/forms/src/Components/Hidden.php
+++ b/packages/forms/src/Components/Hidden.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Filament\Forms\Components;
+
+class Hidden extends Field
+{
+    public function value($value)
+    {
+        $this->default($value);
+
+        return $this;
+    }
+}

--- a/src/Resources/Forms/Components/Hidden.php
+++ b/src/Resources/Forms/Components/Hidden.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Filament\Resources\Forms\Components;
+
+class Hidden extends \Filament\Forms\Components\Hidden
+{
+    use Concerns\InteractsWithResource;
+}


### PR DESCRIPTION
This pull request adds a new dedicated `Hidden` field type that can be used for static data. It can be used like this:

```php
Hidden::make('name')
    ->value('static data')
```

`Hidden::value()` is just an alias for `Hidden::default()`, so they are interchangeable but the `value` method feels more natural since it's not technically a default value.