### PR TITLE
chore: display full PHP version in workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ 8.1, 8.0 ]
+                php: [ 8.1, '8.0' ]
                 laravel: [ 9.*, 8.* ]
                 dependency-version: [ prefer-stable ]
                 include:


### PR DESCRIPTION
Was bugging me that it said `P8` instead of `P 8.0`.