### PR TITLE
feature: add prefix/postfix support and url link feature to select fields

### DIFF
--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -212,7 +212,10 @@
         @endif
 
         @if ($url = $getUrl())
-            <a href="{{ $url }}">
+            <a 
+                href="{{ $url }}"
+                {{ $shouldOpenUrlInNewTab() ? 'target="_blank"' : null }}
+            >
                 <x-heroicon-o-link class="shrink-0 w-5 h-5 text-gray-400 hover:text-primary-500" />
             </a>
         @endif

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -1,3 +1,11 @@
+@php
+    $sideLabelClasses = [
+        'whitespace-nowrap group-focus-within:text-primary-500',
+        'text-gray-400' => ! $errors->has($getStatePath()),
+        'text-danger-400' => $errors->has($getStatePath()),
+    ];
+@endphp
+
 <x-forms::field-wrapper
     :id="$getId()"
     :label="$getLabel()"
@@ -8,183 +16,199 @@
     :required="$isRequired()"
     :state-path="$getStatePath()"
 >
-    @unless ($isSearchable())
-        <select
-            {!! $isAutofocused() ? 'autofocus' : null !!}
-            {!! $isDisabled() ? 'disabled' : null !!}
-            id="{{ $getId() }}"
-            {!! $isRequired() ? 'required' : null !!}
-            {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
-            {{ $attributes->merge($getExtraAttributes())->class([
-                'text-gray-900 block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600 disabled:opacity-70 filament-forms-select-component',
-                'dark:bg-gray-700 dark:text-white' => config('forms.dark_mode'),
-                'border-gray-300' => ! $errors->has($getStatePath()),
-                'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
-                'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
-            ]) }}
-        >
-            @unless ($isPlaceholderSelectionDisabled())
-                <option value="">{{ $getPlaceholder() }}</option>
-            @endif
-
-            @foreach ($getOptions() as $value => $label)
-                <option
-                    value="{{ $value }}"
-                    {!! $isOptionDisabled($value, $label) ? 'disabled' : null !!}
+    <div {{ $attributes->merge($getExtraAttributes())->class(['flex items-center space-x-1 group filament-forms-select-component']) }}>
+        @if ($label = $getPrefixLabel())
+            <span @class($sideLabelClasses)>
+                {{ $label }}
+            </span>
+        @endif
+        
+        <div class="flex-1">
+            @unless ($isSearchable())
+                <select
+                    {!! $isAutofocused() ? 'autofocus' : null !!}
+                    {!! $isDisabled() ? 'disabled' : null !!}
+                    id="{{ $getId() }}"
+                    {!! $isRequired() ? 'required' : null !!}
+                    {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
+                    {{ $attributes->merge($getExtraAttributes())->class([
+                        'text-gray-900 block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600 disabled:opacity-70',
+                        'dark:bg-gray-700 dark:text-white' => config('forms.dark_mode'),
+                        'border-gray-300' => ! $errors->has($getStatePath()),
+                        'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
+                        'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
+                    ]) }}
                 >
-                    {{ $label }}
-                </option>
-            @endforeach
-        </select>
-    @else
-        <div
-            x-data="selectFormComponent({
-                getOptionLabelUsing: async (value) => {
-                    return await $wire.getSelectOptionLabel('{{ $getStatePath() }}')
-                },
-                getSearchResultsUsing: async (query) => {
-                    return await $wire.getSelectSearchResults('{{ $getStatePath() }}', query)
-                },
-                isAutofocused: {{ $isAutofocused() ? 'true' : 'false' }},
-                options: {{ json_encode($getOptions()) }},
-                state: $wire.{{ $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')') }},
-            })"
-            x-on:click.away="closeListbox()"
-            x-on:blur="closeListbox()"
-            x-on:keydown.escape.stop="closeListbox()"
-            {!! ($id = $getId()) ? "id=\"{$id}\"" : null !!}
-            {{ $attributes->merge($getExtraAttributes())->class(['relative']) }}
-            {{ $getExtraAlpineAttributeBag() }}
-        >
-            <div
-                @unless($isDisabled())
-                    x-ref="button"
-                    x-on:click="toggleListboxVisibility()"
-                    x-on:keydown.enter.stop.prevent="isOpen ? selectOption() : openListbox()"
-                    x-on:keydown.space="if (! isOpen) openListbox()"
-                    x-on:keydown.backspace="if (! search) clearState()"
-                    x-on:keydown.clear="if (! search) clearState()"
-                    x-on:keydown.delete="if (! search) clearState()"
-                    x-bind:aria-expanded="isOpen"
-                    aria-haspopup="listbox"
-                    tabindex="1"
-                @endunless
-                @class([
-                    'relative flex items-center py-2 pl-3 pr-10 border bg-white overflow-hidden duration-75 rounded-lg shadow-sm focus-within:border-primary-600 focus-within:ring-1 focus-within:ring-inset focus-within:ring-primary-600 focus:outline-none',
-                    'dark:bg-gray-700' => config('forms.dark_mode'),
-                    'border-gray-300' => ! $errors->has($getStatePath()),
-                    'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
-                    'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
-                ])
-            >
-                <span
-                    x-show="! isOpen"
-                    x-text="label ?? '{{ addslashes($getPlaceholder()) }}'"
-                    @class([
-                        'w-full bg-white',
-                        'dark:bg-gray-700' => config('forms.dark_mode'),
-                    ])
-                ></span>
+                    @unless ($isPlaceholderSelectionDisabled())
+                        <option value="">{{ $getPlaceholder() }}</option>
+                    @endif
 
-                @unless ($isDisabled())
-                    <input
-                        x-ref="search"
-                        x-model.debounce.500ms="search"
-                        x-on:keydown="if (! isOpen) openListbox()"
-                        x-on:keydown.enter.stop.prevent="selectOption()"
-                        x-on:keydown.arrow-up.stop.prevent="focusPreviousOption()"
-                        x-on:keydown.arrow-down.stop.prevent="focusNextOption()"
-                        type="text"
-                        autocomplete="off"
-                        @class([
-                            'w-full p-0 border-0 focus:ring-0 focus:outline-none',
-                            'dark:bg-gray-700' => config('forms.dark_mode'),
-                        ])
-                    />
-
-                    <span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-                        <svg x-show="! isLoading" class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
-                            <path stroke="#6B7280" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 8l4 4 4-4" />
-                        </svg>
-
-                        <svg x-show="isLoading" x-cloak class="w-5 h-5 text-gray-400 animate-spin" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M2 12C2 6.47715 6.47715 2 12 2V5C8.13401 5 5 8.13401 5 12H2Z" />
-                        </svg>
-                    </span>
-                @endunless
-            </div>
-
-            @unless($isDisabled())
+                    @foreach ($getOptions() as $value => $label)
+                        <option
+                            value="{{ $value }}"
+                            {!! $isOptionDisabled($value, $label) ? 'disabled' : null !!}
+                        >
+                            {{ $label }}
+                        </option>
+                    @endforeach
+                </select>
+            @else
                 <div
-                    x-ref="listbox"
-                    x-show="isOpen"
-                    x-transition:leave="ease-in duration-100"
-                    x-transition:leave-start="opacity-100"
-                    x-transition:leave-end="opacity-0"
-                    role="listbox"
-                    x-bind:aria-activedescendant="focusedOptionIndex ? '{{ $getStatePath() }}' + 'Option' + focusedOptionIndex : null"
-                    tabindex="-1"
-                    x-cloak
-                    @class([
-                        'absolute z-10 w-full my-1 bg-white border border-gray-300 rounded-lg shadow-sm focus:outline-none',
-                        'dark:bg-gray-700 dark:border-gray-600' => config('forms.dark_mode'),
-                    ])
+                    x-data="selectFormComponent({
+                        getOptionLabelUsing: async (value) => {
+                            return await $wire.getSelectOptionLabel('{{ $getStatePath() }}')
+                        },
+                        getSearchResultsUsing: async (query) => {
+                            return await $wire.getSelectSearchResults('{{ $getStatePath() }}', query)
+                        },
+                        isAutofocused: {{ $isAutofocused() ? 'true' : 'false' }},
+                        options: {{ json_encode($getOptions()) }},
+                        state: $wire.{{ $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')') }},
+                    })"
+                    x-on:click.away="closeListbox()"
+                    x-on:blur="closeListbox()"
+                    x-on:keydown.escape.stop="closeListbox()"
+                    {!! ($id = $getId()) ? "id=\"{$id}\"" : null !!}
+                    {{ $attributes->merge($getExtraAttributes())->class(['relative']) }}
+                    {{ $getExtraAlpineAttributeBag() }}
                 >
-                    <ul
-                        x-ref="listboxOptionsList"
-                        class="py-1 overflow-auto text-base leading-6 max-h-60 focus:outline-none"
+                    <div
+                        @unless($isDisabled())
+                            x-ref="button"
+                            x-on:click="toggleListboxVisibility()"
+                            x-on:keydown.enter.stop.prevent="isOpen ? selectOption() : openListbox()"
+                            x-on:keydown.space="if (! isOpen) openListbox()"
+                            x-on:keydown.backspace="if (! search) clearState()"
+                            x-on:keydown.clear="if (! search) clearState()"
+                            x-on:keydown.delete="if (! search) clearState()"
+                            x-bind:aria-expanded="isOpen"
+                            aria-haspopup="listbox"
+                            tabindex="1"
+                        @endunless
+                        @class([
+                            'relative flex items-center py-2 pl-3 pr-10 border bg-white overflow-hidden duration-75 rounded-lg shadow-sm focus-within:border-primary-600 focus-within:ring-1 focus-within:ring-inset focus-within:ring-primary-600 focus:outline-none',
+                            'dark:bg-gray-700' => config('forms.dark_mode'),
+                            'border-gray-300' => ! $errors->has($getStatePath()),
+                            'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
+                            'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
+                        ])
                     >
-                        <template x-for="(key, index) in Object.keys(options)" :key="key">
-                            <li
-                                x-bind:id="'{{ $getName() }}' + 'Option' + focusedOptionIndex"
-                                x-on:click="selectOption(index)"
-                                x-on:mouseenter="focusedOptionIndex = index"
-                                x-on:mouseleave="focusedOptionIndex = null"
-                                role="option"
-                                x-bind:aria-selected="focusedOptionIndex === index"
-                                x-bind:class="{
-                                    'text-white bg-primary-500 @if (config('forms.dark_mode')) dark:text-gray-300 dark:bg-gray-600 @endif': index === focusedOptionIndex,
-                                    'text-gray-900 @if (config('forms.dark_mode')) dark:text-gray-300 @endif': index !== focusedOptionIndex,
-                                }"
-                                class="relative flex items-center py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-                            >
-                                <span
-                                    x-text="Object.values(options)[index]"
-                                    x-bind:class="{
-                                        'font-medium': index === focusedOptionIndex,
-                                        'font-normal': index !== focusedOptionIndex,
-                                    }"
-                                    class="block font-normal truncate"
-                                ></span>
-
-                                <span
-                                    x-show="key === state"
-                                    x-bind:class="{
-                                        'text-white': index === focusedOptionIndex,
-                                        'text-primary-500': index !== focusedOptionIndex,
-                                    }"
-                                    class="absolute inset-y-0 right-0 flex items-center pr-4 text-primary-500"
-                                >
-                                    <svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-                                        <path fill-rule="evenodd"
-                                              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                                              clip-rule="evenodd" />
-                                    </svg>
-                                </span>
-                            </li>
-                        </template>
-
-                        <div
-                            x-show="! Object.keys(options).length"
-                            x-text="! search || isLoading ? '{{ $getSearchPrompt() }}' : '{{ $getNoSearchResultsMessage() }}'"
+                        <span
+                            x-show="! isOpen"
+                            x-text="label ?? '{{ addslashes($getPlaceholder()) }}'"
                             @class([
-                                'px-3 py-2 text-sm text-gray-700 cursor-default select-none',
-                                'dark:text-gray-300 dark:text-gray-200' => config('forms.dark_mode'),
+                                'w-full bg-white',
+                                'dark:bg-gray-700' => config('forms.dark_mode'),
                             ])
-                        ></div>
-                    </ul>
+                        ></span>
+
+                        @unless ($isDisabled())
+                            <input
+                                x-ref="search"
+                                x-model.debounce.500ms="search"
+                                x-on:keydown="if (! isOpen) openListbox()"
+                                x-on:keydown.enter.stop.prevent="selectOption()"
+                                x-on:keydown.arrow-up.stop.prevent="focusPreviousOption()"
+                                x-on:keydown.arrow-down.stop.prevent="focusNextOption()"
+                                type="text"
+                                autocomplete="off"
+                                @class([
+                                    'w-full p-0 border-0 focus:ring-0 focus:outline-none',
+                                    'dark:bg-gray-700' => config('forms.dark_mode'),
+                                ])
+                            />
+
+                            <span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
+                                <svg x-show="! isLoading" class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+                                    <path stroke="#6B7280" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 8l4 4 4-4" />
+                                </svg>
+
+                                <svg x-show="isLoading" x-cloak class="w-5 h-5 text-gray-400 animate-spin" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M2 12C2 6.47715 6.47715 2 12 2V5C8.13401 5 5 8.13401 5 12H2Z" />
+                                </svg>
+                            </span>
+                        @endunless
+                    </div>
+
+                    @unless($isDisabled())
+                        <div
+                            x-ref="listbox"
+                            x-show="isOpen"
+                            x-transition:leave="ease-in duration-100"
+                            x-transition:leave-start="opacity-100"
+                            x-transition:leave-end="opacity-0"
+                            role="listbox"
+                            x-bind:aria-activedescendant="focusedOptionIndex ? '{{ $getStatePath() }}' + 'Option' + focusedOptionIndex : null"
+                            tabindex="-1"
+                            x-cloak
+                            @class([
+                                'absolute z-10 w-full my-1 bg-white border border-gray-300 rounded-lg shadow-sm focus:outline-none',
+                                'dark:bg-gray-700 dark:border-gray-600' => config('forms.dark_mode'),
+                            ])
+                        >
+                            <ul
+                                x-ref="listboxOptionsList"
+                                class="py-1 overflow-auto text-base leading-6 max-h-60 focus:outline-none"
+                            >
+                                <template x-for="(key, index) in Object.keys(options)" :key="key">
+                                    <li
+                                        x-bind:id="'{{ $getName() }}' + 'Option' + focusedOptionIndex"
+                                        x-on:click="selectOption(index)"
+                                        x-on:mouseenter="focusedOptionIndex = index"
+                                        x-on:mouseleave="focusedOptionIndex = null"
+                                        role="option"
+                                        x-bind:aria-selected="focusedOptionIndex === index"
+                                        x-bind:class="{
+                                            'text-white bg-primary-500 @if (config('forms.dark_mode')) dark:text-gray-300 dark:bg-gray-600 @endif': index === focusedOptionIndex,
+                                            'text-gray-900 @if (config('forms.dark_mode')) dark:text-gray-300 @endif': index !== focusedOptionIndex,
+                                        }"
+                                        class="relative flex items-center py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
+                                    >
+                                        <span
+                                            x-text="Object.values(options)[index]"
+                                            x-bind:class="{
+                                                'font-medium': index === focusedOptionIndex,
+                                                'font-normal': index !== focusedOptionIndex,
+                                            }"
+                                            class="block font-normal truncate"
+                                        ></span>
+
+                                        <span
+                                            x-show="key === state"
+                                            x-bind:class="{
+                                                'text-white': index === focusedOptionIndex,
+                                                'text-primary-500': index !== focusedOptionIndex,
+                                            }"
+                                            class="absolute inset-y-0 right-0 flex items-center pr-4 text-primary-500"
+                                        >
+                                            <svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+                                                <path fill-rule="evenodd"
+                                                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                                                    clip-rule="evenodd" />
+                                            </svg>
+                                        </span>
+                                    </li>
+                                </template>
+
+                                <div
+                                    x-show="! Object.keys(options).length"
+                                    x-text="! search || isLoading ? '{{ $getSearchPrompt() }}' : '{{ $getNoSearchResultsMessage() }}'"
+                                    @class([
+                                        'px-3 py-2 text-sm text-gray-700 cursor-default select-none',
+                                        'dark:text-gray-300 dark:text-gray-200' => config('forms.dark_mode'),
+                                    ])
+                                ></div>
+                            </ul>
+                        </div>
+                    @endunless
                 </div>
-            @endunless
+            @endif
         </div>
-    @endif
+
+        @if ($label = $getPostfixLabel())
+            <span @class($sideLabelClasses)>
+                {{ $label }}
+            </span>
+        @endif
+    </div>
 </x-forms::field-wrapper>

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -97,7 +97,7 @@
                             x-show="! isOpen"
                             x-text="label ?? '{{ addslashes($getPlaceholder()) }}'"
                             @class([
-                                'w-full bg-white',
+                                'w-full bg-white whitespace-nowrap',
                                 'dark:bg-gray-700' => config('forms.dark_mode'),
                             ])
                         ></span>

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -210,5 +210,11 @@
                 {{ $label }}
             </span>
         @endif
+
+        @if ($url = $getUrl())
+            <a href="{{ $url }}">
+                <x-heroicon-o-link class="shrink-0 w-5 h-5 text-gray-400 hover:text-primary-500" />
+            </a>
+        @endif
     </div>
 </x-forms::field-wrapper>

--- a/packages/forms/src/Components/Concerns/CanOpenUrl.php
+++ b/packages/forms/src/Components/Concerns/CanOpenUrl.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Filament\Forms\Components\Concerns;
+
+use Closure;
+
+trait CanOpenUrl
+{
+    protected bool | Closure $shouldOpenUrlInNewTab = false;
+
+    protected string | Closure | null $url = null;
+
+    public function openUrlInNewTab(bool | Closure $condition = true): static
+    {
+        $this->shouldOpenUrlInNewTab = $condition;
+
+        return $this;
+    }
+
+    public function url(string | Closure | null $url, bool | Closure $shouldOpenInNewTab = false): static
+    {
+        $this->shouldOpenUrlInNewTab = $shouldOpenInNewTab;
+        $this->url = $url;
+
+        return $this;
+    }
+
+    public function getUrl(): ?string
+    {
+        return $this->evaluate($this->url);
+    }
+
+    public function shouldOpenUrlInNewTab(): bool
+    {
+        return $this->evaluate($this->shouldOpenUrlInNewTab);
+    }
+}

--- a/packages/forms/src/Components/Concerns/HasAffixes.php
+++ b/packages/forms/src/Components/Concerns/HasAffixes.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Filament\Forms\Components\Concerns;
+
+use Closure;
+
+trait HasAffixes
+{
+    protected string | Closure | null $postfixLabel = null;
+
+    protected string | Closure | null $prefixLabel = null;
+
+    public function prefix(string | Closure | null $label): static
+    {
+        $this->prefixLabel = $label;
+
+        return $this;
+    }
+
+    public function postfix(string | Closure | null $label): static
+    {
+        $this->postfixLabel = $label;
+
+        return $this;
+    }
+
+    public function suffix(string | Closure | null $label): static
+    {
+        return $this->postfix($label);
+    }
+
+    public function getPrefixLabel(): ?string
+    {
+        return $this->evaluate($this->prefixLabel);
+    }
+
+    public function getPostfixLabel(): ?string
+    {
+        return $this->evaluate($this->postfixLabel);
+    }
+}

--- a/packages/forms/src/Components/Concerns/HasAffixes.php
+++ b/packages/forms/src/Components/Concerns/HasAffixes.php
@@ -29,12 +29,12 @@ trait HasAffixes
         return $this->postfix($label);
     }
 
-    public function getPrefixLabel(): ?string
+    public function getPrefixLabel()
     {
         return $this->evaluate($this->prefixLabel);
     }
 
-    public function getPostfixLabel(): ?string
+    public function getPostfixLabel()
     {
         return $this->evaluate($this->postfixLabel);
     }

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -30,6 +30,8 @@ class Select extends Field
 
     protected string | Closure | null $searchPrompt = null;
 
+    protected string | Closure | null $url = null;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -114,6 +116,13 @@ class Select extends Field
         return $this;
     }
 
+    public function url(string | Closure | null $url): static
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
     public function getOptionLabel(): ?string
     {
         return $this->evaluate($this->getOptionLabelUsing, [
@@ -151,6 +160,11 @@ class Select extends Field
         }
 
         return $results;
+    }
+
+    public function getUrl(): ?string
+    {
+        return $this->evaluate($this->url);
     }
 
     public function isOptionDisabled($value, string $label): bool

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -11,6 +11,7 @@ class Select extends Field
     use Concerns\HasOptions;
     use Concerns\HasPlaceholder;
     use Concerns\HasAffixes;
+    use Concerns\CanOpenUrl;
 
     protected string $view = 'forms::components.select';
 
@@ -29,8 +30,6 @@ class Select extends Field
     protected string | Closure | null $noSearchResultsMessage = null;
 
     protected string | Closure | null $searchPrompt = null;
-
-    protected string | Closure | null $url = null;
 
     protected function setUp(): void
     {
@@ -116,13 +115,6 @@ class Select extends Field
         return $this;
     }
 
-    public function url(string | Closure | null $url): static
-    {
-        $this->url = $url;
-
-        return $this;
-    }
-
     public function getOptionLabel(): ?string
     {
         return $this->evaluate($this->getOptionLabelUsing, [
@@ -160,11 +152,6 @@ class Select extends Field
         }
 
         return $results;
-    }
-
-    public function getUrl(): ?string
-    {
-        return $this->evaluate($this->url);
     }
 
     public function isOptionDisabled($value, string $label): bool

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -10,6 +10,7 @@ class Select extends Field
     use Concerns\HasExtraAlpineAttributes;
     use Concerns\HasOptions;
     use Concerns\HasPlaceholder;
+    use Concerns\HasAffixes;
 
     protected string $view = 'forms::components.select';
 

--- a/packages/forms/src/Components/TextInput.php
+++ b/packages/forms/src/Components/TextInput.php
@@ -14,6 +14,7 @@ class TextInput extends Field
     use Concerns\HasExtraAlpineAttributes;
     use Concerns\HasExtraInputAttributes;
     use Concerns\HasPlaceholder;
+    use Concerns\HasAffixes;
 
     protected string $view = 'forms::components.text-input';
 
@@ -38,10 +39,6 @@ class TextInput extends Field
     protected $minValue = null;
 
     protected int | float | string | Closure | null $step = null;
-
-    protected string | Closure | null $postfixLabel = null;
-
-    protected string | Closure | null $prefixLabel = null;
 
     protected string | Closure | null $type = null;
 
@@ -135,20 +132,6 @@ class TextInput extends Field
         return $this;
     }
 
-    public function prefix(string | Closure | null $label): static
-    {
-        $this->prefixLabel = $label;
-
-        return $this;
-    }
-
-    public function postfix(string | Closure | null $label): static
-    {
-        $this->postfixLabel = $label;
-
-        return $this;
-    }
-
     public function step(int | float | string | Closure | null $interval): static
     {
         $this->step = $interval;
@@ -219,16 +202,6 @@ class TextInput extends Field
     public function getMinValue()
     {
         return $this->evaluate($this->minValue);
-    }
-
-    public function getPrefixLabel(): ?string
-    {
-        return $this->evaluate($this->prefixLabel);
-    }
-
-    public function getPostfixLabel(): ?string
-    {
-        return $this->evaluate($this->postfixLabel);
     }
 
     public function getStep(): int | float | string | null


### PR DESCRIPTION
This PR adds prefix/postfix support to select fields.

My use case for this is adding links to related records when using a BelongsToSelect, eg:

![Screenshot 2022-02-14 at 15 42 02](https://user-images.githubusercontent.com/126740/153897857-8145c8d2-cd8c-4fc7-a719-9211ad6cf631.png)

Notes:

* prefix/postfix properties and methods have been moved to a new `HasAffixes` trait
* `getPrefixLabel` and `getPostfixLabel` can now return more than just a string, so that an `HtmlString` object may be used
* As the `<select>` is no longer the root element the `filament-forms-select-component` class has been moved up to the new wrapper `<div>`. This is potentially a breaking change, but it does keep it consistent with other fields such as text-input.
    * Also the searchable version didn't include `filament-forms-select-component` at all, which this fixes
* I've added `whitespace-nowrap` to the searchable select label, which helps with longer values and is consistent with how a regular select works
* I have added a `suffix` alias for `postfix`, as I think that's a bit more intuitive name, but no worries if you want that removed