### PR TITLE
fix(date-time-picker): missing html closing caret

### DIFF
--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -91,6 +91,7 @@
                             <select
                                 x-model="focusedMonth"
                                 class="grow px-1 py-0 text-lg font-medium text-gray-800 border-0 cursor-pointer focus:ring-0 focus:outline-none dark:bg-gray-700 dark:text-gray-200"
+                            >
                                 <template x-for="(month, index) in months">
                                     <option x-bind:value="index" x-text="month"></option>
                                 </template>


### PR DESCRIPTION
Hi Dan, one of the latest merge commit that introduced dark mode (d490a7e42b0d5f4774bc2a16b62704c8c00abf84), broke the datetime picker. It removed the closing caret `>` for the select element, resulting in alpine rendering issues

Here's the fix :)