### PR TITLE
Add placeholder component

### DIFF
--- a/packages/forms/resources/views/components/placeholder.blade.php
+++ b/packages/forms/resources/views/components/placeholder.blade.php
@@ -1,0 +1,14 @@
+<x-forms::field-group
+    :column-span="$formComponent->getColumnSpan()"
+    :error-key="$formComponent->getName()"
+    :for="$formComponent->getId()"
+    :label="$formComponent->getLabel()"
+>
+    <div class="flex">
+        <span
+            class="block w-full placeholder-gray-400 placeholder-opacity-100 px-3 py-2 cursor-default"
+        >
+            {{ $formComponent->getName() }}
+        </span>
+    </div>
+</x-forms::field-group>

--- a/packages/forms/resources/views/components/placeholder.blade.php
+++ b/packages/forms/resources/views/components/placeholder.blade.php
@@ -8,7 +8,7 @@
         <span
             class="block w-full placeholder-gray-400 placeholder-opacity-100 px-3 py-2 cursor-default"
         >
-            {{ $formComponent->getName() }}
+            {{ $formComponent->getValue() }}
         </span>
     </div>
 </x-forms::field-group>

--- a/packages/forms/src/Components/Placeholder.php
+++ b/packages/forms/src/Components/Placeholder.php
@@ -2,13 +2,17 @@
 
 namespace Filament\Forms\Components;
 
+use Illuminate\Support\Str;
+
 class Placeholder extends Component
 {
     protected $name;
+    protected $value;
 
-    public function __construct($placeholderValue)
+    public function __construct(string $name, string $value)
     {
-        $this->name($placeholderValue);
+        $this->name($name);
+        $this->value($value);
         $this->setUp();
     }
 
@@ -24,8 +28,33 @@ class Placeholder extends Component
         return $this->name;
     }
 
-    public static function make(string $placeholderValue)
+    protected function value($value)
     {
-        return new static($placeholderValue);
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function getLabel()
+    {
+        if ($this->label === null) {
+            return (string) Str::of($this->getName())
+                ->afterLast('.')
+                ->kebab()
+                ->replace(['-', '_'], ' ')
+                ->ucfirst();
+        }
+
+        return parent::getLabel();
+    }
+
+    public static function make(string $name, string $value)
+    {
+        return new static($name, $value);
     }
 }

--- a/packages/forms/src/Components/Placeholder.php
+++ b/packages/forms/src/Components/Placeholder.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Filament\Forms\Components;
+
+class Placeholder extends Component
+{
+    protected $name;
+
+    public function __construct($placeholderValue)
+    {
+        $this->name($placeholderValue);
+        $this->setUp();
+    }
+
+    protected function name($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public static function make(string $placeholderValue)
+    {
+        return new static($placeholderValue);
+    }
+}

--- a/packages/forms/src/Components/Placeholder.php
+++ b/packages/forms/src/Components/Placeholder.php
@@ -7,37 +7,15 @@ use Illuminate\Support\Str;
 class Placeholder extends Component
 {
     protected $name;
+
     protected $value;
 
-    public function __construct(string $name, string $value)
+    public function __construct($name, $value)
     {
         $this->name($name);
         $this->value($value);
+
         $this->setUp();
-    }
-
-    protected function name($name)
-    {
-        $this->name = $name;
-
-        return $this;
-    }
-
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    protected function value($value)
-    {
-        $this->value = $value;
-
-        return $this;
-    }
-
-    public function getValue()
-    {
-        return $this->value;
     }
 
     public function getLabel()
@@ -53,7 +31,31 @@ class Placeholder extends Component
         return parent::getLabel();
     }
 
-    public static function make(string $name, string $value)
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    protected function name($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    protected function value($value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public static function make($name, $value)
     {
         return new static($name, $value);
     }

--- a/src/Resources/Forms/Components/Placeholder.php
+++ b/src/Resources/Forms/Components/Placeholder.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Filament\Resources\Forms\Components;
+
+class Placeholder extends \Filament\Forms\Components\Placeholder
+{
+    use Concerns\CanBeDependentOnResourceRecord;
+}


### PR DESCRIPTION
This PR allows for using a placeholder element in a form. The intention of this is to provide a UX similar to what LinkedIn does here:

![](https://cdn.discordapp.com/attachments/816387015729086494/840297170325209149/Screen_Shot_2021-05-07_at_2.40.20_PM.png)

![](https://cdn.discordapp.com/attachments/816387015729086494/840297162486317086/Screen_Shot_2021-05-07_at_2.40.30_PM.png)

So with this PR, if this UX were needed you could do:

```php
  Components\Grid::make([
      Components\Toggle::make('is_active')
          ->label('Currently working this role')
          ->default(true)
          ->dependable()
          ->stacked(),
      Components\DatePicker::make('started_at'),
// Our conditional field and equivalent placeholder
      Components\DatePicker::make('departed_at')
          ->when(fn ($record) => $record->is_active !== true),
      Components\Placeholder::make('departed_at', 'Present')
          ->when(fn ($record) => $record->is_active === true), // Note the callback logic here is inverted from above.
  ])->columns(3),
```

The end results would be:
![Screen Shot 2021-05-07 at 5 21 01 PM](https://user-images.githubusercontent.com/619938/117509648-9ebb7400-af58-11eb-9c4c-0f2fb0cb1e2d.png)
![Screen Shot 2021-05-07 at 5 20 56 PM](https://user-images.githubusercontent.com/619938/117509649-9f540a80-af58-11eb-9c3b-e2fdcbe27b3d.png)
