### PR TITLE
Use slug syntax for dayjs locale files

### DIFF
--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -7,7 +7,7 @@
 
             window.dayjs_locale = dayjs.locale()
         </script>
-        <script src="//unpkg.com/dayjs@1.10.4/locale/{{ \Illuminate\Support\Str::of(app()->getLocale())->slug() }}.js"></script>
+        <script src="//unpkg.com/dayjs@1.10.4/locale/{{ strtolower(str_replace('_', '-', app()->getLocale())) }}.js"></script>
     @endpush
 @endonce
 

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -7,7 +7,7 @@
 
             window.dayjs_locale = dayjs.locale()
         </script>
-        <script src="//unpkg.com/dayjs@1.10.4/locale/{{ \Illuminate\Support\Str::of(app()->getLocale())->lower()->kebab() }}.js"></script>
+        <script src="//unpkg.com/dayjs@1.10.4/locale/{{ \Illuminate\Support\Str::of(app()->getLocale())->slug() }}.js"></script>
     @endpush
 @endonce
 


### PR DESCRIPTION
There was a small bug causing wrong locale url for DayJS.

Wrong url:
https://unpkg.com/dayjs@1.10.4/locale/pt_br.js

the correct is:
https://unpkg.com/dayjs@1.10.4/locale/pt-br.js

