### PR TITLE
Allows pattern definition to work

### DIFF
--- a/packages/forms/src/Components/TextInput/Mask.php
+++ b/packages/forms/src/Components/TextInput/Mask.php
@@ -318,7 +318,7 @@ class Mask implements Jsonable
 
     public function toJson($options = 0): string
     {
-        $json = json_encode($this->getArrayableConfiguration(), $options);
+        $json = json_encode($this->getArrayableConfiguration(), JSON_UNESCAPED_SLASHES | $options);
 
         return str_replace(
             [


### PR DESCRIPTION
Without this flag, json_encode will escape the slashes that the configuration. Consider the example from the iMask docs

```
var zipMask = IMask(element, {
  mask: '#00000',
  definitions: {
    // <any single char>: <same type as mask (RegExp, Function, etc.)>
    // defaults are '0', 'a', '*'
    '#': /[1-6]/
  }
});
```