### PR TITLE
fix: Badge columns unexpectedly ignoring falsy values

### DIFF
--- a/packages/tables/resources/views/columns/badge-column.blade.php
+++ b/packages/tables/resources/views/columns/badge-column.blade.php
@@ -1,4 +1,6 @@
 @php
+    $state = $getFormattedState();
+
     $stateColor = match ($getStateColor()) {
         'danger' => 'text-danger-700 bg-danger-500/10',
         'primary' => 'text-primary-700 bg-primary-500/10',
@@ -9,7 +11,7 @@
 @endphp
 
 <div class="px-4 py-3">
-    @if ($state = $getFormattedState())
+    @if ($state !== null)
         <span @class([
             'inline-flex items-center justify-center h-6 px-2 text-sm font-medium tracking-tight rounded-full',
             $stateColor => $stateColor,

--- a/packages/tables/resources/views/columns/badge-column.blade.php
+++ b/packages/tables/resources/views/columns/badge-column.blade.php
@@ -11,7 +11,7 @@
 @endphp
 
 <div class="px-4 py-3">
-    @if ($state !== null)
+    @if (blank($state))
         <span @class([
             'inline-flex items-center justify-center h-6 px-2 text-sm font-medium tracking-tight rounded-full',
             $stateColor => $stateColor,


### PR DESCRIPTION
Badge columns will currently ignore any falsy values such as 0 or '0'.

My proposed solution is to explicitly check that the formatted state is null.