### PR TITLE
Fix searchable select width

### DIFF
--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -23,7 +23,7 @@
             </span>
         @endif
 
-        <div class="flex-1">
+        <div class="flex-1 min-w-0">
             @unless ($isSearchable())
                 <select
                     {!! $isAutofocused() ? 'autofocus' : null !!}
@@ -97,7 +97,7 @@
                             x-show="! isOpen"
                             x-text="label ?? '{{ addslashes($getPlaceholder()) }}'"
                             @class([
-                                'w-full bg-white whitespace-nowrap truncate',
+                                'w-full bg-white truncate cursor-text',
                                 'dark:bg-gray-700' => config('forms.dark_mode'),
                             ])
                         ></span>
@@ -113,7 +113,7 @@
                                 type="text"
                                 autocomplete="off"
                                 @class([
-                                    'w-full p-0 border-0 focus:ring-0 focus:outline-none',
+                                    'w-0 grow p-0 border-0 focus:ring-0 focus:outline-none',
                                     'dark:bg-gray-700' => config('forms.dark_mode'),
                                 ])
                             />


### PR DESCRIPTION
Fixes https://github.com/laravel-filament/filament/issues/1734

The fix here was to add `min-w-0` to the select's wrapper div. Flex items have `min-width: auto` by default, which is based on the content width and doesn't play nice with long values that should be truncated.

This PR also addresses a separate issue with the internal search label/input. Both the label and input have `w-full` so are each given 50% of the width, which looks odd when you have long values:

![Screenshot 2022-03-03 at 15 02 53](https://user-images.githubusercontent.com/126740/156591413-0f057425-12e3-4c1c-bd4b-adca236a96be.png)

Simplest fix I could think of was to allow the label to take up all of the space by collapsing the input with `w-0`, but allow that to expand when the search is open with `grow`. Then adding `cursor-text` to the label.

![Screenshot 2022-03-03 at 15 03 26](https://user-images.githubusercontent.com/126740/156591513-582cdfa6-7179-42bb-9795-022f578619f8.png)
![Screenshot 2022-03-03 at 15 04 16](https://user-images.githubusercontent.com/126740/156591601-6229bc97-0dde-4446-85c9-6784715fc0f0.png)

I also removed the redundant `whitespace-nowrap`.

