### PR TITLE
Fix table checkbox alignment

### DIFF
--- a/packages/tables/resources/views/components/checkbox-cell.blade.php
+++ b/packages/tables/resources/views/components/checkbox-cell.blade.php
@@ -1,6 +1,6 @@
 <th {{ $attributes->class(['w-4 px-4 whitespace-nowrap', 'filament-tables-checkbox-cell']) }}>
     <input
-        {{ $checkbox->attributes->class(['border-gray-300 rounded shadow-sm text-primary-600 focus:border-primary-600 focus:ring focus:ring-primary-200 focus:ring-opacity-50']) }}
+        {{ $checkbox->attributes->class(['block border-gray-300 rounded shadow-sm text-primary-600 focus:border-primary-600 focus:ring focus:ring-primary-200 focus:ring-opacity-50']) }}
         type="checkbox"
     />
 </th>


### PR DESCRIPTION
The checkboxes in tables aren't perfectly aligned vertically:

![Screenshot 2022-02-02 at 14 48 45](https://user-images.githubusercontent.com/126740/152177421-ae1f4359-a179-456c-9325-06f8297ec60f.png)

This fixes that:

![Screenshot 2022-02-02 at 14 48 51](https://user-images.githubusercontent.com/126740/152177429-7c57dfd0-25b8-4c7a-a5b0-986f26c357c1.png)

Changes are:

* Add a `block` class to the checkbox element, which overrides the `display: inline-block` property, making the element center to the cell rather than to the baseline

Hope these PR's are OK, please shout if I'm doing anything wrong! 🙂