### PR TITLE
feature: `Select::boolean()`

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -41,6 +41,16 @@ class Select extends Field
         $this->placeholder(__('forms::components.select.placeholder'));
     }
 
+    public function boolean(): static
+    {
+        $this->options([
+            1 => 'Yes',
+            0 => 'No',
+        ]);
+
+        return $this;
+    }
+
     public function getOptionLabelUsing(callable $callback): static
     {
         $this->getOptionLabelUsing = $callback;

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -41,11 +41,11 @@ class Select extends Field
         $this->placeholder(__('forms::components.select.placeholder'));
     }
 
-    public function boolean(): static
+    public function boolean(string $true = 'Yes', string $false = 'No'): static
     {
         $this->options([
-            1 => 'Yes',
-            0 => 'No',
+            1 => $true,
+            0 => $false,
         ]);
 
         return $this;


### PR DESCRIPTION
This pull request adds a new helper method on the `Select` field called `boolean()`.

This method is useful for scenarios where you want the user to answer "Yes" or "No" (I've had to do this multiple times and currently use a macro).

It can be paired with the `whenTruthy()` or `whenFalsy()` method too.