### PR TITLE
Include hidden component containers when hydrating a form

### DIFF
--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -221,7 +221,7 @@ class Builder extends Field
         return $this->getChildComponentContainer()->getComponents();
     }
 
-    public function getChildComponentContainers(): array
+    public function getChildComponentContainers(bool $withHidden = false): array
     {
         return collect($this->getState())
             ->map(function ($itemData, $itemIndex): ComponentContainer {

--- a/packages/forms/src/Components/Concerns/HasChildComponents.php
+++ b/packages/forms/src/Components/Concerns/HasChildComponents.php
@@ -46,7 +46,7 @@ trait HasChildComponents
 
     public function hasChildComponentContainer(bool $withHidden = false): bool
     {
-        if ($this->isHidden() && ! $withHidden) {
+        if ((! $withHidden) && $this->isHidden()) {
             return false;
         }
 

--- a/packages/forms/src/Components/Concerns/HasChildComponents.php
+++ b/packages/forms/src/Components/Concerns/HasChildComponents.php
@@ -35,17 +35,17 @@ trait HasChildComponents
             ->components($this->getChildComponents());
     }
 
-    public function getChildComponentContainers(): array
+    public function getChildComponentContainers(bool $withHidden = false): array
     {
-        if (! $this->hasChildComponentContainer()) {
+        if (! $this->hasChildComponentContainer($withHidden)) {
             return [];
         }
 
         return [$this->getChildComponentContainer()];
     }
 
-    public function hasChildComponentContainer(): bool
+    public function hasChildComponentContainer(bool $withHidden = false): bool
     {
-        return ! $this->isHidden() && $this->getChildComponents() !== [];
+        return $withHidden ?: ! $this->isHidden() && $this->getChildComponents() !== [];
     }
 }

--- a/packages/forms/src/Components/Concerns/HasChildComponents.php
+++ b/packages/forms/src/Components/Concerns/HasChildComponents.php
@@ -46,6 +46,14 @@ trait HasChildComponents
 
     public function hasChildComponentContainer(bool $withHidden = false): bool
     {
-        return $withHidden ?: ! $this->isHidden() && $this->getChildComponents() !== [];
+        if ($this->isHidden() && ! $withHidden) {
+            return false;
+        }
+
+        if ($this->getChildComponents() === []) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/packages/forms/src/Components/HasManyRepeater.php
+++ b/packages/forms/src/Components/HasManyRepeater.php
@@ -90,7 +90,7 @@ class HasManyRepeater extends Repeater
         );
     }
 
-    public function getChildComponentContainers(): array
+    public function getChildComponentContainers(bool $withHidden = false): array
     {
         return collect($this->getState())
             ->map(function ($itemData, $itemKey): ComponentContainer {

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -182,7 +182,7 @@ class Repeater extends Field
         $this->getChildComponentContainers()[$uuid]->hydrateDefaultState();
     }
 
-    public function getChildComponentContainers(): array
+    public function getChildComponentContainers(bool $withHidden = false): array
     {
         return collect($this->getState())
             ->map(function ($itemData, $itemIndex): ComponentContainer {

--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -13,7 +13,7 @@ trait HasState
         foreach ($this->getComponents(withHidden: true) as $component) {
             $component->callAfterStateHydrated();
 
-            foreach ($component->getChildComponentContainers() as $container) {
+            foreach ($component->getChildComponentContainers(withHidden: true) as $container) {
                 $container->callAfterStateHydrated();
             }
         }
@@ -160,7 +160,7 @@ trait HasState
             $component->hydrateDefaultState();
             $component->callAfterStateHydrated();
 
-            foreach ($component->getChildComponentContainers() as $container) {
+            foreach ($component->getChildComponentContainers(withHidden: true) as $container) {
                 $container->hydrateDefaultState();
             }
         }


### PR DESCRIPTION
When calling `$this->form->fill()` to set initial default values or to clear a form after submission, hidden component containers are ignored. 

This PR ensure all fields are hydrated.