### PR TITLE
Allow to use html in prefixes plus add postfix method

### DIFF
--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -28,5 +28,11 @@
             class="block w-full rounded-r placeholder-gray-400 focus:placeholder-gray-500 placeholder-opacity-100 focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50 {{ ! $formComponent->getPrefix() ? 'rounded-l-md' : null }} {{ $errors->has($formComponent->getName()) ? 'border-danger-600 motion-safe:animate-shake' : 'border-gray-300' }}"
             {!! Filament\format_attributes($formComponent->getExtraAttributes()) !!}
         />
+
+        @if ($formComponent->getPostfix())
+            <span class="inline-flex items-center px-3 text-gray-500 border border-l-0 border-gray-300 rounded-r bg-gray-50 whitespace-nowrap sm:text-sm">
+            {!!  $formComponent->getPostfix() !!}
+        </span>
+        @endif
     </div>
 </x-forms::field-group>

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -10,7 +10,7 @@
     <div class="flex border-gray-300 rounded shadow-sm">
         @if ($formComponent->getPrefix())
             <span class="inline-flex items-center px-3 text-gray-500 border border-r-0 border-gray-300 rounded-l bg-gray-50 whitespace-nowrap sm:text-sm">
-                {{ $formComponent->getPrefix() }}
+                {!! $formComponent->getPrefix() !!}
             </span>
         @endif
 

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -25,7 +25,7 @@
             {!! $formComponent->getPlaceholder() ? "placeholder=\"{$formComponent->getPlaceholder()}\"" : null !!}
             {!! $formComponent->isRequired() ? 'required' : null !!}
             {!! $formComponent->getType() ? "type=\"{$formComponent->getType()}\"" : null !!}
-            class="block w-full rounded-r placeholder-gray-400 focus:placeholder-gray-500 placeholder-opacity-100 focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50 {{ ! $formComponent->getPrefix() ? 'rounded-l-md' : null }} {{ $errors->has($formComponent->getName()) ? 'border-danger-600 motion-safe:animate-shake' : 'border-gray-300' }}"
+            class="block w-full placeholder-gray-400 focus:placeholder-gray-500 placeholder-opacity-100 focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50 {{ ! $formComponent->getPrefix() ? 'rounded-l-md' : null }} {{ ! $formComponent->getPostfix() ? 'rounded-r-md' : null }} {{ $errors->has($formComponent->getName()) ? 'border-danger-600 motion-safe:animate-shake' : 'border-gray-300' }}"
             {!! Filament\format_attributes($formComponent->getExtraAttributes()) !!}
         />
 

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -31,8 +31,8 @@
 
         @if ($formComponent->getPostfix())
             <span class="inline-flex items-center px-3 text-gray-500 border border-l-0 border-gray-300 rounded-r bg-gray-50 whitespace-nowrap sm:text-sm">
-            {!!  $formComponent->getPostfix() !!}
-        </span>
+                {!!  $formComponent->getPostfix() !!}
+            </span>
         @endif
     </div>
 </x-forms::field-group>

--- a/packages/forms/src/Components/Concerns/HasPostfix.php
+++ b/packages/forms/src/Components/Concerns/HasPostfix.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Filament\Forms\Components\Concerns;
+
+trait HasPostfix
+{
+    protected $postfix;
+
+    public function getPostfix()
+    {
+        return $this->postfix;
+    }
+
+    public function postfix($postfix)
+    {
+        $this->configure(function () use ($postfix) {
+            $this->postfix = $postfix;
+        });
+
+        return $this;
+    }
+}

--- a/packages/forms/src/Components/TextInput.php
+++ b/packages/forms/src/Components/TextInput.php
@@ -10,8 +10,8 @@ class TextInput extends Field
     use Concerns\CanBeUnique;
     use Concerns\CanBeLengthConstrained;
     use Concerns\HasPlaceholder;
-    use Concerns\HasPrefix;
     use Concerns\HasPostfix;
+    use Concerns\HasPrefix;
 
     protected $type = 'text';
 

--- a/packages/forms/src/Components/TextInput.php
+++ b/packages/forms/src/Components/TextInput.php
@@ -11,6 +11,7 @@ class TextInput extends Field
     use Concerns\CanBeLengthConstrained;
     use Concerns\HasPlaceholder;
     use Concerns\HasPrefix;
+    use Concerns\HasPostfix;
 
     protected $type = 'text';
 


### PR DESCRIPTION
This change allow to use html in field prefixes. This is usefull, if you wanna add an icon as a prefix or if you have two fields with different length prefix (for example short currencies like `€` vs `CAD`) and want to make both of them same width with css classes.

# Icon Example:

```php
Components\TextInput::make("price")
   ->numeric()
   ->prefix('<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.121 15.536c-1.171 1.952-3.07 1.952-4.242 0-1.172-1.953-1.172-5.119 0-7.072 1.171-1.952 3.07-1.952 4.242 0M8 10.5h4m-4 3h4m9-1.5a9 9 0 11-18 0 9 9 0 0118 0z" />
</svg>')
```


# Result

![image](https://user-images.githubusercontent.com/642292/117966467-38519f80-b324-11eb-99db-f6cdb3acb468.png)