### PR TITLE
fix: dont init date picker with default date in init

### DIFF
--- a/packages/forms/resources/js/components/date-time-picker.js
+++ b/packages/forms/resources/js/components/date-time-picker.js
@@ -64,8 +64,6 @@ export default (Alpine) => {
                 this.minute = date.minute()
                 this.second = date.second()
 
-                if (isRequired && ! this.getSelectedDate()) this.setState(date)
-
                 this.setDisplayText()
 
                 if (isAutofocused) this.openPicker()

--- a/packages/forms/resources/js/components/date-time-picker.js
+++ b/packages/forms/resources/js/components/date-time-picker.js
@@ -13,7 +13,6 @@ export default (Alpine) => {
         firstDayOfWeek,
         format,
         isAutofocused,
-        isRequired,
         locale,
         maxDate,
         minDate,
@@ -57,8 +56,8 @@ export default (Alpine) => {
 
                 let date = this.getSelectedDate() ?? dayjs()
 
-                if (this.maxDate !== null && date.isAfter(this.maxDate)) date = isRequired ? this.maxDate : null
-                if (this.minDate !== null && date.isBefore(this.minDate)) date = isRequired ? this.minDate : null
+                if (this.maxDate !== null && date.isAfter(this.maxDate)) date = null
+                if (this.minDate !== null && date.isBefore(this.minDate)) date = null
 
                 this.hour = date.hour()
                 this.minute = date.minute()
@@ -158,8 +157,8 @@ export default (Alpine) => {
                 this.$watch('state', () => {
                     let date = this.getSelectedDate() ?? dayjs()
 
-                    if (this.maxDate !== null && date.isAfter(this.maxDate)) date = isRequired ? this.maxDate : null
-                    if (this.minDate !== null && date.isBefore(this.minDate)) date = isRequired ? this.minDate : null
+                    if (this.maxDate !== null && date.isAfter(this.maxDate)) date = null
+                    if (this.minDate !== null && date.isBefore(this.minDate)) date = null
 
                     this.hour = date.hour()
                     this.minute = date.minute()
@@ -303,18 +302,11 @@ export default (Alpine) => {
 
             setState: function (date) {
                 if (date === null) {
-                    if (isRequired) {
-                        date = dayjs()
+                    this.state = null
 
-                        if (this.maxDate !== null && date.isAfter(this.maxDate)) date = this.maxDate
-                        if (this.minDate !== null && date.isBefore(this.minDate)) date = this.minDate
-                    } else {
-                        this.state = null
+                    this.setDisplayText()
 
-                        this.setDisplayText()
-
-                        return
-                    }
+                    return
                 } else {
                     if (this.dateIsDisabled(date)) return
                 }

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -29,7 +29,6 @@
             firstDayOfWeek: {{ $getFirstDayOfWeek() }},
             format: '{{ convert_date_format($getFormat())->to('day.js') }}',
             isAutofocused: {{ $isAutofocused() ? 'true' : 'false' }},
-            isRequired: {{ $isRequired() ? 'true' : 'false' }},
             locale: '{{ Str::of(app()->getLocale())->lower()->kebab() }}',
             maxDate: '{{ $getMaxDate() }}',
             minDate: '{{ $getMinDate() }}',


### PR DESCRIPTION
Related to #583. Missed a line in `init()`.