### PR TITLE
feature: Markdown field auto bullet

### DIFF
--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -89,6 +89,34 @@
 
                         this.resize()
                     })
+                },
+
+                checkForAutoInsertion($event) {
+                    const lines = this.$refs.textarea.value.split("\n")
+
+                    const currentLine = this.$refs.textarea.value.substring(
+                        0, this.$refs.textarea.value.selectionStart
+                    ).split("\n").length
+
+                    const previousLine = lines[currentLine - 2]
+
+                    if (! previousLine.match(/^(\*\s|-\s)|^(\d)+\./)) {
+                        return;
+                    }
+
+                    if (previousLine.match(/^(\*\s)/)) {
+                        lines[currentLine - 1] = '* '
+                    } else if (previousLine.match(/^(-\s)/)) {
+                        lines[currentLine - 1] = '- '
+                    } else {
+                        const number = previousLine.match(/^(\d)+/)
+
+                        lines[currentLine - 1] = `${parseInt(number) + 1}. `
+                    }
+
+                    this.$refs.textarea.value = lines.join("\n")
+
+                    this.resize()
                 }
             }
         }
@@ -229,8 +257,10 @@
                         {!! $formComponent->getName() ? "{$formComponent->getBindingAttribute()}=\"{$formComponent->getName()}\"" : null !!}
                         {!! $formComponent->getPlaceholder() ? "placeholder=\"{$formComponent->getPlaceholder()}\"" : null !!}
                         {!! $formComponent->isRequired() ? 'required' : null !!}
-                        x-on:input="resize"
-                        x-on:file-attachment-accepted.window="uploadAttachments"
+                        @input="resize"
+                        @keyup.enter="checkForAutoInsertion"
+                        @file-attachment-accepted.window="uploadAttachments"
+                        class="absolute bg-transparent top-0 left-0 block z-1 w-full h-full min-h-full rounded resize-none shadow-sm placeholder-gray-400 focus:placeholder-gray-500 placeholder-opacity-100 focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50 {{ $errors->has($formComponent->getName()) ? 'border-danger-600 motion-safe:animate-shake' : 'border-gray-300' }}"
                         x-ref="textarea"
                         class="absolute bg-transparent top-0 left-0 block z-1 w-full h-full min-h-full rounded resize-none shadow-sm placeholder-gray-400 focus:placeholder-gray-500 placeholder-opacity-100 focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50 {{ $errors->has($formComponent->getName()) ? 'border-danger-600 motion-safe:animate-shake' : 'border-gray-300' }}"
                     ></textarea>

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -32,6 +32,34 @@
 
                 value: '',
 
+                checkForAutoInsertion($event) {
+                    const lines = this.$refs.textarea.value.split("\n")
+
+                    const currentLine = this.$refs.textarea.value.substring(
+                        0, this.$refs.textarea.value.selectionStart
+                    ).split("\n").length
+
+                    const previousLine = lines[currentLine - 2]
+
+                    if (! previousLine.match(/^(\*\s|-\s)|^(\d)+\./)) {
+                        return;
+                    }
+
+                    if (previousLine.match(/^(\*\s)/)) {
+                        lines[currentLine - 1] = '* '
+                    } else if (previousLine.match(/^(-\s)/)) {
+                        lines[currentLine - 1] = '- '
+                    } else {
+                        const number = previousLine.match(/^(\d)+/)
+
+                        lines[currentLine - 1] = `${parseInt(number) + 1}. `
+                    }
+
+                    this.$refs.textarea.value = lines.join("\n")
+
+                    this.resize()
+                },
+
                 init: function () {
                     this.value = this.$refs.textarea.value
 
@@ -90,34 +118,6 @@
                         this.resize()
                     })
                 },
-
-                checkForAutoInsertion($event) {
-                    const lines = this.$refs.textarea.value.split("\n")
-
-                    const currentLine = this.$refs.textarea.value.substring(
-                        0, this.$refs.textarea.value.selectionStart
-                    ).split("\n").length
-
-                    const previousLine = lines[currentLine - 2]
-
-                    if (! previousLine.match(/^(\*\s|-\s)|^(\d)+\./)) {
-                        return;
-                    }
-
-                    if (previousLine.match(/^(\*\s)/)) {
-                        lines[currentLine - 1] = '* '
-                    } else if (previousLine.match(/^(-\s)/)) {
-                        lines[currentLine - 1] = '- '
-                    } else {
-                        const number = previousLine.match(/^(\d)+/)
-
-                        lines[currentLine - 1] = `${parseInt(number) + 1}. `
-                    }
-
-                    this.$refs.textarea.value = lines.join("\n")
-
-                    this.resize()
-                }
             }
         }
     </script>
@@ -257,10 +257,9 @@
                         {!! $formComponent->getName() ? "{$formComponent->getBindingAttribute()}=\"{$formComponent->getName()}\"" : null !!}
                         {!! $formComponent->getPlaceholder() ? "placeholder=\"{$formComponent->getPlaceholder()}\"" : null !!}
                         {!! $formComponent->isRequired() ? 'required' : null !!}
-                        @input="resize"
-                        @keyup.enter="checkForAutoInsertion"
-                        @file-attachment-accepted.window="uploadAttachments"
-                        class="absolute bg-transparent top-0 left-0 block z-1 w-full h-full min-h-full rounded resize-none shadow-sm placeholder-gray-400 focus:placeholder-gray-500 placeholder-opacity-100 focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50 {{ $errors->has($formComponent->getName()) ? 'border-danger-600 motion-safe:animate-shake' : 'border-gray-300' }}"
+                        x-on:input="resize"
+                        x-on:keyup.enter="checkForAutoInsertion"
+                        x-on:file-attachment-accepted.window="uploadAttachments"
                         x-ref="textarea"
                         class="absolute bg-transparent top-0 left-0 block z-1 w-full h-full min-h-full rounded resize-none shadow-sm placeholder-gray-400 focus:placeholder-gray-500 placeholder-opacity-100 focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50 {{ $errors->has($formComponent->getName()) ? 'border-danger-600 motion-safe:animate-shake' : 'border-gray-300' }}"
                     ></textarea>

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -105,13 +105,26 @@
                     }
 
                     if (previousLine.match(/^(\*\s)/)) {
-                        lines[currentLine - 1] = '* '
+                        if (previousLine.trim().length > 1) {
+                            lines[currentLine - 1] = '* '
+                        } else {
+                            delete lines[currentLine - 2]
+                        }
                     } else if (previousLine.match(/^(-\s)/)) {
-                        lines[currentLine - 1] = '- '
+                        if (previousLine.trim().length > 1) {
+                            lines[currentLine - 1] = '- '
+                        } else {
+                            delete lines[currentLine - 2]
+                        }
                     } else {
-                        const number = previousLine.match(/^(\d)+/)
+                        const matches = previousLine.match(/^(\d)+/)
+                        const number = matches[0]
 
-                        lines[currentLine - 1] = `${parseInt(number) + 1}. `
+                        if (previousLine.trim().length > (number.length + 2)) {
+                            lines[currentLine - 1] = `${parseInt(number) + 1}. `
+                        } else {
+                            delete lines[currentLine - 2]
+                        }
                     }
 
                     this.$refs.textarea.value = lines.join("\n")


### PR DESCRIPTION
This pull request adds support for auto-bullet and auto-numbering lists in the Markdown field. That means if you've started an unordered list (for example) and hit enter, the field will automatically add in a new list item for you.

If you don't want that list item, you can just hit Enter again and it will be removed. This will also work for the `- ` syntax for unordered list.

Ordered lists will behave in the same way, the only difference being the numbers will increment on each new line item.