### PR TITLE
Fix contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Install the packages in your app's `composer.json`:
 
 ```json
 "require": {
-    "filament/filament": "fix/error-message as 2.x-dev",
-    "filament/forms": "fix/error-message as 2.x-dev",
-    "filament/tables": "fix/error-message as 2.x-dev",
+    "filament/filament": "dev-fix/error-message as 2.x-dev",
+    "filament/forms": "dev-fix/error-message as 2.x-dev",
+    "filament/tables": "dev-fix/error-message as 2.x-dev",
 },
 "repositories": [
     {


### PR DESCRIPTION
Composer requires branches to be prefixed with `dev-`

> you should prefix your custom branch name with "dev-" (without making it part of the actual branch name)

https://getcomposer.org/doc/05-repositories.md#loading-a-package-from-a-vcs-repository