### PR TITLE
Make Markdown editor controls wrap on smaller devices

### DIFF
--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -17,7 +17,7 @@
     >
         <div class="space-y-2">
             @unless ($isDisabled())
-                <div class="flex justify-between space-x-4 items-stretch h-8">
+                <div class="flex justify-between flex-wrap space-y-4 md:space-y-0  md:space-x-4 items-stretch md:h-8">
                     <markdown-toolbar
                         for="{{ $getId() }}"
                         x-bind:class="{ 'pointer-events-none opacity-75': tab === 'preview' }"

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -17,7 +17,7 @@
     >
         <div class="space-y-2">
             @unless ($isDisabled())
-                <div class="flex justify-between flex-wrap space-y-4 md:space-y-0  md:space-x-4 items-stretch md:h-8">
+                <div class="flex justify-between space-x-4 overflow-x-auto items-stretch h-8">
                     <markdown-toolbar
                         for="{{ $getId() }}"
                         x-bind:class="{ 'pointer-events-none opacity-75': tab === 'preview' }"


### PR DESCRIPTION
I noticed that on smaller devices the controls for the markdown editor overflow the container and cause horizontal scroll. This PR fixes that by adding a `flex-wrap` utility for the smaller devices. 

**Before:**
<img width="382" alt="Schermafbeelding 2021-11-24 om 08 27 57" src="https://user-images.githubusercontent.com/59207045/143193755-818610db-c6c6-4efe-bddf-4675e4d33358.png">

**After:**
<img width="382" alt="Schermafbeelding 2021-11-24 om 08 27 18" src="https://user-images.githubusercontent.com/59207045/143193759-5a25a6bd-b414-4663-bae4-03c94a38d7fc.png">

