### PR TITLE
fix datetime picker again

### DIFF
--- a/packages/forms/resources/js/components/date-time-picker.js
+++ b/packages/forms/resources/js/components/date-time-picker.js
@@ -59,6 +59,10 @@ export default (Alpine) => {
 
             state,
 
+            dayLabels: [],
+
+            months: [],
+
             init: function () {
                 this.focusedDate = dayjs().tz(timezone)
 
@@ -88,12 +92,18 @@ export default (Alpine) => {
                 this.second = date?.second() ?? 0
 
                 this.setDisplayText()
+                this.setMonths()
+                this.setDayLabels()
 
                 if (isAutofocused) {
                     this.openPicker()
                 }
 
-                dayjs.onLocaleUpdated = () => this.setDisplayText()
+                dayjs.onLocaleUpdated = () => {
+                    this.setDisplayText()
+                    this.setMonths()
+                    this.setDayLabels()
+                }
 
                 this.$watch('focusedMonth', () => {
                     this.focusedMonth = +this.focusedMonth
@@ -357,6 +367,14 @@ export default (Alpine) => {
 
             setDisplayText: function () {
                 this.displayText = this.getSelectedDate() ? this.getSelectedDate().format(displayFormat) : ''
+            },
+
+            setMonths: function () {
+                this.months = dayjs.months()
+            },
+
+            setDayLabels: function () {
+                this.dayLabels = this.getDayLabels()
             },
 
             setupDaysGrid: function () {

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -4,12 +4,7 @@
             $locale = strtolower(str_replace('_', '-', app()->getLocale()));
         @endphp
         
-        <script
-            src="//unpkg.com/dayjs@1.10.4/locale/{{ $locale }}.js"
-            onload="dayjs.updateLocale('{{ $locale }}')"
-            async
-            defer
-        ></script>
+        <script src="//unpkg.com/dayjs@1.10.4/locale/{{ $locale }}.js" onload="dayjs.updateLocale('{{ $locale }}')"></script>
     @endpush
 @endonce
 
@@ -97,7 +92,7 @@
                                 x-model="focusedMonth"
                                 class="grow px-1 py-0 text-lg font-medium text-gray-800 border-0 cursor-pointer focus:ring-0 focus:outline-none"
                             >
-                                <template x-for="(month, index) in dayjs.months()">
+                                <template x-for="(month, index) in months">
                                     <option x-bind:value="index" x-text="month"></option>
                                 </template>
                             </select>
@@ -110,7 +105,7 @@
                         </div>
 
                         <div class="grid grid-cols-7 gap-1">
-                            <template x-for="(day, index) in getDayLabels()" :key="index">
+                            <template x-for="(day, index) in dayLabels" :key="index">
                                 <div
                                     x-text="day"
                                     class="text-xs font-medium text-center text-gray-800"


### PR DESCRIPTION
Well, the last solution worked for some reason only in the filament demo repo, i think its because it has so much data that the picker wins the race and then the localized script came after (idk)

Now i'm using another solution that is basically re-render the months and dayNames when the localized script fires `dayjs.updateLocale()`

I think that's cleaner tho.

my bad for the last fix... at least its working now 😅 