### PR TITLE
fix: set initial height for markdown fields only when needed

### DIFF
--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -88,8 +88,10 @@
                 },
 
                 resize: function () {
-                    this.$refs.overlay.style.height = '150px'
-                    this.$refs.overlay.style.height = this.$refs.textarea.scrollHeight + 'px'
+                    if (this.$refs.textarea.scrollHeight > 0) {
+                        this.$refs.overlay.style.height = '150px'
+                        this.$refs.overlay.style.height = this.$refs.textarea.scrollHeight + 'px'
+                    }
 
                     this.overlay = mdhl.highlight(this.value = this.$refs.textarea.value)
                 },


### PR DESCRIPTION
Fixes #547

Before: 
<img width="1188" alt="Bildschirmfoto 2021-08-25 um 21 49 07" src="https://user-images.githubusercontent.com/789541/130867024-8646b5ab-d1d8-4f38-b570-b5fa0bbf71b6.png">

After:
<img width="1191" alt="Bildschirmfoto 2021-08-25 um 23 29 16" src="https://user-images.githubusercontent.com/789541/130867241-60d3f40a-74b2-4a45-bb60-be0702c195d8.png">
