### PR TITLE
fix: Remove initial field values

### DIFF
--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -89,7 +89,6 @@
                     {!! $isDisabled() ? 'disabled' : null !!}
                     type="checkbox"
                     value="{{ $optionValue }}"
-                    {!! in_array($optionValue, $getState()) ? 'checked' : null !!}
                     {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
                     {{ $attributes->merge($getExtraAttributes())->class([
                         'text-primary-600 transition duration-75 rounded shadow-sm focus:border-primary-500 focus:ring-2 focus:ring-primary-500',

--- a/packages/forms/resources/views/components/checkbox.blade.php
+++ b/packages/forms/resources/views/components/checkbox.blade.php
@@ -12,7 +12,6 @@
         <x-slot name="labelPrefix">
     @endif
             <input
-                {!! $getState() ? 'checked' : null !!}
                 {!! $isAutofocused() ? 'autofocus' : null !!}
                 {!! $isDisabled() ? 'disabled' : null !!}
                 id="{{ $getId() }}"

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -60,9 +60,6 @@
             ]) }}
         >
             <input
-                @if (filled($getState()))
-                    value="{{ (new DateTime($getState()))->format($getDisplayFormat()) }}"
-                @endif
                 readonly
                 placeholder="{{ $getPlaceholder() }}"
                 x-model="displayText"

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -217,7 +217,7 @@
                             'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
                             'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
                         ])
-                    >{{ $getState() }}</textarea>
+                    ></textarea>
                 </file-attachment>
 
                 <div

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -28,7 +28,6 @@
                                 id="{{ $getId() }}-{{ $value }}"
                                 type="radio"
                                 value="{{ $value }}"
-                                {!! $value === $getState() ? 'checked' : null !!}
                                 {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
                                 {{ $getExtraInputAttributeBag()->class([
                                     'focus:ring-primary-500 h-4 w-4 text-primary-600',

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -289,7 +289,7 @@
                     'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
                     'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
                 ])
-            >{{ $getState() }}</trix-editor>
+            ></trix-editor>
         @else
             <div x-html="state" @class([
                 'p-3 prose border border-gray-300 rounded-lg shadow-sm',

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -30,7 +30,6 @@
             @foreach ($getOptions() as $value => $label)
                 <option
                     value="{{ $value }}"
-                    {!! $value === $getState() ? 'selected' : null !!}
                     {!! $isOptionDisabled($value, $label) ? 'disabled' : null !!}
                 >
                     {{ $label }}

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -27,9 +27,6 @@
 
         <div class="flex-1">
             <input
-                @if (filled($getState()))
-                    value="{{ $getState() }}"
-                @endif
                 @unless ($hasMask())
                     {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
                     type="{{ $getType() }}"

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -38,5 +38,5 @@
             style="height: 150px"
             {{ $getExtraAlpineAttributeBag() }}
         @endif
-    >{{ $getState() }}</textarea>
+    ></textarea>
 </x-forms::field-wrapper>

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -38,8 +38,6 @@
                     @class([
                         'pointer-events-none relative inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 ease-in-out transition duration-200',
                         'dark:bg-gray-800' => config('forms.dark_mode'),
-                        'translate-x-5 rtl:-translate-x-5' => $getState(),
-                        'translate-x-0' => ! $getState(),
                     ])
                     :class="{
                         'translate-x-5 rtl:-translate-x-5': state,
@@ -64,11 +62,7 @@
                     </span>
 
                     <span
-                        @class([
-                            'absolute inset-0 h-full w-full flex items-center justify-center transition-opacity',
-                            'opacity-100 ease-in duration-200' => $getState(),
-                            'opacity-0 ease-out duration-100' => ! $getState(),
-                        ])
+                        class="absolute inset-0 h-full w-full flex items-center justify-center transition-opacity"
                         aria-hidden="true"
                         :class="{
                             'opacity-100 ease-in duration-200': state,


### PR DESCRIPTION
Removes the initial state set from #1486, as it is causing Livewire DOM-diffing issues in reactive components.