### PR TITLE
Fixes RTL forever🔥

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "filament",
     "scripts": {
-        "build": "node bin/build && mix --production",
+        "build": "rtlcss packages/admin/dist/app.css packages/admin/dist/app-rtl.css && node bin/build && mix --production",
         "watch": "node bin/build && mix watch"
     },
     "devDependencies": {
@@ -29,6 +29,7 @@
         "marked": "^3.0.0",
         "mdhl": "^0.0.6",
         "postcss": "^8.4.4",
+        "rtlcss": "^3.5.0",
         "tailwindcss": "^3.0.0",
         "trix": "^1.3.1"
     }

--- a/packages/admin/resources/views/components/button.blade.php
+++ b/packages/admin/resources/views/components/button.blade.php
@@ -25,12 +25,12 @@
         'w-6 h-6' => $size === 'md',
         'w-7 h-7' => $size === 'lg',
         'w-5 h-5' => $size === 'sm',
-        'mr-1 -ml-2 rtl:ml-1 rtl:-mr-2' => ($iconPosition === 'before') && ($size === 'md'),
-        'mr-2 -ml-3 rtl:ml-2 rtl:-mr-3' => ($iconPosition === 'before') && ($size === 'lg'),
-        'mr-1 -ml-1.5 rtl:ml-1 rtl:-mr-1.5' => ($iconPosition === 'before') && ($size === 'sm'),
-        'ml-1 -mr-2 rtl:mr-1 rtl:-ml-2' => ($iconPosition === 'after') && ($size === 'md'),
-        'ml-2 -mr-3 rtl:mr-2 rtl:-ml-3' => ($iconPosition === 'after') && ($size === 'lg'),
-        'ml-1 -mr-1.5 rtl:mr-1 rtl:-ml-1.5' => ($iconPosition === 'after') && ($size === 'sm'),
+        'mr-1 -ml-2' => ($iconPosition === 'before') && ($size === 'md'),
+        'mr-2 -ml-3' => ($iconPosition === 'before') && ($size === 'lg'),
+        'mr-1 -ml-1.5' => ($iconPosition === 'before') && ($size === 'sm'),
+        'ml-1 -mr-2' => ($iconPosition === 'after') && ($size === 'md'),
+        'ml-2 -mr-3' => ($iconPosition === 'after') && ($size === 'lg'),
+        'ml-1 -mr-1.5' => ($iconPosition === 'after') && ($size === 'sm'),
     ]);
 @endphp
 

--- a/packages/admin/resources/views/components/global-search/results-container.blade.php
+++ b/packages/admin/resources/views/components/global-search/results-container.blade.php
@@ -8,7 +8,7 @@
     x-on:keydown.escape.window="isOpen = false"
     x-on:click.away="isOpen = false"
     x-on:open-global-search-results.window="isOpen = true"
-    {{ $attributes->class(['absolute right-0 rtl:right-auto rtl:left-0 top-auto z-10 mt-2 shadow-xl overflow-hidden rounded-xl w-screen max-w-xs sm:max-w-lg']) }}
+    {{ $attributes->class(['absolute right-0 top-auto z-10 mt-2 shadow-xl overflow-hidden rounded-xl w-screen max-w-xs sm:max-w-lg']) }}
 >
     <div class="overflow-y-scroll overflow-x-hidden max-h-96 bg-white shadow rounded-xl">
         @forelse ($results as $group => $groupedResults)

--- a/packages/admin/resources/views/components/layouts/app.blade.php
+++ b/packages/admin/resources/views/components/layouts/app.blade.php
@@ -11,7 +11,7 @@
 
         <x-filament::layouts.app.sidebar />
 
-        <div class="w-screen space-y-6 flex-1 flex flex-col lg:pl-80 rtl:lg:pl-0 rtl:lg:pr-80">
+        <div class="w-screen space-y-6 flex-1 flex flex-col lg:pl-80">
             <header class="h-[4rem] shrink-0 w-full border-b flex items-center">
                 <div @class([
                     'flex items-center w-full px-2 mx-auto sm:px-4 md:px-6 lg:px-8',

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -1,8 +1,8 @@
 <aside
     x-data="{}"
     x-cloak
-    x-bind:class="$store.sidebar.isOpen ? 'translate-x-0' : '-translate-x-full rtl:lg:-translate-x-0 rtl:translate-x-full'"
-    class="fixed inset-y-0 left-0 rtl:left-auto rtl:right-0 z-20 flex flex-col h-screen overflow-hidden shadow-2xl transition duration-300 bg-white lg:border-r w-80 lg:z-0 lg:translate-x-0"
+    x-bind:class="$store.sidebar.isOpen ? 'translate-x-0' : '-translate-x-full'"
+    class="fixed inset-y-0 left-0 z-20 flex flex-col h-screen overflow-hidden shadow-2xl transition duration-300 bg-white lg:border-r w-80 lg:z-0 lg:translate-x-0"
 >
     <header class="border-b h-[4rem] shrink-0 px-6 flex items-center">
         <a href="{{ config('filament.home_url') }}">

--- a/packages/admin/resources/views/components/notification.blade.php
+++ b/packages/admin/resources/views/components/notification.blade.php
@@ -18,7 +18,7 @@
             x-show="isVisible"
             x-transition
             @class([
-                'flex items-start px-3 py-2 space-x-2 rtl:space-x-reverse text-xs shadow ring-1 rounded-xl',
+                'flex items-start px-3 py-2 space-x-2 text-xs shadow ring-1 rounded-xl',
                 match ($status) {
                     'danger' => 'bg-danger-50 ring-danger-200',
                     'success' => 'bg-success-50 ring-success-200',

--- a/packages/admin/resources/views/widgets/account-widget.blade.php
+++ b/packages/admin/resources/views/widgets/account-widget.blade.php
@@ -3,7 +3,7 @@
         $user = \Filament\Facades\Filament::auth()->user();
     @endphp
 
-    <div class="h-12 flex items-center space-x-4 rtl:space-x-reverse">
+    <div class="h-12 flex items-center space-x-4">
         <div
             class="w-10 h-10 rounded-full bg-gray-200 bg-cover bg-center"
             style="background-image: url('{{ \Filament\Facades\Filament::getUserAvatarUrl($user) }}')"

--- a/packages/admin/resources/views/widgets/filament-info-widget.blade.php
+++ b/packages/admin/resources/views/widgets/filament-info-widget.blade.php
@@ -1,5 +1,5 @@
 <x-filament::card class="relative">
-    <div class="relative h-12 flex flex-col justify-center items-center space-y-2 rtl:space-x-reverse">
+    <div class="relative h-12 flex flex-col justify-center items-center space-y-2">
         <div class="space-y-1">
             <a
                 href="https://filamentadmin.com"
@@ -41,7 +41,7 @@
         </div>
     </div>
 
-    <svg class="h-16 w-16 absolute right-0 rtl:right-auto rtl:left-0 bottom-0" xmlns="http://www.w3.org/2000/svg"
+    <svg class="h-16 w-16 absolute right-0 bottom-0" xmlns="http://www.w3.org/2000/svg"
          width="300.000000pt" height="418.000000pt" viewBox="0 0 300.000000 418.000000"
          preserveAspectRatio="xMidYMid meet">
         <g transform="translate(0 418) scale(.1 -.1)" fill="#111827" xmlns="http://www.w3.org/2000/svg">

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -67,7 +67,7 @@
                 class="w-full h-full p-0 placeholder-gray-400 border-0 focus:placeholder-gray-500 focus:ring-0 focus:outline-none"
             />
 
-            <span class="absolute inset-y-0 right-0 rtl:right-auto rtl:left-0 flex items-center pr-2 rtl:pl-2 pointer-events-none">
+            <span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
                 <svg class="w-5 h-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                 </svg>
@@ -89,7 +89,7 @@
             >
                 <div class="space-y-3">
                     @if ($hasDate())
-                        <div class="flex items-center justify-between space-x-1 rtl:space-x-reverse">
+                        <div class="flex items-center justify-between space-x-1">
                             <select
                                 x-model="focusedMonth"
                                 class="grow p-0 text-lg font-medium text-gray-800 border-0 cursor-pointer focus:ring-0 focus:outline-none"

--- a/packages/forms/resources/views/components/field-wrapper/index.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/index.blade.php
@@ -19,7 +19,7 @@
 
     <div class="space-y-2">
         @if (($label && ! $labelSrOnly) || $hint)
-            <div class="flex items-center justify-between space-x-2 rtl:space-x-reverse">
+            <div class="flex items-center justify-between space-x-2">
                 @if ($label && ! $labelSrOnly)
                     <x-forms::field-wrapper.label
                         :for="$id"

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -5,7 +5,7 @@
     'suffix' => null,
 ])
 
-<label {{ $attributes->class(['inline-flex items-center space-x-3 rtl:space-x-reverse']) }}>
+<label {{ $attributes->class(['inline-flex items-center space-x-3']) }}>
     {{ $prefix }}
 
     <span @class([

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -23,10 +23,10 @@
                     <markdown-toolbar
                         for="{{ $getId() }}"
                         x-bind:class="{ 'pointer-events-none opacity-75': tab === 'preview' }"
-                        class="flex items-stretch space-x-4 rtl:space-x-reverse focus:outline-none"
+                        class="flex items-stretch space-x-4 focus:outline-none"
                     >
                         @if ($hasToolbarButton(['bold', 'italic', 'strike']))
-                            <div class="flex items-stretch space-x-1 rtl:space-x-reverse">
+                            <div class="flex items-stretch space-x-1">
                                 @if ($hasToolbarButton('bold'))
                                     <x-forms::markdown-editor.toolbar-button
                                         title="{{ __('forms::components.markdown_editor.toolbar_buttons.bold') }}"
@@ -60,7 +60,7 @@
                         @endif
 
                         @if ($hasToolbarButton(['link', 'attachFiles', 'codeBlock']))
-                            <div class="flex items-stretch space-x-1 rtl:space-x-reverse">
+                            <div class="flex items-stretch space-x-1">
                                 @if ($hasToolbarButton('link'))
                                     <x-forms::markdown-editor.toolbar-button
                                         title="{{ __('forms::components.markdown_editor.toolbar_buttons.link') }}"
@@ -94,7 +94,7 @@
                         @endif
 
                         @if ($hasToolbarButton(['bulletList', 'orderedList']))
-                            <div class="flex items-stretch space-x-1 rtl:space-x-reverse">
+                            <div class="flex items-stretch space-x-1">
                                 @if ($hasToolbarButton('bulletList'))
                                     <x-forms::markdown-editor.toolbar-button
                                         title="{{ __('forms::components.markdown_editor.toolbar_buttons.bullet_list') }}"
@@ -119,7 +119,7 @@
                     </markdown-toolbar>
 
                     @if ($hasToolbarButton(['edit', 'preview']) && ! $isDisabled())
-                        <div class="flex items-center space-x-4 rtl:space-x-reverse">
+                        <div class="flex items-center space-x-4">
                             @if ($hasToolbarButton('edit'))
                                 <button
                                     x-on:click.prevent="tab = 'edit'"

--- a/packages/forms/resources/views/components/multi-select.blade.php
+++ b/packages/forms/resources/views/components/multi-select.blade.php
@@ -60,7 +60,7 @@
                         class="block w-full border-0"
                     />
 
-                    <span class="absolute inset-y-0 right-0 rtl:right-auto rtl:left-0 flex items-center pr-2 rtl:pr-0 rtl:pl-2 pointer-events-none">
+                    <span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
                         <svg x-show="! isLoading" x-cloak class="w-5 h-5"xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
                             <path stroke="#6B7280" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 8l4 4 4-4" />
                         </svg>
@@ -141,7 +141,7 @@
 
         <div
             x-show="state.length"
-            class="overflow-hidden rtl:space-x-reverse relative w-full px-1 py-1"
+            class="overflow-hidden relative w-full px-1 py-1"
         >
             <div class="flex flex-wrap gap-1">
                 <template class="inline" x-for="option in state" x-bind:key="option">
@@ -151,7 +151,7 @@
                         @endunless
                         type="button"
                         @class([
-                            'inline-flex items-center justify-center h-6 px-2 my-1 text-sm font-medium tracking-tight text-primary-700 rounded-full bg-primary-500/10 space-x-1 rtl:space-x-reverse',
+                            'inline-flex items-center justify-center h-6 px-2 my-1 text-sm font-medium tracking-tight text-primary-700 rounded-full bg-primary-500/10 space-x-1',
                             'cursor-default' => $isDisabled(),
                         ])
                     >

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -51,7 +51,7 @@
 
             <div
                 x-show="state.length"
-                class="overflow-hidden rtl:space-x-reverse relative w-full px-1 py-1"
+                class="overflow-hidden relative w-full px-1 py-1"
             >
                 <div class="flex flex-wrap gap-1">
                     <template class="inline" x-for="tag in state" x-bind:key="tag">

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -35,7 +35,7 @@
                 <span
                     class="pointer-events-none relative inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 ease-in-out transition duration-200 translate-x-0"
                     :class="{
-                        'translate-x-5 rtl:-translate-x-5': state,
+                        'translate-x-5': state,
                         'translate-x-0': ! state,
                     }"
                 >

--- a/packages/tables/resources/views/components/button.blade.php
+++ b/packages/tables/resources/views/components/button.blade.php
@@ -27,12 +27,12 @@
         'w-6 h-6' => $size === 'md',
         'w-7 h-7' => $size === 'lg',
         'w-5 h-5' => $size === 'sm',
-        'mr-1 -ml-2 rtl:ml-1 rtl:-mr-2' => ($iconPosition === 'before') && ($size === 'md'),
-        'mr-2 -ml-3 rtl:ml-2 rtl:-mr-3' => ($iconPosition === 'before') && ($size === 'lg'),
-        'mr-1 -ml-1.5 rtl:ml-1 rtl:-mr-1.5' => ($iconPosition === 'before') && ($size === 'sm'),
-        'ml-1 -mr-2 rtl:mr-1 rtl:-ml-2' => ($iconPosition === 'after') && ($size === 'md'),
-        'ml-2 -mr-3 rtl:mr-2 rtl:-ml-3' => ($iconPosition === 'after') && ($size === 'lg'),
-        'ml-1 -mr-1.5 rtl:mr-1 rtl:-ml-1.5' => ($iconPosition === 'after') && ($size === 'sm'),
+        'mr-1 -ml-2' => ($iconPosition === 'before') && ($size === 'md'),
+        'mr-2 -ml-3' => ($iconPosition === 'before') && ($size === 'lg'),
+        'mr-1 -ml-1.5' => ($iconPosition === 'before') && ($size === 'sm'),
+        'ml-1 -mr-2' => ($iconPosition === 'after') && ($size === 'md'),
+        'ml-2 -mr-3' => ($iconPosition === 'after') && ($size === 'lg'),
+        'ml-1 -mr-1.5' => ($iconPosition === 'after') && ($size === 'sm'),
     ]);
 @endphp
 

--- a/packages/tables/resources/views/components/dropdown/item.blade.php
+++ b/packages/tables/resources/views/components/dropdown/item.blade.php
@@ -17,7 +17,7 @@
     >
         @if ($icon)
             <x-dynamic-component :component="$icon" :class="\Illuminate\Support\Arr::toCssClasses([
-                'mr-2 -ml-1 rtl:ml-2 rtl:-mr-1 group-hover:text-white group-focus:text-white w-6 h-6',
+                'mr-2 -ml-1 group-hover:text-white group-focus:text-white w-6 h-6',
                 'text-primary-500' => $color === 'primary',
                 'text-danger-500' => $color === 'danger',
                 'text-success-500' => $color === 'success',

--- a/packages/tables/resources/views/components/filters/index.blade.php
+++ b/packages/tables/resources/views/components/filters/index.blade.php
@@ -20,7 +20,7 @@
         x-transition:leave-start="opacity-100 translate-y-0"
         x-transition:leave-end="opacity-0 translate-y-2"
         @class([
-            'absolute right-0 rtl:right-auto rtl:left-0 z-10 w-screen pl-12 rtl:pr-12 mt-2 top-full transition',
+            'absolute right-0 z-10 w-screen pl-12 mt-2 top-full transition',
             match ($width) {
                 'xs' => 'max-w-xs',
                 'md' => 'max-w-md',

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -12,7 +12,7 @@
         @endif
         type="button"
         @class([
-            'flex items-center whitespace-nowrap space-x-1 rtl:space-x-reverse font-medium text-sm text-gray-600',
+            'flex items-center whitespace-nowrap space-x-1 font-medium text-sm text-gray-600',
             'cursor-default' => ! $sortable,
         ])
     >

--- a/packages/tables/resources/views/components/pagination/item.blade.php
+++ b/packages/tables/resources/views/components/pagination/item.blade.php
@@ -22,7 +22,7 @@
         ]) }}
     >
         @if ($icon)
-            <x-dynamic-component :component="$icon" class="w-5 h-5 rtl:rotate-180" />
+            <x-dynamic-component :component="$icon" class="w-5 h-5" />
         @endif
 
         <span>{{ $label ?? ($separator ? '...' : '') }}</span>

--- a/packages/tables/resources/views/components/pagination/records-per-page-selector.blade.php
+++ b/packages/tables/resources/views/components/pagination/records-per-page-selector.blade.php
@@ -2,7 +2,7 @@
     'options',
 ])
 
-<div class="flex items-center space-x-2 rtl:space-x-reverse">
+<div class="flex items-center space-x-2">
     <select wire:model="tableRecordsPerPage" id="tableRecordsPerPageSelect" class="h-8 text-sm pr-8 leading-none transition duration-75 border-gray-200 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600">
         @foreach ($options as $option)
             <option value="{{ $option }}">{{ $option }}</option>

--- a/packages/tables/resources/views/components/table.blade.php
+++ b/packages/tables/resources/views/components/table.blade.php
@@ -3,7 +3,7 @@
     'header' => null,
 ])
 
-<table {{ $attributes->class(['w-full text-left rtl:text-right divide-y table-auto']) }}>
+<table {{ $attributes->class(['w-full text-left divide-y table-auto']) }}>
     @if ($header)
         <thead>
             <tr class="bg-gray-50">


### PR DESCRIPTION
Hi🖐️

Using the `rtl` modifier isn't a standard way of doing RTL, and it's a pain for the developers.

In this PR, I removed all `rtl` modifier classes and I added the [RTLCSS](https://rtlcss.com) package so the RTL CSS code automatically get created.

RTLCSS will do everything you need. So, you don't need to worry about RTL anymore.
- You are not going to get any RTL related issues
- No extra work like `rtl:pr-4`
- The source code going to be much cleaner
- And much more...

I set it up so RTLCSS will create a file named `app-rtl.css` in `dist` folder. See `package.json`'s `build` script.

This PR isn't complete because I'm not a Laravel developer and I didn't know how to handle the rest. I only prepared and added some necessary changes. What else needs to be done:
1. Add a config option (for RTL) to users be able to switch between `app.css` and `app-rtl.css` files.
2. Do `npm run build`
3. Please read [RTLCSS docs](https://rtlcss.com/learn) for the config options and more...

---

This isn't 100% necessary but it's good to have. Some icons also need to support RTL. For example, if you are using an icon like this "👉", it needs to look like this "👈" in RTL.

## How to accomplish this?

1. Add the SVG shape name as a class to the `<svg>` tag. For example: `<svg class="svg-dashboard" />`.
2. Add this config to `tailwind.config.js`:
```
theme: {
	extend: {
		scale: {
			'-px': '-1',
		},
	},
},
```
3. add this CSS:
```css
.svg-dashboard {
  @apply -scale-x-px;
}
```
This will do the trick.
You can also add this class `-scale-x-px` to make this "👇" look like this "👆".

---
Thanks for reading🥲 Mention me if you need any help.