### PR TITLE
File Upload - Keep original filename

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -848,6 +848,16 @@ FileUpload::make('attachment')
 
 > Please note, it is the responsibility of the developer to delete these files from the disk if they are removed, as Filament is unaware if they are depended on elsewhere. One way to do this automatically is observing a [model event](https://laravel.com/docs/eloquent#events).
 
+By default, a random file name will be generated for newly-uploaded files. To instead preserve the original filenames of the uploaded files, use the `preserveFilenames()` method:
+
+```php
+use Filament\Forms\Components\FileUpload;
+
+FileUpload::make('attachment')->preserveFilenames()
+```
+
+> Please note, it is the responsibility of the developer to ensure that uploaded file names are unique when using this option.
+
 You may restrict the types of files that may be uploaded using the `acceptedFileTypes()` method, and passing an array of MIME types. You may also use the `image()` method as shorthand to allow all image MIME types.
 
 ```php

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -23,8 +23,6 @@ class BaseFileUpload extends Field
 
     protected bool | Closure $isMultiple = false;
 
-    protected bool | Closure $preserveFilename = false;
-
     protected int | Closure | null $maxSize = null;
 
     protected int | Closure | null $minSize = null;
@@ -32,6 +30,8 @@ class BaseFileUpload extends Field
     protected int | Closure | null $maxFiles = null;
 
     protected int | Closure | null $minFiles = null;
+
+    protected bool | Closure $shouldPreserveFilenames = false;
 
     protected string | Closure $visibility = 'public';
 
@@ -108,7 +108,7 @@ class BaseFileUpload extends Field
         $this->saveUploadedFileUsing(function (BaseFileUpload $component, TemporaryUploadedFile $file): string {
             $storeMethod = $component->getVisibility() === 'public' ? 'storePubliclyAs' : 'storeAs';
 
-            $filename = $component->getPreserveFilename() ? $file->getClientOriginalName() : $file->getFilename();
+            $filename = $component->shouldPreserveFilenames() ? $file->getClientOriginalName() : $file->getFilename();
 
             return $file->{$storeMethod}($component->getDirectory(), $filename, $component->getDiskName());
         });
@@ -141,9 +141,9 @@ class BaseFileUpload extends Field
         return $this;
     }
 
-    public function preserveFilename(bool | Closure $preserveFilename = true): static
+    public function preserveFilenames(bool | Closure $condition = true): static
     {
-        $this->preserveFilename = $preserveFilename;
+        $this->shouldPreserveFilenames = $condition;
 
         return $this;
     }
@@ -249,11 +249,6 @@ class BaseFileUpload extends Field
         return $this->evaluate($this->diskName) ?? config('forms.default_filesystem_disk');
     }
 
-    public function getPreserveFilename(): bool
-    {
-        return $this->evaluate($this->preserveFilename);
-    }
-
     public function getMaxSize(): ?int
     {
         return $this->evaluate($this->maxSize);
@@ -267,6 +262,11 @@ class BaseFileUpload extends Field
     public function getVisibility(): string
     {
         return $this->evaluate($this->visibility);
+    }
+
+    public function shouldPreserveFilenames(): bool
+    {
+        return $this->evaluate($this->shouldPreserveFilenames);
     }
 
     public function getValidationRules(): array

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -23,7 +23,7 @@ class BaseFileUpload extends Field
 
     protected bool | Closure $isMultiple = false;
 
-    protected bool | Closure $keepFilename = false;
+    protected bool | Closure $preserveFilename = false;
 
     protected int | Closure | null $maxSize = null;
 
@@ -108,7 +108,7 @@ class BaseFileUpload extends Field
         $this->saveUploadedFileUsing(function (BaseFileUpload $component, TemporaryUploadedFile $file): string {
             $storeMethod = $component->getVisibility() === 'public' ? 'storePubliclyAs' : 'storeAs';
 
-            $filename = $component->getKeepFilename() ? $file->getClientOriginalName() : $file->getFilename();
+            $filename = $component->getPreserveFilename() ? $file->getClientOriginalName() : $file->getFilename();
 
             return $file->{$storeMethod}($component->getDirectory(), $filename, $component->getDiskName());
         });
@@ -141,9 +141,9 @@ class BaseFileUpload extends Field
         return $this;
     }
 
-    public function keepFilename(bool | Closure $keepFilename = true): static
+    public function preserveFilename(bool | Closure $preserveFilename = true): static
     {
-        $this->keepFilename = $keepFilename;
+        $this->preserveFilename = $preserveFilename;
 
         return $this;
     }
@@ -249,9 +249,9 @@ class BaseFileUpload extends Field
         return $this->evaluate($this->diskName) ?? config('forms.default_filesystem_disk');
     }
 
-    public function getKeepFilename(): bool
+    public function getPreserveFilename(): bool
     {
-        return $this->evaluate($this->keepFilename);
+        return $this->evaluate($this->preserveFilename);
     }
 
     public function getMaxSize(): ?int

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -106,15 +106,11 @@ class BaseFileUpload extends Field
         });
 
         $this->saveUploadedFileUsing(function (BaseFileUpload $component, TemporaryUploadedFile $file): string {
-            if ($this->getKeepFilename()) {
-                $storeMethod = $component->getVisibility() === 'public' ? 'storePubliclyAs' : 'storeAs';
+            $storeMethod = $component->getVisibility() === 'public' ? 'storePubliclyAs' : 'storeAs';
 
-                return $file->{$storeMethod}($component->getDirectory(), $file->getClientOriginalName(), $component->getDiskName());
-            }
+            $filename = $component->getKeepFilename() ? $file->getClientOriginalName() : $file->getFilename();
 
-            $storeMethod = $component->getVisibility() === 'public' ? 'storePublicly' : 'store';
-
-            return $file->{$storeMethod}($component->getDirectory(), $component->getDiskName());
+            return $file->{$storeMethod}($component->getDirectory(), $filename, $component->getDiskName());
         });
     }
 

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -109,12 +109,12 @@ class BaseFileUpload extends Field
             if ($this->getKeepFilename()) {
                 $storeMethod = $component->getVisibility() === 'public' ? 'storePubliclyAs' : 'storeAs';
 
-                return $file->{$storeMethod}($this->getDirectory(), $file->getClientOriginalName(), $this->getDiskName());
+                return $file->{$storeMethod}($component->getDirectory(), $file->getClientOriginalName(), $component->getDiskName());
             }
 
             $storeMethod = $component->getVisibility() === 'public' ? 'storePublicly' : 'store';
 
-            return $file->{$storeMethod}($this->getDirectory(), $this->getDiskName());
+            return $file->{$storeMethod}($component->getDirectory(), $component->getDiskName());
         });
     }
 

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -82,7 +82,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             /** @var FileAdder $mediaAdder */
             $mediaAdder = $record->addMediaFromString($file->get());
 
-            $filename = $component->getKeepFilename() ? $file->getClientOriginalName() : $file->getFilename();
+            $filename = $component->getPreserveFilename() ? $file->getClientOriginalName() : $file->getFilename();
 
             $media = $mediaAdder
                 ->usingFileName($filename)

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -82,8 +82,10 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             /** @var FileAdder $mediaAdder */
             $mediaAdder = $record->addMediaFromString($file->get());
 
+            $filename = $this->getKeepFilename() ? $file->getClientOriginalName() : $file->getFilename();
+
             $media = $mediaAdder
-                ->usingFileName($file->getFilename())
+                ->usingFileName($filename)
                 ->toMediaCollection($component->getCollection(), $component->getDiskName());
 
             return $media->getAttributeValue('uuid');

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -75,7 +75,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
         });
 
         $this->saveUploadedFileUsing(function (SpatieMediaLibraryFileUpload $component, TemporaryUploadedFile $file, ?Model $record): string {
-            if (!method_exists($record, 'addMediaFromString')) {
+            if (! method_exists($record, 'addMediaFromString')) {
                 return $file;
             }
 

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -75,14 +75,14 @@ class SpatieMediaLibraryFileUpload extends FileUpload
         });
 
         $this->saveUploadedFileUsing(function (SpatieMediaLibraryFileUpload $component, TemporaryUploadedFile $file, ?Model $record): string {
-            if (! method_exists($record, 'addMediaFromString')) {
+            if (!method_exists($record, 'addMediaFromString')) {
                 return $file;
             }
 
             /** @var FileAdder $mediaAdder */
             $mediaAdder = $record->addMediaFromString($file->get());
 
-            $filename = $this->getKeepFilename() ? $file->getClientOriginalName() : $file->getFilename();
+            $filename = $component->getKeepFilename() ? $file->getClientOriginalName() : $file->getFilename();
 
             $media = $mediaAdder
                 ->usingFileName($filename)

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -82,7 +82,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             /** @var FileAdder $mediaAdder */
             $mediaAdder = $record->addMediaFromString($file->get());
 
-            $filename = $component->getPreserveFilename() ? $file->getClientOriginalName() : $file->getFilename();
+            $filename = $component->shouldPreserveFilenames() ? $file->getClientOriginalName() : $file->getFilename();
 
             $media = $mediaAdder
                 ->usingFileName($filename)


### PR DESCRIPTION
Gives the user a way to keep the original filename of files on upload.
The default behavior remains the current one to avoid breaking changes, but it can be changed with `->keepFilename()`.

Perhaps users should be warned of the risk of collisions in the event of duplicate filenames or we should implement a way to avoid them.

With images it still doesn't work as `getClientOriginalName()` always returns 'blob', I don't know if you want to wait for this PR ( https://github.com/livewire/livewire/pull/4486), hoping it will be accepted soon.