### PR TITLE
fixing collapsed states

### DIFF
--- a/packages/forms/src/Components/Section.php
+++ b/packages/forms/src/Components/Section.php
@@ -39,7 +39,7 @@ class Section extends Component implements Contracts\CanConcealComponents
     public function collapsed(bool | callable $condition = true): static
     {
         $this->isCollapsed = $condition;
-        $this->collapsible($condition);
+        $this->collapsible(true);
 
         return $this;
     }


### PR DESCRIPTION
This PR should fix referenced in this discussion item here: https://github.com/laravel-filament/filament/discussions/632

Basically, if we pass a condition or callable to the `collapsed()` method, it should only affect the collapse state, and should not convert the section back to a non-collapsible one.