### PR TITLE
fix: __get fallthrough when caching forms

### DIFF
--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -16,9 +16,11 @@ trait InteractsWithForms
 
     protected ?array $cachedForms = null;
 
+    protected bool $isCachingForms = false;
+
     public function __get($property)
     {
-        if ($form = $this->getCachedForm($property)) {
+        if (! $this->isCachingForms && $form = $this->getCachedForm($property)) {
             return $form;
         }
 
@@ -143,7 +145,13 @@ trait InteractsWithForms
 
     protected function cacheForms(): array
     {
-        return $this->cachedForms = $this->getForms();
+        $this->isCachingForms = true;
+
+        $this->cachedForms = $this->getForms();
+
+        $this->isCachingForms = false;
+
+        return $this->cachedForms;
     }
 
     protected function focusConcealedComponents(array $statePaths): void


### PR DESCRIPTION
Fixes an issue where computed properties used inside of `getFormSchema` would cause an infinite loop and `__get` escape.

Adds a new property to determine if caching is in progress and to prevent it from running again, allowing Livewire's `__get` handler to run.