### PR TITLE
Update card borders

### DIFF
--- a/packages/admin/resources/views/components/card/index.blade.php
+++ b/packages/admin/resources/views/components/card/index.blade.php
@@ -6,7 +6,7 @@
 ])
 
 <div {{ $attributes->class([
-    'p-2 space-y-2 bg-white rounded-xl shadow border border-gray-300',
+    'p-2 space-y-2 bg-white rounded-xl shadow',
     'dark:border-gray-600 dark:bg-gray-800' => config('filament.dark_mode'),
 ]) }}>
     @if ($actions || $header || $heading)

--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -13,11 +13,8 @@
 
 <{!! $tag !!}
     {{ $attributes->class([
-        'relative p-6 rounded-2xl filament-stats-card',
-        'bg-white shadow' => ! $flat,
-        'dark:bg-gray-800' => (! $flat) && config('filament.dark_mode'),
-        'border' => $flat,
-        'dark:border-gray-700' => $flat && config('filament.dark_mode'),
+        'relative p-6 rounded-2xl bg-white shadow filament-stats-card',
+        'dark:bg-gray-800' => config('filament.dark_mode'),
     ]) }}
 >
     <div @class([

--- a/packages/forms/resources/views/components/card.blade.php
+++ b/packages/forms/resources/views/components/card.blade.php
@@ -1,7 +1,7 @@
 <div
     {!! $getId() ? "id=\"{$getId()}\"" : null !!}
     {{ $attributes->merge($getExtraAttributes())->class([
-        'p-6 bg-white rounded-xl shadow border border-gray-300 filament-forms-card-component',
+        'p-6 bg-white rounded-xl border border-gray-300 filament-forms-card-component',
         'dark:border-gray-600 dark:bg-gray-800' => config('forms.dark_mode'),
     ]) }}
 >

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -5,7 +5,7 @@
     @endif
     id="{{ $getId() }}"
     {{ $attributes->merge($getExtraAttributes())->class([
-        'p-6 space-y-6 bg-white rounded-xl shadow border border-gray-300 filament-forms-section-component',
+        'p-6 space-y-6 bg-white rounded-xl border border-gray-300 filament-forms-section-component',
         'dark:border-gray-600 dark:bg-gray-800' => config('forms.dark_mode'),
     ]) }}
     {{ $getExtraAlpineAttributeBag() }}


### PR DESCRIPTION
I noticed that you updated the `Card` component to have borders. On the admin panel, this currently looks like this:

<img width="933" alt="Schermafbeelding 2022-03-04 om 12 52 06" src="https://user-images.githubusercontent.com/59207045/156758741-a2a34da4-cb61-4492-8af8-e4c3aaa8fc46.png">

 
To be honest, I think this is quite noisy/incoherent. In the Discord-channel, Dan said that Filament was always internally using the `<x-filament::card>` component, also for the stats overview widget. I could not find that relation, because for the stats overview, you have a separate Blade component in `packages/admin/resources/views/components/stats/card.blade.php`. 

### Restoring admin panel design

Anyways, I updated the `packages/admin/resources/views/components/card/index.blade.php` component, so that it doesn't have a border anymore. **This change did not impact the `Card` component from the Forms package**, so it basically restores the dashboard design to its 'old' look.

### `Card` component

Second, I took a look at the `Card` component. This is an example from the admin panel with a dummy card and section about how it currently looks:

<img width="909" alt="Schermafbeelding 2022-03-04 om 12 59 22" src="https://user-images.githubusercontent.com/59207045/156759823-c5dc412d-9b21-4f0d-8ac5-51eb78d06e40.png">

Personally I think that the shadows on the grey background are bit too heavy when you compare it with the relationmanager below it. It is not really the same style. 

The fix for this is very simple: remove the `shadow` from both the Card and the Section component. This makes the design of both components more consistent with the design/border of the relationmanagers: 

<img width="909" alt="Schermafbeelding 2022-03-04 om 13 05 25" src="https://user-images.githubusercontent.com/59207045/156760513-83ffe52f-b53e-4679-8356-075676ea5828.png">

If I'm really honest, I still prefer the old design with only the `shadow` and no borders, but otherwise I don't have a good idea on how to fix the problem that the `Card` isn't visible on white backgrounds.



