### PR TITLE
Add method to easily override initial table records per page

### DIFF
--- a/packages/tables/src/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Concerns/CanPaginateRecords.php
@@ -15,6 +15,8 @@ trait CanPaginateRecords
 
     public $tableRecordsPerPage;
 
+    protected int $defaultTableRecordsPerPageSelectOption = 10;
+
     public function updatedTableRecordsPerPage(): void
     {
         session()->put([
@@ -46,14 +48,9 @@ trait CanPaginateRecords
         return [5, 10, 25, 50];
     }
 
-    protected function getInitialTableRecordsPerPageSelectOption(): int
-    {
-        return 10;
-    }
-
     protected function getDefaultTableRecordsPerPageSelectOption(): int
     {
-        $perPage = session()->get($this->getTablePerPageSessionKey(), $this->getInitialTableRecordsPerPageSelectOption());
+        $perPage = session()->get($this->getTablePerPageSessionKey(), $this->defaultTableRecordsPerPageSelectOption);
 
         if (in_array($perPage, $this->getTableRecordsPerPageSelectOptions())) {
             return $perPage;

--- a/packages/tables/src/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Concerns/CanPaginateRecords.php
@@ -46,9 +46,14 @@ trait CanPaginateRecords
         return [5, 10, 25, 50];
     }
 
+    protected function getInitialTableRecordsPerPageSelectOption(): int
+    {
+        return 10;
+    }
+
     protected function getDefaultTableRecordsPerPageSelectOption(): int
     {
-        $perPage = session()->get($this->getTablePerPageSessionKey(), 10);
+        $perPage = session()->get($this->getTablePerPageSessionKey(), $this->getInitialTableRecordsPerPageSelectOption());
 
         if (in_array($perPage, $this->getTableRecordsPerPageSelectOptions())) {
             return $perPage;
@@ -73,7 +78,7 @@ trait CanPaginateRecords
     {
         $table = class_basename($this::class);
 
-        return $table . '_per_page';
+        return $table.'_per_page';
     }
 
     public function resetPage(?string $pageName = null): void

--- a/packages/tables/src/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Concerns/CanPaginateRecords.php
@@ -75,7 +75,7 @@ trait CanPaginateRecords
     {
         $table = class_basename($this::class);
 
-        return $table.'_per_page';
+        return $table . '_per_page';
     }
 
     public function resetPage(?string $pageName = null): void


### PR DESCRIPTION
Allows you to override the default records per page count (10) without having to override the entire `getDefaultTableRecordsPerPageSelectOption` method and all its other logic.

There may be a better name than "initial".