### PR TITLE
controlling spacing

### DIFF
--- a/packages/tables/src/Actions/ButtonAction.php
+++ b/packages/tables/src/Actions/ButtonAction.php
@@ -9,7 +9,7 @@ class ButtonAction extends Action
     protected string $view = 'tables::actions.button-action';
 
     protected string | Closure | null $iconPosition = null;
-
+    protected bool $isOnlyIcon = false;
     public function iconPosition(string | Closure | null $position): static
     {
         $this->iconPosition = $position;
@@ -20,5 +20,12 @@ class ButtonAction extends Action
     public function getIconPosition(): ?string
     {
         return $this->evaluate($this->iconPosition);
+    }
+    
+     public function onlyIcon(bool $condition = true): static
+    {
+        $this->isOnlyIcon = $condition;
+
+        return $this;
     }
 }


### PR DESCRIPTION
You may want buttons only to have icons and not write anything in labels, for example in tables icons will take less space and mean more.

Before:
![Bildschirmfoto 2022-02-09 um 14 03 34](https://user-images.githubusercontent.com/9349190/153207261-64b89a64-864c-492a-ab8b-16d3e8b6e1f0.png)


After:
![Bildschirmfoto 2022-02-09 um 14 02 31](https://user-images.githubusercontent.com/9349190/153207303-898b858e-3707-42c5-adfa-c70c066ed4e3.png)

