### PR TITLE
Add scripts before core

### DIFF
--- a/packages/admin/docs/08-plugins.md
+++ b/packages/admin/docs/08-plugins.md
@@ -195,7 +195,7 @@ class ExampleServiceProvider extends PluginServiceProvider
 }
 ```
 
-To add scripts before the core filament script, use the `getBeforeCoreScripts()` method. This is useful if you want to hook into an Alpine event.
+To add scripts before the core Filament script, use the `getBeforeCoreScripts()` method. This is useful if you want to hook into an Alpine event.
 
 ```php
 use Filament\PluginServiceProvider;

--- a/packages/admin/docs/08-plugins.md
+++ b/packages/admin/docs/08-plugins.md
@@ -64,7 +64,7 @@ This will ensure your service provider is automatically loaded by Laravel when t
 
 ## Resources
 
-To register a custom resource, add the fully qualified class name to the `getResources()` method in your service provider.
+To register a custom resource, add the fully qualified class name to the `$resources` property in your service provider.
 
 ```php
 use Filament\PluginServiceProvider;
@@ -73,16 +73,13 @@ use Vendor\Package\Resources\CustomResource;
 
 class ExampleServiceProvider extends PluginServiceProvider
 {
+    protected array $resources = [
+        CustomResource::class,
+    ];
+
     public function configurePackage(Package $package): void
     {
         $package->name('your-package-name');
-    }
-    
-    protected function getResources(): array
-    {
-        return [
-            CustomResource::class,
-        ];
     }
 }
 ```
@@ -91,7 +88,7 @@ Filament will automatically register your `Resource` and ensure that Livewire ca
 
 ## Pages
 
-To register a custom page, add the fully qualified class name to the `getPages()` method in your service provider.
+To register a custom page, add the fully qualified class name to the `$pages` property in your service provider.
 
 ```php
 use Filament\PluginServiceProvider;
@@ -100,16 +97,13 @@ use Vendor\Package\Pages\CustomPage;
 
 class ExampleServiceProvider extends PluginServiceProvider
 {
+    protected array $pages = [
+        CustomPage::class,
+    ];
+    
     public function configurePackage(Package $package): void
     {
         $package->name('your-package-name');
-    }
-    
-    protected function getPages(): array
-    {
-        return [
-            CustomPage::class,
-        ];
     }
 }
 ```
@@ -118,7 +112,7 @@ Filament will automatically register your `Page` and ensure that Livewire can di
 
 ## Widgets
 
-To register a custom widget, add the fully qualified class name to the `getWidgets()` method in your service provider.
+To register a custom widget, add the fully qualified class name to the `$wigdets` property in your service provider.
 
 ```php
 use Filament\PluginServiceProvider;
@@ -127,16 +121,13 @@ use Vendor\Package\Widgers\CustomWidget;
 
 class ExampleServiceProvider extends PluginServiceProvider
 {
+    protected array $widgets = [
+        CustomWidget::class,
+    ];
+
     public function configurePackage(Package $package): void
     {
         $package->name('your-package-name');
-    }
-    
-    protected function getWidgets(): array
-    {
-        return [
-            CustomWidget::class,
-        ];
     }
 }
 ```
@@ -149,7 +140,7 @@ Filament plugins can also register their own frontend assets. These assets will 
 
 ### Stylesheets
 
-To include a custom stylesheet, add it to the `getStyles()` method in your service provider. You should use a unique name as the key and the URL to the stylesheet as the value.
+To include a custom stylesheet, add it to the `$styles` property in your service provider. You should use a unique name as the key and the URL to the stylesheet as the value.
 
 ```php
 use Filament\PluginServiceProvider;
@@ -157,23 +148,20 @@ use Spatie\LaravelPackageTools\Package;
 
 class ExampleServiceProvider extends PluginServiceProvider
 {
+    protected array $styles = [
+        'my-package-styles' => __DIR__ . '/../dist/app.css',
+    ];
+
     public function configurePackage(Package $package): void
     {
         $package->name('your-package-name');
-    }
-    
-    protected function getStyles(): array
-    {
-        return [
-            'my-package-styles' => __DIR__ . '/../dist/app.css',
-        ];
     }
 }
 ```
 
 ### Scripts
 
-To include a custom script, add it to the `getScripts()` method in your service provider. You should use a unique name as the key and the URL to the script as the value. These scripts will be added after the core Filament script.
+To include a custom script, add it to the `$scripts` property in your service provider. You should use a unique name as the key and the URL to the script as the value. These scripts will be added after the core Filament script.
 
 ```php
 use Filament\PluginServiceProvider;
@@ -181,21 +169,18 @@ use Spatie\LaravelPackageTools\Package;
 
 class ExampleServiceProvider extends PluginServiceProvider
 {
+    protected array $scripts = [
+        'my-package-scripts' => __DIR__ . '/../dist/app.js',
+    ];
+
     public function configurePackage(Package $package): void
     {
         $package->name('your-package-name');
     }
-    
-    protected function getScripts(): array
-    {
-        return [
-            'my-package-scripts' => __DIR__ . '/../dist/app.js',
-        ];
-    };
 }
 ```
 
-To add scripts before the core Filament script, use the `getBeforeCoreScripts()` method. This is useful if you want to hook into an Alpine event.
+To add scripts before the core Filament script, use the `$beforeCoreScripts` property. This is useful if you want to hook into an Alpine event.
 
 ```php
 use Filament\PluginServiceProvider;
@@ -203,17 +188,14 @@ use Spatie\LaravelPackageTools\Package;
 
 class ExampleServiceProvider extends PluginServiceProvider
 {
+    protected array $beforeCoreScripts = [
+        'my-package-scripts' => __DIR__ . '/../dist/app.js',
+    ];
+    
     public function configurePackage(Package $package): void
     {
         $package->name('your-package-name');
     }
-    
-    protected function getBeforeCoreScripts(): array
-    {
-        return [
-            'my-package-scripts' => __DIR__ . '/../dist/app.js',
-        ];
-    };
 }
 ```
 

--- a/packages/admin/docs/08-plugins.md
+++ b/packages/admin/docs/08-plugins.md
@@ -173,7 +173,7 @@ class ExampleServiceProvider extends PluginServiceProvider
 
 ### Scripts
 
-To include a custom script, add it to the `getScripts()` method in your service provider. You should use a unique name as the key and the URL to the script as the value.
+To include a custom script, add it to the `getScripts()` method in your service provider. You should use a unique name as the key and the URL to the script as the value. These scripts will be added after the core Filament script.
 
 ```php
 use Filament\PluginServiceProvider;
@@ -187,6 +187,28 @@ class ExampleServiceProvider extends PluginServiceProvider
     }
     
     protected function getScripts(): array
+    {
+        return [
+            'my-package-scripts' => __DIR__ . '/../dist/app.js',
+        ];
+    };
+}
+```
+
+To add scripts before the core filament script, use the `getBeforeCoreScripts()` method. This is useful if you want to hook into an Alpine event.
+
+```php
+use Filament\PluginServiceProvider;
+use Spatie\LaravelPackageTools\Package;
+
+class ExampleServiceProvider extends PluginServiceProvider
+{
+    public function configurePackage(Package $package): void
+    {
+        $package->name('your-package-name');
+    }
+    
+    protected function getBeforeCoreScripts(): array
     {
         return [
             'my-package-scripts' => __DIR__ . '/../dist/app.js',

--- a/packages/admin/src/Facades/Filament.php
+++ b/packages/admin/src/Facades/Filament.php
@@ -28,6 +28,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void registerNavigationItems(array $items)
  * @method static void registerPages(array $pages)
  * @method static void registerResources(array $resources)
+ * @method static void registerBeforeCoreScripts(array $scripts)
  * @method static void registerScripts(array $scripts)
  * @method static void registerScriptData(array $data)
  * @method static void registerStyles(array $styles)

--- a/packages/admin/src/Http/Controllers/AssetController.php
+++ b/packages/admin/src/Http/Controllers/AssetController.php
@@ -23,10 +23,9 @@ class AssetController
         if (Str::endsWith($file, '.js')) {
             $name = Str::beforeLast($file, '.js');
 
-            if(array_key_exists($name, Filament::getScripts())) {
+            if (array_key_exists($name, Filament::getScripts())) {
                 return $this->pretendResponseIsFile(Filament::getScripts()[$name], 'application/javascript; charset=utf-8');
-            }
-            elseif(array_key_exists($name, Filament::getBeforeCoreScripts())) {
+            } elseif (array_key_exists($name, Filament::getBeforeCoreScripts())) {
                 return $this->pretendResponseIsFile(Filament::getBeforeCoreScripts()[$name], 'application/javascript; charset=utf-8');
             } else {
                 abort(404);

--- a/packages/admin/src/Http/Controllers/AssetController.php
+++ b/packages/admin/src/Http/Controllers/AssetController.php
@@ -23,12 +23,14 @@ class AssetController
         if (Str::endsWith($file, '.js')) {
             $name = Str::beforeLast($file, '.js');
 
-            abort_unless(
-                array_key_exists($name, Filament::getScripts()),
-                404,
-            );
-
-            return $this->pretendResponseIsFile(Filament::getScripts()[$name], 'application/javascript; charset=utf-8');
+            if(array_key_exists($name, Filament::getScripts())) {
+                return $this->pretendResponseIsFile(Filament::getScripts()[$name], 'application/javascript; charset=utf-8');
+            }
+            elseif(array_key_exists($name, Filament::getBeforeCoreScripts())) {
+                return $this->pretendResponseIsFile(Filament::getBeforeCoreScripts()[$name], 'application/javascript; charset=utf-8');
+            } else {
+                abort(404);
+            }
         }
 
         if (Str::endsWith($file, '.css')) {

--- a/packages/admin/src/PluginServiceProvider.php
+++ b/packages/admin/src/PluginServiceProvider.php
@@ -16,6 +16,8 @@ abstract class PluginServiceProvider extends PackageServiceProvider
 
     protected array $resources = [];
 
+    protected array $beforeCoreScripts = [];
+
     protected array $scripts = [];
 
     protected array $styles = [];
@@ -67,6 +69,7 @@ abstract class PluginServiceProvider extends PackageServiceProvider
         Facades\Filament::registerWidgets($this->getWidgets());
 
         Facades\Filament::serving(function () {
+            Facades\Filament::registerScripts($this->getBeforeCoreScripts(), true);
             Facades\Filament::registerScripts($this->getScripts());
             Facades\Filament::registerStyles($this->getStyles());
             Facades\Filament::registerScriptData($this->getScriptData());
@@ -127,6 +130,11 @@ abstract class PluginServiceProvider extends PackageServiceProvider
     protected function getScriptData(): array
     {
         return [];
+    }
+
+    protected function getBeforeCoreScripts(): array
+    {
+        return $this->beforeCoreScripts;
     }
 
     protected function getScripts(): array


### PR DESCRIPTION
Had a use case where I wanted to hook into Alpine with `document.addEventListener('alpine:init', () => {...});`. This change enables scripts to placed before the Filament JS to enable hooking (and potentially other things).