### PR TITLE
Form Layout Example Fixes (docs)

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -4,6 +4,17 @@ title: Fields
 
 Field classes can be found in the `Filament\Form\Components` namespace.
 
+They reside within the schema of your form, alongside any [layout components](layout):
+
+```php
+protected function getFormSchema(): array
+{
+    return [
+        // ...
+    ];
+}
+```
+
 Fields may be created using the static `make()` method, passing its name. The name of the field should correspond to a property on your Livewire component. You may use [Livewire's "dot syntax"](https://laravel-livewire.com/docs/properties#binding-nested-data) to bind fields to nested properties such as arrays and Eloquent models.
 
 ```php

--- a/packages/forms/docs/04-layout.md
+++ b/packages/forms/docs/04-layout.md
@@ -4,6 +4,17 @@ title: Layout
 
 Layout component classes can be found in the `Filament\Form\Components` namespace.
 
+Your layout components will need to reside within the `getFormSchema()` method of your Livewire component.
+
+```php
+protected function getFormSchema(): array
+{
+    return [
+        // Components here, returning the fields
+    ];
+}
+```
+
 Components may be created using the static `make()` method. Usually, you will then define the child component `schema()` to display inside:
 
 ```php
@@ -200,7 +211,7 @@ Section::make('Heading')
     ->collapsible()
 ```
 
-You may `collapse()` sections by default:
+Your sections may be `collapsed()` by default:
 
 ```php
 use Filament\Forms\Components\Section;
@@ -209,7 +220,7 @@ Section::make('Heading')
     ->schema([
         // ...
     ])
-    ->collapsible()
+    ->collapsed()
 ```
 
 ## Tabs

--- a/packages/forms/docs/04-layout.md
+++ b/packages/forms/docs/04-layout.md
@@ -4,13 +4,13 @@ title: Layout
 
 Layout component classes can be found in the `Filament\Form\Components` namespace.
 
-Your layout components will need to reside within the `getFormSchema()` method of your Livewire component.
+They reside within the schema of your form, alongside any [fields](fields):
 
 ```php
 protected function getFormSchema(): array
 {
     return [
-        // Components here, returning the fields
+        // ...
     ];
 }
 ```


### PR DESCRIPTION
- fixed a typo in the _Sections Component_ for collapsing a section by default
- made it clear that the components need to be defined within the `getFormSchema()` method