### PR TITLE
asHtml method added to placeholders

### DIFF
--- a/packages/forms/docs/04-layout.md
+++ b/packages/forms/docs/04-layout.md
@@ -239,6 +239,13 @@ use Filament\Forms\Components\Placeholder;
 Placeholder::make('Label')->content('Content, displayed underneath the label')
 ```
 
+If you need to render the state content as HTML then you can use the method asHtml(), eg:
+
+```php
+use Filament\Forms\Components\Placeholder;
+
+Placeholder::make('Label')->content('<h2>Heading<h2>This is rendered as <span class="font-bold">HTML</span>')->asHtml()
+```
 ## Card
 
 The card component may be used to render the form components inside a card:
@@ -302,7 +309,7 @@ use Filament\Forms\Components\Component;
 class Wizard extends Component
 {
     protected string $view = 'filament.forms.components.wizard';
-    
+
     public static function make(): static
     {
         return new static();

--- a/packages/forms/resources/views/components/placeholder.blade.php
+++ b/packages/forms/resources/views/components/placeholder.blade.php
@@ -7,6 +7,10 @@
     :state-path="$getStatePath()"
 >
     <div {{ $attributes->merge($getExtraAttributes()) }}>
-        {{ $getContent() }}
+        @if($getAsHtml())
+            {!! $getContent() !!}
+        @else
+            {{ $getContent() }}
+        @endif
     </div>
 </x-forms::field-wrapper>

--- a/packages/forms/src/Components/Placeholder.php
+++ b/packages/forms/src/Components/Placeholder.php
@@ -13,6 +13,7 @@ class Placeholder extends Component
     protected string $view = 'forms::components.placeholder';
 
     protected $content = null;
+    protected $asHtml = false;
 
     final public function __construct(string $name)
     {
@@ -63,5 +64,17 @@ class Placeholder extends Component
     public function getContent()
     {
         return $this->evaluate($this->content);
+    }
+
+    public function asHtml(bool $renderAsHtml = true): static
+    {
+        $this->asHtml = $renderAsHtml;
+
+        return $this;
+    }
+
+    public function getAsHtml()
+    {
+        return $this->evaluate($this->asHtml);
     }
 }


### PR DESCRIPTION
To gain the possible render as Html to content in a placeholder the method asHtml is added and the default behaviour (non html) is preserved.