### PR TITLE
add filepond-plugin-media-preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "filepond-plugin-image-preview": "^4.6.7",
         "filepond-plugin-image-resize": "^2.0.10",
         "filepond-plugin-image-transform": "^3.8.6",
+        "filepond-plugin-media-preview": "^1.0.9",
         "imask": "^6.1.0",
         "laravel-mix": "^6.0.37",
         "marked": "^4.0.10",
@@ -34,7 +35,6 @@
         "trix": "^1.3.1"
     },
     "dependencies": {
-        "@alpinejs/collapse": "^3.8.1",
-        "filepond-plugin-media-preview": "^1.0.9"
+        "@alpinejs/collapse": "^3.8.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "trix": "^1.3.1"
     },
     "dependencies": {
-        "@alpinejs/collapse": "^3.8.1"
+        "@alpinejs/collapse": "^3.8.1",
+        "filepond-plugin-media-preview": "^1.0.9"
     }
 }

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -6,9 +6,11 @@ import FilePondPluginImageExifOrientation from 'filepond-plugin-image-exif-orien
 import FilePondPluginImagePreview from 'filepond-plugin-image-preview'
 import FilePondPluginImageResize from 'filepond-plugin-image-resize'
 import FilePondPluginImageTransform from 'filepond-plugin-image-transform'
+import FilePondPluginMediaPreview from 'filepond-plugin-media-preview'
 
 import 'filepond/dist/filepond.min.css'
 import 'filepond-plugin-image-preview/dist/filepond-plugin-image-preview.css'
+import 'filepond-plugin-media-preview/dist/filepond-plugin-media-preview.css';
 import '../../css/components/file-upload.css'
 
 FilePond.registerPlugin(FilePondPluginFileValidateSize)
@@ -18,6 +20,7 @@ FilePond.registerPlugin(FilePondPluginImageExifOrientation)
 FilePond.registerPlugin(FilePondPluginImagePreview)
 FilePond.registerPlugin(FilePondPluginImageResize)
 FilePond.registerPlugin(FilePondPluginImageTransform)
+FilePond.registerPlugin(FilePondPluginMediaPreview)
 
 export default (Alpine) => {
     Alpine.data('fileUploadFormComponent', ({
@@ -164,7 +167,7 @@ export default (Alpine) => {
 
                     this.pond.files = shouldAppendFiles ? files : files.reverse()
                 })
-                
+
                 this.pond.on('reorderfiles', async (files) => {
                     const orderedFileKeys = files
                         .map(file => file.source instanceof File ? file.serverId : this.uploadedFileUrlIndex[file.source] ?? null) // file.serverId is null for a file that is not yet uploaded


### PR DESCRIPTION
Adds preview for audios and videos using `nielsboogaard/filepond-plugin-media-preview`

![demo](https://user-images.githubusercontent.com/14329460/154372983-c22ca5f0-2a88-459b-bd95-d2b614d084cb.gif)
