### PR TITLE
Fix badge column height

### DIFF
--- a/packages/tables/resources/views/columns/badge-column.blade.php
+++ b/packages/tables/resources/views/columns/badge-column.blade.php
@@ -10,7 +10,7 @@
     };
 @endphp
 
-<div {{ $attributes->merge($getExtraAttributes())->class(['px-4 py-3 filament-tables-badge-column']) }}>
+<div {{ $attributes->merge($getExtraAttributes())->class(['px-4 py-3 flex filament-tables-badge-column']) }}>
     @if (filled($state))
         <span @class([
             'inline-flex items-center justify-center min-h-6 px-2 py-0.5 text-sm font-medium tracking-tight rounded-xl whitespace-normal',


### PR DESCRIPTION
Very tiny thing I overlooked in https://github.com/laravel-filament/filament/pull/1430.

The badge column container renders 1px taller than the other column containers now:

![Screenshot 2022-02-07 at 16 48 14](https://user-images.githubusercontent.com/126740/152835425-8366a69c-cf98-4e50-9db5-cc1f192ceb99.png)

![Screenshot 2022-02-07 at 16 48 06](https://user-images.githubusercontent.com/126740/152835436-59118c7f-354c-46d3-82b7-44ecc5de521c.png)

The tags column does not have this problem, and it seems to be because it's using flexbox instead of block layout. Using the same display mode in both places fixes the issue (even though flexbox isn't strictly necessary in badge).