### PR TITLE
Add time() method to CanFormatState

### DIFF
--- a/packages/tables/config/tables.php
+++ b/packages/tables/config/tables.php
@@ -4,6 +4,7 @@ return [
 
     'date_format' => 'M j, Y',
     'date_time_format' => 'M j, Y H:i:s',
+    'time_format' => 'H:i',
 
     'default_filesystem_disk' => env('TABLES_FILESYSTEM_DRIVER', 'public'),
 

--- a/packages/tables/config/tables.php
+++ b/packages/tables/config/tables.php
@@ -4,7 +4,7 @@ return [
 
     'date_format' => 'M j, Y',
     'date_time_format' => 'M j, Y H:i:s',
-    'time_format' => 'H:i',
+    'time_format' => 'H:i:s',
 
     'default_filesystem_disk' => env('TABLES_FILESYSTEM_DRIVER', 'public'),
 

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -86,4 +86,13 @@ trait CanFormatState
 
         return $state;
     }
+
+    public function time(?string $format = null): static
+    {
+        $format ??= config('tables.time_format');
+
+        $this->date($format);
+
+        return $this;
+    }
 }


### PR DESCRIPTION
This PR adds a `time()` method to the `CanFormatState` trait, in addition to the already existing `date()` and `dateTime()` formatters.