### PR TITLE
Add extra classes to the main layout and sidebar components

### DIFF
--- a/packages/admin/resources/views/components/layouts/app.blade.php
+++ b/packages/admin/resources/views/components/layouts/app.blade.php
@@ -6,7 +6,7 @@
             x-show="$store.sidebar.isOpen"
             x-transition.opacity.500ms
             x-on:click="$store.sidebar.close()"
-            class="fixed inset-0 z-20 w-full h-full bg-gray-900/50 lg:hidden filament-sidebar-close"
+            class="fixed inset-0 z-20 w-full h-full bg-gray-900/50 lg:hidden filament-sidebar-close-overlay"
         ></div>
 
         <x-filament::layouts.app.sidebar />

--- a/packages/admin/resources/views/components/layouts/app.blade.php
+++ b/packages/admin/resources/views/components/layouts/app.blade.php
@@ -6,13 +6,13 @@
             x-show="$store.sidebar.isOpen"
             x-transition.opacity.500ms
             x-on:click="$store.sidebar.close()"
-            class="fixed inset-0 z-20 w-full h-full bg-gray-900/50 lg:hidden"
+            class="fixed inset-0 z-20 w-full h-full bg-gray-900/50 lg:hidden filament-sidebar-close"
         ></div>
 
         <x-filament::layouts.app.sidebar />
 
-        <div class="w-screen space-y-6 flex-1 flex flex-col lg:pl-80 rtl:lg:pl-0 rtl:lg:pr-80">
-            <header class="h-[4rem] shrink-0 w-full border-b flex items-center">
+        <div class="w-screen space-y-6 flex-1 flex flex-col lg:pl-80 rtl:lg:pl-0 rtl:lg:pr-80 filament-main">
+            <header class="h-[4rem] shrink-0 w-full border-b flex items-center filament-main-header">
                 <div @class([
                     'flex items-center w-full px-2 mx-auto sm:px-4 md:px-6 lg:px-8',
                     match (config('filament.layout.max_content_width')) {
@@ -26,12 +26,12 @@
                         default => 'max-w-7xl',
                     },
                 ])>
-                    <button x-data="{}" x-on:click="$store.sidebar.open()" class="shrink-0 flex items-center justify-center w-10 h-10 text-primary-500 rounded-full hover:bg-gray-500/5 focus:bg-primary-500/10 focus:outline-none lg:hidden">
+                    <button x-data="{}" x-on:click="$store.sidebar.open()" class="shrink-0 flex items-center justify-center w-10 h-10 text-primary-500 rounded-full hover:bg-gray-500/5 focus:bg-primary-500/10 focus:outline-none lg:hidden filament-sidebar-open">
                         <x-heroicon-o-menu class="w-6 h-6" />
                     </button>
 
                     <div class="flex-1 flex items-center justify-between">
-                        <div>
+                        <div class="filament-breadcrumbs">
                             <ul class="hidden gap-4 items-center font-medium text-sm lg:flex">
                                 @foreach ($breadcrumbs as $url => $label)
                                     <li>
@@ -58,7 +58,7 @@
             </header>
 
             <div @class([
-                'flex-1 w-full px-4 mx-auto md:px-6 lg:px-8',
+                'flex-1 w-full px-4 mx-auto md:px-6 lg:px-8 filament-main-content',
                 match (config('filament.layout.max_content_width')) {
                     'xl' => 'max-w-xl',
                     '2xl' => 'max-w-2xl',
@@ -73,7 +73,7 @@
                 {{ $slot }}
             </div>
 
-            <div class="py-4 shrink-0">
+            <div class="py-4 shrink-0 filament-main-footer">
                 <x-filament::footer />
             </div>
         </div>

--- a/packages/admin/resources/views/components/layouts/app.blade.php
+++ b/packages/admin/resources/views/components/layouts/app.blade.php
@@ -12,7 +12,7 @@
         <x-filament::layouts.app.sidebar />
 
         <div class="w-screen space-y-6 flex-1 flex flex-col lg:pl-80 rtl:lg:pl-0 rtl:lg:pr-80 filament-main">
-            <header class="h-[4rem] shrink-0 w-full border-b flex items-center filament-main-header">
+            <header class="h-[4rem] shrink-0 w-full border-b flex items-center filament-main-topbar">
                 <div @class([
                     'flex items-center w-full px-2 mx-auto sm:px-4 md:px-6 lg:px-8',
                     match (config('filament.layout.max_content_width')) {
@@ -26,7 +26,7 @@
                         default => 'max-w-7xl',
                     },
                 ])>
-                    <button x-data="{}" x-on:click="$store.sidebar.open()" class="shrink-0 flex items-center justify-center w-10 h-10 text-primary-500 rounded-full hover:bg-gray-500/5 focus:bg-primary-500/10 focus:outline-none lg:hidden filament-sidebar-open">
+                    <button x-data="{}" x-on:click="$store.sidebar.open()" class="shrink-0 flex items-center justify-center w-10 h-10 text-primary-500 rounded-full hover:bg-gray-500/5 focus:bg-primary-500/10 focus:outline-none lg:hidden filament-sidebar-open-button">
                         <x-heroicon-o-menu class="w-6 h-6" />
                     </button>
 

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -4,13 +4,13 @@
     x-bind:class="$store.sidebar.isOpen ? 'translate-x-0' : '-translate-x-full rtl:lg:-translate-x-0 rtl:translate-x-full'"
     class="fixed inset-y-0 left-0 rtl:left-auto rtl:right-0 z-20 flex flex-col h-screen overflow-hidden shadow-2xl transition duration-300 bg-white lg:border-r w-80 lg:z-0 lg:translate-x-0 filament-sidebar"
 >
-    <header class="border-b h-[4rem] shrink-0 px-6 flex items-center">
+    <header class="border-b h-[4rem] shrink-0 px-6 flex items-center filament-sidebar-header">
         <a href="{{ config('filament.home_url') }}">
             <x-filament::brand />
         </a>
     </header>
 
-    <nav class="flex-1 overflow-y-auto py-6">
+    <nav class="flex-1 overflow-y-auto py-6 filament-sidebar-nav">
         <x-filament::layouts.app.sidebar.start />
 
         <ul class="space-y-6 px-6">


### PR DESCRIPTION
This PR adds some additional classes to the main layout and sidebar components where there were a few gaps, I think due to the elements not being their own components so not receiving classes in the previous PR?

For example there's a `filament-sidebar-footer` class, but no `filament-sidebar-header`, and none of the main elements within `filament-app-layout` have a class, which leaves them quite tricky to target still.

The additional classes (in bold) are:

* filament-app-layout
    * **filament-sidebar-close**
    * **filament-main**
        * **filament-main-header**
            * **filament-sidebar-open**
            * **filament-breadcrumbs**
        * **filament-main-content**
        * **filament-main-footer**
* filament-sidebar
    * **filament-sidebar-header**
    * **filament-sidebar-nav**
    * filament-sidebar-footer

I'm sure you'll want to tweak some of the naming.