### PR TITLE
style: add width to action column

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -183,7 +183,7 @@
                         @endforeach
 
                         @if (count($getActions()))
-                            <th>
+                            <th class="w-5">
                                 <span class="sr-only">
                                     Actions
                                 </span>


### PR DESCRIPTION
Adds a `w-5` class to the actions column so that it will always take up minimum width required for actions.
<img width="413" alt="CleanShot 2021-11-03 at 11 44 31@2x" src="https://user-images.githubusercontent.com/41837763/140054308-99a67f36-1c9a-4d05-9aa9-3aacf5a1a873.png">

If the content takes up more space, it'll expand the column still but without all the excess spacing.