### PR TITLE
Fix new Card component missing col span classes.

### DIFF
--- a/packages/forms/resources/views/components/card.blade.php
+++ b/packages/forms/resources/views/components/card.blade.php
@@ -1,3 +1,21 @@
-<div class="bg-white space-y-6 shadow-xl rounded p-4 md:p-6">
+@php
+    $columnSpanClass = [
+        '',
+        'lg:col-span-1',
+        'lg:col-span-2',
+        'lg:col-span-3',
+        'lg:col-span-4',
+        'lg:col-span-5',
+        'lg:col-span-6',
+        'lg:col-span-7',
+        'lg:col-span-8',
+        'lg:col-span-9',
+        'lg:col-span-10',
+        'lg:col-span-11',
+        'lg:col-span-12',
+    ][$formComponent->getColumnSpan()]
+@endphp
+
+<div class="bg-white space-y-6 shadow-xl rounded p-4 md:p-6 {{ $columnSpanClass }}">
     <x-forms::form :schema="$formComponent->getSchema()" />
 </div>


### PR DESCRIPTION
Add col-span classes to card component view to fix new Card components not being laid out properly:

Code from laravel-filament/demo:

```php
// app/Filament/Resources/ProductResource.php

//...
public static function form(Form $form)
{
    return $form
        ->schema(
            Grid::make([
                Card::make([
                    Components\TextInput::make('name')
                        ->placeholder('Name')
                        ->autofocus()
                        ->required(),
                    Components\RichEditor::make('description')
                        ->placeholder('Description')
                        ->attachmentDirectory('product-attachments'),
                    Components\FileUpload::make('image')->image(),
                ])->columnSpan(2),
                Card::make([
                    Components\TagsInput::make('tags')
                        ->placeholder('Tags'),
                ]),
            ])->columns(3)
        );
}
//...
```
**Before:**

![image](https://user-images.githubusercontent.com/3776888/112751377-9c631300-8fc5-11eb-8837-2e45cc4f0ca5.png)

**After:**
![image](https://user-images.githubusercontent.com/3776888/112751353-70479200-8fc5-11eb-8a91-48e1f7550a95.png)
