### PR TITLE
feature: add meta to fields

### DIFF
--- a/packages/forms/src/Components/Component.php
+++ b/packages/forms/src/Components/Component.php
@@ -23,6 +23,7 @@ class Component extends ViewComponent implements Htmlable
     use Concerns\HasExtraAttributes;
     use Concerns\HasId;
     use Concerns\HasLabel;
+    use Concerns\HasMeta;
     use Concerns\HasState;
     use Concerns\HasView;
     use Concerns\ListensToEvents;

--- a/packages/forms/src/Components/Concerns/HasMeta.php
+++ b/packages/forms/src/Components/Concerns/HasMeta.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Filament\Forms\Components\Concerns;
+
+use Illuminate\Support\Arr;
+
+trait HasMeta
+{
+    protected array $meta = [];
+
+    public function getMeta(string|array $keys = null): mixed
+    {
+        if ($keys !== null) {
+            return Arr::only($this->meta, $keys);
+        }
+
+        return $this->meta;
+    }
+
+    public function hasMeta(string|array $keys): bool
+    {
+        return Arr::has($this->meta, $keys);
+    }
+
+    public function meta(string $key, mixed $value): static
+    {
+        $this->meta[$key] = $value;
+
+        return $this;
+    }
+}

--- a/packages/forms/src/Components/Concerns/HasMeta.php
+++ b/packages/forms/src/Components/Concerns/HasMeta.php
@@ -8,7 +8,7 @@ trait HasMeta
 {
     protected array $meta = [];
 
-    public function getMeta(string|array $keys = null): mixed
+    public function getMeta(string | array $keys = null): mixed
     {
         if ($keys !== null) {
             return Arr::only($this->meta, $keys);
@@ -17,7 +17,7 @@ trait HasMeta
         return $this->meta;
     }
 
-    public function hasMeta(string|array $keys): bool
+    public function hasMeta(string | array $keys): bool
     {
         return Arr::has($this->meta, $keys);
     }

--- a/packages/forms/src/Components/Concerns/HasMeta.php
+++ b/packages/forms/src/Components/Concerns/HasMeta.php
@@ -8,7 +8,14 @@ trait HasMeta
 {
     protected array $meta = [];
 
-    public function getMeta(string | array $keys = null): mixed
+    public function meta(string $key, $value): static
+    {
+        $this->meta[$key] = $value;
+
+        return $this;
+    }
+
+    public function getMeta(string | array | null $keys = null)
     {
         if (is_array($keys)) {
             return Arr::only($this->meta, $keys);
@@ -24,12 +31,5 @@ trait HasMeta
     public function hasMeta(string | array $keys): bool
     {
         return Arr::has($this->meta, $keys);
-    }
-
-    public function meta(string $key, mixed $value): static
-    {
-        $this->meta[$key] = $value;
-
-        return $this;
     }
 }

--- a/packages/forms/src/Components/Concerns/HasMeta.php
+++ b/packages/forms/src/Components/Concerns/HasMeta.php
@@ -10,8 +10,12 @@ trait HasMeta
 
     public function getMeta(string | array $keys = null): mixed
     {
-        if ($keys !== null) {
+        if (is_array($keys)) {
             return Arr::only($this->meta, $keys);
+        }
+
+        if (is_string($keys)) {
+            return Arr::get($this->meta, $keys);
         }
 
         return $this->meta;

--- a/tests/Unit/Forms/ComponentTest.php
+++ b/tests/Unit/Forms/ComponentTest.php
@@ -57,9 +57,14 @@ it('has a label', function () {
 
 it('can have meta', function () {
     $component = (new Component())
-        ->meta('foo', 'bar');
+        ->meta('foo', 'bar')
+        ->meta('bob', 'baz');
 
     expect($component)
         ->hasMeta('foo')->toBeTrue()
-        ->getMeta('foo')->toBe('bar');
+        ->getMeta('foo')->toBe('bar')
+        ->getMeta(['foo', 'bob'])->toEqual([
+            'foo' => 'bar',
+            'bob' => 'baz',
+        ]);
 });

--- a/tests/Unit/Forms/ComponentTest.php
+++ b/tests/Unit/Forms/ComponentTest.php
@@ -54,3 +54,12 @@ it('has a label', function () {
     expect($component)
         ->getLabel()->toBe($label);
 });
+
+it('can have meta', function () {
+    $component = (new Component())
+        ->meta('foo', 'bar');
+
+    expect($component)
+        ->hasMeta('foo')->toBeTrue()
+        ->getMeta('foo')->toBe('bar');
+});


### PR DESCRIPTION
This pull request allows `Component` instances to have additional meta stored against them.

A good example would be a `macro` on the `Component` class. You might want to place a marker on the `Component` to reference at a later date.

This can be done at the moment with dynamic class properties, but that'll likely be deprecated in a future version (https://wiki.php.net/rfc/deprecate_dynamic_properties).