### PR TITLE
Allow file extensions restriction on FilePond

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -892,12 +892,14 @@ FileUpload::make('attachment')->preserveFilenames()
 
 > Please note, it is the responsibility of the developer to ensure that uploaded file names are unique when using this option.
 
-You may restrict the types of files that may be uploaded using the `acceptedFileTypes()` method, and passing an array of MIME types. You may also use the `image()` method as shorthand to allow all image MIME types.
+You may restrict the types and extensions of files that may be uploaded using the `acceptedFileTypes()` method, and passing an array of MIME types and/or extensions. You may also use the `image()` method as shorthand to allow all image MIME types.
+
+> Please note, apparently Chromium based browsers might swap file extensions with their MIME type. For instance `.txt` will allow all plain text files including `.php, .js, .css` and similar.
 
 ```php
 use Filament\Forms\Components\FileUpload;
 
-FileUpload::make('document')->acceptedFileTypes(['application/pdf'])
+FileUpload::make('document')->acceptedFileTypes(['application/pdf', '.docx'])
 FileUpload::make('image')->image()
 ```
 

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -130,7 +130,7 @@ export default (Alpine) => {
                         },
                     },
                     fileValidateTypeDetectType: (source, type) => {
-                        new Promise((resolve, reject) => {
+                        return new Promise((resolve, reject) => {
                             // Detect valid file extensions and return an accepted type if matching
                             let fileName = source.name
                             let acceptedExtensions = acceptedFileTypes.filter((type) => type.startsWith('.'))

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -129,7 +129,7 @@ export default (Alpine) => {
                             load()
                         },
                     },
-                    fileValidateTypeDetectType: (source, type) =>
+                    fileValidateTypeDetectType: (source, type) => {
                         new Promise((resolve, reject) => {
                             // Detect valid file extensions and return an accepted type if matching
                             let fileName = source.name
@@ -138,7 +138,8 @@ export default (Alpine) => {
 
                             let isValid = acceptedExtensions.indexOf(extension) >= 0
                             resolve(isValid ? acceptedFileTypes[0] : '')
-                        }),
+                        })
+                    },
                 })
 
                 this.$watch('state', async () => {

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -22,6 +22,7 @@ FilePond.registerPlugin(FilePondPluginImageTransform)
 export default (Alpine) => {
     Alpine.data('fileUploadFormComponent', ({
         acceptedFileTypes,
+        acceptedFileExtensions,
         deleteUploadedFileUsing,
         getUploadedFileUrlUsing,
         imageCropAspectRatio,
@@ -128,6 +129,16 @@ export default (Alpine) => {
                             load()
                         },
                     },
+                    fileValidateTypeDetectType: (source, type) =>
+                        new Promise((resolve, reject) => {
+                            // Detect valid file extensions and return an accepted type if matching
+                            let fileName = source.name
+                            let acceptedExtensions = acceptedFileTypes.filter((type) => type.startsWith('.'))
+                            let extension = fileName.substr(fileName.lastIndexOf('.'))
+
+                            let isValid = acceptedExtensions.indexOf(extension) >= 0
+                            resolve(isValid ? acceptedFileTypes[0] : '')
+                        }),
                 })
 
                 this.$watch('state', async () => {


### PR DESCRIPTION
The default FilePond validation plugin only checks against MIME types. Sometimes you want to limit on extensions as well. While the `<input type="file">` field supports file extensions via `accept` and works out of the box, FilePond tries to compare the files MIME type against the file extension which always fails. 

This PR adds a custom validator which extracts the allowed extensions from the `allowedFileTypes` and returns a valid MIME type when the files extension is in the list of allowed extensions.