### PR TITLE
feature: mod+s keyboard shortcut for save

### DIFF
--- a/resources/views/components/layouts/base.blade.php
+++ b/resources/views/components/layouts/base.blade.php
@@ -47,6 +47,9 @@
         <script src="{{ $path }}"></script>
     @endforeach
 
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.6.5/mousetrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.6.5/plugins/global-bind/mousetrap-global-bind.min.js"></script>
+
     @stack('filament-scripts')
 </body>
 </html>

--- a/resources/views/resources/pages/create-record.blade.php
+++ b/resources/views/resources/pages/create-record.blade.php
@@ -16,4 +16,15 @@
             </x-forms::container>
         </x-filament::card>
     </x-filament::app-content>
+
+    <div
+        x-data
+        x-init="
+            Mousetrap.bindGlobal('mod+s', $event => {
+                $event.preventDefault()
+
+                document.querySelector(`button[type='submit']`).click()
+            })
+        "
+    ></div>
 </div>

--- a/resources/views/resources/pages/edit-record.blade.php
+++ b/resources/views/resources/pages/edit-record.blade.php
@@ -15,7 +15,7 @@
                         </x-filament::button>
                     </x-slot>
 
-                    <x-filament::card class="space-y-5 max-w-2xl">
+                    <x-filament::card class="max-w-2xl space-y-5">
                         <x-filament::card-header :title="static::$deleteModalHeading">
                             <p class="text-sm text-gray-500">
                                 {{ __(static::$deleteModalDescription) }}
@@ -59,4 +59,15 @@
             :relations="static::getResource()::relations()"
         />
     </x-filament::app-content>
+
+    <div
+        x-data
+        x-init="
+            Mousetrap.bindGlobal(['ctrl+s', 'command+s'], $event => {
+                $event.preventDefault()
+
+                document.querySelector(`button[type='submit']`).click()
+            })
+        "
+    ></div>
 </div>


### PR DESCRIPTION
This pull request adds support for <kbd>Ctrl + S</kbd> and <kbd>Cmd + S</kbd> shortcuts for saving forms on both the create and edit pages.