### PR TITLE
Fix belongstoselect styles

### DIFF
--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -75,7 +75,7 @@
                     'border-gray-300' => ! $errors->has($getStatePath()),
                     'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
                     'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
-                    'bg-gray-50' => $isDisabled(),
+                    'select-none opacity-70' => $isDisabled(),
                 ])
             >
                 <span
@@ -83,7 +83,6 @@
                     x-text="label ?? '{{ addslashes($getPlaceholder()) }}'"
                     @class([
                         'absolute' => !$isDisabled(),
-                        'select-none opacity-75' => $isDisabled(),
                         'w-10/12',
                         'dark:bg-gray-700' => config('forms.dark_mode'),
                     ])
@@ -104,17 +103,17 @@
                             'dark:bg-gray-700' => config('forms.dark_mode'),
                         ])
                     />
-
-                    <span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-                        <svg x-show="! isLoading" class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
-                            <path stroke="#6B7280" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 8l4 4 4-4" />
-                        </svg>
-
-                        <svg x-show="isLoading" x-cloak class="w-5 h-5 text-gray-400 animate-spin" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M2 12C2 6.47715 6.47715 2 12 2V5C8.13401 5 5 8.13401 5 12H2Z" />
-                        </svg>
-                    </span>
                 @endunless
+
+                <span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
+                    <svg x-show="! isLoading" class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+                        <path stroke="#6B7280" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 8l4 4 4-4" />
+                    </svg>
+
+                    <svg x-show="isLoading" x-cloak class="w-5 h-5 text-gray-400 animate-spin" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M2 12C2 6.47715 6.47715 2 12 2V5C8.13401 5 5 8.13401 5 12H2Z" />
+                    </svg>
+                </span>
             </div>
 
             @unless($isDisabled())

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -84,7 +84,7 @@
                     @class([
                         'absolute bg-white' => !$isDisabled(),
                         'select-none opacity-75' => $isDisabled(),
-                        'w-10/12 bg-white pr-2',
+                        'w-10/12',
                         'dark:bg-gray-700' => config('forms.dark_mode'),
                     ])
                 ></span>
@@ -105,7 +105,7 @@
                         ])
                     />
 
-                    <span class="absolute inset-y-0 right-0 flex items-center pr-1 pointer-events-none">
+                    <span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
                         <svg x-show="! isLoading" class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
                             <path stroke="#6B7280" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 8l4 4 4-4" />
                         </svg>

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -82,9 +82,9 @@
                     x-show="! isOpen"
                     x-text="label ?? '{{ addslashes($getPlaceholder()) }}'"
                     @class([
-                        'absolute' => !$isDisabled(),
-                        'w-10/12',
+                        'whitespace-nowrap truncate w-10/12',
                         'dark:bg-gray-700' => config('forms.dark_mode'),
+                        'absolute' => ! $isDisabled(),
                     ])
                 ></span>
 

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -75,13 +75,16 @@
                     'border-gray-300' => ! $errors->has($getStatePath()),
                     'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
                     'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
+                    'bg-gray-50' => $isDisabled(),
                 ])
             >
                 <span
                     x-show="! isOpen"
                     x-text="label ?? '{{ addslashes($getPlaceholder()) }}'"
                     @class([
-                        'w-full bg-white',
+                        'absolute bg-white' => !$isDisabled(),
+                        'select-none opacity-75' => $isDisabled(),
+                        'w-10/12 bg-white pr-2',
                         'dark:bg-gray-700' => config('forms.dark_mode'),
                     ])
                 ></span>
@@ -102,8 +105,8 @@
                         ])
                     />
 
-                    <span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-                        <svg x-show="! isLoading" class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+                    <span class="absolute inset-y-0 right-0 flex items-center pr-1 pointer-events-none">
+                        <svg x-show="! isLoading" class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
                             <path stroke="#6B7280" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 8l4 4 4-4" />
                         </svg>
 

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -82,7 +82,7 @@
                     x-show="! isOpen"
                     x-text="label ?? '{{ addslashes($getPlaceholder()) }}'"
                     @class([
-                        'absolute bg-white' => !$isDisabled(),
+                        'absolute' => !$isDisabled(),
                         'select-none opacity-75' => $isDisabled(),
                         'w-10/12',
                         'dark:bg-gray-700' => config('forms.dark_mode'),


### PR DESCRIPTION
lines 78, 86: to match background, text color and selectable with disabled styles;

line 85: if remove absolute the caret position goes to center when in edit form;

line 87: to correct ring focus at right that cutting a little;
![focus-cutting](https://user-images.githubusercontent.com/19998735/153927409-85547772-9306-49a0-a22d-fa8faed9a59f.png)

lines 109 to match position and size with default select;


