### PR TITLE
Add close button to filter popover

### DIFF
--- a/packages/tables/resources/lang/en/table.php
+++ b/packages/tables/resources/lang/en/table.php
@@ -93,6 +93,10 @@ return [
                 'label' => 'Reset filters',
             ],
 
+            'close' => [
+                'label' => 'Close',
+            ],
+
         ],
 
         'multi_select' => [

--- a/packages/tables/resources/lang/nl/table.php
+++ b/packages/tables/resources/lang/nl/table.php
@@ -85,12 +85,43 @@ return [
         'heading' => 'Geen resultaten gevonden',
     ],
 
+    'filters' => [
+
+        'buttons' => [
+
+            'reset' => [
+                'label' => 'Reset filters',
+            ],
+
+            'close' => [
+                'label' => 'Sluit',
+            ],
+
+        ],
+
+        'multi_select' => [
+            'placeholder' => 'Alles',
+        ],
+
+        'select' => [
+            'placeholder' => 'Alles',
+        ],
+
+    ],
+
     'selection_indicator' => [
+
+        'selected_count' => '1 rij geselecteerd.|:count rijen geselecteerd.',
+
 
         'buttons' => [
 
             'select_all' => [
                 'label' => 'Selecteer alle :count',
+            ],
+
+            'deselect_all' => [
+                'label' => 'Deselecteer alles',
             ],
 
         ],

--- a/packages/tables/resources/views/components/filters/index.blade.php
+++ b/packages/tables/resources/views/components/filters/index.blade.php
@@ -44,7 +44,7 @@
             <x-tables::icon-button
                 icon="heroicon-o-x"
                 x-on:click="isOpen = ! isOpen"
-                :label="__('tables::table.buttons.open_actions.label')"
+                :label=" __('tables::table.filters.buttons.close.label')"
                 {{ $attributes->class(['absolute top-3 right-3']) }}
             />
 

--- a/packages/tables/resources/views/components/filters/index.blade.php
+++ b/packages/tables/resources/views/components/filters/index.blade.php
@@ -42,7 +42,7 @@
         ])>
             {{ $form }}
 
-            <div class="text-right">
+            <div class="text-right space-x-2">
                 <x-tables::link
                     wire:click="resetTableFiltersForm"
                     color="danger"
@@ -50,6 +50,15 @@
                     class="text-sm font-medium"
                 >
                     {{ __('tables::table.filters.buttons.reset.label') }}
+                </x-tables::link>
+
+                <x-tables::link
+                    @click="isOpen = false"
+                    color="success"
+                    tag="button"
+                    class="text-sm font-medium"
+                >
+                    {{ __('tables::table.filters.buttons.close.label') }}
                 </x-tables::link>
             </div>
         </div>

--- a/packages/tables/resources/views/components/filters/index.blade.php
+++ b/packages/tables/resources/views/components/filters/index.blade.php
@@ -40,6 +40,14 @@
             'px-6 py-4 bg-white space-y-6 shadow-xl rounded-xl',
             'dark:bg-gray-700' => config('tables.dark_mode'),
         ])>
+
+        <div @class([
+            'absolute top-3 right-3 w-6 h-6 text-gray-300 hover:bg-gray-200 hover:text-gray-400 rounded',
+            'dark:text-gray-400 dark:hover:bg-gray-600' => config('tables.dark_mode'),
+        ]) @click="isOpen = false">
+            <x-heroicon-o-x />
+        </div>
+
             {{ $form }}
 
             <div class="text-right space-x-2">

--- a/packages/tables/resources/views/components/filters/index.blade.php
+++ b/packages/tables/resources/views/components/filters/index.blade.php
@@ -59,15 +59,6 @@
                 >
                     {{ __('tables::table.filters.buttons.reset.label') }}
                 </x-tables::link>
-
-                <x-tables::link
-                    @click="isOpen = false"
-                    color="success"
-                    tag="button"
-                    class="text-sm font-medium"
-                >
-                    {{ __('tables::table.filters.buttons.close.label') }}
-                </x-tables::link>
             </div>
         </div>
     </div>

--- a/packages/tables/resources/views/components/filters/index.blade.php
+++ b/packages/tables/resources/views/components/filters/index.blade.php
@@ -41,12 +41,12 @@
             'dark:bg-gray-700' => config('tables.dark_mode'),
         ])>
 
-        <div @class([
-            'absolute top-3 right-3 w-6 h-6 text-gray-300 hover:bg-gray-200 hover:text-gray-400 rounded',
-            'dark:text-gray-400 dark:hover:bg-gray-600' => config('tables.dark_mode'),
-        ]) @click="isOpen = false">
-            <x-heroicon-o-x />
-        </div>
+            <x-tables::icon-button
+                icon="heroicon-o-x"
+                x-on:click="isOpen = ! isOpen"
+                :label="__('tables::table.buttons.open_actions.label')"
+                {{ $attributes->class(['absolute top-3 right-3']) }}
+            />
 
             {{ $form }}
 

--- a/packages/tables/resources/views/components/filters/index.blade.php
+++ b/packages/tables/resources/views/components/filters/index.blade.php
@@ -50,7 +50,7 @@
 
             {{ $form }}
 
-            <div class="text-right space-x-2">
+            <div class="text-right">
                 <x-tables::link
                     wire:click="resetTableFiltersForm"
                     color="danger"

--- a/packages/tables/resources/views/components/icon-button.blade.php
+++ b/packages/tables/resources/views/components/icon-button.blade.php
@@ -14,6 +14,7 @@
         'text-gray-500 focus:bg-gray-500/10' => $color === 'secondary',
         'text-success-500 focus:bg-success-500/10' => $color === 'success',
         'text-warning-500 focus:bg-warning-500/10' => $color === 'warning',
+        'hover:bg-gray-300/5' => config('filament.dark_mode'),
     ];
 
     $iconClasses = 'w-5 h-5 filament-tables-icon-button-icon';


### PR DESCRIPTION
See #1706. I opened a new PR because I rebased my fork, but the old PR still shows 200+ unmerged commits, even though the branches are exactly up-to-date.

 Light:

<img width="346" alt="Schermafbeelding 2022-03-04 om 11 28 13" src="https://user-images.githubusercontent.com/59207045/156748351-f94b64e1-c0b2-4b41-9aca-7d2f0f1f9f68.png">

On hover:

<img width="346" alt="Schermafbeelding 2022-03-04 om 11 28 18" src="https://user-images.githubusercontent.com/59207045/156748362-72c8a502-db12-4a1c-bd7a-b63b10d8015a.png">

Dark:

<img width="346" alt="Schermafbeelding 2022-03-04 om 11 28 25" src="https://user-images.githubusercontent.com/59207045/156748363-378c8132-7140-4a09-a6ed-bf7934e7595e.png">

Dark on hover:

<img width="346" alt="Schermafbeelding 2022-03-04 om 11 28 29" src="https://user-images.githubusercontent.com/59207045/156748364-80e0d8ac-ff49-49b2-8a43-f4652f45843e.png">
 

I also added some missing translations.

(PS: that search icon is custom CSS and not Filament.)