### PR TITLE
Refactor CanCallHooks for greater reuse

### DIFF
--- a/src/Resources/Concerns/CanCallHooks.php
+++ b/src/Resources/Concerns/CanCallHooks.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Filament\Resources\RelationManager\Concerns;
+namespace Filament\Resources\Concerns;
 
 trait CanCallHooks
 {

--- a/src/Resources/Pages/Page.php
+++ b/src/Resources/Pages/Page.php
@@ -2,11 +2,14 @@
 
 namespace Filament\Resources\Pages;
 
+use Filament\Resources\Concerns\CanCallHooks;
 use Filament\Resources\Route;
 use Illuminate\Support\Str;
 
 class Page extends \Filament\Pages\Page
 {
+    use CanCallHooks;
+
     public static $resource;
 
     public static function getModel()
@@ -38,14 +41,5 @@ class Page extends \Filament\Pages\Page
         }
 
         abort_unless($this->{$method}() ?? true, 403);
-    }
-
-    protected function callHook($hook)
-    {
-        if (! method_exists($this, $hook)) {
-            return;
-        }
-
-        $this->{$hook}();
     }
 }

--- a/src/Resources/RelationManager/AttachRecord.php
+++ b/src/Resources/RelationManager/AttachRecord.php
@@ -5,13 +5,14 @@ namespace Filament\Resources\RelationManager;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Form;
 use Filament\Forms\HasForm;
+use Filament\Resources\Concerns\CanCallHooks;
 use Filament\Resources\Forms\Actions;
 use Illuminate\Support\Str;
 use Livewire\Component;
 
 class AttachRecord extends Component
 {
-    use Concerns\CanCallHooks;
+    use CanCallHooks;
     use HasForm;
 
     public $manager;

--- a/src/Resources/RelationManager/CreateRecord.php
+++ b/src/Resources/RelationManager/CreateRecord.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Resources\RelationManager;
 
+use Filament\Resources\Concerns\CanCallHooks;
 use Filament\Resources\Forms\Actions;
 use Filament\Resources\Forms\Form;
 use Filament\Resources\Forms\HasForm;
@@ -9,7 +10,7 @@ use Livewire\Component;
 
 class CreateRecord extends Component
 {
-    use Concerns\CanCallHooks;
+    use CanCallHooks;
     use HasForm;
 
     public $manager;

--- a/src/Resources/RelationManager/EditRecord.php
+++ b/src/Resources/RelationManager/EditRecord.php
@@ -3,6 +3,7 @@
 namespace Filament\Resources\RelationManager;
 
 use Filament\Filament;
+use Filament\Resources\Concerns\CanCallHooks;
 use Filament\Resources\Forms\Actions;
 use Filament\Resources\Forms\Form;
 use Filament\Resources\Forms\HasForm;
@@ -10,7 +11,7 @@ use Livewire\Component;
 
 class EditRecord extends Component
 {
-    use Concerns\CanCallHooks;
+    use CanCallHooks;
     use HasForm;
 
     public $manager;

--- a/src/Resources/RelationManager/ListRecords.php
+++ b/src/Resources/RelationManager/ListRecords.php
@@ -3,6 +3,7 @@
 namespace Filament\Resources\RelationManager;
 
 use Filament\Filament;
+use Filament\Resources\Concerns\CanCallHooks;
 use Filament\Resources\Tables\HasTable;
 use Filament\Resources\Tables\RecordActions;
 use Filament\Resources\Tables\Table;
@@ -10,7 +11,7 @@ use Livewire\Component;
 
 class ListRecords extends Component
 {
-    use Concerns\CanCallHooks;
+    use CanCallHooks;
     use HasTable;
 
     public $canAttach;


### PR DESCRIPTION
The same method in the trait is used in the same way on `Resources/Pages/Page.php`, so this just refactors to keep things uniform.