### PR TITLE
Fix unique validation rule for custom primary keys

### DIFF
--- a/src/Resources/Forms/Components/Concerns/CanBeUnique.php
+++ b/src/Resources/Forms/Components/Concerns/CanBeUnique.php
@@ -3,6 +3,7 @@
 namespace Filament\Resources\Forms\Components\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\Rule;
 
 trait CanBeUnique
 {
@@ -11,12 +12,12 @@ trait CanBeUnique
     public function unique($table, $column = null, $except = false)
     {
         $this->configure(function () use ($column, $except, $table) {
-            $rule = "unique:$table,$column";
+            $rule = Rule::unique($table, $column);
 
             $record = $this->getLivewire()->record;
 
             if ($except && $record instanceof Model) {
-                $rule .= ",{$record->getKey()}";
+                $rule->ignore($record->getOriginal($record->getKeyName()), $record->getKeyName());
             }
 
             $this->addRules([$this->getName() => [$rule]]);


### PR DESCRIPTION
**Describe the bug**
The unique validation rule does not work as expected when using custom, editable primary keys. Think of a string `identifier` field on the model, that I want to be able to modify, but at the same time guarantee its uniqueness (not just by throwing a database error).

**To reproduce**
Steps to reproduce the behavior:
1. Have a model with a custom primary key, not auto-incrementing.
2. Add form field for this primary key
3. Add unique rule like the following: `->unique('table', 'identifier', true),`
4. First of all, this will throw an unknown database column error:
```sql
Column not found: 1054 Unknown column 'id' in 'where clause' (SQL: select count(*) as aggregate from `table` where `identifier` = something and `id` <> something)
```
Fair enough, relatively easy fix by updating `CanBeUnique` trait:

```php
public function unique($table, $column = null, $except = false)
{
    $this->configure(function () use ($column, $except, $table) {
        $rule = Rule::unique($table, $column);

        $record = $this->getLivewire()->record;

        if ($except && $record instanceof Model) {
            $rule->ignore($record->getKey(), $record->getKeyName());
        }

        $this->addRules([$this->getName() => [$rule]]);
    });

    return $this;
}
```
The important part here being the usage of `$record->getKeyName()`.

5. Now I can safely update the model when not changing the primary key value, or changing it to a value that does not exist yet.
6. However, if I change it to a value that does already exist for a different model, we get another database error:
```sql
Integrity constraint violation: 1062 Duplicate entry 'other' for key 'PRIMARY' (SQL: update `table` set `identifier` = other, `table`.`updated_at` = 2021-08-19 19:42:39 where `identifier` = something) 
```
Which means the unique rule didn't actually fail. This is due to the fact that when constructing the database query for checking if a record with that identifier already exists, it's not excluding the current value (`something`), but the updated value (`other`). In that case, the count returns 0, rule passes and we get the error.
I'm not entirely sure why this happens as I'm not familiar with Livewire and haven't dived much into the source code, but I suspect that `fill()` is called at some point before executing the validation rules? Either way, I managed to fix it with this additional modification to the `CanBeUnique` trait:

```php
public function unique($table, $column = null, $except = false)
{
    $this->configure(function () use ($column, $except, $table) {
        $rule = Rule::unique($table, $column);

        $record = $this->getLivewire()->record;

        if ($except && $record instanceof Model) {
            $rule->ignore($record->getOriginal($record->getKeyName()), $record->getKeyName());
        }

        $this->addRules([$this->getName() => [$rule]]);
    });

    return $this;
}
```

`$record->getOriginal($record->getKeyName())` will always return `something`, so now we're excluding the correct record from the query, meaning we get a count of 1 back so the validation fails. This shouldn't break anything, as under normal circumstances the current and original value for the primary key will always be the same. 
