### PR TITLE
feature: alias idleLabel to placeholder

### DIFF
--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -170,6 +170,13 @@ class FileUpload extends Field
         return $this;
     }
 
+    public function idleLabel(string | callable $label): static
+    {
+        $this->placeholder($label);
+
+        return $this;
+    }
+
     public function image(): static
     {
         $this->acceptedFileTypes([


### PR DESCRIPTION
Adds an alias from `FileUpload::placeholder()` to `FileUpload::idleLabel()`, since that's the terminology that FilePond uses.