### PR TITLE
Fix sidebar flash

### DIFF
--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -1,6 +1,6 @@
 <aside
     x-data="{}"
-    x-cloak
+    x-cloak="-lg"
     x-bind:class="$store.sidebar.isOpen ? 'translate-x-0' : '-translate-x-full rtl:lg:-translate-x-0 rtl:translate-x-full'"
     class="fixed inset-y-0 left-0 rtl:left-auto rtl:right-0 z-20 flex flex-col h-screen overflow-hidden shadow-2xl transition duration-300 bg-white lg:border-r w-80 lg:z-0 lg:translate-x-0 filament-sidebar"
 >

--- a/packages/admin/resources/views/components/layouts/base.blade.php
+++ b/packages/admin/resources/views/components/layouts/base.blade.php
@@ -11,7 +11,11 @@
 
         <title>{{ $title ? "{$title} - " : null }} {{ config('app.name') }}</title>
 
-        <style>[x-cloak] { display: none !important; }</style>
+        <style>
+            [x-cloak=""] { display: none !important; }
+            @media (max-width: 1024px) { [x-cloak="-lg"] { display: none !important; } }
+            @media (min-width: 1024px) { [x-cloak="lg"] { display: none !important; } }
+        </style>
 
         @livewireStyles
 


### PR DESCRIPTION
This is a bit of a random one, and might only bug me so no worries if you ignore it 😄 .

When you load a page on desktop there’s sometimes a very brief flash when the sidebar isn’t visible:

https://user-images.githubusercontent.com/126740/152324821-333161f5-9915-44aa-aed7-549e6fd95719.mov

This only happens sometimes, and just depends on how quickly the browser evaluates the JS.

It's due to Alpine’s `x-cloak` attribute, which isn’t actually necessary on desktop (as the sidebar is always visible), but is necessary on mobile to avoid the opposite problem.

This PR adds two `x-cloak` variants that only apply below or above the `lg` breakpoint:

* `x-cloak=“-lg”`
* `x-cloak=“lg”`

The `x-cloak` on the sidebar has been changed to the `-lg` variant, preventing it from applying on desktop and fixing the flash.

## Known Issue

It would be really nice to use the actual `lg` breakpoint size into the media query, in case it's being overidden by the user and not the default `1024px`. Unfortunately I don't think this is possible while the CSS is in the HTML, it would need to be moved to a CSS file where you could use `theme('screens.lg')`.