### PR TITLE
feature: support custom global search providers

### DIFF
--- a/packages/admin/resources/views/components/global-search/result-group.blade.php
+++ b/packages/admin/resources/views/components/global-search/result-group.blade.php
@@ -23,9 +23,9 @@
 
     @foreach ($results as $result)
         <x-filament::global-search.result
-            :details="$result['details'] ?? []"
-            :title="$result['title']"
-            :url="$result['url']"
+            :details="$result->details"
+            :title="$result->title"
+            :url="$result->url"
         />
     @endforeach
 </ul>

--- a/packages/admin/resources/views/components/global-search/results-container.blade.php
+++ b/packages/admin/resources/views/components/global-search/results-container.blade.php
@@ -14,7 +14,7 @@
         'overflow-y-scroll overflow-x-hidden max-h-96 bg-white shadow rounded-xl',
         'dark:bg-gray-800' => config('filament.dark_mode'),
     ])>
-        @forelse ($results as $group => $groupedResults)
+        @forelse ($results->getCategories() as $group => $groupedResults)
             <x-filament::global-search.result-group :label="$group" :results="$groupedResults" />
         @empty
             <x-filament::global-search.no-results-message />

--- a/packages/admin/src/Facades/Filament.php
+++ b/packages/admin/src/Facades/Filament.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @method static StatefulGuard auth()
  * @method static array getBeforeCoreScripts()
+ * @method static \Filament\GlobalSearch\Contracts\GlobalSearchProvider getGlobalSearchProvider()
  * @method static array getPages()
  * @method static string | null getModelResource(string | Model $model)
  * @method static array getNavigation()
@@ -25,6 +26,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string | null getUserAvatarUrl(Authenticatable $user)
  * @method static string getUserName(Authenticatable $user)
  * @method static array getWidgets()
+ * @method static void globalSearchProvider(string $provider)
  * @method static void navigation(\Closure $builder)
  * @method static void notify(string $status, string $message, bool $isAfterRedirect = false)
  * @method static void registerNavigationGroups(array $groups)

--- a/packages/admin/src/Facades/Filament.php
+++ b/packages/admin/src/Facades/Filament.php
@@ -3,6 +3,8 @@
 namespace Filament\Facades;
 
 use Closure;
+use Filament\FilamentManager;
+use Filament\GlobalSearch\Contracts\GlobalSearchProvider;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Database\Eloquent\Model;
@@ -11,7 +13,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @method static StatefulGuard auth()
  * @method static array getBeforeCoreScripts()
- * @method static \Filament\GlobalSearch\Contracts\GlobalSearchProvider getGlobalSearchProvider()
+ * @method static GlobalSearchProvider getGlobalSearchProvider()
  * @method static array getPages()
  * @method static string | null getModelResource(string | Model $model)
  * @method static array getNavigation()
@@ -41,7 +43,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void registerWidgets(array $widgets)
  * @method static void serving(Closure $callback)
  *
- * @see \Filament\FilamentManager
+ * @see FilamentManager
  */
 class Filament extends Facade
 {

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -3,7 +3,10 @@
 namespace Filament;
 
 use Closure;
+use Exception;
+use Filament\GlobalSearch\Contracts\GlobalSearchProvider;
 use Filament\Events\ServingFilament;
+use Filament\GlobalSearch\DefaultGlobalSearchProvider;
 use Filament\Models\Contracts\HasAvatar;
 use Filament\Models\Contracts\HasName;
 use Illuminate\Contracts\Auth\Guard;
@@ -15,6 +18,8 @@ use Livewire\Component;
 
 class FilamentManager
 {
+    protected string $globalSearchProvider = DefaultGlobalSearchProvider::class;
+
     protected bool $isNavigationMounted = false;
 
     protected array $navigationGroups = [];
@@ -57,6 +62,15 @@ class FilamentManager
         return collect($builder->getGroups())
             ->merge([null => $builder->getItems()])
             ->toArray();
+    }
+
+    public function globalSearchProvider(string $provider): void
+    {
+        if (! in_array(GlobalSearchProvider::class, class_implements($provider))) {
+            throw new Exception('Global search provider ' . $provider . ' does not implement the ' . GlobalSearchProvider::class . ' interface.');
+        }
+
+        $this->globalSearchProvider = $provider;
     }
 
     public function mountNavigation(): void
@@ -142,6 +156,11 @@ class FilamentManager
         }
 
         $component->dispatchBrowserEvent('notify', ['status' => $status, 'message' => $message]);
+    }
+
+    public function getGlobalSearchProvider(): GlobalSearchProvider
+    {
+        return app($this->globalSearchProvider);
     }
 
     public function getNavigation(): array

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -4,8 +4,8 @@ namespace Filament;
 
 use Closure;
 use Exception;
-use Filament\GlobalSearch\Contracts\GlobalSearchProvider;
 use Filament\Events\ServingFilament;
+use Filament\GlobalSearch\Contracts\GlobalSearchProvider;
 use Filament\GlobalSearch\DefaultGlobalSearchProvider;
 use Filament\Models\Contracts\HasAvatar;
 use Filament\Models\Contracts\HasName;

--- a/packages/admin/src/GlobalSearch/Contracts/GlobalSearchProvider.php
+++ b/packages/admin/src/GlobalSearch/Contracts/GlobalSearchProvider.php
@@ -2,7 +2,9 @@
 
 namespace Filament\GlobalSearch\Contracts;
 
+use Filament\GlobalSearch\GlobalSearchResults;
+
 interface GlobalSearchProvider
 {
-    public function getResults(string $query): ?array;
+    public function getResults(string $query): ?GlobalSearchResults;
 }

--- a/packages/admin/src/GlobalSearch/Contracts/GlobalSearchProvider.php
+++ b/packages/admin/src/GlobalSearch/Contracts/GlobalSearchProvider.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Filament\GlobalSearch\Contracts;
+
+interface GlobalSearchProvider
+{
+    public function getResults(string $query): ?array;
+}

--- a/packages/admin/src/GlobalSearch/DefaultGlobalSearchProvider.php
+++ b/packages/admin/src/GlobalSearch/DefaultGlobalSearchProvider.php
@@ -6,9 +6,9 @@ use Filament\Facades\Filament;
 
 class DefaultGlobalSearchProvider implements Contracts\GlobalSearchProvider
 {
-    public function getResults(string $query): ?array
+    public function getResults(string $query): ?GlobalSearchResults
     {
-        $results = [];
+        $builder = GlobalSearchResults::make();
 
         foreach (Filament::getResources() as $resource) {
             if (! $resource::canGloballySearch()) {
@@ -21,9 +21,9 @@ class DefaultGlobalSearchProvider implements Contracts\GlobalSearchProvider
                 continue;
             }
 
-            $results[$resource::getPluralLabel()] = $resourceResults;
+            $builder->category($resource::getPluralLabel(), $resourceResults);
         }
 
-        return $results;
+        return $builder;
     }
 }

--- a/packages/admin/src/GlobalSearch/DefaultGlobalSearchProvider.php
+++ b/packages/admin/src/GlobalSearch/DefaultGlobalSearchProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Filament\GlobalSearch;
+
+use Filament\Facades\Filament;
+
+class DefaultGlobalSearchProvider implements Contracts\GlobalSearchProvider
+{
+    public function getResults(string $query): ?array
+    {
+        $results = [];
+
+        foreach (Filament::getResources() as $resource) {
+            if (! $resource::canGloballySearch()) {
+                continue;
+            }
+
+            $resourceResults = $resource::getGlobalSearchResults($query);
+
+            if (! $resourceResults->count()) {
+                continue;
+            }
+
+            $results[$resource::getPluralLabel()] = $resourceResults;
+        }
+
+        return $results;
+    }
+}

--- a/packages/admin/src/GlobalSearch/GlobalSearchResult.php
+++ b/packages/admin/src/GlobalSearch/GlobalSearchResult.php
@@ -4,21 +4,12 @@ namespace Filament\GlobalSearch;
 
 use Illuminate\Contracts\Support\Arrayable;
 
-class GlobalSearchResult implements Arrayable
+class GlobalSearchResult
 {
     public function __construct(
-        protected string $title,
-        protected string $url,
-        protected array $details = [],
+        public string $title,
+        public string $url,
+        public array $details = [],
     ) {
-    }
-
-    public function toArray()
-    {
-        return [
-            'title' => $this->title,
-            'url' => $this->url,
-            'details' => $this->details,
-        ];
     }
 }

--- a/packages/admin/src/GlobalSearch/GlobalSearchResult.php
+++ b/packages/admin/src/GlobalSearch/GlobalSearchResult.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Filament\GlobalSearch;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class GlobalSearchResult implements Arrayable
+{
+    public function __construct(
+        protected string $title,
+        protected string $url,
+        protected array $details = [],
+    ) {}
+
+    public function toArray()
+    {
+        return [
+            'title' => $this->title,
+            'url' => $this->url,
+            'details' => $this->details,
+        ];
+    }
+}

--- a/packages/admin/src/GlobalSearch/GlobalSearchResult.php
+++ b/packages/admin/src/GlobalSearch/GlobalSearchResult.php
@@ -10,7 +10,8 @@ class GlobalSearchResult implements Arrayable
         protected string $title,
         protected string $url,
         protected array $details = [],
-    ) {}
+    ) {
+    }
 
     public function toArray()
     {

--- a/packages/admin/src/GlobalSearch/GlobalSearchResult.php
+++ b/packages/admin/src/GlobalSearch/GlobalSearchResult.php
@@ -2,8 +2,6 @@
 
 namespace Filament\GlobalSearch;
 
-use Illuminate\Contracts\Support\Arrayable;
-
 class GlobalSearchResult
 {
     public function __construct(

--- a/packages/admin/src/GlobalSearch/GlobalSearchResults.php
+++ b/packages/admin/src/GlobalSearch/GlobalSearchResults.php
@@ -14,19 +14,19 @@ class GlobalSearchResults
         $this->categories = Collection::make();
     }
 
-    public static function make(): self
+    public static function make(): static
     {
-        return new self();
+        return new static();
     }
 
-    public function category(string $name, Arrayable | array $results = []): static
+    public function category(string $name, array | Arrayable $results = []): static
     {
         $this->categories[$name] = $results;
 
         return $this;
     }
 
-    public function getCategories()
+    public function getCategories(): Collection
     {
         return $this->categories;
     }

--- a/packages/admin/src/GlobalSearch/GlobalSearchResults.php
+++ b/packages/admin/src/GlobalSearch/GlobalSearchResults.php
@@ -5,7 +5,7 @@ namespace Filament\GlobalSearch;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
 
-class GlobalSearchResults implements Arrayable
+class GlobalSearchResults
 {
     protected Collection $categories;
 
@@ -19,16 +19,15 @@ class GlobalSearchResults implements Arrayable
         return new self();
     }
 
-    /** @param \Filament\GlobalSearch\GlobalSearchResult[] $results */
     public function category(string $name, Arrayable | array $results = []): static
     {
-        $this->categories[$name] = Collection::make($results);
+        $this->categories[$name] = $results;
 
         return $this;
     }
 
-    public function toArray()
+    public function getCategories()
     {
-        return $this->categories->toArray();
+        return $this->categories;
     }
 }

--- a/packages/admin/src/GlobalSearch/GlobalSearchResults.php
+++ b/packages/admin/src/GlobalSearch/GlobalSearchResults.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Filament\GlobalSearch;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Collection;
+
+class GlobalSearchResults implements Arrayable
+{
+    protected Collection $categories;
+
+    public function __construct()
+    {
+        $this->categories = Collection::make();
+    }
+
+    public static function make(): self
+    {
+        return new self();
+    }
+
+    /** @param \Filament\GlobalSearch\GlobalSearchResult[] $results */
+    public function category(string $name, Arrayable | array $results = []): static
+    {
+        $this->categories[$name] = Collection::make($results);
+
+        return $this;
+    }
+
+    public function toArray()
+    {
+        return $this->categories->toArray();
+    }
+}

--- a/packages/admin/src/Http/Livewire/GlobalSearch.php
+++ b/packages/admin/src/Http/Livewire/GlobalSearch.php
@@ -3,13 +3,14 @@
 namespace Filament\Http\Livewire;
 
 use Filament\Facades\Filament;
+use Filament\GlobalSearch\GlobalSearchResults;
 use Livewire\Component;
 
 class GlobalSearch extends Component
 {
     public $searchQuery = '';
 
-    public function getResults(): ?array
+    public function getResults(): ?GlobalSearchResults
     {
         $searchQuery = trim($this->searchQuery);
 
@@ -25,7 +26,7 @@ class GlobalSearch extends Component
 
         $this->dispatchBrowserEvent('open-global-search-results');
 
-        return $results->toArray();
+        return $results;
     }
 
     protected function isEnabled(): bool

--- a/packages/admin/src/Http/Livewire/GlobalSearch.php
+++ b/packages/admin/src/Http/Livewire/GlobalSearch.php
@@ -25,7 +25,7 @@ class GlobalSearch extends Component
 
         $this->dispatchBrowserEvent('open-global-search-results');
 
-        return $results;
+        return $results->toArray();
     }
 
     protected function isEnabled(): bool

--- a/packages/admin/src/Http/Livewire/GlobalSearch.php
+++ b/packages/admin/src/Http/Livewire/GlobalSearch.php
@@ -17,20 +17,10 @@ class GlobalSearch extends Component
             return null;
         }
 
-        $results = [];
+        $results = Filament::getGlobalSearchProvider()->getResults($this->searchQuery);
 
-        foreach (Filament::getResources() as $resource) {
-            if (! $resource::canGloballySearch()) {
-                continue;
-            }
-
-            $resourceResults = $resource::getGlobalSearchResults($searchQuery);
-
-            if (! $resourceResults->count()) {
-                continue;
-            }
-
-            $results[$resource::getPluralLabel()] = $resourceResults;
+        if ($results === null) {
+            return $results;
         }
 
         $this->dispatchBrowserEvent('open-global-search-results');

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -4,6 +4,7 @@ namespace Filament\Resources;
 
 use Closure;
 use Filament\Facades\Filament;
+use Filament\GlobalSearch\GlobalSearchResult;
 use Filament\Navigation\NavigationItem;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;
@@ -194,11 +195,11 @@ class Resource
         return $query
             ->limit(50)
             ->get()
-            ->map(fn (Model $record): array => [
-                'details' => static::getGlobalSearchResultDetails($record),
-                'title' => static::getGlobalSearchResultTitle($record),
-                'url' => static::getGlobalSearchResultUrl($record),
-            ]);
+            ->map(fn (Model $record): GlobalSearchResult => new GlobalSearchResult(
+                details: static::getGlobalSearchResultDetails($record),
+                title: static::getGlobalSearchResultTitle($record),
+                url: static::getGlobalSearchResultUrl($record),
+            ));
     }
 
     public static function getLabel(): string

--- a/tests/src/Admin/GlobalSearch/GlobalSearchServiceProvider.php
+++ b/tests/src/Admin/GlobalSearch/GlobalSearchServiceProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Filament\Tests\Admin\GlobalSearch;
+
+use Filament\PluginServiceProvider;
+use Filament\Tests\Admin\Fixtures\Resources\PostResource;
+
+class GlobalSearchServiceProvider extends PluginServiceProvider
+{
+    public static string $name = 'global-search';
+
+    protected function getResources(): array
+    {
+        return [
+            PostResource::class,
+        ];
+    }
+}

--- a/tests/src/Admin/GlobalSearch/GlobalSearchTest.php
+++ b/tests/src/Admin/GlobalSearch/GlobalSearchTest.php
@@ -2,6 +2,8 @@
 
 use Filament\Facades\Filament;
 use Filament\GlobalSearch\Contracts\GlobalSearchProvider;
+use Filament\GlobalSearch\GlobalSearchResult;
+use Filament\GlobalSearch\GlobalSearchResults;
 use Filament\Http\Livewire\GlobalSearch;
 use Filament\Tests\Admin\GlobalSearch\TestCase;
 use Filament\Tests\Models\Post;
@@ -34,14 +36,13 @@ it('can retrieve results via custom search provider', function () {
 
 class CustomSearchProvider implements GlobalSearchProvider
 {
-    public function getResults(string $query): ?array
+    public function getResults(string $query): ?GlobalSearchResults
     {
-        return [
-            'foobarbaz' => [
-                ['details' => [], 'title' => 'foo', 'url' => '#'],
-                ['details' => [], 'title' => 'bar', 'url' => '#'],
-                ['details' => [], 'title' => 'baz', 'url' => '#'],
-            ],
-        ];
+        return GlobalSearchResults::make()
+            ->category('foobarbaz', [
+                new GlobalSearchResult(title: 'foo', url: '#', details: []),
+                new GlobalSearchResult(title: 'bar', url: '#', details: []),
+                new GlobalSearchResult(title: 'baz', url: '#', details: []),
+            ]);
     }
 }

--- a/tests/src/Admin/GlobalSearch/GlobalSearchTest.php
+++ b/tests/src/Admin/GlobalSearch/GlobalSearchTest.php
@@ -1,13 +1,11 @@
 <?php
 
-use Livewire\Livewire;
 use Filament\Facades\Filament;
 use Filament\GlobalSearch\Contracts\GlobalSearchProvider;
-use Filament\Tests\Models\Post;
 use Filament\Http\Livewire\GlobalSearch;
 use Filament\Tests\Admin\GlobalSearch\TestCase;
-use Filament\Tests\Admin\Fixtures\Resources\PostResource;
-use Illuminate\Support\Arr;
+use Filament\Tests\Models\Post;
+use Livewire\Livewire;
 
 uses(TestCase::class);
 

--- a/tests/src/Admin/GlobalSearch/GlobalSearchTest.php
+++ b/tests/src/Admin/GlobalSearch/GlobalSearchTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Livewire\Livewire;
+use Filament\Facades\Filament;
+use Filament\GlobalSearch\Contracts\GlobalSearchProvider;
+use Filament\Tests\Models\Post;
+use Filament\Http\Livewire\GlobalSearch;
+use Filament\Tests\Admin\GlobalSearch\TestCase;
+use Filament\Tests\Admin\Fixtures\Resources\PostResource;
+use Illuminate\Support\Arr;
+
+uses(TestCase::class);
+
+it('can be mounted', function () {
+    Livewire::test(GlobalSearch::class)
+        ->assertOk();
+});
+
+it('can retrieve search results', function () {
+    $post = Post::factory()->create();
+
+    Livewire::test(GlobalSearch::class)
+        ->set('searchQuery', $post->title)
+        ->assertDispatchedBrowserEvent('open-global-search-results')
+        ->assertSee($post->title);
+});
+
+it('can retrieve results via custom search provider', function () {
+    Filament::globalSearchProvider(CustomSearchProvider::class);
+
+    Livewire::test(GlobalSearch::class)
+        ->set('searchQuery', 'foo')
+        ->assertDispatchedBrowserEvent('open-global-search-results')
+        ->assertSee(['foo', 'bar', 'baz']);
+});
+
+class CustomSearchProvider implements GlobalSearchProvider
+{
+    public function getResults(string $query): ?array
+    {
+        return [
+            'foobarbaz' => [
+                ['details' => [], 'title' => 'foo', 'url' => '#'],
+                ['details' => [], 'title' => 'bar', 'url' => '#'],
+                ['details' => [], 'title' => 'baz', 'url' => '#'],
+            ],
+        ];
+    }
+}

--- a/tests/src/Admin/GlobalSearch/TestCase.php
+++ b/tests/src/Admin/GlobalSearch/TestCase.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Filament\Tests\Admin\GlobalSearch;
+
+use Filament\Tests\Models\User;
+use Filament\Tests\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->actingAs(User::factory()->create());
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return array_merge(parent::getPackageProviders($app), [
+            GlobalSearchServiceProvider::class,
+        ]);
+    }
+}


### PR DESCRIPTION
This pull request adds support for custom global search providers. This API will allow developers to change how the global search works and how results are generated.

In theory, somebody could implement a Scout provider for Filament and share it as a package or perhaps a completely custom search provider that uses an alternative service.

Here's how the API works:

```php
public function boot()
{
	Filament::globalSearchProvider(MyCustomSearchProvider::class);
}
```

`MyCustomSearchProvider` is a `class` that implements the `Filament\GlobalSearch\Contracts\GlobalSearchProvider` interface. This interface enforces the class to have a `getResults(string $query): ?array` method.

The array that gets returned should have the following shape:

```php
[
	{category} => [
		[
			'details' => [
				{label} => {value}...
			],
			'title' => {string},
			'url' => {string},
		]...
	]...
]
```

The `category` should be a string that is used to group the results. `details` is an array of `key => value` pairs that will display underneath the result's `title` in the dropdown. The `url` is where the user goes when they click the result.