### PR TITLE
fix: masked inputs not reflecting server changes

### DIFF
--- a/packages/forms/dist/module.esm.js
+++ b/packages/forms/dist/module.esm.js
@@ -21998,6 +21998,9 @@ var text_input_default = (Alpine) => {
         this.mask = IMask(this.$el, getMaskOptionsUsing(IMask)).on("accept", () => {
           this.state = this.mask.unmaskedValue;
         });
+        this.$watch("state", () => {
+          this.mask.unmaskedValue = this.state?.valueOf();
+        });
       }
     };
   });

--- a/packages/forms/resources/js/components/text-input.js
+++ b/packages/forms/resources/js/components/text-input.js
@@ -22,6 +22,10 @@ export default (Alpine) => {
                 this.mask = IMask(this.$el, getMaskOptionsUsing(IMask)).on('accept', () => {
                     this.state = this.mask.unmaskedValue
                 })
+
+                this.$watch('state', () => {
+                    this.mask.unmaskedValue = this.state?.valueOf()
+                })
             }
         }
     })


### PR DESCRIPTION
Fixes a problem where masked inputs weren't reflecting any server-side changes since the value of `state` wasn't being sent back to the mask.