### PR TITLE
generate slug with resource name not model name

### DIFF
--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -267,9 +267,9 @@ class Resource
 
     public static function getSlug(): string
     {
-        return static::$slug ?? (string) Str::of(class_basename(static::getModel()))
-            ->plural()
-            ->kebab();
+        return static::$slug ?? (string)Str::of( str_replace('Rescource', '', class_basename(new static)))
+                ->plural()
+                ->kebab();
     }
 
     public static function getUrl($name = 'index', $params = []): string

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -267,7 +267,8 @@ class Resource
 
     public static function getSlug(): string
     {
-        return static::$slug ?? (string)Str::of(str_replace('Resource', '', class_basename(new static)))
+        return static::$slug ?? (string)Str::of(class_basename(new static))
+                ->replace('Resource', '')
                 ->plural()
                 ->kebab();
     }

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -267,7 +267,7 @@ class Resource
 
     public static function getSlug(): string
     {
-        return static::$slug ?? (string)Str::of( str_replace('Rescource', '', class_basename(new static)))
+        return static::$slug ?? (string)Str::of(str_replace('Resource', '', class_basename(new static)))
                 ->plural()
                 ->kebab();
     }

--- a/tests/src/Admin/Resources/ResourceTest.php
+++ b/tests/src/Admin/Resources/ResourceTest.php
@@ -13,7 +13,7 @@ it('can retrieve Eloquent query for model', function () {
         ->getModel()->toBeInstanceOf(Post::class);
 });
 
-it('can generate a slug based on the model name', function () {
+it('can generate a slug based on the resource name', function () {
     expect(PostResource::getSlug())
         ->toBe('posts');
 });


### PR DESCRIPTION
If you need to generate two resources with the same model, so the result is duplication in the slug for each resource

I know you can override the slug of resources, but I think, it's more efficient to generate correctly at the main function from the first time and leave override to customization only.

so, I created this pull request to generate the default slug with resource name not with model name
so no more needed code for editing the default slug every time.

I think we need to change the `getLabel` function for the same reason if you accept this pull request.

thanks