### PR TITLE
chore: make `Page::notify()` public

### DIFF
--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -77,7 +77,7 @@ class Page extends Component implements Forms\Contracts\HasForms
         return route(static::getRouteName(), $parameters, $absolute);
     }
 
-    protected function notify(string $status, string $message): void
+    public function notify(string $status, string $message): void
     {
         session()->flash('notification', [
             'message' => $message,


### PR DESCRIPTION
Makes the `Page::notify()` method public. Will allow people to request the `Component $livewire` in a callback and call `$livewire->notify()` without having to guarantee execution context of the callback.