### PR TITLE
fix: get phpstan working (again)

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,3 +1,20 @@
 <?php
 
-return require __DIR__ . '/../vendor/orchestra/testbench-core/laravel/bootstrap/app.php';
+use Filament\FilamentServiceProvider;
+use Filament\Forms\FormsServiceProvider;
+use Filament\Tables\TablesServiceProvider;
+use Livewire\LivewireServiceProvider;
+use Orchestra\Testbench\Foundation\Application;
+
+$app = (new Application())
+    ->configure([
+        'enables_package_discoveries' => true,
+    ])
+    ->createApplication();
+
+$app->register(LivewireServiceProvider::class);
+$app->register(FormsServiceProvider::class);
+$app->register(TablesServiceProvider::class);
+$app->register(FilamentServiceProvider::class);
+
+return $app;

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,0 +1,3 @@
+<?php
+
+return require __DIR__ . '/../vendor/orchestra/testbench-core/laravel/bootstrap/app.php';


### PR DESCRIPTION
**2022-02-07 #1**

PHPStan actually runs. It still trips over the missing `livewire` binding in the container, as well as a `filament` binding. It's obviously not loading the service providers through the Testbench.

Will continue investigating.

**2022-02-07 #2**

Took a short source-dive and some sane `dd` debugging helped uncover some problems. Larastan doesn't like our mono-repo setup and relies heavily on Testbench's Laravel bootstrapping to work correctly.

We wouldn't have had any problems if Larastan & Testbench were installed and run for each sub-repo separately. The way around this is to tell Larastan what service providers _actually_ need to be loaded. For now, that's just the main `FilamentServiceProvider` and forms/tables ones, as well as `LivewireServiceProvider`.