### PR TITLE
Add getTableContentFooter() functionality

### DIFF
--- a/packages/tables/resources/views/components/table.blade.php
+++ b/packages/tables/resources/views/components/table.blade.php
@@ -9,7 +9,7 @@
         {{ $slot }}
     </tbody>
 
-    @if(isset($footer))
+    @if ($footer)
         <tfoot>
             <tr class="bg-gray-50">
                 {{ $footer }}

--- a/packages/tables/resources/views/components/table.blade.php
+++ b/packages/tables/resources/views/components/table.blade.php
@@ -8,4 +8,12 @@
     <tbody class="divide-y whitespace-nowrap">
         {{ $slot }}
     </tbody>
+
+    @if(isset($footer))
+        <tfoot>
+            <tr class="bg-gray-50">
+                {{ $footer }}
+            </tr>
+        </tfoot>
+    @endif
 </table>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -1,8 +1,8 @@
 @php
     $actions = $getActions();
     $columns = $getColumns();
-    $header = $getHeader();
     $contentFooter = $getContentFooter();
+    $header = $getHeader();
     $headerActions = $getHeaderActions();
     $heading = $getHeading();
     $isBulkActionsDropdownVisible = $isSelectionEnabled() && $getSelectedRecordCount();
@@ -154,9 +154,9 @@
                         </x-tables::row>
                     @endforeach
 
-                    @if($contentFooter)
+                    @if ($contentFooter)
                         <x-slot name="footer">
-                            {{ $contentFooter->with(['records' => $records, 'columns' => $columns]) }}
+                            {{ $contentFooter->with(['columns' => $columns, 'records' => $records]) }}
                         </x-slot>
                     @endif
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -2,6 +2,7 @@
     $actions = $getActions();
     $columns = $getColumns();
     $header = $getHeader();
+    $contentFooter = $getContentFooter();
     $headerActions = $getHeaderActions();
     $heading = $getHeading();
     $isBulkActionsDropdownVisible = $isSelectionEnabled() && $getSelectedRecordCount();
@@ -152,6 +153,13 @@
                             @endif
                         </x-tables::row>
                     @endforeach
+
+                    @if($contentFooter)
+                        <x-slot name="footer">
+                            {{ $contentFooter->with(['records' => $records, 'columns' => $columns]) }}
+                        </x-slot>
+                    @endif
+
                 </x-tables::table>
             @else
                 @if ($emptyState = $getEmptyState())

--- a/packages/tables/src/Concerns/HasContentFooter.php
+++ b/packages/tables/src/Concerns/HasContentFooter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Filament\Tables\Concerns;
+
+use Illuminate\Contracts\View\View;
+
+trait HasContentFooter
+{
+    protected function getTableContentFooter(): ?View
+    {
+        return null;
+    }
+}

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -17,6 +17,7 @@ trait InteractsWithTable
     use HasColumns;
     use HasEmptyState;
     use HasFilters;
+    use HasContentFooter;
     use HasHeader;
     use HasRecords;
     use Forms\Concerns\InteractsWithForms;
@@ -46,6 +47,7 @@ trait InteractsWithTable
     protected function getTable(): Table
     {
         return $this->makeTable()
+            ->contentFooter($this->getTableContentFooter())
             ->description($this->getTableDescription())
             ->emptyState($this->getTableEmptyState())
             ->emptyStateActions($this->getTableEmptyStateActions())

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -15,9 +15,9 @@ trait InteractsWithTable
     use HasActions;
     use HasBulkActions;
     use HasColumns;
+    use HasContentFooter;
     use HasEmptyState;
     use HasFilters;
-    use HasContentFooter;
     use HasHeader;
     use HasRecords;
     use Forms\Concerns\InteractsWithForms;

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -20,6 +20,8 @@ class Table extends ViewComponent implements Htmlable
     use Macroable;
     use Tappable;
 
+    protected ?View $contentFooter = null;
+
     protected ?string $description = null;
 
     protected ?View $emptyState = null;
@@ -103,6 +105,13 @@ class Table extends ViewComponent implements Htmlable
         return $this;
     }
 
+    public function contentFooter(?View $view): static
+    {
+        $this->contentFooter = $view;
+
+        return $this;
+    }
+
     public function header(?View $view): static
     {
         $this->header = $view;
@@ -159,6 +168,11 @@ class Table extends ViewComponent implements Htmlable
     public function getColumns(): array
     {
         return $this->getLivewire()->getCachedTableColumns();
+    }
+
+    public function getContentFooter(): ?View
+    {
+        return $this->contentFooter;
     }
 
     public function getDescription(): ?string


### PR DESCRIPTION
This PR adds the ability to provide a view which will be displayed at the bottom of the table, but above the paginator. With this view, you could create a totals row or sth at the bottom of the table.

Filament is really a beautiful tool. This was my first time looking at the source code and it is structured really well. Could it be that some things aren't yet documented? E.g. I can't remember reading about providing a heading text or sth.