### PR TITLE
Fix multiselect item layout

### DIFF
--- a/packages/forms/resources/views/components/multi-select.blade.php
+++ b/packages/forms/resources/views/components/multi-select.blade.php
@@ -144,7 +144,7 @@
             class="overflow-hidden rtl:space-x-reverse relative w-full p-2"
         >
             <div class="flex flex-wrap gap-1">
-                <template class="inline" x-for="(option, index) in state" x-bind:key="option">
+                <template class="hidden" x-for="option in state" x-bind:key="option">
                     <button
                         @unless ($isDisabled())
                             x-on:click.stop="deselectOption(option)"
@@ -154,9 +154,6 @@
                             'inline-flex items-center justify-center min-h-6 px-2 py-0.5 text-sm font-medium tracking-tight text-primary-700 rounded-xl bg-primary-500/10 space-x-1 rtl:space-x-reverse',
                             'cursor-default' => $isDisabled(),
                         ])
-                        x-bind:class="{
-                            '-ml-1': index === 0
-                        }"
                     >
                         <span class="text-left" x-text="labels[option]"></span>
 

--- a/packages/forms/resources/views/components/multi-select.blade.php
+++ b/packages/forms/resources/views/components/multi-select.blade.php
@@ -141,24 +141,27 @@
 
         <div
             x-show="state.length"
-            class="overflow-hidden rtl:space-x-reverse relative w-full px-1 py-1"
+            class="overflow-hidden rtl:space-x-reverse relative w-full p-2"
         >
-            <div class="flex flex-wrap gap-1">
-                <template class="inline" x-for="option in state" x-bind:key="option">
+            <div class="flex flex-wrap gap-x-1 gap-y-2">
+                <template class="inline" x-for="(option, index) in state" x-bind:key="option">
                     <button
                         @unless ($isDisabled())
                             x-on:click.stop="deselectOption(option)"
                         @endunless
                         type="button"
                         @class([
-                            'inline-flex items-center justify-center h-6 px-2 my-1 text-sm font-medium tracking-tight text-primary-700 rounded-full bg-primary-500/10 space-x-1 rtl:space-x-reverse',
+                            'inline-flex items-center justify-center min-h-6 px-2 py-0.5 text-sm font-medium tracking-tight text-primary-700 rounded-xl bg-primary-500/10 space-x-1 rtl:space-x-reverse',
                             'cursor-default' => $isDisabled(),
                         ])
+                        x-bind:class="{
+                            '-ml-1': index === 0
+                        }"
                     >
-                        <span x-text="labels[option]"></span>
+                        <span class="text-left" x-text="labels[option]"></span>
 
                         @unless ($isDisabled())
-                            <x-heroicon-s-x class="w-3 h-3" />
+                            <x-heroicon-s-x class="w-3 h-3 shrink-0" />
                         @endunless
                     </button>
                 </template>

--- a/packages/forms/resources/views/components/multi-select.blade.php
+++ b/packages/forms/resources/views/components/multi-select.blade.php
@@ -143,7 +143,7 @@
             x-show="state.length"
             class="overflow-hidden rtl:space-x-reverse relative w-full p-2"
         >
-            <div class="flex flex-wrap gap-x-1 gap-y-2">
+            <div class="flex flex-wrap gap-1">
                 <template class="inline" x-for="(option, index) in state" x-bind:key="option">
                     <button
                         @unless ($isDisabled())

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -52,24 +52,24 @@
 
             <div
                 x-show="state.length"
-                class="overflow-hidden rtl:space-x-reverse relative w-full px-1 py-1"
+                class="overflow-hidden rtl:space-x-reverse relative w-full p-2"
             >
                 <div class="flex flex-wrap gap-1">
-                    <template class="inline" x-for="tag in state" x-bind:key="tag">
+                    <template class="hidden" x-for="tag in state" x-bind:key="tag">
                         <button
                             @unless ($isDisabled())
                                 x-on:click="deleteTag(tag)"
                             @endunless
                             type="button"
                             @class([
-                                'inline-flex items-center justify-center h-6 px-2 my-1 text-sm font-medium tracking-tight text-primary-700 rounded-full bg-primary-500/10 space-x-1',
+                                'inline-flex items-center justify-center min-h-6 px-2 py-0.5 text-sm font-medium tracking-tight text-primary-700 rounded-xl bg-primary-500/10 space-x-1',
                                 'cursor-default' => $isDisabled(),
                             ])
                         >
-                            <span x-text="tag"></span>
+                            <span class="text-left" x-text="tag"></span>
 
                             @unless ($isDisabled())
-                                <x-heroicon-s-x class="w-3 h-3" />
+                                <x-heroicon-s-x class="w-3 h-3 shrink-0" />
                             @endunless
                         </button>
                     </template>

--- a/packages/tables/resources/views/columns/badge-column.blade.php
+++ b/packages/tables/resources/views/columns/badge-column.blade.php
@@ -13,7 +13,7 @@
 <div {{ $attributes->merge($getExtraAttributes())->class(['px-4 py-3', 'filament-tables-badge-column']) }}>
     @if (filled($state))
         <span @class([
-            'inline-flex items-center justify-center h-6 px-2 text-sm font-medium tracking-tight rounded-full',
+            'inline-flex items-center justify-center min-h-6 px-2 py-0.5 text-sm font-medium tracking-tight rounded-xl whitespace-normal',
             $stateColor => $stateColor,
         ])>
             {{ $state }}

--- a/packages/tables/resources/views/columns/tags-column.blade.php
+++ b/packages/tables/resources/views/columns/tags-column.blade.php
@@ -4,7 +4,7 @@
 
 <div {{ $attributes->merge($getExtraAttributes())->class(['px-4 py-3 flex flex-wrap gap-1', 'filament-tables-tags-column']) }}>
     @foreach ($getTags() as $tag)
-        <span class="inline-flex items-center justify-center h-6 px-2 text-sm font-medium tracking-tight rounded-full text-primary-700 bg-primary-500/10">
+        <span class="inline-flex items-center justify-center min-h-6 px-2 py-0.5 text-sm font-medium tracking-tight rounded-xl text-primary-700 bg-primary-500/10 whitespace-normal">
             {{ $tag }}
         </span>
     @endforeach


### PR DESCRIPTION
There are a few glitches with the selected items UI in multiselect fields when you have long label values, or so many options selected that they wrap onto multiple lines:

![Screenshot 2022-02-02 at 16 57 42](https://user-images.githubusercontent.com/126740/152202734-304708a8-fee1-4351-9b8a-66b16ab51200.png)

This fixes those:

![Screenshot 2022-02-02 at 17 36 47](https://user-images.githubusercontent.com/126740/152207232-df093468-555f-4d26-8ce4-cc4f13356b79.png)

Notes:

* There are a bunch of tweaks to the height/padding/margin properties, to make things a bit more reliable
* Swapped `rounded-full` for `rounded-xl` so the radius is consistent on larger items
* Added `hidden` to the `<template>` tag so it doesn't interfere with the item gaps
* Added `shrink-0` to the remove button so it stays the right size
* Added `text-left` to the span as I thought it looked a little neater, that's probably subjective though, you may want to revert that one

Fixes https://github.com/laravel-filament/filament/issues/1411.