### PR TITLE
Update section background-color to white

### DIFF
--- a/packages/forms/resources/views/components/card.blade.php
+++ b/packages/forms/resources/views/components/card.blade.php
@@ -1,8 +1,8 @@
 <div
     {!! $getId() ? "id=\"{$getId()}\"" : null !!}
     {{ $attributes->merge($getExtraAttributes())->class([
-        'p-6 bg-white shadow rounded-xl filament-forms-card-component',
-        'dark:bg-gray-800' => config('forms.dark_mode'),
+        'p-6 bg-white rounded-xl shadow border border-gray-300 filament-forms-card-component',
+        'dark:border-gray-600 dark:bg-gray-800' => config('forms.dark_mode'),
     ]) }}
 >
     {{ $getChildComponentContainer() }}

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -6,7 +6,7 @@
     id="{{ $getId() }}"
     {{ $attributes->merge($getExtraAttributes())->class([
         'p-6 space-y-6 rounded-xl shadow-sm border border-gray-300 filament-forms-section-component bg-white',
-        'dark:border-gray-600' => config('forms.dark_mode'),
+        'dark:border-gray-600 dark:bg-gray-800' => config('forms.dark_mode'),
     ]) }}
     {{ $getExtraAlpineAttributeBag() }}
 >

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -5,7 +5,7 @@
     @endif
     id="{{ $getId() }}"
     {{ $attributes->merge($getExtraAttributes())->class([
-        'p-6 space-y-6 rounded-xl shadow-sm border border-gray-300 filament-forms-section-component',
+        'p-6 space-y-6 rounded-xl shadow-sm border border-gray-300 filament-forms-section-component bg-white',
         'dark:border-gray-600' => config('forms.dark_mode'),
     ]) }}
     {{ $getExtraAlpineAttributeBag() }}

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -5,7 +5,7 @@
     @endif
     id="{{ $getId() }}"
     {{ $attributes->merge($getExtraAttributes())->class([
-        'p-6 space-y-6 rounded-xl shadow-sm border border-gray-300 filament-forms-section-component bg-white',
+        'p-6 space-y-6 bg-white rounded-xl shadow border border-gray-300 filament-forms-section-component',
         'dark:border-gray-600 dark:bg-gray-800' => config('forms.dark_mode'),
     ]) }}
     {{ $getExtraAlpineAttributeBag() }}


### PR DESCRIPTION
As discussed with @danharrin we agreed the background color of the section component `Forms\Components\Section` should be set to white (`bg-white`)

<img width="1241" alt="grafik" src="https://user-images.githubusercontent.com/6502630/156243293-e3aeba1d-5515-45d3-aade-b196bae12bad.png">
