### PR TITLE
Allow dynamically changing the settings property.

### DIFF
--- a/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
+++ b/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
@@ -4,6 +4,7 @@ namespace Filament\Pages;
 
 use Filament\Forms\ComponentContainer;
 use Filament\Pages\Actions\ButtonAction;
+use Illuminate\Support\Str;
 
 /**
  * @property ComponentContainer $form
@@ -25,7 +26,7 @@ class SettingsPage extends Page
     {
         $this->callHook('beforeFill');
 
-        $settings = app(static::$settings);
+        $settings = app(static::getSettings());
 
         $this->form->fill($settings->toArray());
 
@@ -42,7 +43,7 @@ class SettingsPage extends Page
 
         $this->callHook('beforeSave');
 
-        $settings = app(static::$settings);
+        $settings = app(static::getSettings());
 
         $settings->fill($data);
         $settings->save();
@@ -63,6 +64,14 @@ class SettingsPage extends Page
         }
 
         $this->{$hook}();
+    }
+
+    public static function getSettings(): string
+    {
+        return static::$settings ?? (string) Str::of(class_basename(static::class))
+                ->beforeLast('Settings')
+                ->prepend('App\\Settings\\')
+                ->append('Settings');
     }
 
     protected function getFormActions(): array


### PR DESCRIPTION
This pull request adds the ability to dynamically set the settings property of a settings page:

```
public static function getSettings(): string
{
    return config('multitenancy.tenant_model')::checkCurrent()
        ? \App\Settings\Tenant\StoreSettings::class
        : \App\Settings\Landlord\StoreSettings::class;
}
```

in your class the same way you can use the getModel function in the Resource class. This is part of my discussion on multitenancy (#1407).