### PR TITLE
Allow stat cards to be linked, allow `HtmlString` objects in stat card labels and descriptions

### DIFF
--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -1,22 +1,28 @@
 @props([
+    'tag' => 'div',
     'chart' => null,
     'chartColor' => null,
     'color' => null,
     'description' => null,
     'descriptionColor' => null,
     'descriptionIcon' => null,
+    'href' => null,
+    'target' => null,
     'flat' => false,
     'label' => null,
     'value' => null,
 ])
 
-<div {{ $attributes->class([
-    'relative p-6 rounded-2xl filament-stats-card',
-    'bg-white shadow' => ! $flat,
-    'dark:bg-gray-800' => (! $flat) && config('filament.dark_mode'),
-    'border' => $flat,
-    'dark:border-gray-700' => $flat && config('filament.dark_mode'),
-]) }}>
+<{{ $tag }} 
+    {!! ($tag === 'a') ? "href=\"{$href}\" target=\"{$target}\"" : null !!}
+    {{ $attributes->class([
+        'relative p-6 rounded-2xl filament-stats-card',
+        'bg-white shadow' => ! $flat,
+        'dark:bg-gray-800' => (! $flat) && config('filament.dark_mode'),
+        'border' => $flat,
+        'dark:border-gray-700' => $flat && config('filament.dark_mode'),
+    ]) }}
+>
     <div @class([
         'space-y-2',
     ])>
@@ -132,4 +138,4 @@
             </canvas>
         </div>
     @endif
-</div>
+</{{ $tag }}>

--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -13,7 +13,7 @@
     'value' => null,
 ])
 
-<{{ $tag }} 
+<{!! $tag !!} 
     {!! ($tag === 'a') ? "href=\"{$href}\" target=\"{$target}\"" : null !!}
     {{ $attributes->class([
         'relative p-6 rounded-2xl filament-stats-card',
@@ -138,4 +138,4 @@
             </canvas>
         </div>
     @endif
-</{{ $tag }}>
+</{!! $tag !!}>

--- a/packages/admin/resources/views/widgets/stats-overview-widget/card.blade.php
+++ b/packages/admin/resources/views/widgets/stats-overview-widget/card.blade.php
@@ -1,10 +1,17 @@
+@php
+    $url = $getUrl();
+@endphp
+
 <x-filament::stats.card
+    :tag="$url ? 'a' : 'div'"
     :chart="$getChart()"
     :chart-color="$getChartColor()"
     :color="$getColor()"
     :description="$getDescription()"
     :description-color="$getDescriptionColor()"
     :description-icon="$getDescriptionIcon()"
+    :href="$url"
+    :target="$shouldOpenUrlInNewTab() ? '_blank' : null"
     :label="$getLabel()"
     :value="$getValue()"
     class="filament-stats-overview-widget-card"

--- a/packages/admin/src/Widgets/StatsOverviewWidget/Card.php
+++ b/packages/admin/src/Widgets/StatsOverviewWidget/Card.php
@@ -22,6 +22,10 @@ class Card extends Component implements Htmlable
 
     protected ?string $descriptionColor = null;
 
+    protected bool $shouldOpenUrlInNewTab = false;
+
+    protected ?string $url = null;
+
     protected ?string $id = null;
 
     protected string | HtmlString $label;
@@ -71,6 +75,21 @@ class Card extends Component implements Htmlable
     {
         $this->descriptionIcon = $icon;
 
+        return $this;
+    }
+
+    public function openUrlInNewTab(bool $condition = true): static
+    {
+        $this->shouldOpenUrlInNewTab = $condition;
+    
+        return $this;
+    }
+    
+    public function url(?string $url, bool $shouldOpenInNewTab = false): static
+    {
+        $this->shouldOpenUrlInNewTab = $shouldOpenInNewTab;
+        $this->url = $url;
+    
         return $this;
     }
 
@@ -130,6 +149,16 @@ class Card extends Component implements Htmlable
     public function getDescriptionIcon(): ?string
     {
         return $this->descriptionIcon;
+    }
+
+    public function getUrl(): ?string
+    {
+        return $this->url;
+    }
+    
+    public function shouldOpenUrlInNewTab(): bool
+    {
+        return $this->shouldOpenUrlInNewTab;
     }
 
     public function getLabel(): string | HtmlString

--- a/packages/admin/src/Widgets/StatsOverviewWidget/Card.php
+++ b/packages/admin/src/Widgets/StatsOverviewWidget/Card.php
@@ -4,6 +4,7 @@ namespace Filament\Widgets\StatsOverviewWidget;
 
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use Illuminate\View\Component;
 
@@ -15,7 +16,7 @@ class Card extends Component implements Htmlable
 
     protected ?string $color = null;
 
-    protected ?string $description = null;
+    protected string | HtmlString | null $description = null;
 
     protected ?string $descriptionIcon = null;
 
@@ -23,7 +24,7 @@ class Card extends Component implements Htmlable
 
     protected ?string $id = null;
 
-    protected string $label;
+    protected string | HtmlString $label;
 
     protected $value;
 
@@ -52,7 +53,7 @@ class Card extends Component implements Htmlable
         return $this;
     }
 
-    public function description(?string $description): static
+    public function description(string | HtmlString | null $description): static
     {
         $this->description = $description;
 
@@ -80,7 +81,7 @@ class Card extends Component implements Htmlable
         return $this;
     }
 
-    public function label(string $label): static
+    public function label(string | HtmlString $label): static
     {
         $this->label = $label;
 
@@ -116,7 +117,7 @@ class Card extends Component implements Htmlable
         return $this->color;
     }
 
-    public function getDescription(): ?string
+    public function getDescription(): string | HtmlString | null
     {
         return $this->description;
     }
@@ -131,7 +132,7 @@ class Card extends Component implements Htmlable
         return $this->descriptionIcon;
     }
 
-    public function getLabel(): string
+    public function getLabel(): string | HtmlString
     {
         return $this->label;
     }


### PR DESCRIPTION
First go at https://github.com/laravel-filament/filament/discussions/1768

Not sure about the way the optional link has been implemented in `card.blade.php`... Duplicating the entire contents just to switch the wrapping element seems a bit over the top, but also doing it this way is not pretty. Let me know the preferred approach.