### PR TITLE
Fix the signed number mask

### DIFF
--- a/packages/forms/src/Components/TextInput/Mask.php
+++ b/packages/forms/src/Components/TextInput/Mask.php
@@ -315,8 +315,8 @@ class Mask implements Jsonable
             $configuration['scale'] = $this->decimalPlaces;
         }
 
-        if (! $this->isSigned) {
-            $configuration['signed'] = false;
+        if ($this->isSigned) {
+            $configuration['signed'] = true;
         }
 
         if ($this->thousandsSeparator !== null) {


### PR DESCRIPTION
in Imask.js the "signed" option is false by default