### PR TITLE
Fix for labels not working for relationship fields (select and multiselect)

### DIFF
--- a/packages/forms/src/Components/BelongsToManyMultiSelect.php
+++ b/packages/forms/src/Components/BelongsToManyMultiSelect.php
@@ -115,6 +115,14 @@ class BelongsToManyMultiSelect extends MultiSelect
             return (string) $this->label;
         }
 
+        if ($this->label === null) {
+            return (string) Str::of($this->getRelationshipName())
+                ->before('.')
+                ->kebab()
+                ->replace(['-', '_'], ' ')
+                ->ucfirst();
+        }
+
         return parent::getLabel();
     }
 

--- a/packages/forms/src/Components/BelongsToManyMultiSelect.php
+++ b/packages/forms/src/Components/BelongsToManyMultiSelect.php
@@ -112,11 +112,7 @@ class BelongsToManyMultiSelect extends MultiSelect
     public function getLabel(): string
     {
         if ($this->label) {
-            return (string) Str::of($this->getRelationshipName())
-                ->before('.')
-                ->kebab()
-                ->replace(['-', '_'], ' ')
-                ->ucfirst();
+            return (string) $this->label;
         }
 
         return parent::getLabel();

--- a/packages/forms/src/Components/BelongsToManyMultiSelect.php
+++ b/packages/forms/src/Components/BelongsToManyMultiSelect.php
@@ -111,10 +111,6 @@ class BelongsToManyMultiSelect extends MultiSelect
 
     public function getLabel(): string
     {
-        if ($this->label) {
-            return (string) $this->label;
-        }
-
         if ($this->label === null) {
             return (string) Str::of($this->getRelationshipName())
                 ->before('.')

--- a/packages/forms/src/Components/BelongsToSelect.php
+++ b/packages/forms/src/Components/BelongsToSelect.php
@@ -119,6 +119,14 @@ class BelongsToSelect extends Select
             return (string) $this->label;
         }
 
+        if ($this->label === null) {
+            return (string) Str::of($this->getRelationshipName())
+                ->before('.')
+                ->kebab()
+                ->replace(['-', '_'], ' ')
+                ->ucfirst();
+        }
+
         return parent::getLabel();
     }
 

--- a/packages/forms/src/Components/BelongsToSelect.php
+++ b/packages/forms/src/Components/BelongsToSelect.php
@@ -115,10 +115,6 @@ class BelongsToSelect extends Select
 
     public function getLabel(): string
     {
-        if ($this->label) {
-            return (string) $this->label;
-        }
-
         if ($this->label === null) {
             return (string) Str::of($this->getRelationshipName())
                 ->before('.')

--- a/packages/forms/src/Components/BelongsToSelect.php
+++ b/packages/forms/src/Components/BelongsToSelect.php
@@ -116,11 +116,7 @@ class BelongsToSelect extends Select
     public function getLabel(): string
     {
         if ($this->label) {
-            return (string) Str::of($this->getRelationshipName())
-                ->before('.')
-                ->kebab()
-                ->replace(['-', '_'], ' ')
-                ->ucfirst();
+            return (string) $this->label;
         }
 
         return parent::getLabel();


### PR DESCRIPTION
- If a label is present, it should be used, instead of using the relationship name.