### PR TITLE
Reduce uninitialised UI flashes and reflows

### DIFF
--- a/packages/admin/resources/views/components/layouts/app/sidebar/group.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/group.blade.php
@@ -18,7 +18,7 @@
             <x-heroicon-o-chevron-down :class="\Illuminate\Support\Arr::toCssClasses([
                 'w-3 h-3 text-gray-600',
                 'dark:text-gray-300' => config('filament.dark_mode'),
-            ])" x-show="$store.sidebar.groupIsCollapsed(label)" />
+            ])" x-show="$store.sidebar.groupIsCollapsed(label)" x-cloak="" />
 
             <x-heroicon-o-chevron-up :class="\Illuminate\Support\Arr::toCssClasses([
                 'w-3 h-3 text-gray-600',

--- a/packages/admin/resources/views/components/layouts/app/sidebar/group.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/group.blade.php
@@ -18,7 +18,7 @@
             <x-heroicon-o-chevron-down :class="\Illuminate\Support\Arr::toCssClasses([
                 'w-3 h-3 text-gray-600',
                 'dark:text-gray-300' => config('filament.dark_mode'),
-            ])" x-show="$store.sidebar.groupIsCollapsed(label)" x-cloak="" />
+            ])" x-show="$store.sidebar.groupIsCollapsed(label)" x-cloak />
 
             <x-heroicon-o-chevron-up :class="\Illuminate\Support\Arr::toCssClasses([
                 'w-3 h-3 text-gray-600',

--- a/packages/admin/resources/views/components/layouts/base.blade.php
+++ b/packages/admin/resources/views/components/layouts/base.blade.php
@@ -16,7 +16,7 @@
         <title>{{ $title ? "{$title} - " : null }} {{ config('app.name') }}</title>
 
         <style>
-            [x-cloak=""] { display: none !important; }
+            [x-cloak=""], [x-cloak="1"] { display: none !important; }
             @media (max-width: 1023px) { [x-cloak="-lg"] { display: none !important; } }
             @media (min-width: 1024px) { [x-cloak="lg"] { display: none !important; } }
         </style>

--- a/packages/forms/resources/js/components/textarea.js
+++ b/packages/forms/resources/js/components/textarea.js
@@ -7,7 +7,7 @@ export default (Alpine) => {
         render: function () {
             if (this.$el.scrollHeight > 0) {
                 this.$el.style.height = '150px'
-                this.$el.style.height = this.$el.scrollHeight + 'px'
+                this.$el.style.height = this.$el.scrollHeight + 2 + 'px'
             }
         },
     }))

--- a/packages/forms/resources/js/components/textarea.js
+++ b/packages/forms/resources/js/components/textarea.js
@@ -7,7 +7,7 @@ export default (Alpine) => {
         render: function () {
             if (this.$el.scrollHeight > 0) {
                 this.$el.style.height = '150px'
-                this.$el.style.height = this.$el.scrollHeight + 2 + 'px'
+                this.$el.style.height = (this.$el.scrollHeight + 2) + 'px'
             }
         },
     }))

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -89,6 +89,7 @@
                     {!! $isDisabled() ? 'disabled' : null !!}
                     type="checkbox"
                     value="{{ $optionValue }}"
+                    {!! in_array($optionValue, $getState()) ? 'checked' : null !!}
                     {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
                     {{ $attributes->merge($getExtraAttributes())->class([
                         'text-primary-600 transition duration-75 rounded shadow-sm focus:border-primary-500 focus:ring-2 focus:ring-primary-500',

--- a/packages/forms/resources/views/components/checkbox.blade.php
+++ b/packages/forms/resources/views/components/checkbox.blade.php
@@ -12,6 +12,7 @@
         <x-slot name="labelPrefix">
     @endif
             <input
+                {!! $getState() ? 'checked' : null !!}
                 {!! $isAutofocused() ? 'autofocus' : null !!}
                 {!! $isDisabled() ? 'disabled' : null !!}
                 id="{{ $getId() }}"

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -61,7 +61,7 @@
         >
             <input
                 @if (filled($getState()))
-                    value="{{ DateTime::createFromFormat($getFormat(), $getState())->format($getDisplayFormat()) }}"
+                    value="{{ (new DateTime($getState()))->format($getDisplayFormat()) }}"
                 @endif
                 readonly
                 placeholder="{{ $getPlaceholder() }}"

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -61,6 +61,7 @@
         >
             <input
                 readonly
+                value="{{ $getState() ? DateTime::createFromFormat($getFormat(), $getState())->format($getDisplayFormat()) : null }}"
                 placeholder="{{ $getPlaceholder() }}"
                 x-model="displayText"
                 {!! ($id = $getId()) ? "id=\"{$id}\"" : null !!}

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -60,8 +60,10 @@
             ]) }}
         >
             <input
+                @if (filled($getState()))
+                    value="{{ DateTime::createFromFormat($getFormat(), $getState())->format($getDisplayFormat()) }}"
+                @endif
                 readonly
-                value="{{ $getState() ? DateTime::createFromFormat($getFormat(), $getState())->format($getDisplayFormat()) : null }}"
                 placeholder="{{ $getPlaceholder() }}"
                 x-model="displayText"
                 {!! ($id = $getId()) ? "id=\"{$id}\"" : null !!}

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -46,6 +46,7 @@
             },
         })"
         wire:ignore
+        style="min-height: 76px"
         {{ $attributes->merge($getExtraAttributes())->class([
             'filament-forms-file-upload-component',
             'w-32 mx-auto' => $isAvatar(),

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -13,7 +13,6 @@
             state: $wire.{{ $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')') }},
             tab: '{{ $isDisabled() ? 'preview' : 'edit' }}',
         })"
-        x-cloak
         wire:ignore
         {{ $attributes->merge($getExtraAttributes())->class('filament-forms-markdown-editor-component') }}
         {{ $getExtraAlpineAttributeBag() }}
@@ -159,7 +158,10 @@
                                 <button
                                     x-on:click.prevent="tab = 'preview'"
                                     x-bind:class="{ 'text-gray-400 @if (config('forms.dark_mode')) dark:text-gray-400 @endif': tab !== 'preview' }"
-                                    class="text-sm hover:underline"
+                                    @class([
+                                        'text-sm hover:underline',
+                                        'text-gray-400' . (config('forms.dark_mode') ? ' dark:text-gray-400' : null),
+                                    ])
                                 >
                                     {{ __('forms::components.markdown_editor.toolbar_buttons.preview') }}
                                 </button>
@@ -208,7 +210,6 @@
                             })
                         "
                         x-ref="textarea"
-                        style="color: transparent"
                         @class([
                             'tracking-normal whitespace-pre-wrap overflow-y-hidden font-mono block absolute bg-transparent top-0 text-sm left-0 block z-1 w-full h-full min-h-full resize-none transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-600 caret-black',
                             'dark:caret-white' => config('forms.dark_mode'),
@@ -216,7 +217,7 @@
                             'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
                             'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
                         ])
-                    ></textarea>
+                    >{{ $getState() }}</textarea>
                 </file-attachment>
 
                 <div
@@ -233,7 +234,7 @@
             <div @class([
                 'block w-full h-full min-h-full px-3 py-2 bg-white border border-gray-300 rounded-lg shadow-sm focus:border-primary-300',
                 'dark:bg-gray-700 dark:border-gray-600' => config('forms.dark_mode'),
-            ]) x-show="tab === 'preview'" style="min-height: 150px;">
+            ]) x-show="tab === 'preview'" x-cloak style="min-height: 150px;">
                 <div @class([
                     'prose',
                     'dark:prose-invert' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/multi-select.blade.php
+++ b/packages/forms/resources/views/components/multi-select.blade.php
@@ -67,11 +67,11 @@
                     />
 
                     <span class="absolute inset-y-0 right-0 rtl:right-auto rtl:left-0 flex items-center pr-2 rtl:pr-0 rtl:pl-2 pointer-events-none">
-                        <svg x-show="! isLoading" x-cloak class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+                        <svg x-show="! isLoading" class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
                             <path stroke="#6B7280" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 8l4 4 4-4" />
                         </svg>
 
-                        <svg x-show="isLoading" class="animate-spin w-5 h-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                        <svg x-show="isLoading" x-cloak class="animate-spin w-5 h-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M2 12C2 6.47715 6.47715 2 12 2V5C8.13401 5 5 8.13401 5 12H2Z" />>
                         </svg>
                     </span>
@@ -151,6 +151,7 @@
 
         <div
             x-show="state.length"
+            x-cloak
             class="overflow-hidden rtl:space-x-reverse relative w-full p-2"
         >
             <div class="flex flex-wrap gap-1">

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -28,6 +28,7 @@
                                 id="{{ $getId() }}-{{ $value }}"
                                 type="radio"
                                 value="{{ $value }}"
+                                {!! $value === $getState() ? 'checked' : null !!}
                                 {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
                                 {{ $getExtraInputAttributeBag()->class([
                                     'focus:ring-primary-500 h-4 w-4 text-primary-600',

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -27,7 +27,6 @@
                 })
             })
         "
-        x-cloak
         wire:ignore
         {{ $attributes->merge($getExtraAttributes())->class(['space-y-2 filament-forms-rich-editor-component']) }}
         {{ $getExtraAlpineAttributeBag() }}
@@ -241,7 +240,7 @@
                     @endif
                 </div>
 
-                <div data-trix-dialogs class="trix-dialogs">
+                <div data-trix-dialogs class="trix-dialogs" x-cloak>
                     <div
                         data-trix-dialog="href"
                         data-trix-dialog-attribute="href"
@@ -290,7 +289,7 @@
                     'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
                     'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
                 ])
-            />
+            >{{ $getState() }}</trix-editor>
         @else
             <div x-html="state" @class([
                 'p-3 prose border border-gray-300 rounded-lg shadow-sm',

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -85,7 +85,7 @@
                         'absolute w-full bg-white',
                         'dark:bg-gray-700' => config('forms.dark_mode'),
                     ])
-                ></span>
+                >{{ $getOptionLabel() }}</span>
 
                 @unless ($isDisabled())
                     <input
@@ -104,11 +104,11 @@
                     />
 
                     <span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-                        <svg x-show="! isLoading" x-cloak class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+                        <svg x-show="! isLoading" class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
                             <path stroke="#6B7280" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 8l4 4 4-4" />
                         </svg>
 
-                        <svg x-show="isLoading" class="animate-spin w-5 h-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                        <svg x-show="isLoading" x-cloak class="animate-spin w-5 h-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M2 12C2 6.47715 6.47715 2 12 2V5C8.13401 5 5 8.13401 5 12H2Z" />
                         </svg>
                     </span>

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -30,6 +30,7 @@
             @foreach ($getOptions() as $value => $label)
                 <option
                     value="{{ $value }}"
+                    {!! $value === $getState() ? 'selected' : null !!}
                     {!! $isOptionDisabled($value, $label) ? 'disabled' : null !!}
                 >
                     {{ $label }}

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -57,6 +57,7 @@
 
             <div
                 x-show="state.length"
+                x-cloak
                 class="overflow-hidden rtl:space-x-reverse relative w-full p-2"
             >
                 <div class="flex flex-wrap gap-1">

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -27,6 +27,7 @@
 
         <div class="flex-1">
             <input
+                value="{{ $getState() }}"
                 @unless ($hasMask())
                     {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
                     type="{{ $getType() }}"

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -27,7 +27,9 @@
 
         <div class="flex-1">
             <input
-                value="{{ $getState() }}"
+                @if (filled($getState()))
+                    value="{{ $getState() }}"
+                @endif
                 @unless ($hasMask())
                     {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
                     type="{{ $getType() }}"

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -35,6 +35,7 @@
         @if ($shouldAutosize())
             x-data="textareaFormComponent()"
             x-on:input="render()"
+            style="height: 150px"
             {{ $getExtraAlpineAttributeBag() }}
         @endif
     ></textarea>

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -38,5 +38,5 @@
             style="height: 150px"
             {{ $getExtraAlpineAttributeBag() }}
         @endif
-    ></textarea>
+    >{{ $getState() }}</textarea>
 </x-forms::field-wrapper>

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -21,22 +21,25 @@
                     'bg-primary-600': state,
                     'bg-gray-200 @if (config('forms.dark_mode')) dark:bg-gray-700 @endif': ! state,
                 }"
-                x-cloak
                 {!! $isAutofocused() ? 'autofocus' : null !!}
                 {!! $isDisabled() ? 'disabled' : null !!}
                 id="{{ $getId() }}"
                 type="button"
                 {{ $attributes->merge($getExtraAttributes())->class([
-                    'relative inline-flex shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-500 bg-gray-200 filament-forms-toggle-component',
+                    'relative inline-flex shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-500 filament-forms-toggle-component',
                     'border-gray-300' => ! $errors->has($getStatePath()),
                     'border-danger-300 ring-danger-500' => $errors->has($getStatePath()),
+                    'bg-primary-600' => $getState(),
+                    'bg-gray-200' . (config('forms.dark_mode') ? 'dark:bg-gray-700' : null) => ! $getState(),
                 ]) }}
                 {{ $getExtraAlpineAttributeBag() }}
             >
                 <span
                     @class([
-                        'pointer-events-none relative inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 ease-in-out transition duration-200 translate-x-0',
+                        'pointer-events-none relative inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 ease-in-out transition duration-200',
                         'dark:bg-gray-800' => config('forms.dark_mode'),
+                        'translate-x-5 rtl:-translate-x-5' => $getState(),
+                        'translate-x-0' => ! $getState(),
                     ])
                     :class="{
                         'translate-x-5 rtl:-translate-x-5': state,
@@ -44,7 +47,11 @@
                     }"
                 >
                     <span
-                        class="absolute inset-0 h-full w-full flex items-center justify-center transition-opacity opacity-100 ease-in duration-200"
+                        @class([
+                            'absolute inset-0 h-full w-full flex items-center justify-center transition-opacity',
+                            'opacity-0 ease-out duration-100' => $getState(),
+                            'opacity-100 ease-in duration-200' => ! $getState(),
+                        ])
                         aria-hidden="true"
                         :class="{
                             'opacity-0 ease-out duration-100': state,
@@ -57,7 +64,11 @@
                     </span>
 
                     <span
-                        class="absolute inset-0 h-full w-full flex items-center justify-center transition-opacity opacity-0 ease-out duration-100"
+                        @class([
+                            'absolute inset-0 h-full w-full flex items-center justify-center transition-opacity',
+                            'opacity-100 ease-in duration-200' => $getState(),
+                            'opacity-0 ease-out duration-100' => ! $getState(),
+                        ])
                         aria-hidden="true"
                         :class="{
                             'opacity-100 ease-in duration-200': state,

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -30,7 +30,7 @@
                     'border-gray-300' => ! $errors->has($getStatePath()),
                     'border-danger-300 ring-danger-500' => $errors->has($getStatePath()),
                     'bg-primary-600' => $getState(),
-                    'bg-gray-200' . (config('forms.dark_mode') ? 'dark:bg-gray-700' : null) => ! $getState(),
+                    'bg-gray-200' . (config('forms.dark_mode') ? ' dark:bg-gray-700' : null) => ! $getState(),
                 ]) }}
                 {{ $getExtraAlpineAttributeBag() }}
             >

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -21,7 +21,6 @@
                     'bg-primary-600': state,
                     'bg-gray-200 @if (config('forms.dark_mode')) dark:bg-gray-700 @endif': ! state,
                 }"
-                x-cloak
                 {!! $isAutofocused() ? 'autofocus' : null !!}
                 {!! $isDisabled() ? 'disabled' : null !!}
                 id="{{ $getId() }}"

--- a/packages/tables/resources/views/components/filters/index.blade.php
+++ b/packages/tables/resources/views/components/filters/index.blade.php
@@ -5,13 +5,13 @@
 
 <div
     x-data="{ isOpen: false }"
-    x-cloak
     {{ $attributes->class(['relative inline-block filament-tables-filters']) }}
 >
     <x-tables::filters.trigger />
 
     <div
         x-show="isOpen"
+        x-cloak
         x-on:click.away="isOpen = false"
         x-transition:enter="ease duration-300"
         x-transition:enter-start="opacity-0 -translate-y-2"

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -135,8 +135,8 @@
 >
     <x-tables::container>
         <div
-            x-show="hasHeader = ({{ ($header || $heading || $headerActions || $isSearchVisible || $isFiltersDropdownVisible) ? 'true' : 'false' }} || selectedRecords.length)"
-            x-cloak
+            x-show="hasHeader = ({{ ($renderHeader = ($header || $heading || $headerActions || $isSearchVisible || $isFiltersDropdownVisible)) ? 'true' : 'false' }} || selectedRecords.length)"
+            {!! ! $renderHeader ? 'x-cloak' : null !!}
         >
             @if ($header)
                 {{ $header }}
@@ -157,8 +157,8 @@
             @endif
 
             <div
-                x-show="{{ ($isSearchVisible || $isFiltersDropdownVisible) ? 'true' : 'false' }} || selectedRecords.length"
-                x-cloak
+                x-show="{{ ($renderHeaderDiv = ($isSearchVisible || $isFiltersDropdownVisible)) ? 'true' : 'false' }} || selectedRecords.length"
+                {!! ! $renderHeaderDiv ? 'x-cloak' : null !!}
                 class="flex items-center justify-between p-2 h-14"
             >
                 <div>
@@ -193,6 +193,8 @@
             @class([
                 'overflow-y-auto relative',
                 'dark:border-gray-700' => config('tables.dark_mode'),
+                'rounded-t-xl' => ! $renderHeader,
+                'border-t' => $renderHeader,
             ])
             x-bind:class="{
                 'rounded-t-xl': ! hasHeader,


### PR DESCRIPTION
Related to my previous sidebar PR, this reduces uninitialised UI flashes and reflows on page load in a few other spots, to make things feel a little snappier and smoother. The goal is to make the initial render before JS initialisation as close as possible to how it looks after initialisation, within reason. The video below demonstrates what I'm referring to (after the changes is around the half-way point):

https://user-images.githubusercontent.com/126740/152842352-81ba4159-8f32-4a5e-8310-62d81824cfb1.mov

These pre-initialisation UI changes have been implemented:

- [x] Table headers are visible (when applicable)
- [x] Table filter button is visible (when applicable)
- [x] Navigation close group button is hidden
- [x] These fields have tweaked UI:
    - [x] Textarea height is set correctly (when blank)
        - [x] There's also a small bug fix to the `scrollHeight` calculation, which wasn't taking the border into account
    - [x] File Upload height is set correctly (when blank and no custom ratio is set)
    - [x] Multi Select field dropdown lists and loading icons are hidden 
    - [x] Tag dropdown lists and loading icons are hidden 
    - [x] Select loading icons are hidden
    - [x] Rich Editor UI is visible
    - [x] Markdown Editor UI is visible
    - [x] Toggle UI is visible
- [x] These fields have initial values/state set:
    - [x] Checkbox
    - [x] Checkbox List
    - [x] Datetime
    - [x] Markdown
    - [x] Markdown Editor
    - [x] Radio
    - [x] Rich Editor
    - [x] Select
    - [x] Text
    - [x] Textarea
    - [x] Toggle

This won't be able to cover absolutely everything. Some things probably aren't worth the hassle of pre-rendering server side, like the initial value/state of a multi-select. And some things simply aren't known server side, like the scroll height of a textarea. But I think even just these changes make things feel much smoother.