### PR TITLE
Fixes issue #1410

### DIFF
--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -231,6 +231,10 @@ trait InteractsWithForms
                 ->schema($this->getFormSchema())
                 ->model($this->getFormModel())
                 ->statePath($this->getFormStatePath()),
+            'mountedActionForm' => $this->makeForm()
+                ->schema(($action = $this->getMountedAction()) ? $action->getFormSchema() : [])
+                ->statePath('mountedActionData')
+                ->model($this->getMountedActionFormModel()),
         ];
     }
 


### PR DESCRIPTION
When using a page, it would be nice that this behavior comes by default, since usually when managing pages with forms, we'll use actions.