### PR TITLE
feature: `Mask::money`

### DIFF
--- a/packages/forms/src/Components/TextInput/Mask.php
+++ b/packages/forms/src/Components/TextInput/Mask.php
@@ -122,6 +122,20 @@ class Mask implements Jsonable
         return $this;
     }
 
+    public function money(string $prefix, string $thousandsSeparator = ',', int $decimalPlaces = 2): static
+    {
+        $this
+            ->patternBlocks([
+                'money' => fn (Mask $mask) => $mask
+                    ->numeric()
+                    ->thousandsSeparator($thousandsSeparator)
+                    ->decimalPlaces($decimalPlaces)
+            ])
+            ->pattern("{$prefix}money");
+
+        return $this;
+    }
+
     public function numeric(bool $condition = true): static
     {
         $this->isNumeric = $condition;

--- a/packages/forms/src/Components/TextInput/Mask.php
+++ b/packages/forms/src/Components/TextInput/Mask.php
@@ -129,7 +129,7 @@ class Mask implements Jsonable
                 'money' => fn (Mask $mask) => $mask
                     ->numeric()
                     ->thousandsSeparator($thousandsSeparator)
-                    ->decimalPlaces($decimalPlaces)
+                    ->decimalPlaces($decimalPlaces),
             ])
             ->pattern("{$prefix}money");
 


### PR DESCRIPTION
Adds a new `Mask::money(string $prefix, string $thousandsSeparator = ',', int $decimalPlaces = 2)` method.

Can be used to display currencies inside of a `TextInput`:

```php
TextInput::make('price')
    ->mask(fn ($mask) => $mask->money('£'))
```