### PR TITLE
Add missing Exception class

### DIFF
--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Concerns/Translatable.php
@@ -2,6 +2,8 @@
 
 namespace Filament\Resources\Concerns;
 
+use Exception;
+
 trait Translatable
 {
     public static function getDefaultTranslatableLocale(): string


### PR DESCRIPTION
Fixes the bellow error by import the exception class: 
<img width="1427" alt="image" src="https://user-images.githubusercontent.com/12927166/155759299-89f25454-2f50-4db6-8a1f-bac9dca4b301.png">

This will help you if you forget to add the `HasTranslations` trait to the model class to understand what is going wrong. 

<img width="910" alt="image" src="https://user-images.githubusercontent.com/12927166/155759173-d470e335-c296-422a-b0e0-831360647eb2.png">

