### PR TITLE
Make classes configurable

### DIFF
--- a/packages/admin/config/filament.php
+++ b/packages/admin/config/filament.php
@@ -177,4 +177,17 @@ return [
         ],
     ],
 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default classes
+    |--------------------------------------------------------------------------
+    |
+    | You may customise some parts of filaments default classes
+    |
+    */
+
+    'styles' => [
+        'form_action_buttons' => 'flex flex-wrap items-center gap-4'
+    ]
 ];

--- a/packages/admin/config/filament.php
+++ b/packages/admin/config/filament.php
@@ -188,6 +188,7 @@ return [
     */
 
     'styles' => [
+        'sidebar_container' => 'fixed inset-y-0 left-0 z-20 flex flex-col h-screen overflow-hidden shadow-2xl transition duration-300 bg-white lg:border-r w-80 lg:z-0 lg:translate-x-0',
         'form_action_buttons' => 'flex flex-wrap items-center gap-4'
     ]
 ];

--- a/packages/admin/config/filament.php
+++ b/packages/admin/config/filament.php
@@ -188,7 +188,7 @@ return [
     */
 
     'styles' => [
-        'sidebar_container' => 'fixed inset-y-0 left-0 z-20 flex flex-col h-screen overflow-hidden shadow-2xl transition duration-300 bg-white lg:border-r w-80 lg:z-0 lg:translate-x-0',
+        'sidebar_container' => 'fixed inset-y-0 left-0 z-20 flex flex-col h-screen overflow-hidden shadow-2xl rounded-r-2xl transition duration-300 bg-white lg:border-r w-80 lg:z-0 lg:translate-x-0',
         'form_action_buttons' => 'flex flex-wrap items-center gap-4'
     ]
 ];

--- a/packages/admin/resources/views/components/actions/index.blade.php
+++ b/packages/admin/resources/views/components/actions/index.blade.php
@@ -13,7 +13,7 @@
     @endphp
 
     @if (count($actions))
-        <div {{ $attributes->class(['flex flex-wrap items-center gap-4']) }}>
+        <div {{ $attributes->class([config("filament.styles.form_action_button_row")]) }}>
             @foreach ($actions as $action)
                 {{ $action }}
             @endforeach

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -2,7 +2,7 @@
     x-data="{}"
     x-cloak
     x-bind:class="$store.sidebar.isOpen ? 'translate-x-0' : '-translate-x-full'"
-    class="fixed inset-y-0 left-0 z-20 flex flex-col h-screen overflow-hidden shadow-2xl rounded-r-2xl transition duration-300 bg-white lg:border-r w-80 lg:z-0 lg:translate-x-0"
+    class="{{ config("filament.styles.sidebar_container") }}"
 >
     <header class="border-b h-[4rem] flex-shrink-0 px-6 flex items-center">
         <a href="{{ \Filament\Facades\Filament::geturl() }}">


### PR DESCRIPTION
As discussed yesterday on discord, I have made the classes of the button row on forms and the sidebar configurable. I have wrapped it into `styles` array, so someone could add more class-configs in the future.

With this pull request, a developer can change for example the placement  of the buttons to center:

```
'form_action_button_row' => 'flex flex-wrap items-center gap-4 justify-center'
```

![image](https://user-images.githubusercontent.com/642292/145567369-251276dd-0a63-4d91-8989-f687bef05c58.png)

and he can for example remove the (in my opinion) weird rounded corners in the sidebar:

```
'sidebar_container' => 'fixed inset-y-0 left-0 z-20 flex flex-col h-screen overflow-hidden shadow-2xl transition duration-300 bg-white lg:border-r w-80 lg:z-0 lg:translate-x-0',
```

![image](https://user-images.githubusercontent.com/642292/145567633-3f48fe69-582f-4eb4-862e-394b2e403f0b.png)

As default value, I have used your existing classes (so the buttons are left for now and there are still these rounded corners on the sidebar).

What do you think?