### PR TITLE
hotfix: style registration in service provider

### DIFF
--- a/src/PluginServiceProvider.php
+++ b/src/PluginServiceProvider.php
@@ -46,7 +46,7 @@ abstract class PluginServiceProvider extends ServiceProvider
                 }
 
                 foreach ($this->styles() as $name => $path) {
-                    Filament::registerScript($name, $path);
+                    Filament::registerStyle($name, $path);
                 }
 
                 Filament::provideToScript($this->scriptData());


### PR DESCRIPTION
Fixes an issue where styles were being registered using `registerScript` instead of `registerStyle`.