### PR TITLE
Change method cache from boot to booted Trait 

### DIFF
--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -35,7 +35,6 @@ trait InteractsWithTable
         $this->cacheTableColumns();
 
         $this->cacheTableFilters();
-        
         $this->getTableFiltersForm()->fill();
     }
 

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -24,11 +24,6 @@ trait InteractsWithTable
 
     protected Table $table;
 
-    public function bootInteractsWithTable(): void
-    {
-        
-    }
-
     public function bootedInteractsWithTable(): void
     {
         $this->table = $this->getTable();

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -26,6 +26,11 @@ trait InteractsWithTable
 
     public function bootInteractsWithTable(): void
     {
+        
+    }
+
+    public function bootedInteractsWithTable(): void
+    {
         $this->table = $this->getTable();
 
         $this->cacheTableActions();
@@ -35,6 +40,7 @@ trait InteractsWithTable
         $this->cacheTableColumns();
 
         $this->cacheTableFilters();
+        
         $this->getTableFiltersForm()->fill();
     }
 


### PR DESCRIPTION
Move all table entities from

- bootInteractsWithTable 
to 
- bootedInteractsWithTable

Now the public properties setted in mount method is accessible.

#701 Fixed