### PR TITLE
Remove transition effect for sections

### DIFF
--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -54,7 +54,7 @@
         </div>
     </div>
 
-    <div id="{{ $formComponent->getId() }}-content" x-show.transition="open" :aria-expanded="open.toString()">
+    <div id="{{ $formComponent->getId() }}-content" x-show="open" :aria-expanded="open.toString()">
         <x-forms::form :schema="$formComponent->getSchema()" :columns="$formComponent->getColumns()" />
     </div>
 </section>


### PR DESCRIPTION
In my opinion, the backend looks more professional and cleaner if the transition effect is not used when form sections are opened.