### PR TITLE
Set default locale when all translatable fields are blank

### DIFF
--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
@@ -37,7 +37,7 @@ trait Translatable
         $resourceLocales = $resource::getTranslatableLocales();
         $defaultLocale = $resource::getDefaultTranslatableLocale();
 
-        $this->activeFormLocale = in_array($defaultLocale, $availableLocales) ? $defaultLocale : array_intersect($availableLocales, $resourceLocales)[0];
+        $this->activeFormLocale = in_array($defaultLocale, $availableLocales) ? $defaultLocale : array_intersect($availableLocales, $resourceLocales)[0] ?? $defaultLocale;
         $this->record->setLocale($this->activeFormLocale);
     }
 


### PR DESCRIPTION
When all fields in the `$translatable` property on a model are empty it throws an `undefined offset 0` error. 

When this happens it will now use the default locale so the form still loads and can be filled.