### PR TITLE
Add "expanded" attribute to card component

### DIFF
--- a/resources/views/components/card.blade.php
+++ b/resources/views/components/card.blade.php
@@ -1,3 +1,5 @@
-<div {{ $attributes->merge(['class' => 'bg-white shadow-xl rounded p-4 md:p-6']) }}>
+@props(['expanded' => false])
+
+<div {{ $attributes->class(['bg-white shadow-xl rounded p-4 md:p-6', 'col-span-full' => $expanded]) }}>
     {{ $slot }}
 </div>

--- a/resources/views/components/card.blade.php
+++ b/resources/views/components/card.blade.php
@@ -1,5 +1,10 @@
-@props(['expanded' => false])
+@props([
+    'expanded' => false,
+])
 
-<div {{ $attributes->class(['bg-white shadow-xl rounded p-4 md:p-6', 'col-span-full' => $expanded]) }}>
+<div {{ $attributes->class([
+    'bg-white shadow-xl rounded p-4 md:p-6',
+    'col-span-full' => $expanded,
+]) }}>
     {{ $slot }}
 </div>


### PR DESCRIPTION
This PR introduces a `expanded` attribute that can be passed to cards to set them full-width. It's particularly useful when building a widget that needs to display large data, such as charts etc.

An example of the default widget with the attribute:

```blade
<x-filament::card class="flex" expanded>
    ...
</x-filament::card>
```

![image](https://user-images.githubusercontent.com/6277291/126180760-744df9d3-6074-48e4-817e-02add09f47b6.png)

**Please note** that a new assets build is required to include the `col-span-full` class into the minified CSS 🌈 