### PR TITLE
Update forms documentation with additional search options

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -427,7 +427,6 @@ class App extends Model
     protected $casts = [
         'technologies' => 'array',
     ];
-
     // ...
 }
 ```
@@ -494,7 +493,6 @@ class User extends Model
     protected $casts = [
         'is_admin' => 'boolean',
     ];
-
     // ...
 }
 ```
@@ -547,7 +545,6 @@ class User extends Model
     protected $casts = [
         'is_admin' => 'boolean',
     ];
-
     // ...
 }
 ```
@@ -972,7 +969,6 @@ class Post extends Model
     protected $casts = [
         'tags' => 'array',
     ];
-
     // ...
 }
 ```

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -427,6 +427,7 @@ class App extends Model
     protected $casts = [
         'technologies' => 'array',
     ];
+    
     // ...
 }
 ```
@@ -493,6 +494,7 @@ class User extends Model
     protected $casts = [
         'is_admin' => 'boolean',
     ];
+    
     // ...
 }
 ```
@@ -545,6 +547,7 @@ class User extends Model
     protected $casts = [
         'is_admin' => 'boolean',
     ];
+    
     // ...
 }
 ```
@@ -969,6 +972,7 @@ class Post extends Model
     protected $casts = [
         'tags' => 'array',
     ];
+    
     // ...
 }
 ```

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -349,6 +349,25 @@ Select::make('authorId')
     ->searchable()
 ```
 
+If you have a lot of options would rather populate it based on a database search or other external data source, you can use the `getSearchResultsUsing()` method and pass a callback containing the search query string. Make sure to return a `$key => $value` array of results.
+
+Next, you'll want to transform the selected value into a label. You can do this using the `getOptionLabelUsing()` method. This also accepts a callback containing the selected value. You can tranform the value into a label by returning a string.
+
+```php
+Select::make('post_id')
+    ->searchable()
+    ->getSearchResultsUsing(function ($query) {
+        // use the search $query to return a $key => $value array of results
+        return Post::where('title', 'like', "%$query%")->pluck('title', 'id')->toArray();
+    })
+    ->getOptionLabelUsing(function ($value) {
+        // use $value and transform it into a label for the selected option
+        if ($value) {
+            return Post::find($value)->title;
+        }
+    }),
+```
+
 ### Dependant selects
 
 Commonly, you may desire "dependant" select inputs, which populate their options based on the state of another.
@@ -408,7 +427,7 @@ class App extends Model
     protected $casts = [
         'technologies' => 'array',
     ];
-    
+
     // ...
 }
 ```
@@ -475,7 +494,7 @@ class User extends Model
     protected $casts = [
         'is_admin' => 'boolean',
     ];
-    
+
     // ...
 }
 ```
@@ -528,7 +547,7 @@ class User extends Model
     protected $casts = [
         'is_admin' => 'boolean',
     ];
-    
+
     // ...
 }
 ```
@@ -953,7 +972,7 @@ class Post extends Model
     protected $casts = [
         'tags' => 'array',
     ];
-    
+
     // ...
 }
 ```

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -349,9 +349,9 @@ Select::make('authorId')
     ->searchable()
 ```
 
-If you have a lot of options would rather populate it based on a database search or other external data source, you can use the `getSearchResultsUsing()` method and pass a callback containing the search query string. Make sure to return a `$key => $value` array of results.
+If you have a lot of options and want to populate it based on a database search or other external data source, you can use the `getSearchResultsUsing()` method and pass a callback containing the search query string. Make sure to return a `$key => $value` array of results.
 
-Next, you'll want to transform the selected value into a label. You can do this using the `getOptionLabelUsing()` method. This also accepts a callback containing the selected value. You can tranform the value into a label by returning a string.
+Next, you'll want to transform the selected value into a label. You can do this using the `getOptionLabelUsing()` method. This also accepts a callback containing the selected value. You can transform the value into a label by returning a string.
 
 ```php
 Select::make('post_id')

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -349,23 +349,17 @@ Select::make('authorId')
     ->searchable()
 ```
 
-If you have a lot of options and want to populate it based on a database search or other external data source, you can use the `getSearchResultsUsing()` method and pass a callback containing the search query string. Make sure to return a `$key => $value` array of results.
+If you have lots of options and want to populate them based on a database search or other external data source, you can use the `getSearchResultsUsing()` and `getOptionLabelUsing()` methods instead of `options()`.
 
-Next, you'll want to transform the selected value into a label. You can do this using the `getOptionLabelUsing()` method. This also accepts a callback containing the selected value. You can transform the value into a label by returning a string.
+The `getSearchResultsUsing()` method accepts a callback that returns search results in `$key => $value` format.
+
+The `getOptionLabelUsing()` method accepts a callback that transforms the selected option `$value` into a label.
 
 ```php
-Select::make('post_id')
+Select::make('authorId')
     ->searchable()
-    ->getSearchResultsUsing(function ($query) {
-        // use the search $query to return a $key => $value array of results
-        return Post::where('title', 'like', "%$query%")->pluck('title', 'id')->toArray();
-    })
-    ->getOptionLabelUsing(function ($value) {
-        // use $value and transform it into a label for the selected option
-        if ($value) {
-            return Post::find($value)->title;
-        }
-    }),
+    ->getSearchResultsUsing(fn (string $query) => User::where('name', 'like', "%{$query}%")->pluck('name', 'id'))
+    ->getOptionLabelUsing(fn ($value): ?string => User::find($value)?->name)),
 ```
 
 ### Dependant selects


### PR DESCRIPTION
This PR documents the `getSearchResultsUsing()` and `getOptionLabelUsing()` methods to further customize the `searchable()` method on a select field.

These methods are very helpful when needing to search a very large result set either directly from the database or an external data source such as an API.