### PR TITLE
White background

### DIFF
--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -275,7 +275,7 @@
                 toolbar="trix-toolbar-{{ $getId() }}"
                 x-ref="trix"
                 {{ $attributes->merge($getExtraAttributes())->class([
-                    'block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-600 prose max-w-none',
+                    'bg-white block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-600 prose max-w-none',
                     'border-gray-300' => ! $errors->has($getStatePath()),
                     'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
                 ]) }}


### PR DESCRIPTION
Add `bg-white` to align with other inputs white background. Not sure if that was left out intentionally for some reason?