### PR TITLE
Allow to change classes of components (example)

### DIFF
--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -20,7 +20,7 @@
     x-data="{ open: {{ $formComponent->isCollapsed() ? 'false' : 'true' }} }"
     x-on:open.window="if ($event.detail === '{{ $formComponent->getId() }}') open = true"
     aria-labelledby="{{ $formComponent->getId() }}-heading"
-    class="space-y-4 p-4 rounded border border-gray-200 bg-gray-50 {{ $columnSpanClass }}"
+    class="{{ $formComponent->getChangedClasses('space-y-4 p-4 rounded border border-gray-200 bg-gray-50 ' . $columnSpanClass) }}"
 >
     <div class="flex items-start justify-between space-x-4 rtl:space-x-reverse">
         <div class="space-y-1">

--- a/packages/forms/src/Components/Component.php
+++ b/packages/forms/src/Components/Component.php
@@ -2,13 +2,14 @@
 
 namespace Filament\Forms\Components;
 
+use Filament\Forms\Components\Concerns\CanChangeClass;
 use Filament\Forms\Form;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Tappable;
 
 class Component
 {
-    use Tappable;
+    use Tappable, CanChangeClass;
 
     protected $columnSpan = 1;
 

--- a/packages/forms/src/Components/Concerns/CanChangeClass.php
+++ b/packages/forms/src/Components/Concerns/CanChangeClass.php
@@ -5,28 +5,42 @@ namespace Filament\Forms\Components\Concerns;
 trait CanChangeClass
 {
     protected $addClasses;
-    protected $removedClasses;
+    protected $removeClasses;
 
     public function getChangedClasses($currentClasses = '')
     {
-        $classes = array_merge(
-            explode(' ', trim($currentClasses)),
-            explode(' ', trim($this->addClasses)),
-        );
-        $removeClasses = explode(' ', trim($this->removedClasses));
+        if(is_string($this->removeClasses)) {
+            $classes = array_merge(
+                explode(' ', trim($currentClasses)),
+                explode(' ', trim($this->addClasses)),
+            );
+            $removeClasses = explode(' ', trim($this->removeClasses));
 
-        $classes = array_filter($classes, function($item) use ($removeClasses) {
-            return !in_array($item, $removeClasses);
-        });
+            $classes = array_filter($classes, function($item) use ($removeClasses) {
+                return !in_array($item, $removeClasses);
+            });
 
-        return implode(' ', $classes);
+            return implode(' ', $classes);
+        }
+        elseif(is_bool($this->removeClasses) && $this->removeClasses) {
+            return $this->addClasses;
+        }
+
+
+        return $currentClasses . ' ' . $this->addClasses;
     }
 
-    public function changeClass($addClasses = '', $removedClasses = '')
+    /**
+     * @param string $addClasses
+     * @param string|boolean $removeClasses
+     *
+     * @return $this
+     */
+    public function changeClass($addClasses = '', $removeClasses = '')
     {
-        $this->configure(function () use ($addClasses, $removedClasses) {
+        $this->configure(function () use ($addClasses, $removeClasses) {
             $this->addClasses = $addClasses;
-            $this->removedClasses = $removedClasses;
+            $this->removeClasses = $removeClasses;
         });
 
         return $this;

--- a/packages/forms/src/Components/Concerns/CanChangeClass.php
+++ b/packages/forms/src/Components/Concerns/CanChangeClass.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Filament\Forms\Components\Concerns;
+
+trait CanChangeClass
+{
+    protected $addClasses;
+    protected $removedClasses;
+
+    public function getChangedClasses($currentClasses = '')
+    {
+        $classes = array_merge(
+            explode(' ', trim($currentClasses)),
+            explode(' ', trim($this->addClasses)),
+        );
+        $removeClasses = explode(' ', trim($this->removedClasses));
+
+        $classes = array_filter($classes, function($item) use ($removeClasses) {
+            return !in_array($item, $removeClasses);
+        });
+
+        return implode(' ', $classes);
+    }
+
+    public function changeClass($addClasses = '', $removedClasses = '')
+    {
+        $this->configure(function () use ($addClasses, $removedClasses) {
+            $this->addClasses = $addClasses;
+            $this->removedClasses = $removedClasses;
+        });
+
+        return $this;
+    }
+}


### PR DESCRIPTION
This is a draft. I will finalize it, if you will accept the PR later. Atm I have implemented it just for `Components\Section`.

What does it do? It gives the user the possibility to change the css classes on components. For example, you can now change the background color of a section. This is how a regular section looks like (if outside a card):

![image](https://user-images.githubusercontent.com/642292/117996355-62b25580-b342-11eb-8fc9-6318de685d51.png)


Now you can change the bg-color:

```php
Components\Section::make(
    'Heading',
    'Subheading',
    [],
)
    ->changeClass('bg-blue-200', 'bg-gray-50')
```

![image](https://user-images.githubusercontent.com/642292/117998423-2d0e6c00-b344-11eb-81f7-cf4f1a791295.png)


Or you can even remove all stylings:

```
Components\Section::make(
    'Heading',
    'Subheading',
    [],
)
    ->changeClass('', true)
```

![image](https://user-images.githubusercontent.com/642292/117997868-a9ed1600-b343-11eb-89ab-a3b69888c8a5.png)

I can add this functionality to all components if you like. What do you think?