### PR TITLE
addRecordActions method in Table 

### DIFF
--- a/packages/tables/resources/views/components/table.blade.php
+++ b/packages/tables/resources/views/components/table.blade.php
@@ -89,7 +89,7 @@
                         </td>
                     @endforeach
 
-                    <td class="px-6 py-4 text-right whitespace-nowrap">
+                    <td class="px-6 py-4 whitespace-nowrap flex justify-end items-center space-x-2">
                         @foreach ($table->getRecordActions() as $recordAction)
                             {{ $recordAction->render($record) }}
                         @endforeach

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -212,22 +212,20 @@ class Table
 
     public function pushRecordActions($actions)
     {
-        $this->recordActions = collect($this->recordActions)
-            ->push(
-                collect(value($actions))->map(fn ($action) => $action->table($this))
-            )
-            ->toArray();
+        $this->recordActions = array_merge(
+            $this->recordActions,
+            collect(value($actions))->map(fn ($action) => $action->table($this))->toArray(),
+        );
 
         return $this;
     }
 
     public function prependRecordActions($actions)
     {
-        $this->recordActions = collect($this->recordActions)
-            ->prepend(
-                collect(value($actions))->map(fn ($action) => $action->table($this))
-            )
-            ->toArray();
+        $this->recordActions = array_merge(
+            collect(value($actions))->map(fn ($action) => $action->table($this))->toArray(),
+            $this->recordActions,
+        );
 
         return $this;
     }

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -212,12 +212,20 @@ class Table
 
     public function addRecordActions($actions)
     {
+        if(last($this->recordActions)->getName() == "edit") {
+            $edit = array_pop($this->recordActions);
+        }
+
         $this->recordActions = array_merge(
             $this->recordActions,
             collect(value($actions))
                 ->map(fn ($action) => $action->table($this))
                 ->toArray()
         );
+
+        if(isset($edit)) {
+            $this->recordActions[] = $edit;
+        }
 
         return $this;
     }

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -210,22 +210,24 @@ class Table
         return $this;
     }
 
-    public function addRecordActions($actions)
+    public function pushRecordActions($actions)
     {
-        if(last($this->recordActions)->getName() == "edit") {
-            $edit = array_pop($this->recordActions);
-        }
+        $this->recordActions = collect($this->recordActions)
+            ->push(
+                collect(value($actions))->map(fn ($action) => $action->table($this))
+            )
+            ->toArray();
 
-        $this->recordActions = array_merge(
-            $this->recordActions,
-            collect(value($actions))
-                ->map(fn ($action) => $action->table($this))
-                ->toArray()
-        );
+        return $this;
+    }
 
-        if(isset($edit)) {
-            $this->recordActions[] = $edit;
-        }
+    public function prependRecordActions($actions)
+    {
+        $this->recordActions = collect($this->recordActions)
+            ->prepend(
+                collect(value($actions))->map(fn ($action) => $action->table($this))
+            )
+            ->toArray();
 
         return $this;
     }

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -204,10 +204,20 @@ class Table
     public function recordActions($actions)
     {
         $this->recordActions = collect(value($actions))
-            ->map(function ($action) {
-                return $action->table($this);
-            })
+            ->map(fn ($action) => $action->table($this))
             ->toArray();
+
+        return $this;
+    }
+
+    public function addRecordActions($actions)
+    {
+        $this->recordActions = array_merge(
+            $this->recordActions,
+            collect(value($actions))
+                ->map(fn ($action) => $action->table($this))
+                ->toArray()
+        );
 
         return $this;
     }


### PR DESCRIPTION
Per discussion #273 here is a new `addRecordActions` method. 

This will first pull the "Edit" link from the actions array and push it back to the end, ensuring it is always the last action displayed in the table. 

I also added a few tailwind classes to display multiple action icons a bit better.

I can now do this...

```php
->addRecordActions([
    Icon::make('')->icon('heroicon-s-cloud-download'),
    Icon::make('')->icon('heroicon-s-star'),
    Impersonate::make(),
]);
```

... and see this:

<img width="413" alt="CleanShot 2021-03-27 at 09 48 52@2x" src="https://user-images.githubusercontent.com/203749/112722754-ac092b80-8ee1-11eb-81b1-c8c7393a1c49.png">