### PR TITLE
feature: allow components to be conditionally modified

### DIFF
--- a/packages/forms/src/Components/Component.php
+++ b/packages/forms/src/Components/Component.php
@@ -14,6 +14,7 @@ class Component extends ViewComponent implements Htmlable
     use Concerns\BelongsToContainer;
     use Concerns\BelongsToModel;
     use Concerns\CanBeConcealed;
+    use Concerns\CanBeConditionallyModified;
     use Concerns\CanBeDisabled;
     use Concerns\CanBeHidden;
     use Concerns\CanSpanColumns;

--- a/packages/forms/src/Components/Concerns/CanBeConditionallyModified.php
+++ b/packages/forms/src/Components/Concerns/CanBeConditionallyModified.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Filament\Forms\Components\Concerns;
+
+trait CanBeConditionallyModified
+{
+    public function if(bool | callable $condition, callable $then, ?callable $default = null): static
+    {
+        $result = $this->evaluate($condition);
+        $default ??= fn () => [];
+
+        if ($result) {
+            $this->evaluate($then);
+        } else {
+            $this->evaluate($default);
+        }
+
+        return $this;
+    }
+}

--- a/tests/Unit/Forms/ConditionallyModifiedComponentsTest.php
+++ b/tests/Unit/Forms/ConditionallyModifiedComponentsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Filament\Forms\ComponentContainer;
+use Filament\Forms\Components\Component;
+use Tests\TestCase;
+use Tests\Unit\Forms\Fixtures\Livewire;
+
+uses(TestCase::class);
+
+test('components can be conditionally modified', function () {
+    $component = (new Component())
+        ->container(ComponentContainer::make(Livewire::make()))
+        ->if(true, fn (Component $component) => $component->label('Foo'));
+
+    expect($component)
+        ->getLabel()->toBe('Foo');
+
+    $component->if(fn () => true, fn (Component $component) => $component->label('Bar'));
+
+    expect($component)
+        ->getLabel()->toBe('Bar');
+
+    $component->if(
+        fn () => false,
+        fn (Component $component) => $component->label('Bob'),
+        fn (Component $component) => $component->label('Baz')
+    );
+
+    expect($component)
+            ->getLabel()->toBe('Baz');
+});


### PR DESCRIPTION
This PR adds a new `Component::if()` method that allows you to conditionally modify a component, similar to how the `when` method works in 1.x.

```php
Component::make()
    ->if(true, fn ($component) => $component->label('It is true!'), fn ($component) => $component->label('It is false.'))
```

The `$condition` argument also accepts a `callable` that is run through `$this->evaluate` so you can conditionally modify a component based on some state or similar.

This is definitely an "advanced" feature, but would be useful for re-using forms, e.g. creating & updating a user with the same form, where the email needs to be unique when creating but if you're editing, you can ignore the current user's email (just an example).