### PR TITLE
Wrap tags

### DIFF
--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -38,7 +38,7 @@
                 x-show="state.length"
                 class="overflow-hidden rtl:space-x-reverse relative w-full px-1 py-1"
             >
-                <div class="flex gap-1">
+                <div class="flex flex-wrap gap-1">
                     <template class="inline" x-for="tag in state" x-bind:key="tag">
                         <button
                             @unless ($isDisabled())


### PR DESCRIPTION
If there are many tags, so they do not fit into one row, the tags are cut off currently. By using `.flex-wrap` the tags wrap into the next row.