### PR TITLE
fix: wrong slug generation on pages

### DIFF
--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -72,7 +72,9 @@ class Page extends Component implements Forms\Contracts\HasForms
         return function () {
             $slug = static::getSlug();
 
-            Route::get($slug, static::class)->name($slug);
+            Route::get($slug, static::class)
+                ->middleware(static::getMiddlewares())
+                ->name($slug);
         };
     }
 

--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -85,7 +85,9 @@ class Page extends Component implements Forms\Contracts\HasForms
 
     public static function getSlug(): string
     {
-        return static::$slug ?? Str::kebab(static::$title ?? class_basename(static::class));
+        return static::$slug ?? Str::of(static::$title ?? class_basename(static::class))
+                ->kebab()
+                ->slug();
     }
 
     public static function getUrl(array $parameters = [], bool $absolute = true): string

--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -72,9 +72,7 @@ class Page extends Component implements Forms\Contracts\HasForms
         return function () {
             $slug = static::getSlug();
 
-            Route::get($slug, static::class)
-                ->middleware(static::getMiddlewares())
-                ->name($slug);
+            Route::get($slug, static::class)->name($slug);
         };
     }
 
@@ -85,7 +83,9 @@ class Page extends Component implements Forms\Contracts\HasForms
 
     public static function getSlug(): string
     {
-        return static::$slug ?? Str::slug(static::$title ?? class_basename(static::class));
+        return static::$slug ?? Str::of(static::$title ?? class_basename(static::class))
+            ->kebab()
+            ->slug();
     }
 
     public static function getUrl(array $parameters = [], bool $absolute = true): string
@@ -116,7 +116,10 @@ class Page extends Component implements Forms\Contracts\HasForms
 
     protected static function getNavigationLabel(): string
     {
-        return static::$navigationLabel ?? static::getTitle();
+        return static::$navigationLabel ?? static::$title ?? Str::of(class_basename(static::class))
+            ->kebab()
+            ->replace('-', ' ')
+            ->title();
     }
 
     protected static function getNavigationSort(): ?int

--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -76,7 +76,7 @@ class Page extends Component implements Forms\Contracts\HasForms
 
     public static function getSlug(): string
     {
-        return static::$slug ?? Str::kebab(static::$title ?? class_basename(static::class));
+        return static::$slug ?? Str::slug(static::$title ?? class_basename(static::class));
     }
 
     public static function getUrl(array $parameters = [], bool $absolute = true): string
@@ -107,10 +107,7 @@ class Page extends Component implements Forms\Contracts\HasForms
 
     protected static function getNavigationLabel(): string
     {
-        return static::$navigationLabel ?? static::$title ?? Str::of(class_basename(static::class))
-            ->kebab()
-            ->replace('-', ' ')
-            ->title();
+        return static::$navigationLabel ?? static::getTitle();
     }
 
     protected static function getNavigationSort(): ?int

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -275,7 +275,7 @@ class Resource
     {
         return static::$slug ?? (string) Str::of(class_basename(static::getModel()))
             ->plural()
-            ->kebab();
+            ->slug();
     }
 
     public static function getUrl($name = 'index', $params = []): string

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -285,6 +285,7 @@ class Resource
     {
         return static::$slug ?? (string) Str::of(class_basename(static::getModel()))
             ->plural()
+            ->kebab()
             ->slug();
     }
 


### PR DESCRIPTION
This pr fixes wrong slug generation problem for pages.

Case: in currently code lines, not converts ü-ğ-ö etc. characters and addes this like this characters to directly url.

Solution: I'm converted first to kebab case because if page dont have custom title will get from class name. Later, i used Str::slug() helper function for fix ü-ğ-ö etc. characters.