### PR TITLE
 Allow to display a conversion

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/docs/03-table-columns.md
+++ b/packages/spatie-laravel-media-library-plugin/docs/03-table-columns.md
@@ -20,4 +20,12 @@ SpatieMediaLibraryImageColumn::make('avatar')->collection('avatars'),
 
 The [collection](https://spatie.be/docs/laravel-medialibrary/v9/working-with-media-collections/simple-media-collections) you to group files into categories.
 
+You may also specify a `conversion()` to use, if present:
+
+```php
+use Filament\Tables\Components\SpatieMediaLibraryImageColumn;
+
+SpatieMediaLibraryImageColumn::make('avatar')->conversion('thumb'),
+```
+
 The media library image column supports all the customization options of the [original image column](/docs/tables/columns#image-column).

--- a/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -9,7 +9,7 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
 {
     protected ?string $collection = null;
 
-    protected ?string $conversion = '';
+    protected string $conversion = '';
 
     public function collection(string $collection): static
     {
@@ -30,7 +30,7 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
         return $this->collection ?? 'default';
     }
 
-    public function getConversion(Media $media): ?string
+    public function getConversion(Media $media): string
     {
         return $media->hasGeneratedConversion($this->conversion) ? $this->conversion : '';
     }

--- a/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -3,10 +3,13 @@
 namespace Filament\Tables\Columns;
 
 use Illuminate\Database\Eloquent\Builder;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class SpatieMediaLibraryImageColumn extends ImageColumn
 {
     protected ?string $collection = null;
+
+    protected ?string $conversion = '';
 
     public function collection(string $collection): static
     {
@@ -15,9 +18,21 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
         return $this;
     }
 
+    public function conversion(string $conversion): static
+    {
+        $this->conversion = $conversion;
+
+        return $this;
+    }
+
     public function getCollection(): ?string
     {
         return $this->collection ?? 'default';
+    }
+
+    public function getConversion(Media $media): ?string
+    {
+        return $media->hasGeneratedConversion($this->conversion) ? $this->conversion : '';
     }
 
     public function getImagePath(): ?string
@@ -32,7 +47,7 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
             ->getMedia($this->getCollection())
             ->first();
 
-        return $media?->getUrl();
+        return $media?->getUrl($this->getConversion($media));
     }
 
     public function applyEagreLoading(Builder $query): Builder


### PR DESCRIPTION
Pass a conversion name along (e.g. 'thumb') to display a converted image rather then original.

- if no conversion provided: return empty string (will display the original image)
- if conversion doesn't exist on collection: return empty string (will display the original image)
- if conversion exist: profit