### PR TITLE
Added new missing Spanish translations.

### DIFF
--- a/packages/admin/resources/lang/es/layout.php
+++ b/packages/admin/resources/lang/es/layout.php
@@ -7,11 +7,11 @@ return [
     'buttons' => [
 
         'dark_mode' => [
-            'label' => 'Modo oscuro',
+            'label' => 'A modo oscuro',
         ],
 
         'light_mode' => [
-            'label' => 'Modo claro',
+            'label' => 'A modo claro',
         ],
         
         'logout' => [

--- a/packages/admin/resources/lang/es/login.php
+++ b/packages/admin/resources/lang/es/login.php
@@ -4,7 +4,7 @@ return [
 
     'title' => 'Login',
 
-    'heading' => 'Entra a tu cuenta',
+    'heading' => 'Entre a su cuenta',
 
     'buttons' => [
 
@@ -17,7 +17,7 @@ return [
     'fields' => [
 
         'email' => [
-            'label' => 'Email',
+            'label' => 'Correo electrónico',
         ],
 
         'password' => [
@@ -32,7 +32,7 @@ return [
 
     'messages' => [
         'failed' => 'Estas credenciales no coinciden con nuestros registros.',
-        'throttled' => 'Demasiados intentos. Prueba de nuevo en :seconds segundos.',
+        'throttled' => 'Demasiados intentos. Intente de nuevo en :seconds segundos.',
     ],
 
 ];

--- a/packages/admin/resources/lang/es/pages/actions.php
+++ b/packages/admin/resources/lang/es/pages/actions.php
@@ -1,3 +1,28 @@
 <?php
 
-return [];
+return [
+
+    'modal' => [
+
+        'requires_confirmation_subheading' => '¿Está segura/o de hacer esto?',
+
+        'buttons' => [
+
+            'cancel' => [
+                'label' => 'Cancelar',
+            ],
+
+            'confirm' => [
+                'label' => 'Confirmar',
+            ],
+
+            'submit' => [
+                'label' => 'Enviar',
+            ],
+
+        ],
+
+    ],
+
+];
+

--- a/packages/admin/resources/lang/es/resources/pages/edit-record.php
+++ b/packages/admin/resources/lang/es/resources/pages/edit-record.php
@@ -16,7 +16,7 @@ return [
 
                 'heading' => 'Borrar :label',
 
-                'subheading' => '¿Estás seguro?',
+                'subheading' => '¿Está segura/o de hacer esto?',
 
                 'buttons' => [
 

--- a/packages/admin/resources/lang/es/resources/pages/list-records.php
+++ b/packages/admin/resources/lang/es/resources/pages/list-records.php
@@ -19,7 +19,7 @@ return [
                     ],
 
                     'create_and_create_another' => [
-                        'label' => 'Guardar & crear otro',
+                        'label' => 'Guardar y crear otro',
                     ],
 
                 ],            
@@ -70,9 +70,9 @@ return [
 
         'bulk_actions' => [
             'delete' => [
-                'label' => 'Borrar seleccionado',
+                'label' => 'Borrar seleccionado(s)',
                 'messages' => [
-                    'deleted' => 'Registro(s) borrados',
+                    'deleted' => 'Registro(s) borrado(s)',
                 ],
             ],
 

--- a/packages/admin/resources/lang/es/resources/relation-managers/attach.php
+++ b/packages/admin/resources/lang/es/resources/relation-managers/attach.php
@@ -25,7 +25,7 @@ return [
                 ],
 
                 'attach_and_attach_another' => [
-                    'label' => 'Vincular & vincular otro',
+                    'label' => 'Vincular y vincular otro',
                 ],
 
             ],

--- a/packages/admin/resources/lang/es/resources/relation-managers/create.php
+++ b/packages/admin/resources/lang/es/resources/relation-managers/create.php
@@ -17,7 +17,7 @@ return [
                 ],
 
                 'create_and_create_another' => [
-                    'label' => 'Crear & crear otro',
+                    'label' => 'Crear y crear otro',
                 ],
 
             ],

--- a/packages/admin/resources/lang/es/widgets/account-widget.php
+++ b/packages/admin/resources/lang/es/widgets/account-widget.php
@@ -10,6 +10,6 @@ return [
 
     ],
 
-    'welcome' => 'Bienvenido/a, :user',
+    'welcome' => 'Bienvenida/o, :user',
 
 ];


### PR DESCRIPTION
Also, fixed minor details in Spanish translations.

For example, I changed "you" imperative (tú) informal to "you" (usted) formal version .

Added missing female support, setting it first. o/a => a/o.