### PR TITLE
Fix table header color in light mode

### DIFF
--- a/packages/tables/resources/views/components/table.blade.php
+++ b/packages/tables/resources/views/components/table.blade.php
@@ -11,7 +11,7 @@
         <thead>
             <tr @class([
                 'bg-gray-50',
-                'dark:bg-gray-500/10',
+                'dark:bg-gray-500/10' => config('tables.dark_mode'),
             ])>
                 {{ $header }}
             </tr>


### PR DESCRIPTION
Dark class is missing a `config('tables.dark_mode')` check, causing the dark background to apply in light mode.