### PR TITLE
Allow overwrite forms for views

### DIFF
--- a/packages/admin/src/Resources/Pages/Concerns/UsesResourceForm.php
+++ b/packages/admin/src/Resources/Pages/Concerns/UsesResourceForm.php
@@ -11,7 +11,11 @@ trait UsesResourceForm
     protected function getResourceForm(): Form
     {
         if (! $this->resourceForm) {
-            $this->resourceForm = static::getResource()::form(Form::make()->columns(2));
+            if (method_exists(static::class, 'customForm')) {
+                $this->resourceForm = static::customForm(Form::make()->columns(2));
+            } else {
+                $this->resourceForm = static::getResource()::form(Form::make()->columns(2));
+            }
         }
 
         return $this->resourceForm;


### PR DESCRIPTION
I wanted to be able to overwrite the form for each view (create, edit, view). The documentation does not contain information about this. I found the simplest solution that may not be correct. And I decided to share it. Now I can implement a method in each view that will overwrite the default form. For example:
```
class ViewCustomer extends ViewRecord
{
    protected static string $resource = CustomerResource::class;

    public static function customForm(Form $form): Form
    {
        return $form
            ->schema([]);
    }
}
```

