### PR TITLE
add sort indicator for all sortable columns

### DIFF
--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -25,17 +25,20 @@
             {{ $slot }}
         </span>
 
-        @if ($isSortColumn)
-            <span @class([
-                'relative flex items-center',
+        @if($sortable)
+        <span @class([
+                'relative flex-col items-center',
                 'dark:text-gray-300' => config('tables.dark_mode'),
             ])>
-                @if ($sortDirection === 'asc')
-                    <x-heroicon-s-chevron-up class="w-3 h-3" />
-                @elseif ($sortDirection === 'desc')
-                    <x-heroicon-s-chevron-down class="w-3 h-3" />
-                @endif
-            </span>
+
+            <x-heroicon-s-chevron-up
+                class="w-3 h-3 {{ ($isSortColumn && $sortDirection === 'asc') ? null : 'text-gray-400' }}"
+            />
+
+            <x-heroicon-s-chevron-down
+                class="w-3 h-3 {{ ($isSortColumn && $sortDirection === 'desc') ? null : 'text-gray-400' }}"
+            />
+        </span>
         @endif
     </button>
 </th>

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -33,7 +33,7 @@
                 @if ($isSortColumn && $sortDirection === 'asc')
                     <x-heroicon-s-chevron-up class="w-3 h-3" />
                 @else
-                    <x-heroicon-s-chevron-down class="\Illuminate\Support\Arr::toCssClasses(['w-3 h-3', 'opacity-50' => ! $isSortColumn])" />
+                    <x-heroicon-s-chevron-down :class="\Illuminate\Support\Arr::toCssClasses(['w-3 h-3', 'opacity-50' => ! $isSortColumn])" />
                 @endif
 
             </span>

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -25,23 +25,18 @@
             {{ $slot }}
         </span>
 
-        @if($sortable)
-        <span @class([
+        @if ($sortable)
+            <span @class([
                 'relative flex items-center',
                 'dark:text-gray-300' => config('tables.dark_mode'),
             ])>
+                @if ($isSortColumn && $sortDirection === 'asc')
+                    <x-heroicon-s-chevron-up class="w-3 h-3" />
+                @else
+                    <x-heroicon-s-chevron-down class="\Illuminate\Support\Arr::toCssClasses(['w-3 h-3', 'opacity-50' => ! $isSortColumn])" />
+                @endif
 
-            @if($isSortColumn && $sortDirection === 'asc')
-            <x-heroicon-s-chevron-up
-                class="w-3 h-3"
-            />
-            @else
-            <x-heroicon-s-chevron-down
-                class="w-3 h-3 {{ !($isSortColumn && $sortDirection === 'desc') ? 'opacity-50' : null }}"
-            />
-            @endif
-
-        </span>
+            </span>
         @endif
     </button>
 </th>

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -27,17 +27,20 @@
 
         @if($sortable)
         <span @class([
-                'relative flex-col items-center',
+                'relative flex items-center',
                 'dark:text-gray-300' => config('tables.dark_mode'),
             ])>
 
+            @if($isSortColumn && $sortDirection === 'asc')
             <x-heroicon-s-chevron-up
-                class="w-3 h-3 {{ ($isSortColumn && $sortDirection === 'asc') ? null : 'text-gray-400' }}"
+                class="w-3 h-3"
             />
-
+            @else
             <x-heroicon-s-chevron-down
-                class="w-3 h-3 {{ ($isSortColumn && $sortDirection === 'desc') ? null : 'text-gray-400' }}"
+                class="w-3 h-3 {{ !($isSortColumn && $sortDirection === 'desc') ? 'opacity-50' : null }}"
             />
+            @endif
+
         </span>
         @endif
     </button>


### PR DESCRIPTION
how can users know the sortable columns? 
So I added a sort indicator to all sortable columns and when the user uses these, it will be shown with different text colors depending on the sorting direction.


![image](https://user-images.githubusercontent.com/6294478/153228107-03b2e75a-f09e-448e-a5d7-20c487f9ae1c.png)
