### PR TITLE
feature(tables): support passing callable to table heading

### DIFF
--- a/packages/tables/src/Concerns/HasHeader.php
+++ b/packages/tables/src/Concerns/HasHeader.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Tables\Concerns;
 
+use Closure;
 use Filament\Tables\Actions\Action;
 use Illuminate\Contracts\View\View;
 
@@ -46,7 +47,7 @@ trait HasHeader
         return [];
     }
 
-    protected function getTableHeading(): string | callable | null
+    protected function getTableHeading(): string | Closure | null
     {
         return null;
     }

--- a/packages/tables/src/Concerns/HasHeader.php
+++ b/packages/tables/src/Concerns/HasHeader.php
@@ -46,7 +46,7 @@ trait HasHeader
         return [];
     }
 
-    protected function getTableHeading(): ?string
+    protected function getTableHeading(): string | callable | null
     {
         return null;
     }

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -35,7 +35,7 @@ class Table extends ViewComponent implements Htmlable
 
     protected ?View $header = null;
 
-    protected string | null | Closure $heading = null;
+    protected string | Closure | null $heading = null;
 
     protected bool $isPaginationEnabled = true;
 
@@ -109,9 +109,9 @@ class Table extends ViewComponent implements Htmlable
         return $this;
     }
 
-    public function heading(string | null | callable $heading): static
+    public function heading(string | Closure | null $heading): static
     {
-        $this->heading = is_callable($heading) ? Closure::fromCallable($heading) : $heading;
+        $this->heading = $heading;
 
         return $this;
     }

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Tables;
 
+use Closure;
 use Filament\Forms\ComponentContainer;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\BulkAction;
@@ -34,7 +35,7 @@ class Table extends ViewComponent implements Htmlable
 
     protected ?View $header = null;
 
-    protected ?string $heading = null;
+    protected string | null | Closure $heading = null;
 
     protected bool $isPaginationEnabled = true;
 
@@ -108,9 +109,9 @@ class Table extends ViewComponent implements Htmlable
         return $this;
     }
 
-    public function heading(?string $heading): static
+    public function heading(string | null | callable $heading): static
     {
-        $this->heading = $heading;
+        $this->heading = is_callable($heading) ? Closure::fromCallable($heading) : $heading;
 
         return $this;
     }
@@ -209,7 +210,7 @@ class Table extends ViewComponent implements Htmlable
 
     public function getHeading(): ?string
     {
-        return $this->heading;
+        return value($this->heading);
     }
 
     public function getMountedAction(): ?Action


### PR DESCRIPTION
Allows you to return a Closure/callable from `getTableHeading` that will compute the value at render/call-time.

> `callable` isn't a valid prop-type, hence the conversion into a `Closure`.