### PR TITLE
Add Dutch translations for settings and translatable plugins

### DIFF
--- a/packages/spatie-laravel-settings-plugin/resources/lang/nl/pages/settings-page.php
+++ b/packages/spatie-laravel-settings-plugin/resources/lang/nl/pages/settings-page.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+
+    'form' => [
+
+        'actions' => [
+
+            'save' => [
+                'label' => 'Opslaan',
+            ],
+
+        ],
+
+    ],
+
+    'messages' => [
+        'saved' => 'Opgeslagen',
+    ],
+
+];

--- a/packages/spatie-laravel-translatable-plugin/resources/lang/nl/actions.php
+++ b/packages/spatie-laravel-translatable-plugin/resources/lang/nl/actions.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    'active_form_locale' => [
+        'label' => 'Taal',
+    ],
+
+];


### PR DESCRIPTION
This PR adds Dutch translations for the Settings and Translatable plugins.

While Dutch has multiple locale strings available (such as nl_NL for the Netherlands and nl_BE and Flemish Belgium), the ones here should be applicable to all of them.