### PR TITLE
Add a disabled style to text, textarea fields

### DIFF
--- a/packages/forms/docs/01-installation.md
+++ b/packages/forms/docs/01-installation.md
@@ -55,6 +55,11 @@ module.exports = {
             }, // [tl! focus:end]
         },
     },
+    variants: {
+        extend: {
+            backgroundColor: ["disabled"], // [tl! focus:start]
+        },
+    },
     plugins: [
         require('@tailwindcss/forms'), // [tl! focus:start]
         require('@tailwindcss/typography'), // [tl! focus:end]

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -52,9 +52,9 @@
                 {!! ($interval = $getStep()) ? "step=\"{$interval}\"" : null !!}
                 {!! $isRequired() ? 'required' : null !!}
                 {{ $attributes->merge($getExtraAttributes())->class([
-                    'block w-full h-10 transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600',
+                    'block w-full h-10 transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600 disabled:bg-gray-200',
                     'border-gray-300' => ! $errors->has($getStatePath()),
-                    'border-danger-600 ring-danger-600 disabled:bg-gray-200' => $errors->has($getStatePath()),
+                    'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
                 ]) }}
             />
         </div>

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -54,7 +54,7 @@
                 {{ $attributes->merge($getExtraAttributes())->class([
                     'block w-full h-10 transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600',
                     'border-gray-300' => ! $errors->has($getStatePath()),
-                    'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
+                    'border-danger-600 ring-danger-600 disabled:bg-gray-200' => $errors->has($getStatePath()),
                 ]) }}
             />
         </div>

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -23,7 +23,7 @@
         {{ $attributes->merge($getExtraAttributes())->class([
             'block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-600',
             'border-gray-300' => ! $errors->has($getStatePath()),
-            'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
+            'border-danger-600 ring-danger-600 disabled:bg-gray-200' => $errors->has($getStatePath()),
         ]) }}
     ></textarea>
 </x-forms::field-wrapper>


### PR DESCRIPTION
Update text-field and textarea components to include disabled: state styling. Requires update to tailwind.config.js