### PR TITLE
feature(tables): support static select filters

### DIFF
--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -10,10 +10,16 @@ class SelectFilter extends Filter
 {
     protected ?string $column = null;
 
+    protected bool $static = false;
+
     protected array | Arrayable $options = [];
 
     public function apply(Builder $query, array $data = []): Builder
     {
+        if ($this->static) {
+            return $query;
+        }
+
         if ($this->hasQueryModificationCallback()) {
             return parent::apply($query, $data);
         }
@@ -37,6 +43,13 @@ class SelectFilter extends Filter
     public function options(array | Arrayable $options): static
     {
         $this->options = $options;
+
+        return $this;
+    }
+
+    public function static(bool $static = true): static
+    {
+        $this->static = $static;
 
         return $this;
     }

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -10,13 +10,13 @@ class SelectFilter extends Filter
 {
     protected ?string $column = null;
 
-    protected bool $static = false;
+    protected bool $isStatic = false;
 
     protected array | Arrayable $options = [];
 
     public function apply(Builder $query, array $data = []): Builder
     {
-        if ($this->static) {
+        if ($this->isStatic) {
             return $query;
         }
 
@@ -47,9 +47,9 @@ class SelectFilter extends Filter
         return $this;
     }
 
-    public function static(bool $static = true): static
+    public function static(bool $condition = true): static
     {
-        $this->static = $static;
+        $this->isStatic = $condition;
 
         return $this;
     }


### PR DESCRIPTION
Adds a new `SelectFilter::static()` method that will prevent the filter from automatically modifying the query with a `where` or deferred `query()` callback.

Useful for pseudo-filters that need to be handled manually (without creating a custom form, etc).