### PR TITLE
fix: resolve original file type even if extension does not match

### DIFF
--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -131,13 +131,13 @@ export default (Alpine) => {
                     },
                     fileValidateTypeDetectType: (source, type) => {
                         return new Promise((resolve, reject) => {
-                            // Detect valid file extensions and return an accepted type if matching
-                            let fileName = source.name
-                            let acceptedExtensions = acceptedFileTypes.filter((type) => type.startsWith('.'))
-                            let extension = fileName.substr(fileName.lastIndexOf('.'))
+                            // Detect valid file extensions and return any accepted type if matching
+                            let filename = source.name
+                            let extension = filename.substr(filename.lastIndexOf('.'))
 
-                            let isValid = acceptedExtensions.indexOf(extension) >= 0
-                            resolve(isValid ? acceptedFileTypes[0] : '')
+                            if( acceptedFileTypes.includes(extension) ) resolve(acceptedFileTypes[0])
+
+                            resolve(type)
                         })
                     },
                 })

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -132,10 +132,14 @@ export default (Alpine) => {
                     fileValidateTypeDetectType: (source, type) => {
                         return new Promise((resolve, reject) => {
                             // Detect valid file extensions and return any accepted type if matching
-                            let filename = source.name
-                            let extension = filename.substr(filename.lastIndexOf('.'))
+                            let fileName = source.name
+                            let extension = fileName.substr(fileName.lastIndexOf('.'))
 
-                            if( acceptedFileTypes.includes(extension) ) resolve(acceptedFileTypes[0])
+                            if (acceptedFileTypes.includes(extension)) {
+                                resolve(acceptedFileTypes[0])
+                                
+                                return
+                            }
 
                             resolve(type)
                         })


### PR DESCRIPTION
Recently this commit (fba57700e358571230d2e4974a07db18c0dd5bb1) broke the file validation, since it will not return the default `type` that filepond need to do validation.

Currently, given the example:
```php
->acceptedFileTypes(['image/png', '.jpg'])
```
if uploading a `.png` file, the validation will fail, because it will return `''` [(See)](https://github.com/laravel-filament/filament/commit/fba57700e358571230d2e4974a07db18c0dd5bb1#diff-9ca487f871dd58846f89f01cb20f5e468ca577dfe6446695a573d6b7704174e1R140), since '.png' is not in the accepted array (even though image/png is)

another example:
```php
->acceptedFileTypes(['image/png'])
```
this will fail too, since when checking the extension (`.png`) it will not be present on the array (event though `image/png` is)


This PR fixes the behavior, returning the original file `type` (that should always be returned) according to [Filepond Docs](https://pqina.nl/filepond/docs/getting-started/examples/validate-file-type/)