### PR TITLE
Radio field

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -408,7 +408,7 @@ class App extends Model
     protected $casts = [
         'technologies' => 'array',
     ];
-    
+
     // ...
 }
 ```
@@ -475,7 +475,7 @@ class User extends Model
     protected $casts = [
         'is_admin' => 'boolean',
     ];
-    
+
     // ...
 }
 ```
@@ -528,9 +528,52 @@ class User extends Model
     protected $casts = [
         'is_admin' => 'boolean',
     ];
-    
+
     // ...
 }
+```
+
+## Radio
+
+The radio provides a radio button group for selecting a single value from from a list of predefined options:
+
+```php
+use Filament\Forms\Components\Radio;
+
+Radio::make('status')
+    ->options([
+        'draft' => 'Draft',
+        'scheduled' => 'Scheduled',
+        'published' => 'Published'
+    ]);
+```
+
+You can optionally provide descriptions to each option using the `descriptions()` method:
+
+```php
+use Filament\Forms\Components\Radio;
+
+Radio::make('status')
+    ->options([
+        'draft' => 'Draft',
+        'scheduled' => 'Scheduled',
+        'published' => 'Published'
+    ])
+    ->descriptions([
+        'draft' => 'Is not visible.',
+        'scheduled' => 'Will be visible.',
+        'published' => 'Is visible.'
+    ]);
+```
+
+Be sure to use the same `key` in the descriptions array as the `key` in the options array so the right description matches the right option.
+
+If you want a simple boolean radio button group (e.g Yes or No), you can use the `boolean()` method:
+
+```php
+Radio::make('feedback')
+    ->label('Do you like this post?')
+    ->boolean();
 ```
 
 ## Date-time picker
@@ -953,7 +996,7 @@ class Post extends Model
     protected $casts = [
         'tags' => 'array',
     ];
-    
+
     // ...
 }
 ```

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -535,7 +535,7 @@ class User extends Model
 
 ## Radio
 
-The radio provides a radio button group for selecting a single value from from a list of predefined options:
+The radio input provides a radio button group for selecting a single value from a list of predefined options:
 
 ```php
 use Filament\Forms\Components\Radio;
@@ -545,7 +545,7 @@ Radio::make('status')
         'draft' => 'Draft',
         'scheduled' => 'Scheduled',
         'published' => 'Published'
-    ]);
+    ])
 ```
 
 You can optionally provide descriptions to each option using the `descriptions()` method:
@@ -563,12 +563,12 @@ Radio::make('status')
         'draft' => 'Is not visible.',
         'scheduled' => 'Will be visible.',
         'published' => 'Is visible.'
-    ]);
+    ])
 ```
 
 Be sure to use the same `key` in the descriptions array as the `key` in the options array so the right description matches the right option.
 
-If you want a simple boolean radio button group (e.g Yes or No), you can use the `boolean()` method:
+If you want a simple boolean radio button group, with "Yes" and "No" options, you can use the `boolean()` method:
 
 ```php
 Radio::make('feedback')

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -7,36 +7,39 @@
     :required="$isRequired()"
     :state-path="$getStatePath()"
 >
-<div class="space-y-4">
+<div class="pt-2 space-y-5">
     @foreach ($getOptions() as $value => $label)
-        <div class="flex items-center">
-            <input
-                name="{{ $getId() }}"
-                id="{{ $value }}"
-                type="radio"
-                value="{{ $value }}"
-                {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
-                {{ $attributes->merge($getExtraAttributes())->class([
-                    'focus:ring-primary-500 h-4 w-4 text-primary-600',
-                    'border-gray-300' => ! $errors->has($getStatePath()),
-                    'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
-                ]) }}
-                {!! $isOptionDisabled($value, $label) ? 'disabled' : null !!}
-            />
-            <label for="{{ $value }}" @class([
-                'block ml-3 text-sm font-medium',
-                'text-gray-700' => ! $errors->has($getStatePath()),
-                'text-danger-600' => $errors->has($getStatePath()),
-            ])>
-
-                {{ $label }}
+        <div class="relative flex items-start">
+            <div class="flex items-center h-5">
+                <input
+                    name="{{ $getId() }}"
+                    id="{{ $value }}"
+                    type="radio"
+                    value="{{ $value }}"
+                    {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
+                    {{ $attributes->merge($getExtraAttributes())->class([
+                        'focus:ring-primary-500 h-4 w-4 text-primary-600',
+                        'border-gray-300' => ! $errors->has($getStatePath()),
+                        'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
+                    ]) }}
+                    {!! $isOptionDisabled($value, $label) ? 'disabled' : null !!}
+                />
+            </div>
+            <div class="ml-3 text-sm">
+                <label for="{{ $value }}" @class([
+                    'font-medium',
+                    'text-gray-700' => ! $errors->has($getStatePath()),
+                    'text-danger-600' => $errors->has($getStatePath()),
+                ])>
+                    {{ $label }}
+                </label>
 
                 @if($hasDescription($value))
                     <p id="{{ $value }}-description" class="text-gray-500">
                         {{ $getDescription($value) }}
                     </p>
                 @endif
-            </label>
+            </div>
         </div>
     @endforeach
 </div>

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -1,0 +1,43 @@
+<x-forms::field-wrapper
+    :id="$getId()"
+    :label="$getLabel()"
+    :label-sr-only="$isLabelHidden()"
+    :helper-text="$getHelperText()"
+    :hint="$getHint()"
+    :required="$isRequired()"
+    :state-path="$getStatePath()"
+>
+<div class="space-y-4">
+    @foreach ($getOptions() as $value => $label)
+        <div class="flex items-center">
+            <input
+                name="{{ $getId() }}"
+                id="{{ $value }}"
+                type="radio"
+                value="{{ $value }}"
+                {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
+                {{ $attributes->merge($getExtraAttributes())->class([
+                    'focus:ring-primary-500 h-4 w-4 text-primary-600',
+                    'border-gray-300' => ! $errors->has($getStatePath()),
+                    'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
+                ]) }}
+                {!! $isOptionDisabled($value, $label) ? 'disabled' : null !!}
+            />
+            <label for="{{ $value }}" @class([
+                'block ml-3 text-sm font-medium',
+                'text-gray-700' => ! $errors->has($getStatePath()),
+                'text-danger-600' => $errors->has($getStatePath()),
+            ])>
+
+                {{ $label }}
+
+                @if($hasDescription($value))
+                    <p id="{{ $value }}-description" class="text-gray-500">
+                        {{ $getDescription($value) }}
+                    </p>
+                @endif
+            </label>
+        </div>
+    @endforeach
+</div>
+</x-forms::field-wrapper>

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -13,7 +13,7 @@
             <div class="flex items-center h-5">
                 <input
                     name="{{ $getId() }}"
-                    id="{{ $value }}"
+                    id="{{ $getId() }}-{{ $value }}"
                     type="radio"
                     value="{{ $value }}"
                     {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
@@ -26,7 +26,7 @@
                 />
             </div>
             <div class="ml-3 text-sm">
-                <label for="{{ $value }}" @class([
+                <label for="{{ $getId() }}-{{ $value }}" @class([
                     'font-medium',
                     'text-gray-700' => ! $errors->has($getStatePath()),
                     'text-danger-600' => $errors->has($getStatePath()),
@@ -34,8 +34,8 @@
                     {{ $label }}
                 </label>
 
-                @if($hasDescription($value))
-                    <p id="{{ $value }}-description" class="text-gray-500">
+                @if ($hasDescription($value))
+                    <p class="text-gray-500">
                         {{ $getDescription($value) }}
                     </p>
                 @endif

--- a/packages/forms/src/Components/Radio.php
+++ b/packages/forms/src/Components/Radio.php
@@ -76,15 +76,22 @@ class Radio extends Field
         return $options;
     }
 
+    public function descriptions(array | Arrayable | callable $descriptions): static
+    {
+        $this->descriptions = $descriptions;
+
+        return $this;
+    }
+
     public function hasDescription($value): bool
     {
-        return isset($this->getDescriptions[$value]);
+        return isset($this->getDescriptions()[$value]);
     }
 
     public function getDescription($value): string
     {
         if ($this->hasDescription($value)) {
-            return $this->getDescriptions[$value];
+            return $this->getDescriptions()[$value];
         }
 
         return '';

--- a/packages/forms/src/Components/Radio.php
+++ b/packages/forms/src/Components/Radio.php
@@ -17,14 +17,6 @@ class Radio extends Field
     protected function setUp(): void
     {
         parent::setUp();
-
-        $this->getOptionLabelUsing(function (Radio $component, $value): ?string {
-            if (array_key_exists($value, $options = $component->getOptions())) {
-                return $options[$value];
-            }
-
-            return $value;
-        });
     }
 
     public function boolean(string $trueLabel = 'Yes', string $falseLabel = 'No'): static
@@ -44,36 +36,11 @@ class Radio extends Field
         return $this;
     }
 
-    public function getOptionLabelUsing(callable $callback): static
-    {
-        $this->getOptionLabelUsing = $callback;
-
-        return $this;
-    }
-
     public function options(array | Arrayable | callable $options): static
     {
         $this->options = $options;
 
         return $this;
-    }
-
-    public function getOptionLabel(): ?string
-    {
-        return $this->evaluate($this->getOptionLabelUsing, [
-            'value' => $this->getState(),
-        ]);
-    }
-
-    public function getOptions(): array
-    {
-        $options = $this->evaluate($this->options);
-
-        if ($options instanceof Arrayable) {
-            $options = $options->toArray();
-        }
-
-        return $options;
     }
 
     public function descriptions(array | Arrayable | callable $descriptions): static
@@ -85,16 +52,12 @@ class Radio extends Field
 
     public function hasDescription($value): bool
     {
-        return isset($this->getDescriptions()[$value]);
+        return array_key_exists($value, $this->getDescriptions());
     }
 
-    public function getDescription($value): string
+    public function getDescription($value): ?string
     {
-        if ($this->hasDescription($value)) {
-            return $this->getDescriptions()[$value];
-        }
-
-        return '';
+        return $this->getDescriptions()[$value] ?? null;
     }
 
     public function getDescriptions(): array
@@ -106,6 +69,17 @@ class Radio extends Field
         }
 
         return $descriptions;
+    }
+
+    public function getOptions(): array
+    {
+        $options = $this->evaluate($this->options);
+
+        if ($options instanceof Arrayable) {
+            $options = $options->toArray();
+        }
+
+        return $options;
     }
 
     public function isOptionDisabled($value, string $label): bool

--- a/packages/forms/src/Components/Radio.php
+++ b/packages/forms/src/Components/Radio.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Filament\Forms\Components;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class Radio extends Field
+{
+    protected string $view = 'forms::components.radio';
+
+    protected $options = [];
+
+    protected $descriptions = [];
+
+    protected $isOptionDisabled = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->getOptionLabelUsing(function (Radio $component, $value): ?string {
+            if (array_key_exists($value, $options = $component->getOptions())) {
+                return $options[$value];
+            }
+
+            return $value;
+        });
+    }
+
+    public function boolean(string $trueLabel = 'Yes', string $falseLabel = 'No'): static
+    {
+        $this->options([
+            1 => $trueLabel,
+            0 => $falseLabel,
+        ]);
+
+        return $this;
+    }
+
+    public function disableOptionWhen(bool | callable $callback): static
+    {
+        $this->isOptionDisabled = $callback;
+
+        return $this;
+    }
+
+    public function getOptionLabelUsing(callable $callback): static
+    {
+        $this->getOptionLabelUsing = $callback;
+
+        return $this;
+    }
+
+    public function options(array | Arrayable | callable $options): static
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    public function getOptionLabel(): ?string
+    {
+        return $this->evaluate($this->getOptionLabelUsing, [
+            'value' => $this->getState(),
+        ]);
+    }
+
+    public function getOptions(): array
+    {
+        $options = $this->evaluate($this->options);
+
+        if ($options instanceof Arrayable) {
+            $options = $options->toArray();
+        }
+
+        return $options;
+    }
+
+    public function hasDescription($value): bool
+    {
+        return isset($this->getDescriptions[$value]);
+    }
+
+    public function getDescription($value): string
+    {
+        if ($this->hasDescription($value)) {
+            return $this->getDescriptions[$value];
+        }
+
+        return '';
+    }
+
+    public function getDescriptions(): array
+    {
+        $descriptions = $this->evaluate($this->descriptions);
+
+        if ($descriptions instanceof Arrayable) {
+            $descriptions = $descriptions->toArray();
+        }
+
+        return $descriptions;
+    }
+
+    public function isOptionDisabled($value, string $label): bool
+    {
+        if ($this->isOptionDisabled === null) {
+            return false;
+        }
+
+        return (bool) $this->evaluate($this->isOptionDisabled, [
+            'label' => $label,
+            'value' => $value,
+        ]);
+    }
+}


### PR DESCRIPTION
This PR adds a new field called `Radio`.  This allows you to define a radio button group using the following API:

```php
use Filament\Forms\Components\Radio;

Radio::make('status')
    ->options([
        'draft' => 'Draft',
        'scheduled' => 'Scheduled',
        'published' => 'Published'
    ])
```

The HTML output would look something like this:

<img width="159" alt="Screen Shot 2021-11-24 at 10 40 46 PM" src="https://user-images.githubusercontent.com/4267904/143392397-bc5f2a9d-9cd5-4ff1-a640-3158e828027e.png">


You can optionally add descriptions to the options:

```php
use Filament\Forms\Components\Radio;

Radio::make('status')
    ->options([
        'draft' => 'Draft',
        'scheduled' => 'Scheduled',
        'published' => 'Published'
    ])
    ->descriptions([
        'draft' => 'Is not visible.',
        'scheduled' => 'Will be visible.',
        'published' => 'Is visible.'
    ]);
```

The HTML output would look something like this:

<img width="258" alt="Screen Shot 2021-11-24 at 10 20 34 PM" src="https://user-images.githubusercontent.com/4267904/143392144-4f71cbbd-8a2c-4195-901e-9bd178e689af.png">

If you only want a simple `Yes` or `No` radio button group that returns a `boolean` value:

```php
use Filament\Forms\Components\Radio;

Radio::make('is_public')->boolean()
```

HTML Output:

<img width="152" alt="Screen Shot 2021-11-24 at 10 20 08 PM" src="https://user-images.githubusercontent.com/4267904/143392681-99a987a3-11eb-4d0c-81c9-4caf5a0e6f77.png">

I've also updated the documentation to include a new field called `Radio`.