### PR TITLE
fix: badge/tags column alignment, header cell alignment

### DIFF
--- a/packages/tables/resources/views/columns/badge-column.blade.php
+++ b/packages/tables/resources/views/columns/badge-column.blade.php
@@ -10,7 +10,15 @@
     };
 @endphp
 
-<div {{ $attributes->merge($getExtraAttributes())->class(['px-4 py-3 flex filament-tables-badge-column']) }}>
+<div {{ $attributes->merge($getExtraAttributes())->class([
+    'px-4 py-3 flex filament-tables-badge-column',
+    match ($getAlignment()) {
+        'left' => 'justify-start',
+        'center' => 'justify-center',
+        'right' => 'justify-end',
+        default => null,
+    },
+]) }}>
     @if (filled($state))
         <span @class([
             'inline-flex items-center justify-center min-h-6 px-2 py-0.5 text-sm font-medium tracking-tight rounded-xl whitespace-normal',

--- a/packages/tables/resources/views/columns/tags-column.blade.php
+++ b/packages/tables/resources/views/columns/tags-column.blade.php
@@ -2,7 +2,15 @@
     $state = $getTags();
 @endphp
 
-<div {{ $attributes->merge($getExtraAttributes())->class(['px-4 py-3 flex flex-wrap gap-1 filament-tables-tags-column']) }}>
+<div {{ $attributes->merge($getExtraAttributes())->class([
+    'px-4 py-3 flex flex-wrap gap-1 filament-tables-tags-column',
+    match ($getAlignment()) {
+        'left' => 'justify-start',
+        'center' => 'justify-center',
+        'right' => 'justify-end',
+        default => null,
+    },
+]) }}>
     @foreach ($getTags() as $tag)
         <span @class([
             'inline-flex items-center justify-center min-h-6 px-2 py-0.5 text-sm font-medium tracking-tight rounded-xl text-primary-700 bg-primary-500/10 whitespace-normal',

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -8,7 +8,7 @@
 ])
 
 <th {{ $attributes->merge($extraAttributes)->class([
-    'px-4 py-2 filament-tables-header-cell',
+    'p-0 filament-tables-header-cell',
     'dark:bg-gray-800' => config('tables.dark_mode'),
 ]) }}>
     <button
@@ -17,7 +17,7 @@
         @endif
         type="button"
         @class([
-            'flex items-center w-full whitespace-nowrap space-x-1 rtl:space-x-reverse font-medium text-sm text-gray-600',
+            'flex items-center w-full px-4 py-2 whitespace-nowrap space-x-1 rtl:space-x-reverse font-medium text-sm text-gray-600',
             'dark:text-gray-300' => config('tables.dark_mode'),
             'cursor-default' => ! $sortable,
             match ($alignment) {

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -4,6 +4,7 @@
     'name',
     'sortable' => false,
     'sortDirection',
+    'alignment' => null,
 ])
 
 <th {{ $attributes->merge($extraAttributes)->class([
@@ -16,9 +17,15 @@
         @endif
         type="button"
         @class([
-            'flex items-center whitespace-nowrap space-x-1 rtl:space-x-reverse font-medium text-sm text-gray-600',
+            'flex items-center w-full whitespace-nowrap space-x-1 rtl:space-x-reverse font-medium text-sm text-gray-600',
             'dark:text-gray-300' => config('tables.dark_mode'),
             'cursor-default' => ! $sortable,
+            match ($alignment) {
+                'left' => 'justify-start',
+                'center' => 'justify-center',
+                'right' => 'justify-end',
+                default => null,
+            },
         ])
     >
         <span>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -229,6 +229,7 @@
                                 :extra-attributes="$column->getExtraHeaderAttributes()"
                                 :is-sort-column="$getSortColumn() === $column->getName()"
                                 :name="$column->getName()"
+                                :alignment="$column->getAlignment()"
                                 :sortable="$column->isSortable()"
                                 :sort-direction="$getSortDirection()"
                                 :class="$getHiddenClasses($column)"


### PR DESCRIPTION
This PR fixes these issues:

* Alignment in badge and tags columns (these  columns use flexbox so `text-align` doesn't work as intended)
* Alignment in table header cells
* The header cells have also been tweaked so the button fills the cell, so the whole cell is clickable when sorting

Before:

![Screenshot 2022-02-14 at 15 03 32](https://user-images.githubusercontent.com/126740/153889230-1a1bb9d1-45fa-4300-8e1d-b3a6c7345271.png)

After:

![Screenshot 2022-02-14 at 15 03 42](https://user-images.githubusercontent.com/126740/153889245-a3cf02a4-b6a6-4a09-83ba-d1420de2f0c1.png)

