### PR TITLE
feature: advanced (isolated) navigation API

### DIFF
--- a/packages/admin/src/Facades/Filament.php
+++ b/packages/admin/src/Facades/Filament.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string | null getUserAvatarUrl(Authenticatable $user)
  * @method static string getUserName(Authenticatable $user)
  * @method static array getWidgets()
+ * @method static void navigation(\Closure $builder)
  * @method static void registerNavigationGroups(array $groups)
  * @method static void registerNavigationItems(array $items)
  * @method static void registerPages(array $pages)

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -34,7 +34,7 @@ class FilamentManager
 
     protected array $widgets = [];
 
-    protected ?Closure $navigationBuilder;
+    protected ?Closure $navigationBuilder = null;
 
     public function auth(): Guard
     {

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -6,7 +6,6 @@ use Closure;
 use Filament\Events\ServingFilament;
 use Filament\Models\Contracts\HasAvatar;
 use Filament\Models\Contracts\HasName;
-use Filament\Navigation\NavigationBuilder;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -49,9 +49,7 @@ class FilamentManager
     public function buildNavigation(): array
     {
         /** @var \Filament\Navigation\NavigationBuilder $builder */
-        $builder = app()->call($this->navigationBuilder, [
-            'builder' => new NavigationBuilder(),
-        ]);
+        $builder = app()->call($this->navigationBuilder);
 
         return collect($builder->getGroups())
             ->merge([null => $builder->getItems()])

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -50,7 +50,7 @@ class FilamentManager
     {
         /** @var \Filament\Navigation\NavigationBuilder $builder */
         $builder = app()->call($this->navigationBuilder, [
-            'builder' => new NavigationBuilder
+            'builder' => new NavigationBuilder(),
         ]);
 
         return collect($builder->getGroups())

--- a/packages/admin/src/Navigation/NavigationBuilder.php
+++ b/packages/admin/src/Navigation/NavigationBuilder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Filament\Navigation;
+
+class NavigationBuilder
+{
+    /** @var array<string, \Filament\Navigation\NavigationItem[]> */
+    protected array $groups = [];
+
+    /** @var \Filament\Navigation\NavigationItem[] */
+    protected array $items = [];
+
+    public function group(string $name, array $items = []): static
+    {
+        $this->groups[$name] = collect($items)->each(
+            fn (NavigationItem $item, $i) => $item->group($name)->sort($i)
+        )->toArray();
+
+        return $this;
+    }
+
+    public function item(NavigationItem $item): static
+    {
+        $this->items[] = $item;
+
+        return $this;
+    }
+
+    /** @param \Filament\Navigation\NavigationItem[] $items */
+    public function items(array $items): static
+    {
+        foreach ($items as $item) {
+            $this->item($item);
+        }
+
+        return $this;
+    }
+
+    public function getGroups(): array
+    {
+        return $this->groups;
+    }
+
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+}

--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -40,7 +40,12 @@ class Page extends Component implements Forms\Contracts\HasForms
             return;
         }
 
-        Filament::registerNavigationItems([
+        Filament::registerNavigationItems(static::getNavigationItems());
+    }
+
+    public static function getNavigationItems(): array
+    {
+        return [
             NavigationItem::make()
                 ->group(static::getNavigationGroup())
                 ->icon(static::getNavigationIcon())
@@ -48,7 +53,7 @@ class Page extends Component implements Forms\Contracts\HasForms
                 ->label(static::getNavigationLabel())
                 ->sort(static::getNavigationSort())
                 ->url(static::getNavigationUrl()),
-        ]);
+        ];
     }
 
     public static function getRouteName(): string

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -55,9 +55,14 @@ class Resource
             return;
         }
 
+        Filament::registerNavigationItems(static::getNavigationItems());
+    }
+
+    public static function getNavigationItems(): array
+    {
         $routeBaseName = static::getRouteBaseName();
 
-        Filament::registerNavigationItems([
+        return [
             NavigationItem::make()
                 ->group(static::getNavigationGroup())
                 ->icon(static::getNavigationIcon())
@@ -65,7 +70,7 @@ class Resource
                 ->label(static::getNavigationLabel())
                 ->sort(static::getNavigationSort())
                 ->url(static::getNavigationUrl()),
-        ]);
+        ];
     }
 
     public static function table(Table $table): Table


### PR DESCRIPTION
This pull request lays the foundations for a more advanced Navigation API that allows complete control over the navigation sidebar.

It introduces a new `Filament::navigation()` method which can be called from the `boot` method of a `ServiceProvider`.

```php
use Filament\Navigation\NavigationBuilder;

// The `$builder` is required since the callback is invoked through the container.
Filament::navigation(function (NavigationBuilder $builder) {

});
```

Once you add this callback function, Filament's default automatic navigation will be disabled and your sidebar will be empty. This is done on purpose, since this new API is designed to give you complete control over the navigation.

If you want to register a new group, you can call the `NavigationBuilder::group` method.

```php
Filament::navigation(function (NavigationBuilder $builder) {
    $builder->group('Settings', [
        // An array of `NavigationItem` objects.
    ]);
});
```

You provide the name of the group and an array of `NavigationItem` objects to be rendered. If you've got a `Resource` or `Page` you'd like to register in this group, you can use the following syntax:

```php
Filament::navigation(function (NavigationBuilder $builder) {
    $builder->group('Content', [
        ...PageResource::getNavigationItems(),
        ...CategoryResource::getNavigationItems(),
    ]);
});
```

The `Resource::getNavigationItems()` and `Page::getNavigationItems()` methods were introduced in this PR, so anybody who has overwritten the original `registerNavigationItems()` method will need to do some extra work to get this syntax working.

You can also register ungrouped items using the `NavigationBuilder::item()` and `NavigationBuilder::items()` methods.
