### PR TITLE
Fix input flickering problem

### DIFF
--- a/packages/admin/resources/views/components/actions/select-action.blade.php
+++ b/packages/admin/resources/views/components/actions/select-action.blade.php
@@ -7,7 +7,7 @@
         id="{{ $getId() }}"
         wire:model="{{ $getName() }}"
         {{ $attributes->class([
-            'text-gray-900 border-gray-300 invalid:text-gray-400 block w-full h-9 py-1 duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600',
+            'text-gray-900 border-gray-300 invalid:text-gray-400 block w-full h-9 py-1 transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600',
         ]) }}
     >
         @if (($placeholder = $getPlaceholder()) !== null)

--- a/packages/admin/resources/views/components/global-search/input.blade.php
+++ b/packages/admin/resources/views/components/global-search/input.blade.php
@@ -14,7 +14,7 @@
             placeholder="{{ __('filament::global-search.field.placeholder') }}"
             type="search"
             autocomplete="off"
-            class="block w-full h-10 pl-10 lg:text-lg bg-gray-400/10 placeholder-gray-500 border-transparent duration-75 rounded-lg focus:bg-white focus:placeholder-gray-400 focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600"
+            class="block w-full h-10 pl-10 lg:text-lg bg-gray-400/10 placeholder-gray-500 border-transparent transition duration-75 rounded-lg focus:bg-white focus:placeholder-gray-400 focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600"
         >
     </div>
 </div>

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -2,7 +2,7 @@
     x-data="{}"
     x-cloak
     x-bind:class="$store.sidebar.isOpen ? 'translate-x-0' : '-translate-x-full rtl:lg:-translate-x-0 rtl:translate-x-full'"
-    class="fixed inset-y-0 left-0 rtl:left-auto rtl:right-0 z-20 flex flex-col h-screen overflow-hidden shadow-2xl duration-300 bg-white lg:border-r w-80 lg:z-0 lg:translate-x-0"
+    class="fixed inset-y-0 left-0 rtl:left-auto rtl:right-0 z-20 flex flex-col h-screen overflow-hidden shadow-2xl transition duration-300 bg-white lg:border-r w-80 lg:z-0 lg:translate-x-0"
 >
     <header class="border-b h-[4rem] shrink-0 px-6 flex items-center">
         <a href="{{ url('/') }}">

--- a/packages/admin/resources/views/components/modal/index.blade.php
+++ b/packages/admin/resources/views/components/modal/index.blade.php
@@ -39,7 +39,7 @@
         x-transition:leave-start="opacity-100"
         x-transition:leave-end="opacity-0"
         x-cloak
-        class="fixed inset-0 z-40 flex items-center min-h-screen p-4 overflow-y-auto"
+        class="fixed inset-0 z-40 flex items-center min-h-screen p-4 overflow-y-auto transition"
     >
         <button
             x-on:click="isOpen = false"

--- a/packages/admin/resources/views/widgets/chart-widget.blade.php
+++ b/packages/admin/resources/views/widgets/chart-widget.blade.php
@@ -7,7 +7,7 @@
         @if ($filters = $this->getFilters())
             <select
                 wire:model="filter"
-                class="text-gray-900 border-gray-300 block h-10 duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600"
+                class="text-gray-900 border-gray-300 block h-10 transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600"
             >
                 @foreach ($filters as $value => $label)
                     <option value="{{ $value }}">

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -90,7 +90,7 @@
                     value="{{ $optionValue }}"
                     {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
                     {{ $attributes->merge($getExtraAttributes())->class([
-                        'text-primary-600 duration-75 rounded shadow-sm focus:border-primary-500 focus:ring-2 focus:ring-primary-500',
+                        'text-primary-600 transition duration-75 rounded shadow-sm focus:border-primary-500 focus:ring-2 focus:ring-primary-500',
                         'border-gray-300' => ! $errors->has($getStatePath()),
                         'border-danger-300 ring-danger-500' => $errors->has($getStatePath()),
                     ]) }}

--- a/packages/forms/resources/views/components/checkbox.blade.php
+++ b/packages/forms/resources/views/components/checkbox.blade.php
@@ -22,7 +22,7 @@
                         ->merge($getExtraAttributes())
                         ->merge($getExtraInputAttributeBag()->getAttributes())
                         ->class([
-                            'text-primary-600 duration-75 rounded shadow-sm focus:border-primary-500 focus:ring-2 focus:ring-primary-500',
+                            'text-primary-600 transition duration-75 rounded shadow-sm focus:border-primary-500 focus:ring-2 focus:ring-primary-500',
                             'border-gray-300' => ! $errors->has($getStatePath()),
                             'border-danger-300 ring-danger-500' => $errors->has($getStatePath()),
                         ])

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -136,7 +136,7 @@
                                         'cursor-not-allowed': dayIsDisabled(day),
                                         'opacity-50': focusedDate.date() !== day && dayIsDisabled(day),
                                     }"
-                                    class="text-sm leading-none leading-loose text-center duration-100 ease-in-out rounded-full"
+                                    class="text-sm leading-none leading-loose text-center transition duration-100 ease-in-out rounded-full"
                                 ></div>
                             </template>
                         </div>

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -185,7 +185,7 @@
                         x-ref="textarea"
                         style="caret-color: black; color: transparent"
                         @class([
-                            'tracking-normal whitespace-pre-wrap overflow-y-hidden font-mono block absolute bg-transparent top-0 text-sm left-0 block z-1 w-full h-full min-h-full resize-none duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-600',
+                            'tracking-normal whitespace-pre-wrap overflow-y-hidden font-mono block absolute bg-transparent top-0 text-sm left-0 block z-1 w-full h-full min-h-full resize-none transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-600',
                             'border-gray-300' => ! $errors->has($getStatePath()),
                             'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
                         ])

--- a/packages/forms/resources/views/components/markdown-editor/toolbar-button.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor/toolbar-button.blade.php
@@ -1,7 +1,7 @@
 <button
     x-bind:disabled="tab === 'preview'"
     type="button"
-    {{ $attributes->class(['border-gray-300 bg-white text-base text-gray-800 text-xs py-1 px-3 cursor-pointer font-medium border rounded duration-200 shadow-sm hover:bg-gray-100 focus:ring-primary-200 focus:ring focus:ring-opacity-50']) }}
+    {{ $attributes->class(['border-gray-300 bg-white text-base text-gray-800 text-xs py-1 px-3 cursor-pointer font-medium border rounded transition duration-200 shadow-sm hover:bg-gray-100 focus:ring-primary-200 focus:ring focus:ring-opacity-50']) }}
 >
     {{ $slot }}
 </button>

--- a/packages/forms/resources/views/components/multi-select.blade.php
+++ b/packages/forms/resources/views/components/multi-select.blade.php
@@ -21,7 +21,7 @@
         })"
         {!! ($id = $getId()) ? "id=\"{$id}\"" : null !!}
         {{ $attributes->merge($getExtraAttributes())->class([
-            'block w-full duration-75 divide-y rounded-lg shadow-sm border focus-within:border-primary-600 focus-within:ring-1 focus-within:ring-primary-600',
+            'block w-full transition duration-75 divide-y rounded-lg shadow-sm border focus-within:border-primary-600 focus-within:ring-1 focus-within:ring-primary-600',
             'border-gray-300' => ! $errors->has($getStatePath()),
             'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
         ]) }}
@@ -83,7 +83,7 @@
                     x-bind:aria-activedescendant="focusedOptionIndex ? '{{ $getStatePath() }}' + 'Option' + focusedOptionIndex : null"
                     tabindex="-1"
                     x-cloak
-                    class="absolute z-10 w-full my-1 bg-white border border-gray-300 rounded-lg shadow-sm focus:outline-none"
+                    class="absolute z-10 w-full my-1 bg-white border border-gray-300 rounded-lg shadow-sm focus:outline-none transition"
                 >
                     <ul
                         x-ref="listboxOptionsList"

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -277,7 +277,7 @@
                 toolbar="trix-toolbar-{{ $getId() }}"
                 x-ref="trix"
                 @class([
-                    'bg-white block w-full duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-600 prose max-w-none',
+                    'bg-white block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-600 prose max-w-none',
                     'border-gray-300' => ! $errors->has($getStatePath()),
                     'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
                 ])

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -15,7 +15,7 @@
             {!! $isRequired() ? 'required' : null !!}
             {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
             {{ $attributes->merge($getExtraAttributes())->class([
-                'text-gray-900 block w-full h-10 duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600',
+                'text-gray-900 block w-full h-10 transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600',
                 'border-gray-300' => ! $errors->has($getStatePath()),
                 'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
             ]) }}

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -18,7 +18,7 @@
         <div
             x-show="state.length || {{ $isDisabled() ? 'false' : 'true' }}"
             @class([
-                'block w-full duration-75 divide-y rounded-lg shadow-sm border overflow-hidden focus-within:border-primary-600 focus-within:ring-1 focus-within:ring-primary-600',
+                'block w-full transition duration-75 divide-y rounded-lg shadow-sm border overflow-hidden focus-within:border-primary-600 focus-within:ring-1 focus-within:ring-primary-600',
                 'border-gray-300' => ! $errors->has($getStatePath()),
                 'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
             ])

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -53,7 +53,7 @@
                 {!! ($interval = $getStep()) ? "step=\"{$interval}\"" : null !!}
                 {!! $isRequired() ? 'required' : null !!}
                 {{ $getExtraInputAttributeBag()->class([
-                    'block w-full h-10 duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600',
+                    'block w-full h-10 transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600',
                     'border-gray-300' => ! $errors->has($getStatePath()),
                     'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
                 ]) }}

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -25,7 +25,7 @@
                 ->merge($getExtraAttributes())
                 ->merge($getExtraInputAttributeBag()->getAttributes())
                 ->class([
-                    'block w-full duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-600',
+                    'block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-600',
                     'border-gray-300' => ! $errors->has($getStatePath()),
                     'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
                 ])

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -33,7 +33,7 @@
                 {{ $getExtraAlpineAttributeBag() }}
             >
                 <span
-                    class="pointer-events-none relative inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 ease-in-out duration-200 translate-x-0"
+                    class="pointer-events-none relative inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 ease-in-out transition duration-200 translate-x-0"
                     :class="{
                         'translate-x-5 rtl:-translate-x-5': state,
                         'translate-x-0': ! state,

--- a/packages/tables/resources/views/components/filters/index.blade.php
+++ b/packages/tables/resources/views/components/filters/index.blade.php
@@ -20,7 +20,7 @@
         x-transition:leave-start="opacity-100 translate-y-0"
         x-transition:leave-end="opacity-0 translate-y-2"
         @class([
-            'absolute right-0 rtl:right-auto rtl:left-0 z-10 w-screen pl-12 rtl:pr-12 mt-2 top-full',
+            'absolute right-0 rtl:right-auto rtl:left-0 z-10 w-screen pl-12 rtl:pr-12 mt-2 top-full transition',
             match ($width) {
                 'xs' => 'max-w-xs',
                 'md' => 'max-w-md',

--- a/packages/tables/resources/views/components/modal/index.blade.php
+++ b/packages/tables/resources/views/components/modal/index.blade.php
@@ -39,7 +39,7 @@
         x-transition:leave-start="opacity-100"
         x-transition:leave-end="opacity-0"
         x-cloak
-        class="fixed inset-0 z-40 flex items-center min-h-screen p-4 overflow-y-auto"
+        class="fixed inset-0 z-40 flex items-center min-h-screen p-4 overflow-y-auto transition"
     >
         <button
             x-on:click="isOpen = false"

--- a/packages/tables/resources/views/components/pagination/records-per-page-selector.blade.php
+++ b/packages/tables/resources/views/components/pagination/records-per-page-selector.blade.php
@@ -3,7 +3,7 @@
 ])
 
 <div class="flex items-center space-x-2 rtl:space-x-reverse">
-    <select wire:model="tableRecordsPerPage" id="tableRecordsPerPageSelect" class="h-8 text-sm pr-8 leading-none duration-75 border-gray-200 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600">
+    <select wire:model="tableRecordsPerPage" id="tableRecordsPerPageSelect" class="h-8 text-sm pr-8 leading-none transition duration-75 border-gray-200 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600">
         @foreach ($options as $option)
             <option value="{{ $option }}">{{ $option }}</option>
         @endforeach

--- a/packages/tables/resources/views/components/search-input.blade.php
+++ b/packages/tables/resources/views/components/search-input.blade.php
@@ -14,7 +14,7 @@
             placeholder="{{ __('tables::table.fields.search_query.placeholder') }}"
             type="search"
             autocomplete="off"
-            class="block w-full h-9 pl-9 placeholder-gray-400 duration-75 border-gray-200 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600"
+            class="block w-full h-9 pl-9 placeholder-gray-400 transition duration-75 border-gray-200 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600"
         >
     </div>
 </div>


### PR DESCRIPTION
This PR fixes a flickering problem I noticed on Safari, which also seems to appear on Chrome. (Other browsers not tested.)

It basically comes down to the fact that an `<input>` or `<select>` element flickers when it only has a `transition-duration` specified and a user selects it. If you add the Tailwind `transition` property, everything works fine. See the below short screencasts.

**[Before (it flickers on select)](https://stream.new/v/7HufSaAwVOdzV1LIkqpDW2VIiT7d4vWco1zM6VCnbZU)**
**[After (no flickering, it goes smooth)](https://stream.new/v/ZUCmfg3r2icVWAn6bY9QrXuhvKQX8fN4cEfEoSgV02Vo)**

I didn't test this yet on the admin panel, but perhaps we should add the `transition` property there as well.