### PR TITLE
Allow string rules()

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -62,8 +62,12 @@ trait CanBeValidated
         return $this;
     }
 
-    public function rules(array $rules, bool | Closure $condition = true): static
+    public function rules(string | array $rules, bool | Closure $condition = true): static
     {
+        if(is_string($rules)) {
+            $rules = explode('|', $rules);
+        }
+        
         $this->rules = array_merge(
             $this->rules,
             array_map(fn (string | object $rule) => [$rule, $condition], $rules),

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -64,7 +64,7 @@ trait CanBeValidated
 
     public function rules(string | array $rules, bool | Closure $condition = true): static
     {
-        if(is_string($rules)) {
+        if (is_string($rules)) {
             $rules = explode('|', $rules);
         }
         


### PR DESCRIPTION
This PR adds support for validation `rules()` as `string`. 
Less typing :)

Example:
```php
TextInput::make('name')->rules('required|string|min:2|max:125'),
```