### PR TITLE
added code by @DanHarrin to fix the problem with limit() on TextColumns

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -39,7 +39,13 @@ trait CanFormatState
 
     public function limit(int $length = 100, string $end = '...'): static
     {
-        $this->formatStateUsing(fn ($state): string => Str::limit($state, $length, $end));
+        $this->formatStateUsing(function ($state) use ($length, $end): ?string {
+            if (blank($state)) {
+                return null;
+            }
+
+            return Str::limit($state, $length, $end);
+        });
 
         return $this;
     }


### PR DESCRIPTION
Previously if the table had any entries with a NULL value it would error out, Dan provided the following fix on Discord.