### PR TITLE
Correctly load KeyValue for both relations and resources

### DIFF
--- a/packages/forms/resources/views/components/key-value.blade.php
+++ b/packages/forms/resources/views/components/key-value.blade.php
@@ -29,10 +29,21 @@
                         })
                     }
 
-                    this.$watch('value', () => {
-                        if (this.value) return
+                    this.$watch('value', (newValues) => {
+                        if (newValues && typeof newValues === 'object') {
+                            let index = 0
 
-                        this.value = {}
+                            for (const [key, value] of Object.entries(newValues)) {
+                                if (typeof this.rows['index'] === 'undefined') {
+                                    this.rows[index] = { key, value }
+                                } else {
+                                    this.rows[index].key = key
+                                    this.rows[index].value = value
+                                }
+
+                                index++
+                            }
+                        }
                     })
 
                     if (this.isSortable) {


### PR DESCRIPTION
Fixes #486 

When using `KeyValue` on a relation, `value` at init (Alpine init) will be a Proxy to Livewire, therefore there's no content to be loaded. I found that a simple solution is to adapt the `$watch` of `value` and, if it's an object (the user values, because sometimes it can be also a `Proxy` instance) update the rows.

I added a condition to check if that row exists or create it to be backward compatible also with `KeyValue` inside a Resource.

My first solution was to recreate the rows array and populate it with the new values, but if you clicked "Add row" and then edited another row, the new (empty) row would disappear.

Repo to reproduce the issue: https://github.com/danilopolani/filament-demo