### PR TITLE
Fix syntax error in toggle field example

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -549,7 +549,7 @@ Toggles may also use an "on icon" and an "off icon". These are displayed on its 
 use Filament\Forms\Components\Toggle;
 
 Toggle::make('is_admin')
-    ->onIcon('heroicon-s-lightning-bolt'),
+    ->onIcon('heroicon-s-lightning-bolt')
     ->offIcon('heroicon-s-user')
 ```
 


### PR DESCRIPTION
When copy-pasting the `Toggle` on/off icon snippet, I noticed that there's a comma in a place it doesn't belong, causing a syntax error.

This PR fixes that :)