### PR TITLE
feature: support passing array to whenTruthy and whenFalsy

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeHidden.php
+++ b/packages/forms/src/Components/Concerns/CanBeHidden.php
@@ -2,6 +2,8 @@
 
 namespace Filament\Forms\Components\Concerns;
 
+use Illuminate\Support\Arr;
+
 trait CanBeHidden
 {
     protected $isHidden = false;
@@ -20,16 +22,36 @@ trait CanBeHidden
         return $this;
     }
 
-    public function whenTruthy(string $path): static
+    public function whenTruthy(string | array $paths): static
     {
-        $this->hidden(fn (callable $get): bool => ! $get($path));
+        $paths = Arr::wrap($paths);
+
+        $this->hidden(function (callable $get) use ($paths): bool {
+            foreach ($paths as $path) {
+                if (! $get($path)) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
 
         return $this;
     }
 
-    public function whenFalsy(string $path): static
+    public function whenFalsy(string | array $paths): static
     {
-        $this->hidden(fn (callable $get): bool => (bool) $get($path));
+        $paths = Arr::wrap($paths);
+
+        $this->hidden(function (callable $get) use ($paths): bool {
+            foreach ($paths as $path) {
+                if (!! $get($path)) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
 
         return $this;
     }

--- a/packages/forms/src/Components/Concerns/CanBeHidden.php
+++ b/packages/forms/src/Components/Concerns/CanBeHidden.php
@@ -45,7 +45,7 @@ trait CanBeHidden
 
         $this->hidden(function (callable $get) use ($paths): bool {
             foreach ($paths as $path) {
-                if (!! $get($path)) {
+                if (! ! $get($path)) {
                     return true;
                 }
             }

--- a/tests/Unit/Forms/HiddenComponentsTest.php
+++ b/tests/Unit/Forms/HiddenComponentsTest.php
@@ -47,6 +47,30 @@ test('components can be hidden based on condition', function () {
 
     expect($container->getComponents())
         ->toHaveLength(0);
+
+    $container
+        ->components([
+            (new Component())
+                ->whenFalsy([$statePath, 'bob']),
+        ])
+        ->fill([
+            'bob' => true,
+        ]);
+
+    expect($container->getComponents())
+        ->toHaveLength(0);
+
+    $container
+        ->components([
+            (new Component())
+                ->whenTruthy([$statePath, 'bob']),
+        ])
+        ->fill([
+            'bob' => true,
+        ]);
+
+    expect($container->getComponents())
+        ->toHaveLength(1);
 });
 
 test('hidden components are not returned from container', function () {


### PR DESCRIPTION
Adds support for passing an array of state paths to `whenTruthy` and `whenFalsy`. This will make the field visible when all paths are truthy/falsy.