### PR TITLE
(fix) Fix type hinting for sortable()

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanBeSortable.php
+++ b/packages/tables/src/Columns/Concerns/CanBeSortable.php
@@ -10,7 +10,7 @@ trait CanBeSortable
 
     protected ?array $sortColumns = [];
 
-    public function sortable(bool $condition = true): static
+    public function sortable(bool | array $condition = true): static
     {
         if (is_array($condition)) {
             $this->isSortable = true;


### PR DESCRIPTION
As stated in the [docs](https://filamentadmin.com/docs/2.x/tables/columns#sorting), argument $condition could be `bool` or `array`. Because only `bool` is currently allowed, we cannot use an accessor column.