### PR TITLE
fix: Markdown editor content misalignment

### DIFF
--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -207,7 +207,7 @@
                     x-ref="overlay"
                     x-html="overlay"
                     style="padding: 8px 12px"
-                    class="w-full h-full border border-transparent font-mono tracking-normal text-black break-words whitespace-pre-wrap"
+                    class="w-full h-full border border-transparent font-mono tracking-normal text-base text-gray-900 break-words whitespace-pre-wrap"
                 ></div>
             </div>
 


### PR DESCRIPTION
When a non-`text-base` font size is used for a form, the markdown editor content becomes misaligned. This is because the textarea is using a different fontsize to the formatting overlay.

To fix this, we must force `text-base` onto the formatting overlay as well.

<img width="460" alt="Screenshot 2021-10-06 at 09 57 03" src="https://user-images.githubusercontent.com/41773797/136171986-d46a4bf5-bf88-4f9e-9316-d4e0c021c801.png">
