### PR TITLE
fix: wire ignore masked inputs

### DIFF
--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -32,6 +32,7 @@
                         state: $wire.{{ $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')') }},
                     })"
                     type="text"
+                    wire:ignore
                 @endunless
                 {!! ($autocomplete = $getAutocomplete()) ? "autocomplete=\"{$autocomplete}\"" : null !!}
                 {!! $isAutofocused() ? 'autofocus' : null !!}


### PR DESCRIPTION
Masked inputs lose their state when the input is `lazy` or `reactive`. This pull request adds the `wire:ignore` attribute to the `input` when it has a mask.