### PR TITLE
Fix markdown field text color

### DIFF
--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -4,7 +4,7 @@
     <style>
         [x-data^="markdownEditor"] textarea {
             caret-color: black;
-            color: transparent;
+            color: black;
         }
 
         [x-ref="overlay"] {

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -4,7 +4,6 @@
     <style>
         [x-data^="markdownEditor"] textarea {
             caret-color: black;
-            color: black;
         }
 
         [x-ref="overlay"] {


### PR DESCRIPTION
Fixes a bug where the font color is transparent when using the markdown field editor in a modal.