### PR TITLE
Fix translation string from create-record resource page

### DIFF
--- a/src/Resources/Pages/CreateRecord.php
+++ b/src/Resources/Pages/CreateRecord.php
@@ -12,7 +12,7 @@ class CreateRecord extends Page
 {
     use HasForm;
 
-    public static $cancelButtonLabel = 'filament::resources/pages/edit-record.buttons.cancel.label';
+    public static $cancelButtonLabel = 'filament::resources/pages/create-record.buttons.cancel.label';
 
     public static $createAnotherButtonLabel = 'filament::resources/pages/create-record.buttons.createAnother.label';
 


### PR DESCRIPTION
This PR just fixes a small typo on the `CreateRecord` resource page.