### PR TITLE
feature: configuring and configured hooks for PluginServiceProvider

### DIFF
--- a/packages/admin/src/PluginServiceProvider.php
+++ b/packages/admin/src/PluginServiceProvider.php
@@ -22,19 +22,9 @@ abstract class PluginServiceProvider extends PackageServiceProvider
 
     protected array $widgets = [];
 
-    public function configuringPackage(Package $package)
-    {
-        //
-    }
-
-    public function configuredPackage(Package $package)
-    {
-        //
-    }
-
     public function configurePackage(Package $package): void
     {
-        $this->configuringPackage($package);
+        $this->packageConfiguring($package);
 
         $package
             ->name(static::$name)
@@ -54,7 +44,15 @@ abstract class PluginServiceProvider extends PackageServiceProvider
             $package->hasViews();
         }
 
-        $this->configuredPackage($package);
+        $this->packageConfigured($package);
+    }
+
+    public function packageConfiguring(Package $package): void
+    {
+    }
+
+    public function packageConfigured(Package $package): void
+    {
     }
 
     public function packageRegistered(): void

--- a/packages/admin/src/PluginServiceProvider.php
+++ b/packages/admin/src/PluginServiceProvider.php
@@ -22,8 +22,20 @@ abstract class PluginServiceProvider extends PackageServiceProvider
 
     protected array $widgets = [];
 
+    public function configuringPackage(Package $package)
+    {
+        //
+    }
+
+    public function configuredPackage(Package $package)
+    {
+        //
+    }
+
     public function configurePackage(Package $package): void
     {
+        $this->configuringPackage($package);
+
         $package
             ->name(static::$name)
             ->hasCommands($this->getCommands());
@@ -41,6 +53,8 @@ abstract class PluginServiceProvider extends PackageServiceProvider
         if (file_exists($this->package->basePath('/../resources/views'))) {
             $package->hasViews();
         }
+
+        $this->configuredPackage($package);
     }
 
     public function packageRegistered(): void


### PR DESCRIPTION
Adds 2 new hooks for the `PluginServiceProvider`:

* `configuringPackage`
* `configuredPackage`

These can be used by plugin developers to easily register migrations, etc with the `PackageServiceProvider` that we extend. At the minute, the only way to do this is overriding the `configurePackage` method and calling `parent::configurePackage` which could cause problems if people forget to call it, just like the old `parent::boot()` problems from `Model` files :)