### PR TITLE
Fix date column always shown in english

### DIFF
--- a/packages/tables/src/Columns/Text.php
+++ b/packages/tables/src/Columns/Text.php
@@ -33,7 +33,7 @@ class Text extends Column
     {
         $this->configure(function () use ($format) {
             $this->formatUsing = function ($value) use ($format) {
-                $value = Carbon::parse($value)->format($format);
+                $value = Carbon::parse($value)->translatedFormat($format);
 
                 return $value;
             };


### PR DESCRIPTION
Changes the use of Carbon's ```format``` for ```translatedFormat``` so ```Text``` columns containing dates are shown in the correct language when changing locales.