### PR TITLE
fix: use exists property

### DIFF
--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -54,7 +54,7 @@ trait HasState
 
             $componentModel = $component->getModel();
 
-            if ($componentModel instanceof Model && $componentModel->exists()) {
+            if ($componentModel instanceof Model && $componentModel->exists) {
                 $component->saveRelationships();
             }
 


### PR DESCRIPTION
Using ->exists() on eloquent model execute query on each call.
Replace by property to use cached value.