### PR TITLE
refactor: getComponent using getFlatFields

### DIFF
--- a/packages/forms/src/Concerns/HasComponents.php
+++ b/packages/forms/src/Concerns/HasComponents.php
@@ -33,7 +33,7 @@ trait HasComponents
              ? $callback
              : fn (Component $component): bool => $component instanceof Field && $component->getStatePath() === $callback;
 
-         return collect($this->getFlatComponents())->first($callback);
+        return collect($this->getFlatComponents())->first($callback);
     }
 
     public function getFlatComponents(): array

--- a/packages/forms/src/Concerns/HasComponents.php
+++ b/packages/forms/src/Concerns/HasComponents.php
@@ -29,11 +29,13 @@ trait HasComponents
 
     public function getComponent(string | callable $callback): ?Component
     {
-        $callback = is_callable($callback)
-            ? $callback
-            : fn (Component $component): bool => $component->getName() === $callback;
-
-        return collect($this->getFlatFields())->first($callback);
+        $fields = $this->getFlatFields();
+        
+        if (is_callable($callback)) {
+            return collect($fields)->first($callback);
+        }
+        
+        return $fields[$callback] ?? null;
     }
 
     public function getFlatComponents(): array

--- a/packages/forms/src/Concerns/HasComponents.php
+++ b/packages/forms/src/Concerns/HasComponents.php
@@ -29,13 +29,11 @@ trait HasComponents
 
     public function getComponent(string | callable $callback): ?Component
     {
-        $fields = $this->getFlatFields();
+        $callback = is_callable($callback)
+             ? $callback
+             : fn (Component $component): bool => $component instanceof Field && $component->getStatePath() === $callback;
 
-        if (is_callable($callback)) {
-            return collect($fields)->first($callback);
-        }
-
-        return $fields[$callback] ?? null;
+         return collect($this->getFlatComponents())->first($callback);
     }
 
     public function getFlatComponents(): array

--- a/packages/forms/src/Concerns/HasComponents.php
+++ b/packages/forms/src/Concerns/HasComponents.php
@@ -31,9 +31,9 @@ trait HasComponents
     {
         $callback = is_callable($callback)
             ? $callback
-            : fn (Component $component): bool => $component instanceof Field && $component->getName() === $callback;
+            : fn (Component $component): bool => $component->getName() === $callback;
 
-        return collect($this->components)->first($callback);
+        return collect($this->getFlatFields())->first($callback);
     }
 
     public function getFlatComponents(): array

--- a/packages/forms/src/Concerns/HasComponents.php
+++ b/packages/forms/src/Concerns/HasComponents.php
@@ -30,11 +30,11 @@ trait HasComponents
     public function getComponent(string | callable $callback): ?Component
     {
         $fields = $this->getFlatFields();
-        
+
         if (is_callable($callback)) {
             return collect($fields)->first($callback);
         }
-        
+
         return $fields[$callback] ?? null;
     }
 


### PR DESCRIPTION
Changes `HasComponents::getComponent()` to use `getFlatFields` to ensure child containers are searched.