### PR TITLE
Adds flags to `make:filament-widget` command

### DIFF
--- a/packages/admin/src/Commands/Aliases/MakeWidgetCommand.php
+++ b/packages/admin/src/Commands/Aliases/MakeWidgetCommand.php
@@ -8,5 +8,5 @@ class MakeWidgetCommand extends Commands\MakeWidgetCommand
 {
     protected $hidden = true;
 
-    protected $signature = 'filament:widget {name?} {--R|resource=} {--F|force} {--C|chart-widget} {--S|stats-widget}';
+    protected $signature = 'filament:widget {name?} {--R|resource=} {--C|chart} {--S|stats-overview} {--F|force}';
 }

--- a/packages/admin/src/Commands/Aliases/MakeWidgetCommand.php
+++ b/packages/admin/src/Commands/Aliases/MakeWidgetCommand.php
@@ -8,5 +8,5 @@ class MakeWidgetCommand extends Commands\MakeWidgetCommand
 {
     protected $hidden = true;
 
-    protected $signature = 'filament:widget {name?} {--R|resource=} {--F|force}';
+    protected $signature = 'filament:widget {name?} {--R|resource=} {--F|force} {--C|chart-widget} {--S|stats-widget}';
 }

--- a/packages/admin/src/Commands/MakeWidgetCommand.php
+++ b/packages/admin/src/Commands/MakeWidgetCommand.php
@@ -3,7 +3,6 @@
 namespace Filament\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 class MakeWidgetCommand extends Command

--- a/packages/admin/src/Commands/MakeWidgetCommand.php
+++ b/packages/admin/src/Commands/MakeWidgetCommand.php
@@ -2,9 +2,9 @@
 
 namespace Filament\Commands;
 
-use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 class MakeWidgetCommand extends Command
 {
@@ -70,7 +70,7 @@ class MakeWidgetCommand extends Command
 
         if (! $this->option('force') && $this->checkForCollision([
             $path,
-            $this->option('stats-widget') || $this->option('chart-widget') ? : $viewPath,
+            $this->option('stats-widget') || $this->option('chart-widget') ?: $viewPath,
         ])) {
             return static::INVALID;
         }
@@ -80,18 +80,18 @@ class MakeWidgetCommand extends Command
                 'class' => $widgetClass,
                 'namespace' => filled($resource) ? "App\\Filament\\Resources\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') : 'App\\Filament\\Widgets' . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : ''),
             ]);
-        }
-        else if ($this->option('chart-widget')) {
-            $chart = $this->choice('Select Widget Chart type ?',
-                $this->listChartTypes()->toArray()
-            , 0);
+        } elseif ($this->option('chart-widget')) {
+            $chart = $this->choice(
+                'Select Widget Chart type ?',
+                $this->listChartTypes()->toArray(),
+                0
+            );
             $this->copyStubToApp('ChartWidget', $path, [
                 'class' => $widgetClass,
                 'namespace' => filled($resource) ? "App\\Filament\\Resources\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') : 'App\\Filament\\Widgets' . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : ''),
-                'chart' => Str::replace(' ', '', $chart)
+                'chart' => Str::replace(' ', '', $chart),
             ]);
-        }
-        else {
+        } else {
             $this->copyStubToApp('Widget', $path, [
                 'class' => $widgetClass,
                 'namespace' => filled($resource) ? "App\\Filament\\Resources\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') : 'App\\Filament\\Widgets' . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : ''),
@@ -121,7 +121,7 @@ class MakeWidgetCommand extends Command
             'PieChartWidget',
             'PolarAreaChartWidget',
             'RadarChartWidget',
-            'ScatterChartWidget'
-        ])->map(fn ($chart) => Str::of($chart)->replace('Widget','')->headline());
+            'ScatterChartWidget',
+        ])->map(fn ($chart) => Str::of($chart)->replace('Widget', '')->headline());
     }
 }

--- a/packages/admin/stubs/ChartWidget.stub
+++ b/packages/admin/stubs/ChartWidget.stub
@@ -1,0 +1,20 @@
+<?php
+
+namespace {{ namespace }};
+
+use Filament\Widgets\{{ chart }}Widget;
+
+class {{ class }} extends {{ chart }}Widget
+{
+    protected function getHeading(): string
+    {
+        return '';
+    }
+
+    protected function getData(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/packages/admin/stubs/ChartWidget.stub
+++ b/packages/admin/stubs/ChartWidget.stub
@@ -6,10 +6,7 @@ use Filament\Widgets\{{ chart }}Widget;
 
 class {{ class }} extends {{ chart }}Widget
 {
-    protected function getHeading(): string
-    {
-        return '';
-    }
+    protected static ?string $heading = 'Chart';
 
     protected function getData(): array
     {

--- a/packages/admin/stubs/StatsOverviewWidget.stub
+++ b/packages/admin/stubs/StatsOverviewWidget.stub
@@ -10,7 +10,7 @@ class {{ class }} extends BaseWidget
     protected function getCards(): array
     {
         return [
-            //...
+            //
         ];
     }
 }

--- a/packages/admin/stubs/StatsOverviewWidget.stub
+++ b/packages/admin/stubs/StatsOverviewWidget.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace {{ namespace }};
+
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Card;
+
+class {{ class }} extends BaseWidget
+{
+    protected function getCards(): array
+    {
+        return [
+            //...
+        ];
+    }
+}


### PR DESCRIPTION
This PR adds the following two flags to the `make:filament-widget` command:

1. `--S|stats-widget` to generate Stats Overview Widgets without any hassle
```bash 
php artisan filament:widget OrderStatsWidget -S
```
will generate:
```php
<?php

namespace App\Filament\Widgets;

use Filament\Widgets\StatsOverviewWidget as BaseWidget;
use Filament\Widgets\StatsOverviewWidget\Card;

class OrderStatsWidget extends BaseWidget
{
    protected function getCards(): array
    {
        return [
            //...
        ];
    }
}
```
2. `--C|chart-widget` to generate Chart Widgets with ease
```bash 
php artisan filament:widget IncomeLineChartWidget -C
```
after the optional resource question will ask:
```bash
Select Widget Chart type ? [Bar Chart]:
  [0] Bar Chart
  [1] Bubble Chart
  [2] Doughnut Chart
  [3] Line Chart
  [4] Pie Chart
  [5] Polar Area Chart
  [6] Radar Chart
  [7] Scatter Chart
 > 3
```
will generate:
```php
<?php

namespace App\Filament\Widgets;

use Filament\Widgets\LineChartWidget;

class IncomeLineChart extends LineChartWidget
{
    protected function getHeading(): string
    {
        return '';
    }

    protected function getData(): array
    {
        return [
            //
        ];
    }
}