### PR TITLE
feature: `Component::whenTruthy` and `Component::whenFalsy`

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeHidden.php
+++ b/packages/forms/src/Components/Concerns/CanBeHidden.php
@@ -22,7 +22,7 @@ trait CanBeHidden
 
     public function whenTruthy(string $path): static
     {
-        $this->visible(fn (callable $get): bool => !! $get($path));
+        $this->visible(fn (callable $get): bool => ! ! $get($path));
 
         return $this;
     }

--- a/packages/forms/src/Components/Concerns/CanBeHidden.php
+++ b/packages/forms/src/Components/Concerns/CanBeHidden.php
@@ -20,6 +20,20 @@ trait CanBeHidden
         return $this;
     }
 
+    public function whenTruthy(string $path): static
+    {
+        $this->visible(fn (callable $get): bool => !! $get($path));
+
+        return $this;
+    }
+
+    public function whenFalsy(string $path): static
+    {
+        $this->visible(fn (callable $get): bool => ! $get($path));
+
+        return $this;
+    }
+
     public function visible(bool | callable $condition = true): static
     {
         $this->isHidden = fn (): bool => ! $this->evaluate($condition);

--- a/tests/Unit/Forms/HiddenComponentsTest.php
+++ b/tests/Unit/Forms/HiddenComponentsTest.php
@@ -20,7 +20,7 @@ test('components can be hidden based on condition', function () {
     $container = ComponentContainer::make(Livewire::make())
         ->components([
             (new Component())
-                ->when(fn (callable $get) => $get('foo_bar') === false)
+                ->when(fn (callable $get) => $get('foo_bar') === false),
         ])
         ->fill([
             'foo_bar' => true,
@@ -31,7 +31,7 @@ test('components can be hidden based on condition', function () {
 
     $container->components([
         (new Component())
-            ->whenTruthy('foo_bar')
+            ->whenTruthy('foo_bar'),
     ]);
 
     expect($container->getComponents())
@@ -39,7 +39,7 @@ test('components can be hidden based on condition', function () {
 
     $container->components([
         (new Component())
-            ->whenFalsy('foo_bar')
+            ->whenFalsy('foo_bar'),
     ]);
 
     expect($container->getComponents())

--- a/tests/Unit/Forms/HiddenComponentsTest.php
+++ b/tests/Unit/Forms/HiddenComponentsTest.php
@@ -16,6 +16,36 @@ test('components can be hidden', function () {
         ->isHidden()->toBeTrue();
 });
 
+test('components can be hidden based on condition', function () {
+    $container = ComponentContainer::make(Livewire::make())
+        ->components([
+            (new Component())
+                ->when(fn (callable $get) => $get('foo_bar') === false)
+        ])
+        ->fill([
+            'foo_bar' => true,
+        ]);
+
+    expect($container->getComponents())
+        ->toHaveCount(0);
+
+    $container->components([
+        (new Component())
+            ->whenTruthy('foo_bar')
+    ]);
+
+    expect($container->getComponents())
+        ->toHaveLength(1);
+
+    $container->components([
+        (new Component())
+            ->whenFalsy('foo_bar')
+    ]);
+
+    expect($container->getComponents())
+        ->toHaveLength(0);
+});
+
 test('hidden components are not returned from container', function () {
     $components = [];
 


### PR DESCRIPTION
Adds 2 new methods - `Component::whenTruthy` and `Component::whenFalsy`

They both accept a string (the name of the field / the path to the piece of state). This is most useful when you want to conditionally render a field based on the presence of another field, saves you writing the callback function and using `$get` yourself.