### PR TITLE
Dashboard label translation and icon customization

### DIFF
--- a/packages/admin/config/filament.php
+++ b/packages/admin/config/filament.php
@@ -73,6 +73,9 @@ return [
         'register' => [
             Pages\Dashboard::class,
         ],
+        'dashboard' => [
+            'icon' => 'heroicon-o-home',
+        ],
     ],
 
     /*

--- a/packages/admin/resources/lang/en/pages/dashboard.php
+++ b/packages/admin/resources/lang/en/pages/dashboard.php
@@ -3,5 +3,6 @@
 return [
 
     'title' => 'Dashboard',
+    'label' => 'Dashboard',
 
 ];

--- a/packages/admin/src/Pages/Dashboard.php
+++ b/packages/admin/src/Pages/Dashboard.php
@@ -7,7 +7,10 @@ use Illuminate\Support\Facades\Route;
 
 class Dashboard extends Page
 {
-    protected static ?string $navigationIcon = 'heroicon-o-home';
+    protected static function getNavigationIcon(): string
+    {
+        return config('filament.pages.dashboard.icon', 'heroicon-o-home');
+    }
 
     protected static ?int $navigationSort = -2;
 
@@ -18,6 +21,11 @@ class Dashboard extends Page
         return function () {
             Route::get('/', static::class)->name(static::getSlug());
         };
+    }
+    
+    protected static function getNavigationLabel(): string
+    {
+        return static::$navigationLabel ?? __('filament::pages/dashboard.label');
     }
 
     protected function getTitle(): string


### PR DESCRIPTION
Currently title is translated.
Should the label also use filament::pages/dashboard.title?
Or separate for the option of them being different?