### PR TITLE
feature: get fields from container by name or callback

### DIFF
--- a/packages/forms/src/Concerns/HasComponents.php
+++ b/packages/forms/src/Concerns/HasComponents.php
@@ -4,7 +4,7 @@ namespace Filament\Forms\Concerns;
 
 use Closure;
 use Filament\Forms\Components\Component;
-use Illuminate\Support\Collection;
+use Filament\Forms\Components\Field;
 
 trait HasComponents
 {
@@ -28,17 +28,17 @@ trait HasComponents
         return $this;
     }
 
-    public function getComponents(): array
-    {
-        return array_filter($this->components, fn (Component $component) => ! $component->isHidden());
-    }
-
     public function getComponent(string | Closure $callback): ?Component
     {
         $callback = $callback instanceof Closure
             ? $callback
-            : fn (Component $component) => method_exists($component, 'getName') && $component->getName() === $callback;
+            : fn (Component $component) => $component instanceof Field && $component->getName() === $callback;
 
-        return Collection::make($this->components)->first($callback);
+        return collect($this->components)->first($callback);
+    }
+
+    public function getComponents(): array
+    {
+        return array_filter($this->components, fn (Component $component) => ! $component->isHidden());
     }
 }

--- a/packages/forms/src/Concerns/HasComponents.php
+++ b/packages/forms/src/Concerns/HasComponents.php
@@ -3,6 +3,7 @@
 namespace Filament\Forms\Concerns;
 
 use Filament\Forms\Components\Component;
+use Illuminate\Support\Collection;
 
 trait HasComponents
 {
@@ -29,5 +30,11 @@ trait HasComponents
     public function getComponents(): array
     {
         return array_filter($this->components, fn (Component $component) => ! $component->isHidden());
+    }
+
+    public function getComponent(string $name): ?Component
+    {
+        return Collection::make($this->components)
+            ->first(fn (Component $component) => $component->getName() === $name);
     }
 }

--- a/packages/forms/src/Concerns/HasComponents.php
+++ b/packages/forms/src/Concerns/HasComponents.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Forms\Concerns;
 
+use Closure;
 use Filament\Forms\Components\Component;
 use Illuminate\Support\Collection;
 
@@ -32,9 +33,12 @@ trait HasComponents
         return array_filter($this->components, fn (Component $component) => ! $component->isHidden());
     }
 
-    public function getComponent(string $name): ?Component
+    public function getComponent(string | Closure $callback): ?Component
     {
-        return Collection::make($this->components)
-            ->first(fn (Component $component) => $component->getName() === $name);
+        $callback = $callback instanceof Closure
+            ? $callback
+            : fn (Component $component) => method_exists($component, 'getName') && $component->getName() === $callback;
+
+        return Collection::make($this->components)->first($callback);
     }
 }

--- a/packages/forms/src/Concerns/HasComponents.php
+++ b/packages/forms/src/Concerns/HasComponents.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Forms\Concerns;
 
-use Closure;
 use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Field;
 
@@ -28,11 +27,11 @@ trait HasComponents
         return $this;
     }
 
-    public function getComponent(string | Closure $callback): ?Component
+    public function getComponent(string | callable $callback): ?Component
     {
-        $callback = $callback instanceof Closure
+        $callback = is_callable($callback)
             ? $callback
-            : fn (Component $component) => $component instanceof Field && $component->getName() === $callback;
+            : fn (Component $component): bool => $component instanceof Field && $component->getName() === $callback;
 
         return collect($this->components)->first($callback);
     }

--- a/tests/Unit/Forms/ComponentContainerTest.php
+++ b/tests/Unit/Forms/ComponentContainerTest.php
@@ -2,6 +2,7 @@
 
 use Filament\Forms\ComponentContainer;
 use Filament\Forms\Components\Component;
+use Filament\Forms\Components\TextInput;
 use Tests\TestCase;
 use Tests\Unit\Forms\Fixtures\Livewire;
 
@@ -40,4 +41,15 @@ it('belongs to parent component', function () {
 
     expect($container)
         ->getParentComponent()->toBe($component);
+});
+
+it('can return a component by name and callback', function () {
+    $container = ComponentContainer::make(Livewire::make())
+        ->components([
+            $input = TextInput::make('foo_bar')
+        ]);
+
+    expect($container)
+        ->getComponent('foo_bar')->toBe($input)
+        ->getComponent(fn (Component $component) => $component->getName() === 'foo_bar')->toBe($input);
 });

--- a/tests/Unit/Forms/ComponentContainerTest.php
+++ b/tests/Unit/Forms/ComponentContainerTest.php
@@ -46,7 +46,7 @@ it('belongs to parent component', function () {
 it('can return a component by name and callback', function () {
     $container = ComponentContainer::make(Livewire::make())
         ->components([
-            $input = TextInput::make('foo_bar')
+            $input = TextInput::make('foo_bar'),
         ]);
 
     expect($container)


### PR DESCRIPTION
Adds a new `ComponentContainer::getComponent(string|Closure)` method.

Can be used to get a single component from the container without writing the filter with `getComponents`.

An example might be checking if a particular field has a piece of meta (since #566).

Can either pass a string and it will check if a `getName` method exists on the component before comparing the values, or pass in a `Closure` for a custom filter callback.