### PR TITLE
changed the color of placeholder to gray-500

### DIFF
--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -73,7 +73,7 @@
                 <span
                     x-show="! isOpen"
                     x-text="label ?? '{{ addslashes($getPlaceholder()) }}'"
-                    x-bind:class="label ? '' : 'text-gray-500'"
+                    x-bind:class="label ? '' : 'text-gray-500 select-none'"
                     class="absolute w-full bg-white"
                 ></span>
 

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -73,6 +73,7 @@
                 <span
                     x-show="! isOpen"
                     x-text="label ?? '{{ addslashes($getPlaceholder()) }}'"
+                    x-bind:class="label ? '' : 'text-gray-500'"
                     class="absolute w-full bg-white"
                 ></span>
 


### PR DESCRIPTION
Placeholder color is changed to `text-gray-500` and added `select-none`.

Old:
<img width="623" alt="Screen Shot 2021-12-23 at 14 09 56" src="https://user-images.githubusercontent.com/1384327/147196286-9ac122b1-07a0-4f87-ac35-fa8d11eb991f.png">

New:
<img width="626" alt="Screen Shot 2021-12-23 at 14 08 16" src="https://user-images.githubusercontent.com/1384327/147196163-a3f8a9db-02b5-4d68-b840-b9b207c88377.png">
