### PR TITLE
:sparkles: Get a resource by his model FQCN

### DIFF
--- a/packages/admin/src/Facades/Filament.php
+++ b/packages/admin/src/Facades/Filament.php
@@ -5,12 +5,14 @@ namespace Filament\Facades;
 use Closure;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static StatefulGuard auth()
  * @method static array getBeforeCoreScripts()
  * @method static array getPages()
+ * @method static string | null getModelResource(string | Model $model)
  * @method static array getNavigation()
  * @method static array getNavigationGroups()
  * @method static array getNavigationItems()

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -182,7 +182,7 @@ class FilamentManager
         return array_unique($this->resources);
     }
 
-    public function getResource(string | Model $model): ?string
+    public function getModelResource(string | Model $model): ?string
     {
         if ($model instanceof Model) {
             $model = $model::class;
@@ -192,7 +192,7 @@ class FilamentManager
             if ($model !== $resource::getModel()) {
                 continue;
             }
-            
+
             return $resource;
         }
 

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -6,6 +6,7 @@ use Closure;
 use Filament\Events\ServingFilament;
 use Filament\Models\Contracts\HasAvatar;
 use Filament\Models\Contracts\HasName;
+use Filament\Resources\Resource;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
@@ -179,6 +180,26 @@ class FilamentManager
     public function getResources(): array
     {
         return array_unique($this->resources);
+    }
+
+    public function getResource(Model | string $model): ?Resource
+    {
+        $modelFqcn = ($model instanceof Model)
+            ? $model::class
+            : $model;
+
+        foreach ($this->getResources() as $resourceClass) {
+            /**
+             * @var Resource $instance
+             */
+            $instance = new $resourceClass();
+
+            if ($modelFqcn === $instance::getModel()) {
+                return $instance;
+            }
+        }
+
+        return null;
     }
 
     public function getScripts(): array

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -182,20 +182,16 @@ class FilamentManager
         return array_unique($this->resources);
     }
 
-    public function getResource(Model | string $model): ?Resource
+    public function getResource(Model | string $model): ?string
     {
         $modelFqcn = ($model instanceof Model)
             ? $model::class
             : $model;
 
-        foreach ($this->getResources() as $resourceClass) {
-            /**
-             * @var Resource $instance
-             */
-            $instance = new $resourceClass();
+        foreach ($this->getResources() as $resourceFqcn) {
 
-            if ($modelFqcn === $instance::getModel()) {
-                return $instance;
+            if ($modelFqcn === $resourceFqcn::getModel()) {
+                return $resourceFqcn;
             }
         }
 

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -182,17 +182,18 @@ class FilamentManager
         return array_unique($this->resources);
     }
 
-    public function getResource(Model | string $model): ?string
+    public function getResource(string | Model $model): ?string
     {
-        $modelFqcn = ($model instanceof Model)
-            ? $model::class
-            : $model;
+        if ($model instanceof Model) {
+            $model = $model::class;
+        }
 
-        foreach ($this->getResources() as $resourceFqcn) {
-
-            if ($modelFqcn === $resourceFqcn::getModel()) {
-                return $resourceFqcn;
+        foreach ($this->getResources() as $resource) {
+            if ($model !== $resource::getModel()) {
+                continue;
             }
+            
+            return $resource;
         }
 
         return null;


### PR DESCRIPTION
New method `getResource(string $model): ?Resource` on `FilamentManager` to get a resource by his associated model FQCN. 

In my case this method is useful when I want make a link to a resource page on morph relation. I can get directly the resource associated to the `model_type` in morph relation.

Example of my usage : 

```php
Tables\Columns\TextColumn::make('relation')
    ->label(__('relation'))
    ->getStateUsing(fn(Media $record) => $record->model_type . ': ' . $record->model_id)
    ->url(fn(Media $record) => Filament::getResource($record->model)::getUrl('edit', ['record' => $record->model]), true)
```

Render of this example : 

![image](https://user-images.githubusercontent.com/1284914/152665128-50afac5c-a57b-4d4e-9207-82f43584f3c5.png)
