### PR TITLE
Fix typo for Tailwind CSS init command

### DIFF
--- a/packages/admin/docs/07-appearance.md
+++ b/packages/admin/docs/07-appearance.md
@@ -12,7 +12,7 @@ Themes use [Tailwind CSS](https://tailwindcss.com), the Tailwind Forms plugin, a
 npm install tailwindcss @tailwindcss/forms @tailwindcss/typography --save-dev
 ```
 
-To finish installing Tailwind, you must create a new `tailwind.config.js` file in the root of your project. The easiest way to do this is by running `npm tailwindcss init`.
+To finish installing Tailwind, you must create a new `tailwind.config.js` file in the root of your project. The easiest way to do this is by running `npx tailwindcss init`.
 
 In `tailwind.config.js`, enable JIT mode, register the plugins you installed, and add custom colors used by the form builder:
 


### PR DESCRIPTION
The command should use `npx` instead of `npm` as documented in the official Tailwind CSS docs: https://tailwindcss.com/docs/installation