### PR TITLE
Update Mask.php

### DIFF
--- a/packages/forms/src/Components/TextInput/Mask.php
+++ b/packages/forms/src/Components/TextInput/Mask.php
@@ -149,6 +149,7 @@ class Mask implements Jsonable
                     ->numeric()
                     ->thousandsSeparator($thousandsSeparator)
                     ->decimalPlaces($decimalPlaces)
+                    ->padFractionalZeros()
                     ->normalizeZeros(false),
             ])
             ->pattern("{$prefix}money")


### PR DESCRIPTION
->padFractionalZeros() is needed to stop ensure ->decimalPlaces($decimalPlaces) is respected and always there. Found that when editing an existing number, it would remove decimals while typing, etc. This solves the issue.