### PR TITLE
[1.X] fix: added record prefix to same validation

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeCompared.php
+++ b/packages/forms/src/Components/Concerns/CanBeCompared.php
@@ -20,7 +20,7 @@ trait CanBeCompared
     public function same($field)
     {
         $this->configure(function () use ($field) {
-            $this->addRules([$this->getName() => ["same:{$field}"]]);
+            $this->addRules([$this->getName() => ["same:record.{$field}"]]);
         });
 
         return $this;


### PR DESCRIPTION
The "same" validation has an error because the object "record" doesn't exist