### PR TITLE
Add decimal quantity to currency in Text column

### DIFF
--- a/packages/tables/src/Columns/Text.php
+++ b/packages/tables/src/Columns/Text.php
@@ -16,7 +16,7 @@ class Text extends Column
 
     public function currency($symbol = '$', $decimalSeparator = '.', $thousandsSeparator = ',', $decimals = 2)
     {
-        $this->configure(function () use ($decimalSeparator, $symbol, $thousandsSeparator, $decimals) {
+        $this->configure(function () use ($decimals, $decimalSeparator, $symbol, $thousandsSeparator) {
             $this->formatUsing = function ($value) use ($decimals, $decimalSeparator, $symbol, $thousandsSeparator) {
                 if (! is_numeric($value)) {
                     return $this->getDefaultValue();

--- a/packages/tables/src/Columns/Text.php
+++ b/packages/tables/src/Columns/Text.php
@@ -17,7 +17,7 @@ class Text extends Column
     public function currency($symbol = '$', $decimalSeparator = '.', $thousandsSeparator = ',', $decimals = 2)
     {
         $this->configure(function () use ($decimalSeparator, $symbol, $thousandsSeparator, $decimals) {
-            $this->formatUsing = function ($value) use ($decimalSeparator, $symbol, $thousandsSeparator, $decimals) {
+            $this->formatUsing = function ($value) use ($decimals, $decimalSeparator, $symbol, $thousandsSeparator) {
                 if (! is_numeric($value)) {
                     return $this->getDefaultValue();
                 }

--- a/packages/tables/src/Columns/Text.php
+++ b/packages/tables/src/Columns/Text.php
@@ -14,15 +14,15 @@ class Text extends Column
 
     protected $formatUsing;
 
-    public function currency($symbol = '$', $decimalSeparator = '.', $thousandsSeparator = ',')
+    public function currency($symbol = '$', $decimalSeparator = '.', $thousandsSeparator = ',', $decimals = 2)
     {
-        $this->configure(function () use ($decimalSeparator, $symbol, $thousandsSeparator) {
-            $this->formatUsing = function ($value) use ($decimalSeparator, $symbol, $thousandsSeparator) {
+        $this->configure(function () use ($decimalSeparator, $symbol, $thousandsSeparator, $decimals) {
+            $this->formatUsing = function ($value) use ($decimalSeparator, $symbol, $thousandsSeparator, $decimals) {
                 if (! is_numeric($value)) {
                     return $this->getDefaultValue();
                 }
 
-                return $symbol . number_format($value, 2, $decimalSeparator, $thousandsSeparator);
+                return $symbol . number_format($value, $decimals, $decimalSeparator, $thousandsSeparator);
             };
         });
 


### PR DESCRIPTION
Some currencies doesn't use two decimal after decimal separator, so it will be useful if it's customizable.