### PR TITLE
Dont output actions column if there aren't any actions

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -231,7 +231,9 @@
                             </x-tables::header-cell>
                         @endforeach
 
-                        <th class="w-5"></th>
+                        @if ($actions)
+                            <th class="w-5"></th>
+                        @endif
                     </x-slot>
 
                     @if ($isSelectionEnabled())
@@ -280,7 +282,9 @@
                                 </x-tables::cell>
                             @endforeach
 
-                            <x-tables::actions-cell :actions="$actions" :record="$record" />
+                            @if ($actions)
+                                <x-tables::actions-cell :actions="$actions" :record="$record" />
+                            @endif
                         </x-tables::row>
                     @endforeach
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -8,7 +8,8 @@
     $isSearchVisible = $isSearchable();
     $isFiltersDropdownVisible = $isFilterable();
 
-    $columnsCount = count($columns) + 1;
+    $columnsCount = count($columns);
+    if (count($actions)) $columnsCount++;
     if ($isSelectionEnabled()) $columnsCount++;
 
     $getHiddenClasses = function (\Filament\Tables\Columns\Column $column): ?string {
@@ -231,7 +232,7 @@
                             </x-tables::header-cell>
                         @endforeach
 
-                        @if ($actions)
+                        @if (count($actions))
                             <th class="w-5"></th>
                         @endif
                     </x-slot>
@@ -282,7 +283,7 @@
                                 </x-tables::cell>
                             @endforeach
 
-                            @if ($actions)
+                            @if (count($actions))
                                 <x-tables::actions-cell :actions="$actions" :record="$record" />
                             @endif
                         </x-tables::row>


### PR DESCRIPTION
Dont output the table actions column if there aren't any actions defined. Cleans up some empty space at the end of the rows.