### PR TITLE
Add resource name flag

### DIFF
--- a/packages/admin/src/Commands/Aliases/MakeResourceCommand.php
+++ b/packages/admin/src/Commands/Aliases/MakeResourceCommand.php
@@ -8,5 +8,5 @@ class MakeResourceCommand extends Commands\MakeResourceCommand
 {
     protected $hidden = true;
 
-    protected $signature = 'filament:resource {name?} {--G|generate} {--S|simple}';
+    protected $signature = 'filament:resource {model?} {--N|name=} {--G|generate} {--S|simple}';
 }

--- a/packages/admin/stubs/Resource.stub
+++ b/packages/admin/stubs/Resource.stub
@@ -16,7 +16,7 @@ class {{ resourceClass }} extends Resource
     protected static ?string $model = {{ modelClass }}::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-collection';
-
+{{ resourceNameParts }}
     public static function form(Form $form): Form
     {
         return $form

--- a/packages/admin/stubs/SimpleResource.stub
+++ b/packages/admin/stubs/SimpleResource.stub
@@ -15,7 +15,7 @@ class {{ resourceClass }} extends Resource
     protected static ?string $model = {{ modelClass }}::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-collection';
-
+{{ resourceNameParts }}
     public static function form(Form $form): Form
     {
         return $form


### PR DESCRIPTION
add {--N|name=} option to specify resource name 

`make:filament-resource {model?} {--N|name=}`

current behaviour: Model name is the Resource name 

with -N option: filenames, slug and labels will use the resource name passed in
