### PR TITLE
Add support for enum casts in PHP 8.1

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -74,7 +74,7 @@ trait CanFormatState
             $state = app()->call($this->formatStateUsing, [
                 'livewire' => $this->getLivewire(),
                 'record' => $this->getRecord(),
-                'state' => (interface_exists(\BackedEnum::class) && $state instanceof \BackedEnum) ? $state->value : $state,
+                'state' => (interface_exists(\BackedEnum::class) && $state instanceof \BackedEnum::class) ? $state->value : $state,
             ]);
         }
 

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -67,13 +67,13 @@ trait CanFormatState
     {
         $state = $this->getState();
 
-if ($this->formatStateUsing instanceof Closure) {
-    $state = app()->call($this->formatStateUsing, [
-        'livewire' => $this->getLivewire(),
-        'record' => $this->getRecord(),
-        'state' => (interface_exists(\BackedEnum::class) && $state instanceof \BackedEnum::class) ? $state->value : $state,
-    ]);
-}
+        if ($this->formatStateUsing instanceof Closure) {
+            $state = app()->call($this->formatStateUsing, [
+                'livewire' => $this->getLivewire(),
+                'record' => $this->getRecord(),
+                'state' => ( interface_exists(\BackedEnum::class) && ($state instanceof \BackedEnum) ) ? $state->value : $state,
+            ]);
+        }
 
         return $state;
     }

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -71,7 +71,7 @@ trait CanFormatState
             $state = app()->call($this->formatStateUsing, [
                 'livewire' => $this->getLivewire(),
                 'record' => $this->getRecord(),
-                'state' => (interface_exists(\BackedEnum::class) && ($state instanceof \BackedEnum)) ? $state->value : $state,
+                'state' => $state,
             ]);
         }
 

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -67,9 +67,6 @@ trait CanFormatState
     {
         $state = $this->getState();
 
-        phpinfo();
-        die();
-
         if ($this->formatStateUsing instanceof Closure) {
             $state = app()->call($this->formatStateUsing, [
                 'livewire' => $this->getLivewire(),

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -71,7 +71,7 @@ trait CanFormatState
             $state = app()->call($this->formatStateUsing, [
                 'livewire' => $this->getLivewire(),
                 'record' => $this->getRecord(),
-                'state' => ( interface_exists(\BackedEnum::class) && ($state instanceof \BackedEnum) ) ? $state->value : $state,
+                'state' => (interface_exists(\BackedEnum::class) && ($state instanceof \BackedEnum)) ? $state->value : $state,
             ]);
         }
 

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -67,13 +67,13 @@ trait CanFormatState
     {
         $state = $this->getState();
 
-        if ($this->formatStateUsing instanceof Closure) {
-            $state = app()->call($this->formatStateUsing, [
-                'livewire' => $this->getLivewire(),
-                'record' => $this->getRecord(),
-                'state' => (interface_exists(\BackedEnum::class) && $state instanceof \BackedEnum::class) ? $state->value : $state,
-            ]);
-        }
+if ($this->formatStateUsing instanceof Closure) {
+    $state = app()->call($this->formatStateUsing, [
+        'livewire' => $this->getLivewire(),
+        'record' => $this->getRecord(),
+        'state' => (interface_exists(\BackedEnum::class) && $state instanceof \BackedEnum::class) ? $state->value : $state,
+    ]);
+}
 
         return $state;
     }

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -67,11 +67,14 @@ trait CanFormatState
     {
         $state = $this->getState();
 
+        phpinfo();
+        die();
+
         if ($this->formatStateUsing instanceof Closure) {
             $state = app()->call($this->formatStateUsing, [
                 'livewire' => $this->getLivewire(),
                 'record' => $this->getRecord(),
-                'state' => $state,
+                'state' => (interface_exists(\BackedEnum::class) && $state instanceof \BackedEnum) ? $state->value : $state,
             ]);
         }
 

--- a/packages/tables/src/Columns/Concerns/HasState.php
+++ b/packages/tables/src/Columns/Concerns/HasState.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Tables\Columns\Concerns;
 
+use BackedEnum;
 use Closure;
 use Illuminate\Support\Arr;
 
@@ -41,8 +42,16 @@ trait HasState
             $state = Arr::get($this->getRecord(), $this->getName());
         }
 
+        if (
+            interface_exists(BackedEnum::class) &&
+            ($state instanceof BackedEnum) &&
+            property_exists($state, 'value')
+        ) {
+            $state = $state->value;
+        }
+
         if ($state === null) {
-            return value($this->getDefaultState());
+            $state = value($this->getDefaultState());
         }
 
         return $state;


### PR DESCRIPTION
This PR adds support for enums/casts in PHP 8.1. 

I encountered this issue when working with an Eloquent model that has an enum cast. In the below example, the `$record->status_type` is cast as an enum, leading to errors about an illegal offset type. (It was trying to use an enum as an array key.)
```php
BadgeColumn::make('status_type')->label('Status')->enum((array) StatusType::labels()),
```

This PR adds a simple check for the cases where we have an enum that's backed by a string. In that situation it will use the backed value.

```php
if ($this->formatStateUsing instanceof Closure) {
    $state = app()->call($this->formatStateUsing, [
        'livewire' => $this->getLivewire(),
        'record' => $this->getRecord(),
        'state' => (interface_exists(\BackedEnum::class) && $state instanceof \BackedEnum::class) ? $state->value : $state,
    ]);
}
```

I tested it and this implementation also works on PHP 8.0.