### PR TITLE
Allow to trigger delete events on child relations

### DIFF
--- a/packages/forms/src/Components/RelationshipRepeater.php
+++ b/packages/forms/src/Components/RelationshipRepeater.php
@@ -46,7 +46,9 @@ class RelationshipRepeater extends Repeater
                 $recordsToDelete[] = $keyToCheckForDeletion;
             }
 
-            $relationship->whereIn($localKeyName, $recordsToDelete)->delete();
+            $relationship->whereIn($localKeyName, $recordsToDelete)->get()->each(function ($record) {
+                $record->delete();
+            });
 
             $childComponentContainers = $component->getChildComponentContainers();
 

--- a/packages/forms/src/Components/RelationshipRepeater.php
+++ b/packages/forms/src/Components/RelationshipRepeater.php
@@ -5,6 +5,7 @@ namespace Filament\Forms\Components;
 use Closure;
 use Filament\Forms\ComponentContainer;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Support\Str;
 
@@ -46,9 +47,7 @@ class RelationshipRepeater extends Repeater
                 $recordsToDelete[] = $keyToCheckForDeletion;
             }
 
-            $relationship->whereIn($localKeyName, $recordsToDelete)->get()->each(function ($record) {
-                $record->delete();
-            });
+            $relationship->whereIn($localKeyName, $recordsToDelete)->get()->each(fn (Model $record) => $record->delete());
 
             $childComponentContainers = $component->getChildComponentContainers();
 


### PR DESCRIPTION
This fixes the issue #1527 that specifies that when deleting child relations, deleting and delete events from model observer are not triggered.