### PR TITLE
fix: CanViewRecord hiding all relations in edit page

### DIFF
--- a/packages/admin/src/Resources/Pages/EditRecord.php
+++ b/packages/admin/src/Resources/Pages/EditRecord.php
@@ -44,7 +44,7 @@ class EditRecord extends Page implements Forms\Contracts\HasForms
 
         $this->fillForm();
 
-        $this->activeRelationManager ??= $this->getRelationManagers()[0] ?? null;
+        $this->activeRelationManager ??= $this->getRelationManagers()[1] ?? null;
     }
 
     protected function fillForm(): void


### PR DESCRIPTION
This fixes hidden relationship table when using CanViewRecord.