### PR TITLE
feature: Builder component: ability to disable add / delete button [Forms]

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -48,17 +48,19 @@
                                         </button>
                                     @endunless
 
-                                    <button
-                                        wire:click="dispatchFormEvent('builder::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
-                                        type="button"
-                                        class="w-full flex items-center justify-center h-8 text-danger-600 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-danger-600 focus:bg-primary-50 focus:border-primary-600"
-                                    >
-                                        <span class="sr-only">
-                                            {{ __('forms::components.builder.buttons.delete_item.label') }}
-                                        </span>
+                                    @unless($isItemDeletionDisabled())
+                                        <button
+                                            wire:click="dispatchFormEvent('builder::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                            type="button"
+                                            class="w-full flex items-center justify-center h-8 text-danger-600 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-danger-600 focus:bg-primary-50 focus:border-primary-600"
+                                        >
+                                            <span class="sr-only">
+                                                {{ __('forms::components.builder.buttons.delete_item.label') }}
+                                            </span>
 
-                                        <x-heroicon-s-trash class="w-5 h-5" />
-                                    </button>
+                                            <x-heroicon-s-trash class="w-5 h-5" />
+                                        </button>
+                                    @endunless
                                 </div>
                             </div>
 
@@ -122,7 +124,7 @@
             </ul>
         @endif
 
-        @if (blank($getMaxItems()) || ($getMaxItems() > $getItemsCount()))
+        @if (blank($getMaxItems()) || ($getMaxItems() > $getItemsCount()) || $isItemCreationDisabled())
             <div x-data="{ isCreateButtonDropdownOpen: false }" class="relative flex justify-center">
                 <button
                     x-on:click="isCreateButtonDropdownOpen = true"

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -21,6 +21,10 @@ class Builder extends Field
     protected string | Closure | null $createItemButtonLabel = null;
 
     protected bool | Closure $isItemMovementDisabled = false;
+    
+    protected bool | Closure $isItemCreationDisabled = false;
+    
+    protected bool | Closure $isItemDeletionDisabled = false;
 
     protected function setUp(): void
     {
@@ -43,6 +47,10 @@ class Builder extends Field
                         return;
                     }
 
+                    if ($component->isItemCreationDisabled()) {
+                        return;
+                    }
+                    
                     if ($statePath !== $component->getStatePath()) {
                         return;
                     }
@@ -77,6 +85,10 @@ class Builder extends Field
             'builder::deleteItem' => [
                 function (Builder $component, string $statePath, string $uuidToDelete): void {
                     if ($component->isDisabled()) {
+                        return;
+                    }
+                    
+                    if ($component->isItemDeletionDisabled()) {
                         return;
                     }
 
@@ -175,6 +187,20 @@ class Builder extends Field
         return $this;
     }
 
+    public function disableItemCreation(bool | Closure $condition = true): static
+    {
+        $this->isItemCreationDisabled = $condition;
+
+        return $this;
+    }
+    
+    public function disableItemDeletion(bool | Closure $condition = true): static
+    {
+        $this->isItemDeletionDisabled = $condition;
+
+        return $this;
+    }    
+
     public function hydrateDefaultItemState(string $uuid): void
     {
         $this->getChildComponentContainers()[$uuid]->hydrateDefaultState();
@@ -222,5 +248,15 @@ class Builder extends Field
     public function isItemMovementDisabled(): bool
     {
         return $this->evaluate($this->isItemMovementDisabled);
+    }
+    
+    public function isItemCreationDisabled(): bool
+    {
+        return $this->evaluate($this->isItemCreationDisabled);
+    }
+
+    public function isItemDeletionDisabled(): bool
+    {
+        return $this->evaluate($this->isItemDeletionDisabled);
     }
 }


### PR DESCRIPTION
Offers the ability to disable the adding and/or removing of items (blocks) in the block builder component. Along with the existing "disableItemMovement" there will be two new methods available:

```php
->disableItemCreation($bool | Closure $condition = true)

->disableItemDeletion($bool | Closure $condition = true)
```

Example
```php
public static function form(Form $form): Form
{
    return $form
        ->schema([
            Builder::make('blocks')
                ->disableItemCreation(true)
                ->disableItemDeletion(true)

                // existing method
                ->disableItemMovement(false)
                ->blocks([
                    Builder\Block::make('heading')
                        ->schema([
                            TextInput::make('content')->required(),
                            Select::make('level')
                                ->options([
                                    'h1' => 'Heading 1',
                                    'h2' => 'Heading 2',
                                ])
                                ->required(),
                        ]),
                    Builder\Block::make('paragraph')
                        ->schema([
                            MarkdownEditor::make('content')->required(),
                        ]),
                ])
        ]);
}
```