### PR TITLE
Add radio buttons component

### DIFF
--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -1,0 +1,38 @@
+<script>
+    function radios(config) {
+        return {
+            name: config.name,
+            options: config.initialOptions,
+            required: config.required,
+            value: config.value,
+        }
+    }
+</script>
+<x-forms::field-group :column-span="$formComponent->getColumnSpan()" :error-key="$formComponent->getName()" :for="$formComponent->getId()" :help-message="$formComponent->getHelpMessage()" :hint="$formComponent->getHint()" :label="$formComponent->getLabel()" :required="$formComponent->isRequired()">
+    <div x-data="radios({
+            initialOptions: {{ json_encode($formComponent->getOptions()) }},
+            name: '{{ $formComponent->getName() }}',
+            required: {{ $formComponent->isRequired() ? 'true' : 'false' }},
+            @if (Str::of($formComponent->getBindingAttribute())->startsWith('wire:model'))
+                value: @entangle($formComponent->getName()){{ Str::of($formComponent->getBindingAttribute())->after('wire:model') }},
+            @endif
+            })" wire:model.defer="{{ $formComponent->getName() }}">
+        <template x-for="(key, index) in Object.keys(options)" :key="index">
+            <div>
+                <input x-bind:id="'{{ $formComponent->getName() }}'+'_'+key" {!! $formComponent->isAutofocused() ? 'autofocus' : null !!}
+                {!! $formComponent->isDisabled() ? 'disabled' : null !!}
+                {!! $formComponent->getName() ? "{$formComponent->getBindingAttribute()}=\"{$formComponent->getName()}\"" : null !!}
+                {!! $formComponent->isRequired() ? 'required' : null !!}
+                class="text-primary-600 shadow-sm focus:border-primary-700 focus:ring focus:ring-blue-200 radio focus:ring-opacity-50 {{ $errors->has($formComponent->getName()) ? 'border-danger-600 ' : 'border-gray-300' }}"
+                {!! Filament\format_attributes($formComponent->getExtraAttributes()) !!}
+                type="radio"
+                name="{{$formComponent->getName()}}"
+                x-bind:value="key"
+                x-bind:checked="key === value"
+                />
+                <label x-bind:for="'{{ $formComponent->getName() }}'+'_'+key" x-text="options[key]"></label>
+            </div>
+        </template>
+    </div>
+
+</x-forms::field-group>

--- a/packages/forms/src/Components/Radio.php
+++ b/packages/forms/src/Components/Radio.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Filament\Forms\Components;
+
+class Radio extends Field
+{
+    use Concerns\CanBeAutofocused;
+
+    protected $options = [];
+
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    public function options($options)
+    {
+        $this->configure(function () use ($options) {
+            $this->options = $options;
+        });
+
+        return $this;
+    }
+}

--- a/src/Resources/Forms/Components/Radio.php
+++ b/src/Resources/Forms/Components/Radio.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Filament\Resources\Forms\Components;
+
+class Radio extends \Filament\Forms\Components\Radio
+{
+    use Concerns\InteractsWithResource;
+}


### PR DESCRIPTION
### **Add ability to create radio buttons list**
_I think that this feature is going to be useful/recommended for some projects._
**How to use :**
It's the same as a SELECT component.

` Components\Radio::make('radio_test')->label('Radio test')->options(['red' => 'Rouge','green' => 'Vert','blue' => 'Bleu','yellow' => 'Jaune'])`

**Accepted attributes :**
`->required()`

**Screen shots :**
![radio-button-pr](https://user-images.githubusercontent.com/44349019/113430303-d40cf900-93d1-11eb-86d2-f7b89d665d2b.PNG)
