### PR TITLE
Fix small bug in MultiSelect template

### DIFF
--- a/packages/forms/resources/views/components/multi-select.blade.php
+++ b/packages/forms/resources/views/components/multi-select.blade.php
@@ -154,7 +154,7 @@
                             'cursor-default' => $isDisabled(),
                         ])
                     >
-                        <span x-text="labels[option]"></span>
+                        <span x-text="options[option]"></span>
 
                         @unless ($isDisabled())
                             <x-heroicon-s-x class="w-3 h-3" />


### PR DESCRIPTION
When an item was selected, it was not being displayed properly because the x-text was using an unexistent array.