### PR TITLE
value should be casted to string

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -26,7 +26,7 @@ class Select extends Field
         $this->placeholder('forms::fields.select.placeholder');
 
         $this->getDisplayValueUsing(function ($value) {
-            return $this->getOptions()[strval($value)] ?? null;
+            return $this->getOptions()[(string) $value] ?? null;
         });
 
         $this->getOptionSearchResultsUsing(function ($search) {

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -26,7 +26,7 @@ class Select extends Field
         $this->placeholder('forms::fields.select.placeholder');
 
         $this->getDisplayValueUsing(function ($value) {
-            return $this->getOptions()[$value] ?? null;
+            return $this->getOptions()[strval($value)] ?? null;
         });
 
         $this->getOptionSearchResultsUsing(function ($search) {


### PR DESCRIPTION
Right now the exact model value is used - with a package like https://github.com/spatie/laravel-enum this leads to problems.
This casts the real model value to string - this still works with numeric array keys as PHP casts the string back to integer if needed.