### PR TITLE
Add hook to register plugin macros

### DIFF
--- a/packages/admin/src/PluginServiceProvider.php
+++ b/packages/admin/src/PluginServiceProvider.php
@@ -100,6 +100,8 @@ abstract class PluginServiceProvider extends PackageServiceProvider
         foreach ($this->getWidgets() as $widget) {
             Livewire::component($widget::getName(), $widget);
         }
+        
+        $this->registerMacros();
     }
 
     protected function getCommands(): array
@@ -141,4 +143,6 @@ abstract class PluginServiceProvider extends PackageServiceProvider
     {
         return $this->widgets;
     }
+    
+    protected function registerMacros(): void {}
 }


### PR DESCRIPTION
Instead of overriding the `packageBooted()` method when extending the `Filament/PluginServiceProvider`, this PR adds a method that also makes it possible for Filament to control _when_ `macros` should be registered.

Also suggest to add the method to the Plugin development documentation.