### PR TITLE
Cache chart data and stats cards to prevent multiple executions

### DIFF
--- a/packages/admin/resources/views/widgets/chart-widget.blade.php
+++ b/packages/admin/resources/views/widgets/chart-widget.blade.php
@@ -44,7 +44,7 @@
                     },
 
                     initChart: function (data = null) {
-                        data = data ?? {{ json_encode($this->getData()) }}
+                        data = data ?? {{ json_encode($this->getCachedData()) }}
 
                         return this.chart = new Chart($el, {
                             type: '{{ $this->getType() }}',

--- a/packages/admin/resources/views/widgets/stats-overview-widget.blade.php
+++ b/packages/admin/resources/views/widgets/stats-overview-widget.blade.php
@@ -1,6 +1,6 @@
 <x-filament::widget class="filament-stats-overview-widget">
     <x-filament::stats :columns="$this->getColumns()">
-        @foreach ($this->getCards() as $card)
+        @foreach ($this->getCachedCards() as $card)
             {{ $card }}
         @endforeach
     </x-filament::stats>

--- a/packages/admin/src/Widgets/ChartWidget.php
+++ b/packages/admin/src/Widgets/ChartWidget.php
@@ -16,14 +16,22 @@ class ChartWidget extends Widget
 
     protected static string $view = 'filament::widgets.chart-widget';
 
+    protected array $cachedData = [];
+
     public function mount()
     {
+        $this->cachedData = $this->getData();
         $this->dataChecksum = $this->generateDataChecksum();
     }
 
     protected function generateDataChecksum(): string
     {
-        return md5(json_encode($this->getData()));
+        return md5(json_encode($this->getCachedData()));
+    }
+
+    protected function getCachedData(): array
+    {
+        return $this->cachedData;
     }
 
     protected function getData(): array
@@ -59,7 +67,7 @@ class ChartWidget extends Widget
             $this->dataChecksum = $newDataChecksum;
 
             $this->emitSelf('updateChartData', [
-                'data' => $this->getData(),
+                'data' => $this->getCachedData(),
             ]);
         }
     }
@@ -72,7 +80,7 @@ class ChartWidget extends Widget
             $this->dataChecksum = $newDataChecksum;
 
             $this->emitSelf('filterChartData', [
-                'data' => $this->getData(),
+                'data' => $this->getCachedData(),
             ]);
         }
     }

--- a/packages/admin/src/Widgets/StatsOverviewWidget.php
+++ b/packages/admin/src/Widgets/StatsOverviewWidget.php
@@ -8,13 +8,25 @@ class StatsOverviewWidget extends Widget
 
     protected static string $view = 'filament::widgets.stats-overview-widget';
 
+    protected array $cachedCards = [];
+
+    public function mount()
+    {
+        $this->cachedCards = $this->getCards();
+    }
+
     protected function getColumns(): int
     {
-        return match ($count = count($this->getCards())) {
+        return match ($count = count($this->getCachedCards())) {
             5, 6, 9, 11 => 3,
             7, 8, 10, 12 => 4,
             default => $count,
         };
+    }
+
+    protected function getCachedCards(): array
+    {
+        return $this->cachedCards;
     }
 
     protected function getCards(): array


### PR DESCRIPTION
The getData() method on ChartWidget was being called twice without cache, the same occurs in the getCards() in StatsOverviewWidget which is called in 4 different places.

With this PR I called the respective methods in component mount() to cache data and reuse the result where needed using a different method: getCachedCards in StatsOverview and getCachedData in Chart.