### PR TITLE
fix(hydrate-issue): missing child component check

### DIFF
--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -171,7 +171,7 @@ trait HasState
     public function hydrateNullState(): static
     {
         foreach ($this->getComponents(withHidden: true) as $component) {
-            if ($component->getChildComponentContainers()) {
+            if ($component->hasChildComponentContainer()) {
                 foreach ($component->getChildComponentContainers() as $container) {
                     $container->hydrateNullState();
                 }

--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -171,10 +171,12 @@ trait HasState
     public function hydrateNullState(): static
     {
         foreach ($this->getComponents(withHidden: true) as $component) {
-            $component->hydrateNullState();
-
-            foreach ($component->getChildComponentContainers() as $container) {
-                $container->hydrateNullState();
+            if ($component->getChildComponentContainers()) {
+                foreach ($component->getChildComponentContainers() as $container) {
+                    $container->hydrateNullState();
+                }
+            } else {
+                $component->hydrateNullState();
             }
         }
 


### PR DESCRIPTION
When I use fill function for the form in custom page, I got the this error when I use layout fields like Section, Tabs. 

I'm solved problem with this code lines.

Error Message: Cannot assign null to property \ClassName::$data of type array
