### PR TITLE
Locale DatePicker and DateTimePicker

### DIFF
--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -1,13 +1,10 @@
 @once
     @push('scripts')
         <script src="//unpkg.com/dayjs@1.10.4/dayjs.min.js"></script>
-        <script src="//unpkg.com/dayjs@1.10.4/plugin/localeData.js"></script>
-        <script>
-            dayjs.extend(window.dayjs_plugin_localeData)
-
-            window.dayjs_locale = dayjs.locale()
-        </script>
         <script src="//unpkg.com/dayjs@1.10.4/locale/{{ strtolower(str_replace('_', '-', app()->getLocale())) }}.js"></script>
+        <script>
+            window.dayjs_locale = window.dayjs_locale_{{strtolower(app()->getLocale())}};
+        </script>
     @endpush
 @endonce
 

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -3,7 +3,7 @@
         <script src="//unpkg.com/dayjs@1.10.4/dayjs.min.js"></script>
         <script src="//unpkg.com/dayjs@1.10.4/locale/{{ strtolower(str_replace('_', '-', app()->getLocale())) }}.js"></script>
         <script>
-            window.dayjs_locale = window.dayjs_locale_{{strtolower(app()->getLocale())}};
+            window.dayjs_locale = window.dayjs_locale_{{ strtolower(app()->getLocale()) }};
         </script>
     @endpush
 @endonce


### PR DESCRIPTION
With this change I'm passing the translation object directly, for some reason using locale name dont work.

This fix #1335 

I also removed the localeData script call that was being made in the blade file because it is already imported in js.

![image](https://user-images.githubusercontent.com/7275012/151854404-e0fa277d-c44c-43bb-be57-b4cd6d6946df.png)
![image](https://user-images.githubusercontent.com/7275012/151854459-7d39de65-b9d8-455b-8506-e7b8c66c1fd0.png)
