### PR TITLE
removed z-10 from paginated item

### DIFF
--- a/packages/tables/resources/views/components/pagination/item.blade.php
+++ b/packages/tables/resources/views/components/pagination/item.blade.php
@@ -16,13 +16,13 @@
             'focus:text-primary-600' => (! $active) && (! $disabled) && (! $icon) && (! $separator),
             'transition' => ((! $active) && (! $disabled) && (! $separator)) || $active,
             'text-primary-600' => ((! $active) && (! $disabled) && $icon && (! $separator)) || $active,
-            'z-10 focus:underline bg-primary-500/10 ring-2 ring-primary-500' => $active,
+            'focus:underline bg-primary-500/10 ring-2 ring-primary-500' => $active,
             'cursor-not-allowed opacity-75' => $disabled,
             'cursor-default' => $separator,
         ]) }}
     >
         @if ($icon)
-            <x-dynamic-component :component="$icon" class="h-5 w-5 rtl:rotate-180" />
+            <x-dynamic-component :component="$icon" class="w-5 h-5 rtl:rotate-180" />
         @endif
 
         <span>{{ $label ?? ($separator ? '...' : '') }}</span>


### PR DESCRIPTION
#1172

assuming it wasn't intentional to have z-10 class applied, so tiny fix for the paginated item peeking through any drop downs used on table filters:

![chrome_amsvWmxfJR](https://user-images.githubusercontent.com/2905728/148760450-a571fc7d-25d0-4482-ab3c-a6c10beba16e.png)

