### PR TITLE
Add Spanish missing translations

### DIFF
--- a/packages/admin/resources/lang/es/layout.php
+++ b/packages/admin/resources/lang/es/layout.php
@@ -5,6 +5,15 @@ return [
     'direction' => 'ltr',
 
     'buttons' => [
+
+        'dark_mode' => [
+            'label' => 'Modo oscuro',
+        ],
+
+        'light_mode' => [
+            'label' => 'Modo claro',
+        ],
+        
         'logout' => [
             'label' => 'Salir',
         ],

--- a/packages/admin/resources/lang/es/resources/pages/edit-record.php
+++ b/packages/admin/resources/lang/es/resources/pages/edit-record.php
@@ -16,7 +16,7 @@ return [
 
                 'heading' => 'Borrar :label',
 
-                'subheading' => '¿Estas seguro?',
+                'subheading' => '¿Estás seguro?',
 
                 'buttons' => [
 
@@ -27,6 +27,9 @@ return [
                 ],
 
             ],
+            'messages' => [
+                'deleted' => 'Borrado',
+            ],            
 
         ],
 

--- a/packages/admin/resources/lang/es/resources/pages/list-records.php
+++ b/packages/admin/resources/lang/es/resources/pages/list-records.php
@@ -7,16 +7,59 @@ return [
     'actions' => [
 
         'create' => [
-            'label' => 'Crear :label',
+            'label' => 'Nuevo :label',
+            'modal' => [
+
+                'heading' => 'Nuevo :label',
+
+                'actions' => [
+
+                    'create' => [
+                        'label' => 'Nuevo',
+                    ],
+
+                    'create_and_create_another' => [
+                        'label' => 'Guardar & crear otro',
+                    ],
+
+                ],            
         ],
+            'messages' => [
+                'created' => 'Registro creado',
+            ],
+
+        ],            
 
     ],
     'table' => [
 
         'actions' => [
+            'delete' => [
 
+                'label' => 'Borrar',
+
+                'messages' => [
+                    'deleted' => 'Registro borrado',
+                ],
+
+            ],
             'edit' => [
                 'label' => 'Editar',
+                'modal' => [
+
+                    'heading' => 'Editar :label',
+
+                    'actions' => [
+
+                        'save' => [
+                            'label' => 'Guardar',
+                        ],
+
+                    ],       
+                ],
+                'messages' => [
+                    'saved' => 'Registro actualizado',
+                ],
             ],
 
             'view' => [
@@ -28,6 +71,9 @@ return [
         'bulk_actions' => [
             'delete' => [
                 'label' => 'Borrar seleccionado',
+                'messages' => [
+                    'deleted' => 'Registro(s) borrados',
+                ],
             ],
 
         ],

--- a/packages/admin/resources/lang/es/widgets/account-widget.php
+++ b/packages/admin/resources/lang/es/widgets/account-widget.php
@@ -10,6 +10,6 @@ return [
 
     ],
 
-    'welcome' => 'Bienvenido, :user',
+    'welcome' => 'Bienvenido/a, :user',
 
 ];


### PR DESCRIPTION
Corrected spelling in one translation: estas => estás

Added female support to welcome message: bienvenido (male) bienvenida
(female). Then: "Bienvenido/a"