### PR TITLE
fix: year input allowing more or less than 4 chars

### DIFF
--- a/packages/forms/resources/js/components/date-time-picker.js
+++ b/packages/forms/resources/js/components/date-time-picker.js
@@ -116,10 +116,11 @@ export default (Alpine) => {
                 })
 
                 this.$watch('focusedYear', () => {
-                    if( this.focusedYear.length > 4 )
+                    if (this.focusedYear.length > 4) {
                         this.focusedYear = this.focusedYear.substring(0, 4)
+                    }
 
-                    if (! this.focusedYear || this.focusedYear.length !== 4) {
+                    if ((! this.focusedYear) || (this.focusedYear.length !== 4)) {
                         return
                     }
 

--- a/packages/forms/resources/js/components/date-time-picker.js
+++ b/packages/forms/resources/js/components/date-time-picker.js
@@ -8,7 +8,7 @@ dayjs.extend(customParseFormat)
 dayjs.extend(localeData)
 dayjs.extend(timezone)
 dayjs.extend(utc)
-dayjs.extend((option, Dayjs, dayjs) => {    
+dayjs.extend((option, Dayjs, dayjs) => {
     dayjs.onLocaleUpdated = () => {},
     dayjs.updateLocale = (locale) => {
         dayjs.locale(locale)
@@ -116,7 +116,10 @@ export default (Alpine) => {
                 })
 
                 this.$watch('focusedYear', () => {
-                    if (! this.focusedYear) {
+                    if( this.focusedYear.length > 4 )
+                        this.focusedYear = this.focusedYear.substring(0, 4)
+
+                    if (! this.focusedYear || this.focusedYear.length !== 4) {
                         return
                     }
 

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -111,6 +111,7 @@
 
                             <input
                                 type="number"
+                                inputmode="numeric"
                                 x-model.debounce="focusedYear"
                                 @class([
                                     'w-20 p-0 text-lg text-right border-0 focus:ring-0 focus:outline-none',


### PR DESCRIPTION
this fixes #1507

- The year input was allowing to input more or less than 4 numbers, which strangely causes errors only on mobile.
- Use `inputmode="numeric"` to open correct keyboard