### PR TITLE
Add autocapitalize attribute to  maintained concerns

### DIFF
--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -38,6 +38,7 @@
                     wire:ignore
                 @endunless
                 {!! ($autocomplete = $getAutocomplete()) ? "autocomplete=\"{$autocomplete}\"" : null !!}
+                {!! ($autocapitalize = $getAutocapitalize()) ? "autocapitalize=\"{$autocapitalize}\"" : null !!}
                 {!! $isAutofocused() ? 'autofocus' : null !!}
                 {!! $isDisabled() ? 'disabled' : null !!}
                 id="{{ $getId() }}"

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -37,8 +37,8 @@
                     type="text"
                     wire:ignore
                 @endunless
-                {!! ($autocomplete = $getAutocomplete()) ? "autocomplete=\"{$autocomplete}\"" : null !!}
                 {!! ($autocapitalize = $getAutocapitalize()) ? "autocapitalize=\"{$autocapitalize}\"" : null !!}
+                {!! ($autocomplete = $getAutocomplete()) ? "autocomplete=\"{$autocomplete}\"" : null !!}
                 {!! $isAutofocused() ? 'autofocus' : null !!}
                 {!! $isDisabled() ? 'disabled' : null !!}
                 id="{{ $getId() }}"

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -8,8 +8,8 @@
     :state-path="$getStatePath()"
 >
     <textarea
-        {!! ($autocomplete = $getAutocomplete()) ? "autocomplete=\"{$autocomplete}\"" : null !!}
         {!! ($autocapitalize = $getAutocapitalize()) ? "autocapitalize=\"{$autocapitalize}\"" : null !!}
+        {!! ($autocomplete = $getAutocomplete()) ? "autocomplete=\"{$autocomplete}\"" : null !!}
         {!! $isAutofocused() ? 'autofocus' : null !!}
         {!! ($cols = $getCols()) ? "cols=\"{$cols}\"" : null !!}
         {!! $isDisabled() ? 'disabled' : null !!}

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -9,6 +9,7 @@
 >
     <textarea
         {!! ($autocomplete = $getAutocomplete()) ? "autocomplete=\"{$autocomplete}\"" : null !!}
+        {!! ($autocapitalize = $getAutocapitalize()) ? "autocapitalize=\"{$autocapitalize}\"" : null !!}
         {!! $isAutofocused() ? 'autofocus' : null !!}
         {!! ($cols = $getCols()) ? "cols=\"{$cols}\"" : null !!}
         {!! $isDisabled() ? 'disabled' : null !!}

--- a/packages/forms/src/Components/Concerns/CanBeAutocapitalized.php
+++ b/packages/forms/src/Components/Concerns/CanBeAutocapitalized.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Filament\Forms\Components\Concerns;
+
+trait CanBeAutocapitalized
+{
+    protected $autocapitalize = null;
+
+    public function autocapitalize(string | callable $autocapitalize = 'on'): static
+    {
+        $this->autocapitalize = $autocapitalize;
+
+        return $this;
+    }
+
+    public function disableAutocapitalize(bool | callable $condition = true): static
+    {
+        $this->autocapitalize(function () use ($condition): ?string {
+            return $this->evaluate($condition) ? 'off' : null;
+        });
+
+        return $this;
+    }
+
+    public function getAutocapitalize(): ?string
+    {
+        return $this->evaluate($this->autocapitalize);
+    }
+}

--- a/packages/forms/src/Components/TextInput.php
+++ b/packages/forms/src/Components/TextInput.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Support\Arrayable;
 
 class TextInput extends Field
 {
+    use Concerns\CanBeAutocapitalized;
     use Concerns\CanBeAutocompleted;
     use Concerns\CanBeLengthConstrained;
     use Concerns\HasPlaceholder;

--- a/packages/forms/src/Components/Textarea.php
+++ b/packages/forms/src/Components/Textarea.php
@@ -4,6 +4,7 @@ namespace Filament\Forms\Components;
 
 class Textarea extends Field
 {
+    use Concerns\CanBeAutocapitalized;
     use Concerns\CanBeAutocompleted;
     use Concerns\CanBeLengthConstrained;
     use Concerns\HasPlaceholder;


### PR DESCRIPTION
It creates a more direct way to overwrite autocapitalize and deals with at the concerns level rather than in extraAttributes for greater clarity. The side effect of this should be on mobile devices that the keyboard is always in caps mode.