### PR TITLE
feature: set mountedTableActionRecord

### DIFF
--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanCreateRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanCreateRecords.php
@@ -46,6 +46,8 @@ trait CanCreateRecords
 
         $record = $this->getRelationship()->create($data);
         $form->model($record)->saveRelationships();
+        
+        $this->mountedTableActionRecord = $record->getKey();
 
         $this->callHook('afterCreate');
 


### PR DESCRIPTION
Set the `mountedTableActionRecord` after creating a record. Useful for edge cases and it follows the same behaviour (as expected) from the update concern