### PR TITLE
Add ability to disable RelationManager list edit action

### DIFF
--- a/resources/views/relation-manager.blade.php
+++ b/resources/views/relation-manager.blade.php
@@ -33,20 +33,22 @@
             </x-filament::modal>
         @endif
 
-        <x-filament::modal
-            class="w-full max-w-4xl"
-            :name="static::class . 'RelationManagerEditModal'"
-        >
-            <x-filament::card class="space-y-5">
-                <x-filament::card-header :title="static::$editModalHeading" />
+        @if ($this->canEdit())
+            <x-filament::modal
+                class="w-full max-w-4xl"
+                :name="static::class . 'RelationManagerEditModal'"
+            >
+                <x-filament::card class="space-y-5">
+                    <x-filament::card-header :title="static::$editModalHeading" />
 
-                @livewire(static::getComponent('edit'), [
-                    'manager' => static::class,
-                    'model' => $this->getModel(),
-                    'owner' => $this->getOwner(),
-                ])
-            </x-filament::card>
-        </x-filament::modal>
+                    @livewire(static::getComponent('edit'), [
+                        'manager' => static::class,
+                        'model' => $this->getModel(),
+                        'owner' => $this->getOwner(),
+                    ])
+                </x-filament::card>
+            </x-filament::modal>
+        @endif
 
         @if ($this->canAttach())
             <x-filament::modal

--- a/src/Resources/RelationManager.php
+++ b/src/Resources/RelationManager.php
@@ -84,6 +84,11 @@ class RelationManager extends Component
         return Filament::can('create', $this->getModel());
     }
 
+    public function canEdit()
+    {
+        return true;
+    }
+
     public function canDelete()
     {
         return true;

--- a/src/Resources/RelationManager/ListRecords.php
+++ b/src/Resources/RelationManager/ListRecords.php
@@ -95,6 +95,10 @@ class ListRecords extends Component
     {
         $manager = $this->manager;
 
+        if (!app($manager)->canEdit()) {
+            return [];
+        }
+
         return [
             RecordActions\Link::make('edit')
                 ->label($manager::$editRecordActionLabel)

--- a/src/Resources/RelationManager/ListRecords.php
+++ b/src/Resources/RelationManager/ListRecords.php
@@ -95,15 +95,13 @@ class ListRecords extends Component
     {
         $manager = $this->manager;
 
-        if (!app($manager)->canEdit()) {
-            return [];
-        }
+        $canEdit = (new $manager)->canEdit();
 
         return [
             RecordActions\Link::make('edit')
                 ->label($manager::$editRecordActionLabel)
                 ->action('openEdit')
-                ->when(fn ($record) => Filament::can('update', $record)),
+                ->when(fn ($record) => $canEdit && Filament::can('update', $record)),
         ];
     }
 


### PR DESCRIPTION
This just adds a very simple method to complement the `canCreate`, `canDelete`, and `canDetach` methods. The benefit of this is a very easy way to make the relation manager only allow attach and detach actions.