### PR TITLE
feature: Builder component: ability to disable add / delete button [Forms]

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -7,81 +7,76 @@
     :required="$isRequired()"
     :state-path="$getStatePath()"
 >
-    <div {{ $attributes->merge($getExtraAttributes())->class(['space-y-4']) }}>
+    <div {{ $attributes->merge($getExtraAttributes())->class(['space-y-2']) }}>
         @if (count($containers = $getChildComponentContainers()))
-            <ul>
+            <ul class="space-y-2">
                 @foreach ($containers as $uuid => $item)
                     <li
                         x-data="{ isCreateButtonDropdownOpen: false, isCreateButtonVisible: false }"
                         x-on:click="isCreateButtonVisible = true"
                         x-on:click.away="isCreateButtonVisible = false"
                         wire:key="{{ $item->getStatePath() }}"
+                        class="relative p-6 bg-white shadow-sm rounded-lg border border-gray-300"
                     >
-                        <div class="flex">
-                            @unless ($isItemMovementDisabled() && $isItemDeletionDisabled())
-                            <div class="w-8">
-                                <div class="bg-white divide-y shadow-sm rounded-l-lg border-b border-l border-t border-gray-300 overflow-hidden">
-                                    @unless ($loop->first || $isItemMovementDisabled())
-                                        <button
-                                            wire:click="dispatchFormEvent('builder::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
-                                            type="button"
-                                            class="w-full flex items-center justify-center h-8 text-gray-800 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600"
-                                        >
-                                            <span class="sr-only">
-                                                {{ __('forms::components.builder.buttons.move_item_up.label') }}
-                                            </span>
+                        {{ $item }}
 
-                                            <x-heroicon-s-chevron-up class="w-5 h-5" />
-                                        </button>
-                                    @endunless
+                        @unless ($isItemDeletionDisabled() && ($isItemMovementDisabled() && ($loop->count <= 1)))
+                            <div class="absolute top-0 right-0 h-6 flex divide-x rounded-bl-lg rounded-tr-lg border-gray-300 border-b border-l overflow-hidden">
+                                @unless ($loop->first || $isItemMovementDisabled())
+                                    <button
+                                        wire:click="dispatchFormEvent('builder::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                        type="button"
+                                        class="flex items-center justify-center w-6 text-gray-800 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600"
+                                    >
+                                        <span class="sr-only">
+                                            {{ __('forms::components.repeater.buttons.move_item_up.label') }}
+                                        </span>
 
-                                    @unless ($loop->last || $isItemMovementDisabled())
-                                        <button
-                                            wire:click="dispatchFormEvent('builder::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
-                                            type="button"
-                                            class="w-full flex items-center justify-center h-8 text-gray-800 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600"
-                                        >
-                                            <span class="sr-only">
-                                                {{ __('forms::components.builder.buttons.move_item_down.label') }}
-                                            </span>
+                                        <x-heroicon-s-chevron-up class="w-4 h-4" />
+                                    </button>
+                                @endunless
 
-                                            <x-heroicon-s-chevron-down class="w-5 h-5" />
-                                        </button>
-                                    @endunless
+                                @unless ($loop->last || $isItemMovementDisabled())
+                                    <button
+                                        wire:click="dispatchFormEvent('builder::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                        type="button"
+                                        class="flex items-center justify-center w-6 text-gray-800 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600"
+                                    >
+                                        <span class="sr-only">
+                                            {{ __('forms::components.repeater.buttons.move_item_down.label') }}
+                                        </span>
 
-                                    @unless($isItemDeletionDisabled())
-                                        <button
-                                            wire:click="dispatchFormEvent('builder::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
-                                            type="button"
-                                            class="w-full flex items-center justify-center h-8 text-danger-600 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-danger-600 focus:bg-primary-50 focus:border-primary-600"
-                                        >
-                                            <span class="sr-only">
-                                                {{ __('forms::components.builder.buttons.delete_item.label') }}
-                                            </span>
+                                        <x-heroicon-s-chevron-down class="w-4 h-4" />
+                                    </button>
+                                @endunless
 
-                                            <x-heroicon-s-trash class="w-5 h-5" />
-                                        </button>
-                                    @endunless
-                                </div>
+                                @unless ($isItemDeletionDisabled())
+                                    <button
+                                        wire:click="dispatchFormEvent('builder::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                        type="button"
+                                        class="flex items-center justify-center w-6 text-danger-600 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-danger-600 focus:bg-primary-50 focus:border-primary-600"
+                                    >
+                                        <span class="sr-only">
+                                            {{ __('forms::components.repeater.buttons.delete_item.label') }}
+                                        </span>
+
+                                        <x-heroicon-s-trash class="w-4 h-4" />
+                                    </button>
+                                @endunless
                             </div>
-                            @endunless
+                        @endunless
 
-                            <div class="flex-1 p-6 bg-white shadow-sm rounded-r-lg rounded-b-lg border border-gray-300">
-                                {{ $item }}
-                            </div>
-                        </div>
-
-                        @unless ($loop->last)
-                            <div class="h-12 flex items-center justify-center">
-                                <div
-                                    x-show="isCreateButtonVisible || isCreateButtonDropdownOpen"
-                                    x-transition
-                                    class="relative flex justify-center"
-                                >
+                        @if ((! $loop->last) && (! $isItemCreationDisabled()) && (blank($getMaxItems()) || ($getMaxItems() > $getItemsCount())))
+                            <div
+                                x-show="isCreateButtonVisible || isCreateButtonDropdownOpen"
+                                x-transition
+                                class="absolute bottom-0 inset-x-0 -mb-7 z-10 h-12 flex items-center justify-center"
+                            >
+                                <div class="relative flex justify-center">
                                     <button
                                         x-on:click="isCreateButtonDropdownOpen = true"
                                         type="button"
-                                        class="flex items-center justify-center h-8 w-8 rounded-full text-gray-800 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50"
+                                        class="flex items-center justify-center h-8 w-8 rounded-full border border-gray-300 text-gray-800 bg-white hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50"
                                         x-bind:class="{
                                             'bg-gray-50': isCreateButtonDropdownOpen,
                                         }"
@@ -93,76 +88,35 @@
                                         <x-heroicon-o-plus class="w-5 h-5" />
                                     </button>
 
-                                    <div
-                                        x-show="isCreateButtonDropdownOpen"
-                                        x-on:click.away="isCreateButtonDropdownOpen = false"
-                                        x-transition
-                                        class="absolute z-10 mt-9 shadow-xl overflow-hidden rounded-xl w-52"
-                                    >
-                                        <ul class="py-1 space-y-1 bg-white shadow rounded-xl">
-                                            @foreach ($getBlocks() as $block)
-                                                <li>
-                                                    <button
-                                                        wire:click="dispatchFormEvent('builder::createItem', '{{ $getStatePath() }}', '{{ $block->getName() }}', '{{ $uuid }}')"
-                                                        x-on:click="isCreateButtonDropdownOpen = false"
-                                                        type="button"
-                                                        class="flex items-center w-full h-8 px-3 text-sm font-medium focus:outline-none hover:text-white hover:bg-primary-600 focus:bg-primary-700 focus:text-white group"
-                                                    >
-                                                        @if ($icon = $block->getIcon())
-                                                            <x-dynamic-component :component="$icon" class="mr-2 -ml-1 text-primary-500 w-5 h-5 group-hover:text-white group-focus:text-white" />
-                                                        @endif
-
-                                                        {{ $block->getLabel() }}
-                                                    </button>
-                                                </li>
-                                            @endforeach
-                                        </ul>
-                                    </div>
+                                    <x-forms::builder.block-picker
+                                        :blocks="$getBlocks()"
+                                        :create-after-item="$uuid"
+                                        :state-path="$getStatePath()"
+                                    />
                                 </div>
                             </div>
-                        @endunless
+                        @endif
                     </li>
                 @endforeach
             </ul>
         @endif
 
-        @if ((blank($getMaxItems()) || ($getMaxItems() > $getItemsCount())) && !$isItemCreationDisabled())
+        @if ((! $isItemCreationDisabled()) && (blank($getMaxItems()) || ($getMaxItems() > $getItemsCount())))
             <div x-data="{ isCreateButtonDropdownOpen: false }" class="relative flex justify-center">
                 <button
                     x-on:click="isCreateButtonDropdownOpen = true"
                     type="button"
-                    class="w-full h-9 px-4 inline-flex items-center justify-center font-medium tracking-tight rounded-lg text-gray-800 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600"
+                    class="w-full h-9 px-4 inline-flex space-x-1 items-center justify-center font-medium tracking-tight rounded-lg text-gray-800 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600"
                 >
-                    <x-heroicon-s-plus class="w-6 h-6 mr-1 -ml-2" />
+                    <x-heroicon-s-plus class="w-5 h-5" />
 
                     {{ $getCreateItemButtonLabel() }}
                 </button>
 
-                <div
-                    x-show="isCreateButtonDropdownOpen"
-                    x-on:click.away="isCreateButtonDropdownOpen = false"
-                    x-transition
-                    class="absolute z-10 mt-9 shadow-xl overflow-hidden rounded-xl w-52"
-                >
-                    <ul class="py-1 space-y-1 bg-white shadow rounded-xl">
-                        @foreach ($getBlocks() as $block)
-                            <li>
-                                <button
-                                    wire:click="dispatchFormEvent('builder::createItem', '{{ $getStatePath() }}', '{{ $block->getName() }}')"
-                                    x-on:click="isCreateButtonDropdownOpen = false"
-                                    type="button"
-                                    class="flex items-center w-full h-8 px-3 text-sm font-medium focus:outline-none hover:text-white hover:bg-primary-600 focus:bg-primary-700 focus:text-white group"
-                                >
-                                    @if ($icon = $block->getIcon())
-                                        <x-dynamic-component :component="$icon" class="mr-2 -ml-1 text-primary-500 w-5 h-5 group-hover:text-white group-focus:text-white" />
-                                    @endif
-
-                                    {{ $block->getLabel() }}
-                                </button>
-                            </li>
-                        @endforeach
-                    </ul>
-                </div>
+                <x-forms::builder.block-picker
+                    :blocks="$getBlocks()"
+                    :state-path="$getStatePath()"
+                />
             </div>
         @endif
     </div>

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -48,17 +48,19 @@
                                         </button>
                                     @endunless
 
-                                    <button
-                                        wire:click="dispatchFormEvent('builder::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
-                                        type="button"
-                                        class="w-full flex items-center justify-center h-8 text-danger-600 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-danger-600 focus:bg-primary-50 focus:border-primary-600"
-                                    >
-                                        <span class="sr-only">
-                                            {{ __('forms::components.builder.buttons.delete_item.label') }}
-                                        </span>
+                                    @unless($isItemDeletionDisabled())
+                                        <button
+                                            wire:click="dispatchFormEvent('builder::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                            type="button"
+                                            class="w-full flex items-center justify-center h-8 text-danger-600 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-danger-600 focus:bg-primary-50 focus:border-primary-600"
+                                        >
+                                            <span class="sr-only">
+                                                {{ __('forms::components.builder.buttons.delete_item.label') }}
+                                            </span>
 
-                                        <x-heroicon-s-trash class="w-5 h-5" />
-                                    </button>
+                                            <x-heroicon-s-trash class="w-5 h-5" />
+                                        </button>
+                                    @endunless
                                 </div>
                             </div>
 
@@ -122,7 +124,7 @@
             </ul>
         @endif
 
-        @if (blank($getMaxItems()) || ($getMaxItems() > $getItemsCount()))
+        @if (blank($getMaxItems()) || ($getMaxItems() > $getItemsCount()) || $isItemCreationDisabled())
             <div x-data="{ isCreateButtonDropdownOpen: false }" class="relative flex justify-center">
                 <button
                     x-on:click="isCreateButtonDropdownOpen = true"

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -18,6 +18,7 @@
                         wire:key="{{ $item->getStatePath() }}"
                     >
                         <div class="flex">
+                            @unless ($isItemMovementDisabled() && $isItemDeletionDisabled())
                             <div class="w-8">
                                 <div class="bg-white divide-y shadow-sm rounded-l-lg border-b border-l border-t border-gray-300 overflow-hidden">
                                     @unless ($loop->first || $isItemMovementDisabled())
@@ -63,6 +64,7 @@
                                     @endunless
                                 </div>
                             </div>
+                            @endunless
 
                             <div class="flex-1 p-6 bg-white shadow-sm rounded-r-lg rounded-b-lg border border-gray-300">
                                 {{ $item }}
@@ -124,7 +126,7 @@
             </ul>
         @endif
 
-        @if (blank($getMaxItems()) || ($getMaxItems() > $getItemsCount()) || $isItemCreationDisabled())
+        @if ((blank($getMaxItems()) || ($getMaxItems() > $getItemsCount())) && !$isItemCreationDisabled())
             <div x-data="{ isCreateButtonDropdownOpen: false }" class="relative flex justify-center">
                 <button
                     x-on:click="isCreateButtonDropdownOpen = true"

--- a/packages/forms/resources/views/components/builder/block-picker.blade.php
+++ b/packages/forms/resources/views/components/builder/block-picker.blade.php
@@ -1,0 +1,31 @@
+@props([
+    'blocks',
+    'createAfterItem' => null,
+    'statePath',
+])
+
+<div
+    x-show="isCreateButtonDropdownOpen"
+    x-on:click.away="isCreateButtonDropdownOpen = false"
+    x-transition
+    {{ $attributes->class(['absolute z-10 mt-10 shadow-xl border overflow-hidden rounded-xl w-52']) }}
+>
+    <ul class="py-1 space-y-1 bg-white shadow rounded-xl">
+        @foreach ($blocks as $block)
+            <li>
+                <button
+                    wire:click="dispatchFormEvent('builder::createItem', '{{ $statePath }}', '{{ $block->getName() }}' {{ $createAfterItem ? ", '{$createAfterItem}'" : '' }})"
+                    x-on:click="isCreateButtonDropdownOpen = false"
+                    type="button"
+                    class="flex items-center w-full h-8 px-3 text-sm font-medium focus:outline-none hover:text-white hover:bg-primary-600 focus:bg-primary-700 focus:text-white group"
+                >
+                    @if ($icon = $block->getIcon())
+                        <x-dynamic-component :component="$icon" class="mr-2 -ml-1 text-primary-500 w-5 h-5 group-hover:text-white group-focus:text-white" />
+                    @endif
+
+                    {{ $block->getLabel() }}
+                </button>
+            </li>
+        @endforeach
+    </ul>
+</div>

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -7,27 +7,29 @@
     :required="$isRequired()"
     :state-path="$getStatePath()"
 >
-    <div {{ $attributes->merge($getExtraAttributes())->class(['space-y-4']) }}>
+    <div {{ $attributes->merge($getExtraAttributes())->class(['space-y-2']) }}>
         @if (count($containers = $getChildComponentContainers()))
-            <ul class="space-y-4">
+            <ul class="space-y-2">
                 @foreach ($containers as $uuid => $item)
                     <li
                         wire:key="{{ $item->getStatePath() }}"
-                        class="flex"
+                        class="relative p-6 bg-white shadow-sm rounded-lg border border-gray-300"
                     >
-                        <div class="w-8">
-                            <div class="bg-white divide-y shadow-sm rounded-l-lg border-b border-l border-t border-gray-300 overflow-hidden">
+                        {{ $item }}
+
+                        @unless ($isItemDeletionDisabled() && ($isItemMovementDisabled() && ($loop->count <= 1)))
+                            <div class="absolute top-0 right-0 h-6 flex divide-x rounded-bl-lg rounded-tr-lg border-gray-300 border-b border-l overflow-hidden">
                                 @unless ($loop->first || $isItemMovementDisabled())
                                     <button
                                         wire:click="dispatchFormEvent('repeater::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
                                         type="button"
-                                        class="w-full flex items-center justify-center h-8 text-gray-800 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600"
+                                        class="flex items-center justify-center w-6 text-gray-800 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600"
                                     >
                                         <span class="sr-only">
                                             {{ __('forms::components.repeater.buttons.move_item_up.label') }}
                                         </span>
 
-                                        <x-heroicon-s-chevron-up class="w-5 h-5" />
+                                        <x-heroicon-s-chevron-up class="w-4 h-4" />
                                     </button>
                                 @endunless
 
@@ -35,47 +37,47 @@
                                     <button
                                         wire:click="dispatchFormEvent('repeater::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
                                         type="button"
-                                        class="w-full flex items-center justify-center h-8 text-gray-800 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600"
+                                        class="flex items-center justify-center w-6 text-gray-800 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600"
                                     >
                                         <span class="sr-only">
                                             {{ __('forms::components.repeater.buttons.move_item_down.label') }}
                                         </span>
 
-                                        <x-heroicon-s-chevron-down class="w-5 h-5" />
+                                        <x-heroicon-s-chevron-down class="w-4 h-4" />
                                     </button>
                                 @endunless
 
-                                <button
-                                    wire:click="dispatchFormEvent('repeater::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
-                                    type="button"
-                                    class="w-full flex items-center justify-center h-8 text-danger-600 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-danger-600 focus:bg-primary-50 focus:border-primary-600"
-                                >
-                                    <span class="sr-only">
-                                        {{ __('forms::components.repeater.buttons.delete_item.label') }}
-                                    </span>
+                                @unless ($isItemDeletionDisabled())
+                                    <button
+                                        wire:click="dispatchFormEvent('repeater::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                        type="button"
+                                        class="flex items-center justify-center w-6 text-danger-600 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-danger-600 focus:bg-primary-50 focus:border-primary-600"
+                                    >
+                                        <span class="sr-only">
+                                            {{ __('forms::components.repeater.buttons.delete_item.label') }}
+                                        </span>
 
-                                    <x-heroicon-s-trash class="w-5 h-5" />
-                                </button>
+                                        <x-heroicon-s-trash class="w-4 h-4" />
+                                    </button>
+                                @endunless
                             </div>
-                        </div>
-
-                        <div class="flex-1 p-6 bg-white shadow-sm rounded-r-lg rounded-b-lg border border-gray-300">
-                            {{ $item }}
-                        </div>
+                        @endunless
                     </li>
                 @endforeach
             </ul>
         @endif
 
-        @if (blank($getMaxItems()) || ($getMaxItems() > $getItemsCount()))
+        @if ((blank($getMaxItems()) || ($getMaxItems() > $getItemsCount())) && (! $isItemCreationDisabled()))
             <button
                 wire:click="dispatchFormEvent('repeater::createItem', '{{ $getStatePath() }}')"
                 type="button"
-                class="w-full h-9 px-4 inline-flex items-center justify-center font-medium tracking-tight rounded-lg text-gray-800 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600"
+                class="w-full h-9 px-4 inline-flex space-x-1 items-center justify-center font-medium tracking-tight rounded-lg text-gray-800 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600"
             >
-                <x-heroicon-s-plus class="w-6 h-6 mr-1 -ml-2" />
+                <x-heroicon-s-plus class="w-5 h-5" />
 
-                {{ $getCreateItemButtonLabel() }}
+                <span>
+                    {{ $getCreateItemButtonLabel() }}
+                </span>
             </button>
         @endif
     </div>

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -21,6 +21,10 @@ class Builder extends Field
     protected string | Closure | null $createItemButtonLabel = null;
 
     protected bool | Closure $isItemMovementDisabled = false;
+    
+    protected bool | Closure $isItemCreationDisabled = false;
+    
+    protected bool | Closure $isItemDeletionDisabled = false;
 
     protected function setUp(): void
     {
@@ -43,6 +47,10 @@ class Builder extends Field
                         return;
                     }
 
+                    if ($component->isItemCreationDisabled()) {
+                        return;
+                    }
+                    
                     if ($statePath !== $component->getStatePath()) {
                         return;
                     }
@@ -77,6 +85,10 @@ class Builder extends Field
             'builder::deleteItem' => [
                 function (Builder $component, string $statePath, string $uuidToDelete): void {
                     if ($component->isDisabled()) {
+                        return;
+                    }
+                    
+                    if ($component->isItemDeletionDisabled()) {
                         return;
                     }
 
@@ -175,6 +187,20 @@ class Builder extends Field
         return $this;
     }
 
+    public function disableItemCreation(bool | Closure $condition = true): static
+    {
+        $this->isItemCreationDisabled = $condition;
+
+        return $this;
+    }
+    
+    public function disableItemDeletion(bool | Closure $condition = true): static
+    {
+        $this->isItemDeletionDisabled = $condition;
+
+        return $this;
+    }    
+
     public function hydrateDefaultItemState(string $uuid): void
     {
         $this->getChildComponentContainers()[$uuid]->hydrateDefaultState();
@@ -222,5 +248,15 @@ class Builder extends Field
     public function isItemMovementDisabled(): bool
     {
         return $this->evaluate($this->isItemMovementDisabled);
+    }
+    
+    public function isItemCreationDisabled(): bool
+    {
+        return $this->evaluate($this->isItemCreationDisabled);
+    }
+
+    public function isItemDeletionDisabled(): bool
+    {
+        return $this->evaluate($this->isItemDeletionDisabled);
     }
 }

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -193,13 +193,13 @@ class Builder extends Field
 
         return $this;
     }
-    
+
     public function disableItemDeletion(bool | Closure $condition = true): static
     {
         $this->isItemDeletionDisabled = $condition;
 
         return $this;
-    }    
+    }
 
     public function hydrateDefaultItemState(string $uuid): void
     {

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -16,6 +16,10 @@ class Repeater extends Field
 
     protected string | Closure | null $createItemButtonLabel = null;
 
+    protected bool | Closure $isItemCreationDisabled = false;
+
+    protected bool | Closure $isItemDeletionDisabled = false;
+
     protected bool | Closure $isItemMovementDisabled = false;
 
     protected function setUp(): void
@@ -150,6 +154,20 @@ class Repeater extends Field
         return $this;
     }
 
+    public function disableItemCreation(bool | Closure $condition = true): static
+    {
+        $this->isItemCreationDisabled = $condition;
+
+        return $this;
+    }
+
+    public function disableItemDeletion(bool | Closure $condition = true): static
+    {
+        $this->isItemDeletionDisabled = $condition;
+
+        return $this;
+    }
+
     public function disableItemMovement(bool | Closure $condition = true): static
     {
         $this->isItemMovementDisabled = $condition;
@@ -176,6 +194,16 @@ class Repeater extends Field
     public function getCreateItemButtonLabel(): string
     {
         return $this->evaluate($this->createItemButtonLabel);
+    }
+
+    public function isItemCreationDisabled(): bool
+    {
+        return $this->evaluate($this->isItemCreationDisabled);
+    }
+
+    public function isItemDeletionDisabled(): bool
+    {
+        return $this->evaluate($this->isItemDeletionDisabled);
     }
 
     public function isItemMovementDisabled(): bool


### PR DESCRIPTION
Offers the possibility to disable the adding and/or removing of items (blocks) in the block builder component. Along with the existing "disableItemMovement" there will be two new methods available:

```php
->disableItemCreation($bool | Closure $condition = true)

->disableItemDeletion($bool | Closure $condition = true)
```

Example
```php
public static function form(Form $form): Form
{
    return $form
        ->schema([
            Builder::make('blocks')
                ->disableItemCreation(true)
                ->disableItemDeletion(true)

                // existing method
                ->disableItemMovement(false)
                ->blocks([
                    Builder\Block::make('heading')
                        ->schema([
                            TextInput::make('content')->required(),
                            Select::make('level')
                                ->options([
                                    'h1' => 'Heading 1',
                                    'h2' => 'Heading 2',
                                ])
                                ->required(),
                        ]),
                    Builder\Block::make('paragraph')
                        ->schema([
                            MarkdownEditor::make('content')->required(),
                        ]),
                ])
        ]);
}
```