### PR TITLE
Locale filepond

### DIFF
--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -2,14 +2,18 @@
     @push('scripts')
         @php
             $locale = strtolower(str_replace('_', '-', app()->getLocale()));
-            $defaultLocaleData = ($placeholder = $getPlaceholder()) ? "{labelIdle: '{$placeholder}'}" : '{}';
-            if (!str_contains($locale, '-')) {
+            
+            $defaultLocaleData = ($placeholder = $getPlaceholder()) ? "{ labelIdle: '{$placeholder}' }" : '{}';
+            
+            if (! str_contains($locale, '-')) {
                 $locale .= '-' . $locale;
             }
         @endphp
+        
         <script type="module">
-            import localeData from 'https://cdn.skypack.dev/filepond/locale/{{$locale}}.js';
-            window.dispatchEvent(new CustomEvent('filepond-locale-updated', {detail: {...localeData, ...{!! $defaultLocaleData !!} }}));
+            import localeData from 'https://cdn.skypack.dev/filepond/locale/{{$locale}}.js'
+            
+            window.dispatchEvent(new CustomEvent('filepond-locale-updated', { detail: {...localeData, ...{!! $defaultLocaleData !!} } }))
         </script>
     @endpush
 @endonce
@@ -61,7 +65,7 @@
                 }, error, progress)
             },
         })"
-        @filepond-locale-updated.window="pond.setOptions($event.detail)"
+        x-on:filepond-locale-updated.window="pond.setOptions($event.detail)"
         wire:ignore
         style="min-height: 76px"
         {{ $attributes->merge($getExtraAttributes())->class([

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -13,7 +13,7 @@
         <script type="module">
             import localeData from 'https://cdn.skypack.dev/filepond/locale/{{$locale}}.js'
             
-            window.dispatchEvent(new CustomEvent('filepond-locale-updated', { detail: {...localeData, ...{!! $defaultLocaleData !!} } }))
+            window.dispatchEvent(new CustomEvent('filepond-locale-updated', { detail: { ...localeData, ...{!! $defaultLocaleData !!} } }))
         </script>
     @endpush
 @endonce

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -1,3 +1,19 @@
+@once
+    @push('scripts')
+        @php
+            $locale = strtolower(str_replace('_', '-', app()->getLocale()));
+            $defaultLocaleData = ($placeholder = $getPlaceholder()) ? "{labelIdle: '{$placeholder}'}" : '{}';
+            if (!str_contains($locale, '-')) {
+                $locale .= '-' . $locale;
+            }
+        @endphp
+        <script type="module">
+            import localeData from 'https://cdn.skypack.dev/filepond/locale/{{$locale}}.js';
+            window.dispatchEvent(new CustomEvent('filepond-locale-updated', {detail: {...localeData, ...{!! $defaultLocaleData !!} }}));
+        </script>
+    @endpush
+@endonce
+
 <x-forms::field-wrapper
     :id="$getId()"
     :label="$getLabel()"
@@ -45,6 +61,7 @@
                 }, error, progress)
             },
         })"
+        @filepond-locale-updated.window="pond.setOptions($event.detail)"
         wire:ignore
         style="min-height: 76px"
         {{ $attributes->merge($getExtraAttributes())->class([


### PR DESCRIPTION
I load the filepond locale as a JavaScript module using <script type="module"> (https://caniuse.com/es6-module) and dispatch "filepond-locale-updated" event with the json data.

The field component listens for the event and calls pond.setOptions() to update locale data.

pt_BR
![image](https://user-images.githubusercontent.com/7275012/155229521-e18992c3-df40-4a71-93de-3004cd868f2f.png)

zh_CN
![image](https://user-images.githubusercontent.com/7275012/155230196-9782e3ba-e01b-4102-843f-09096d3a558d.png)

fr
![image](https://user-images.githubusercontent.com/7275012/155230842-8ef40daa-bc18-439b-adc5-865eda2b9267.png)

Tested using the filament-demo