### PR TITLE
Fix issue in BelongsToSelect when initialDipslayValue contains a single quote

### DIFF
--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -192,7 +192,7 @@
         x-data="select({
             autofocus: {{ $formComponent->isAutofocused() ? 'true' : 'false' }},
             emptyOptionsMessage: '{{ __($formComponent->getEmptyOptionsMessage()) }}',
-            initialDisplayValue: {{ data_get($this, $formComponent->getName()) !== null ? '\'' . addslashes($formComponent->getDisplayValue(data_get($this, $formComponent->getName()))) . '\'' : 'null' }},
+            initialDisplayValue: {{ data_get($this, $formComponent->getName()) !== null ? json_encode($formComponent->getDisplayValue(data_get($this, $formComponent->getName()))): 'null' }},
             initialOptions: {{ json_encode($formComponent->getOptions()) }},
             name: '{{ $formComponent->getName() }}',
             noSearchResultsMessage: '{{ __($formComponent->getNoSearchResultsMessage()) }}',

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -192,7 +192,7 @@
         x-data="select({
             autofocus: {{ $formComponent->isAutofocused() ? 'true' : 'false' }},
             emptyOptionsMessage: '{{ __($formComponent->getEmptyOptionsMessage()) }}',
-            initialDisplayValue: {{ data_get($this, $formComponent->getName()) !== null ? '\'' . $formComponent->getDisplayValue(data_get($this, $formComponent->getName())) . '\'' : 'null' }},
+            initialDisplayValue: {{ data_get($this, $formComponent->getName()) !== null ? '\'' . addslashes($formComponent->getDisplayValue(data_get($this, $formComponent->getName()))) . '\'' : 'null' }},
             initialOptions: {{ json_encode($formComponent->getOptions()) }},
             name: '{{ $formComponent->getName() }}',
             noSearchResultsMessage: '{{ __($formComponent->getNoSearchResultsMessage()) }}',


### PR DESCRIPTION
**Describe the bug**
Using BelongsToSelect field and the initialDisplayValue contains a single quote in the string for example "A'ali" or "
O'Reilly" will cause this alpine error.

```
Alpine Error: "SyntaxError: missing } after property list"

Expression: "select({
            autofocus: false,
            emptyOptionsMessage: 'Start typing to search...',
            initialDisplayValue: 'A'ali',
            initialOptions: [],
            name: 'record.area_id',
            noSearchResultsMessage: 'No options match your search.',
            required: true,
                            value:  window.Livewire.find('olD0buI7uf4vyKJTx7fF').entangle('record.area_id') .defer,
                    })"
```

**Proposed fix**

use `addslashes()` to handle this in case the initialDisplayValue string contains a single quote or double quote.
