### PR TITLE
Changes to markdown editor

### DIFF
--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -78,7 +78,7 @@
 
                     this.$refs.overlay.style.padding = window.getComputedStyle(this.$refs.textarea).padding
 
-                    this.overlay = mdhl.highlight(this.$refs.textarea.value)
+                    this.resize()
 
                     this.$watch('tab', () => {
                         if (this.tab !== 'preview') return
@@ -88,7 +88,10 @@
                 },
 
                 resize: function () {
-                    this.$el.style.height = this.$refs.textarea.style.height
+                    this.$refs.textarea.style.height = 'auto'
+                    this.$refs.overlay.style.height = 'auto'
+                    this.$refs.textarea.style.height = this.$refs.textarea.scrollHeight + 'px'
+                    this.$refs.overlay.style.height = this.$refs.textarea.scrollHeight + 'px'
 
                     this.overlay = mdhl.highlight(this.value = this.$refs.textarea.value)
                 },
@@ -274,11 +277,11 @@
                         x-on:keyup.enter="checkForAutoInsertion"
                         x-on:file-attachment-accepted.window="uploadAttachments"
                         x-ref="textarea"
-                        class="absolute bg-transparent top-0 left-0 block z-1 w-full h-full min-h-full rounded resize-none shadow-sm placeholder-gray-400 focus:placeholder-gray-500 placeholder-opacity-100 focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50 {{ $errors->has($formComponent->getName()) ? 'border-danger-600 motion-safe:animate-shake' : 'border-gray-300' }}"
+                        class="absolute bg-transparent top-0 left-0 block z-1 w-full h-full min-h-full rounded resize-none shadow-sm placeholder-gray-400 focus:placeholder-gray-500 placeholder-opacity-100 focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50 font-mono leading-normal overflow-y-hidden {{ $errors->has($formComponent->getName()) ? 'border-danger-600 motion-safe:animate-shake' : 'border-gray-300' }}"
                     ></textarea>
                 </file-attachment>
 
-                <div class="w-full h-full text-black break-words" x-ref="overlay" x-html="overlay"></div>
+                <div class="w-full h-full text-black break-words font-mono leading-normal mt-px" x-ref="overlay" x-html="overlay"></div>
             </div>
 
             <div class="block w-full h-full min-h-full px-6 py-4 border border-gray-300 rounded shadow-sm focus:border-blue-300" x-show="tab === 'preview'" style="min-height: 150px;">


### PR DESCRIPTION
Several changes.

1. Normalize fonts. `font-mono leading-normal`. Unfortunately, if you have non-monospaced fonts, bolding and other operations will not line up properly in the editor / preview.
2. Hide scrollbars on textarea with `overflow-y-hidden`. 
3. Add a 1px offset to the overlay with `mt-px`. Because the input has a border, we're ever so slightly off. This fixes it. We could also add a transparent border or something.
4. Stop resizing the entire element, and resize the texture and overlay directly. This has the advantage of not messing with the flow of the document, and growing directly. 
5. Use the resize function in the init to make sure we have the correct height when loading in content.

You may wonder why we're resetting the height. It's a problem with the browser scrollHeight calculation that has been around for a long time (see: https://stackoverflow.com/questions/57953324/wrong-scrollheight-on-auto-grow-textarea-after-input-deletion) ... This little bug is infuriating, and really only affects the input when deleting content after resizing it larger.