### PR TITLE
fix: HasAction: Pass all data to actions created from string

### DIFF
--- a/packages/tables/src/Actions/BulkAction.php
+++ b/packages/tables/src/Actions/BulkAction.php
@@ -74,9 +74,7 @@ class BulkAction
         $action = $this->action;
 
         if (is_string($action)) {
-            $action = function (HasTable $livewire, Collection $records) use ($action) {
-                return $livewire->{$action}($records);
-            };
+            $action = fn (...$args) => $this->getLivewire()->{$action}(...$args);
         }
 
         return $action;

--- a/packages/tables/src/Actions/BulkAction.php
+++ b/packages/tables/src/Actions/BulkAction.php
@@ -74,7 +74,7 @@ class BulkAction
         $action = $this->action;
 
         if (is_string($action)) {
-            $action = fn (...$args) => $this->getLivewire()->{$action}(...$args);
+            $action = Closure::fromCallable([$this->getLivewire(), $action]);
         }
 
         return $action;

--- a/packages/tables/src/Actions/BulkAction.php
+++ b/packages/tables/src/Actions/BulkAction.php
@@ -3,8 +3,6 @@
 namespace Filament\Tables\Actions;
 
 use Closure;
-use Filament\Tables\Contracts\HasTable;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;

--- a/packages/tables/src/Actions/Concerns/HasAction.php
+++ b/packages/tables/src/Actions/Concerns/HasAction.php
@@ -22,13 +22,7 @@ trait HasAction
         $action = $this->action;
 
         if (is_string($action)) {
-            $action = function (HasTable $livewire, ?Model $record) use ($action) {
-                if ($record) {
-                    return $livewire->{$action}($record);
-                }
-
-                return $livewire->{$action}();
-            };
+            $action = fn (...$args) => $this->getLivewire()->{$action}(...$args);
         }
 
         return $action;

--- a/packages/tables/src/Actions/Concerns/HasAction.php
+++ b/packages/tables/src/Actions/Concerns/HasAction.php
@@ -20,7 +20,7 @@ trait HasAction
         $action = $this->action;
 
         if (is_string($action)) {
-            $action = fn (...$args) => $this->getLivewire()->{$action}(...$args);
+            $action = Closure::fromCallable([$this->getLivewire(), $action]);
         }
 
         return $action;

--- a/packages/tables/src/Actions/Concerns/HasAction.php
+++ b/packages/tables/src/Actions/Concerns/HasAction.php
@@ -3,8 +3,6 @@
 namespace Filament\Tables\Actions\Concerns;
 
 use Closure;
-use Filament\Tables\Contracts\HasTable;
-use Illuminate\Database\Eloquent\Model;
 
 trait HasAction
 {


### PR DESCRIPTION
As mentioned in Discord: Actions created from a string received different data than callables.
https://discord.com/channels/883083792112300104/883085267383226478/928258984081784892