### PR TITLE
Possible hide of the select placeholder option

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -368,6 +368,22 @@ Select::make('status')
 
 <img src="https://user-images.githubusercontent.com/41773797/147612885-888dfd64-6256-482d-b4bc-840191306d2d.png">
 
+You can hide the placeholder (Select an option) with the `noPlaceholder()` method:
+
+```php
+use App\Models\User;
+use Filament\Forms\Components\Select;
+
+Select::make('forced')
+    ->label('You are forced to select one of these:')
+    ->noPlaceholder()
+    ->options([
+        'draft' => 'Draft', // if no option selected this will be when stored
+        'review' => 'In review',
+        'published' => 'Published',
+    ])
+```
+
 You may enable a search input to allow easier access to many options, using the `searchable()` method:
 
 ```php

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -20,7 +20,9 @@
                 'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
             ]) }}
         >
-            <option value="">{{ $getPlaceholder() }}</option>
+            @if($isVisiblePlaceholder())
+                <option value="">{{ $getPlaceholder() }}</option>
+            @endif
 
             @foreach ($getOptions() as $value => $label)
                 <option

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -26,6 +26,8 @@ class Select extends Field
 
     protected string | Closure | null $searchPrompt = null;
 
+    protected bool | Closure | null $visiblePlaceholder = true;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -171,5 +173,17 @@ class Select extends Field
     public function isSearchable(): bool
     {
         return (bool) $this->evaluate($this->isSearchable);
+    }
+
+    public function noPlaceholder(bool | Closure $condition = true): static
+    {
+        $this->visiblePlaceholder = !$condition;
+
+        return $this;
+    }
+
+    public function isVisiblePlaceholder(): bool
+    {
+        return (bool) $this->evaluate($this->visiblePlaceholder);
     }
 }


### PR DESCRIPTION
I would like to hide the option serving as a placeholder for the Select component via a new method noPlaceholder added.