### PR TITLE
Add dusk selectors to form components

### DIFF
--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -93,7 +93,7 @@
                     {!! $isDisabled ? 'disabled' : null !!}
                     type="checkbox"
                     value="{{ $optionValue }}"
-                    dusk="filament.{{ $getStatePath() }}"
+                    dusk="filament.forms.{{ $getStatePath() }}"
                     {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
                     {{ $attributes->merge($getExtraAttributes())->class([
                         'text-primary-600 transition duration-75 rounded shadow-sm focus:border-primary-500 focus:ring-2 focus:ring-primary-500',

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -93,6 +93,7 @@
                     {!! $isDisabled ? 'disabled' : null !!}
                     type="checkbox"
                     value="{{ $optionValue }}"
+                    dusk="{{ $getStatePath() }}"
                     {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
                     {{ $attributes->merge($getExtraAttributes())->class([
                         'text-primary-600 transition duration-75 rounded shadow-sm focus:border-primary-500 focus:ring-2 focus:ring-primary-500',

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -93,7 +93,7 @@
                     {!! $isDisabled ? 'disabled' : null !!}
                     type="checkbox"
                     value="{{ $optionValue }}"
-                    dusk="{{ $getStatePath() }}"
+                    dusk="filament.{{ $getStatePath() }}"
                     {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
                     {{ $attributes->merge($getExtraAttributes())->class([
                         'text-primary-600 transition duration-75 rounded shadow-sm focus:border-primary-500 focus:ring-2 focus:ring-primary-500',

--- a/packages/forms/resources/views/components/checkbox.blade.php
+++ b/packages/forms/resources/views/components/checkbox.blade.php
@@ -18,6 +18,7 @@
                 type="checkbox"
                 {!! $isRequired() ? 'required' : null !!}
                 {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
+                dusk="{{ $getStatePath() }}"
                 {{
                     $attributes
                         ->merge($getExtraAttributes())

--- a/packages/forms/resources/views/components/checkbox.blade.php
+++ b/packages/forms/resources/views/components/checkbox.blade.php
@@ -18,7 +18,7 @@
                 type="checkbox"
                 {!! $isRequired() ? 'required' : null !!}
                 {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
-                dusk="{{ $getStatePath() }}"
+                dusk="filament.{{ $getStatePath() }}"
                 {{
                     $attributes
                         ->merge($getExtraAttributes())

--- a/packages/forms/resources/views/components/checkbox.blade.php
+++ b/packages/forms/resources/views/components/checkbox.blade.php
@@ -18,7 +18,7 @@
                 type="checkbox"
                 {!! $isRequired() ? 'required' : null !!}
                 {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
-                dusk="filament.{{ $getStatePath() }}"
+                dusk="filament.forms.{{ $getStatePath() }}"
                 {{
                     $attributes
                         ->merge($getExtraAttributes())

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -48,7 +48,7 @@
             x-on:keydown.delete.stop.prevent="clearState()"
             x-bind:aria-expanded="open"
             aria-label="{{ $getPlaceholder() }}"
-            dusk="{{ $getStatePath() }}.open"
+            dusk="filament.{{ $getStatePath() }}.open"
             @endunless
             type="button"
             {{ $getExtraTriggerAttributeBag()->class([
@@ -104,7 +104,7 @@
                                     'grow px-1 py-0 text-lg font-medium text-gray-800 border-0 cursor-pointer focus:ring-0 focus:outline-none',
                                     'dark:bg-gray-700 dark:text-gray-200' => config('forms.dark_mode'),
                                 ])
-                                dusk="{{ $getStatePath() }}.focusedMonth"
+                                dusk="filament.{{ $getStatePath() }}.focusedMonth"
                             >
                                 <template x-for="(month, index) in months">
                                     <option x-bind:value="index" x-text="month"></option>
@@ -119,7 +119,7 @@
                                     'w-20 p-0 text-lg text-right border-0 focus:ring-0 focus:outline-none',
                                     'dark:bg-gray-700 dark:text-gray-200' => config('forms.dark_mode'),
                                 ])
-                                dusk="{{ $getStatePath() }}.focusedYear"
+                                dusk="filament.{{ $getStatePath() }}.focusedYear"
                             />
                         </div>
 
@@ -156,7 +156,7 @@
                                         'cursor-not-allowed': dayIsDisabled(day),
                                         'opacity-50': focusedDate.date() !== day && dayIsDisabled(day),
                                     }"
-                                    x-bind:dusk="'{{ $getStatePath() }}' + '.focusedDate.' + day"
+                                    x-bind:dusk="filament.'{{ $getStatePath() }}' + '.focusedDate.' + day"
                                     class="text-sm leading-loose text-center transition duration-100 ease-in-out rounded-full"
                                 ></div>
                             </template>
@@ -183,7 +183,7 @@
                                     'bg-gray-50' => $hasDate(),
                                     'dark:bg-gray-800' => $hasDate() && config('forms.dark_mode'),
                                 ])
-                                dusk="{{ $getStatePath() }}.hour"
+                                dusk="filament.{{ $getStatePath() }}.hour"
                             />
 
                             <span
@@ -207,7 +207,7 @@
                                     'bg-gray-50' => $hasDate(),
                                     'dark:bg-gray-800' => $hasDate() && config('forms.dark_mode'),
                                 ])
-                                dusk="{{ $getStatePath() }}.minute"
+                                dusk="filament.{{ $getStatePath() }}.minute"
                             />
 
                             @if ($hasSeconds())
@@ -227,7 +227,7 @@
                                     type="number"
                                     inputmode="numeric"
                                     x-model.debounce="second"
-                                    dusk="{{ $getStatePath() }}.second"
+                                    dusk="filament.{{ $getStatePath() }}.second"
                                     @class([
                                         'w-16 p-0 pr-1 text-xl text-center text-gray-700 border-0 focus:ring-0 focus:outline-none',
                                         'dark:text-gray-200' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -48,7 +48,7 @@
             x-on:keydown.delete.stop.prevent="clearState()"
             x-bind:aria-expanded="open"
             aria-label="{{ $getPlaceholder() }}"
-            dusk="filament.{{ $getStatePath() }}.open"
+            dusk="filament.forms.{{ $getStatePath() }}.open"
             @endunless
             type="button"
             {{ $getExtraTriggerAttributeBag()->class([
@@ -104,7 +104,7 @@
                                     'grow px-1 py-0 text-lg font-medium text-gray-800 border-0 cursor-pointer focus:ring-0 focus:outline-none',
                                     'dark:bg-gray-700 dark:text-gray-200' => config('forms.dark_mode'),
                                 ])
-                                dusk="filament.{{ $getStatePath() }}.focusedMonth"
+                                dusk="filament.forms.{{ $getStatePath() }}.focusedMonth"
                             >
                                 <template x-for="(month, index) in months">
                                     <option x-bind:value="index" x-text="month"></option>
@@ -119,7 +119,7 @@
                                     'w-20 p-0 text-lg text-right border-0 focus:ring-0 focus:outline-none',
                                     'dark:bg-gray-700 dark:text-gray-200' => config('forms.dark_mode'),
                                 ])
-                                dusk="filament.{{ $getStatePath() }}.focusedYear"
+                                dusk="filament.forms.{{ $getStatePath() }}.focusedYear"
                             />
                         </div>
 
@@ -156,7 +156,7 @@
                                         'cursor-not-allowed': dayIsDisabled(day),
                                         'opacity-50': focusedDate.date() !== day && dayIsDisabled(day),
                                     }"
-                                    x-bind:dusk="filament.'{{ $getStatePath() }}' + '.focusedDate.' + day"
+                                    x-bind:dusk="filament.forms.'{{ $getStatePath() }}' + '.focusedDate.' + day"
                                     class="text-sm leading-loose text-center transition duration-100 ease-in-out rounded-full"
                                 ></div>
                             </template>
@@ -183,7 +183,7 @@
                                     'bg-gray-50' => $hasDate(),
                                     'dark:bg-gray-800' => $hasDate() && config('forms.dark_mode'),
                                 ])
-                                dusk="filament.{{ $getStatePath() }}.hour"
+                                dusk="filament.forms.{{ $getStatePath() }}.hour"
                             />
 
                             <span
@@ -207,7 +207,7 @@
                                     'bg-gray-50' => $hasDate(),
                                     'dark:bg-gray-800' => $hasDate() && config('forms.dark_mode'),
                                 ])
-                                dusk="filament.{{ $getStatePath() }}.minute"
+                                dusk="filament.forms.{{ $getStatePath() }}.minute"
                             />
 
                             @if ($hasSeconds())
@@ -227,7 +227,7 @@
                                     type="number"
                                     inputmode="numeric"
                                     x-model.debounce="second"
-                                    dusk="filament.{{ $getStatePath() }}.second"
+                                    dusk="filament.forms.{{ $getStatePath() }}.second"
                                     @class([
                                         'w-16 p-0 pr-1 text-xl text-center text-gray-700 border-0 focus:ring-0 focus:outline-none',
                                         'dark:text-gray-200' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -36,18 +36,19 @@
     >
         <button
             @unless($isDisabled())
-                x-ref="button"
-                x-on:click="togglePickerVisibility()"
-                x-on:keydown.enter.stop.prevent="open ? selectDate() : openPicker()"
-                x-on:keydown.arrow-left.stop.prevent="focusPreviousDay()"
-                x-on:keydown.arrow-right.stop.prevent="focusNextDay()"
-                x-on:keydown.arrow-up.stop.prevent="focusPreviousWeek()"
-                x-on:keydown.arrow-down.stop.prevent="focusNextWeek()"
-                x-on:keydown.backspace.stop.prevent="clearState()"
-                x-on:keydown.clear.stop.prevent="clearState()"
-                x-on:keydown.delete.stop.prevent="clearState()"
-                x-bind:aria-expanded="open"
-                aria-label="{{ $getPlaceholder() }}"
+            x-ref="button"
+            x-on:click="togglePickerVisibility()"
+            x-on:keydown.enter.stop.prevent="open ? selectDate() : openPicker()"
+            x-on:keydown.arrow-left.stop.prevent="focusPreviousDay()"
+            x-on:keydown.arrow-right.stop.prevent="focusNextDay()"
+            x-on:keydown.arrow-up.stop.prevent="focusPreviousWeek()"
+            x-on:keydown.arrow-down.stop.prevent="focusNextWeek()"
+            x-on:keydown.backspace.stop.prevent="clearState()"
+            x-on:keydown.clear.stop.prevent="clearState()"
+            x-on:keydown.delete.stop.prevent="clearState()"
+            x-bind:aria-expanded="open"
+            aria-label="{{ $getPlaceholder() }}"
+            dusk="{{ $getStatePath() }}.open"
             @endunless
             type="button"
             {{ $getExtraTriggerAttributeBag()->class([
@@ -103,6 +104,7 @@
                                     'grow px-1 py-0 text-lg font-medium text-gray-800 border-0 cursor-pointer focus:ring-0 focus:outline-none',
                                     'dark:bg-gray-700 dark:text-gray-200' => config('forms.dark_mode'),
                                 ])
+                                dusk="{{ $getStatePath() }}.focusedMonth"
                             >
                                 <template x-for="(month, index) in months">
                                     <option x-bind:value="index" x-text="month"></option>
@@ -117,6 +119,7 @@
                                     'w-20 p-0 text-lg text-right border-0 focus:ring-0 focus:outline-none',
                                     'dark:bg-gray-700 dark:text-gray-200' => config('forms.dark_mode'),
                                 ])
+                                dusk="{{ $getStatePath() }}.focusedYear"
                             />
                         </div>
 
@@ -153,6 +156,7 @@
                                         'cursor-not-allowed': dayIsDisabled(day),
                                         'opacity-50': focusedDate.date() !== day && dayIsDisabled(day),
                                     }"
+                                    x-bind:dusk="'{{ $getStatePath() }}' + '.focusedDate.' + day"
                                     class="text-sm leading-loose text-center transition duration-100 ease-in-out rounded-full"
                                 ></div>
                             </template>
@@ -179,6 +183,7 @@
                                     'bg-gray-50' => $hasDate(),
                                     'dark:bg-gray-800' => $hasDate() && config('forms.dark_mode'),
                                 ])
+                                dusk="{{ $getStatePath() }}.hour"
                             />
 
                             <span
@@ -202,6 +207,7 @@
                                     'bg-gray-50' => $hasDate(),
                                     'dark:bg-gray-800' => $hasDate() && config('forms.dark_mode'),
                                 ])
+                                dusk="{{ $getStatePath() }}.minute"
                             />
 
                             @if ($hasSeconds())
@@ -221,6 +227,7 @@
                                     type="number"
                                     inputmode="numeric"
                                     x-model.debounce="second"
+                                    dusk="{{ $getStatePath() }}.second"
                                     @class([
                                         'w-16 p-0 pr-1 text-xl text-center text-gray-700 border-0 focus:ring-0 focus:outline-none',
                                         'dark:text-gray-200' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -36,19 +36,19 @@
     >
         <button
             @unless($isDisabled())
-            x-ref="button"
-            x-on:click="togglePickerVisibility()"
-            x-on:keydown.enter.stop.prevent="open ? selectDate() : openPicker()"
-            x-on:keydown.arrow-left.stop.prevent="focusPreviousDay()"
-            x-on:keydown.arrow-right.stop.prevent="focusNextDay()"
-            x-on:keydown.arrow-up.stop.prevent="focusPreviousWeek()"
-            x-on:keydown.arrow-down.stop.prevent="focusNextWeek()"
-            x-on:keydown.backspace.stop.prevent="clearState()"
-            x-on:keydown.clear.stop.prevent="clearState()"
-            x-on:keydown.delete.stop.prevent="clearState()"
-            x-bind:aria-expanded="open"
-            aria-label="{{ $getPlaceholder() }}"
-            dusk="filament.forms.{{ $getStatePath() }}.open"
+                x-ref="button"
+                x-on:click="togglePickerVisibility()"
+                x-on:keydown.enter.stop.prevent="open ? selectDate() : openPicker()"
+                x-on:keydown.arrow-left.stop.prevent="focusPreviousDay()"
+                x-on:keydown.arrow-right.stop.prevent="focusNextDay()"
+                x-on:keydown.arrow-up.stop.prevent="focusPreviousWeek()"
+                x-on:keydown.arrow-down.stop.prevent="focusNextWeek()"
+                x-on:keydown.backspace.stop.prevent="clearState()"
+                x-on:keydown.clear.stop.prevent="clearState()"
+                x-on:keydown.delete.stop.prevent="clearState()"
+                x-bind:aria-expanded="open"
+                aria-label="{{ $getPlaceholder() }}"
+                dusk="filament.forms.{{ $getStatePath() }}.open"
             @endunless
             type="button"
             {{ $getExtraTriggerAttributeBag()->class([

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -81,7 +81,7 @@
             {!! ($id = $getId()) ? "id=\"{$id}\"" : null !!}
             type="file"
             {{ $getExtraInputAttributeBag() }}
-            dusk="filament.{{ $getStatePath() }}"
+            dusk="filament.forms.{{ $getStatePath() }}"
         />
     </div>
 </x-forms::field-wrapper>

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -81,7 +81,7 @@
             {!! ($id = $getId()) ? "id=\"{$id}\"" : null !!}
             type="file"
             {{ $getExtraInputAttributeBag() }}
-            dusk="{{ $getStatePath() }}"
+            dusk="filament.{{ $getStatePath() }}"
         />
     </div>
 </x-forms::field-wrapper>

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -81,6 +81,7 @@
             {!! ($id = $getId()) ? "id=\"{$id}\"" : null !!}
             type="file"
             {{ $getExtraInputAttributeBag() }}
+            dusk="{{ $getStatePath() }}"
         />
     </div>
 </x-forms::field-wrapper>

--- a/packages/forms/resources/views/components/hidden.blade.php
+++ b/packages/forms/resources/views/components/hidden.blade.php
@@ -4,4 +4,5 @@
     type="hidden"
     {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
     {{ $attributes->merge($getExtraAttributes())->class(['filament-forms-hidden-component']) }}
+    dusk="{{ $getStatePath() }}"
 />

--- a/packages/forms/resources/views/components/hidden.blade.php
+++ b/packages/forms/resources/views/components/hidden.blade.php
@@ -4,5 +4,5 @@
     type="hidden"
     {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
     {{ $attributes->merge($getExtraAttributes())->class(['filament-forms-hidden-component']) }}
-    dusk="filament.{{ $getStatePath() }}"
+    dusk="filament.forms.{{ $getStatePath() }}"
 />

--- a/packages/forms/resources/views/components/hidden.blade.php
+++ b/packages/forms/resources/views/components/hidden.blade.php
@@ -4,5 +4,5 @@
     type="hidden"
     {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
     {{ $attributes->merge($getExtraAttributes())->class(['filament-forms-hidden-component']) }}
-    dusk="{{ $getStatePath() }}"
+    dusk="filament.{{ $getStatePath() }}"
 />

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -179,6 +179,7 @@
                         {!! ($placeholder = $getPlaceholder()) ? "placeholder=\"{$placeholder}\"" : null !!}
                         {!! $isRequired() ? 'required' : null !!}
                         x-model="state"
+                        dusk="{{ $getStatePath() }}"
                         x-on:keyup.enter="checkForAutoInsertion"
                         x-on:file-attachment-accepted.window="
                             attachment = $event.detail?.attachments?.[0]

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -179,7 +179,7 @@
                         {!! ($placeholder = $getPlaceholder()) ? "placeholder=\"{$placeholder}\"" : null !!}
                         {!! $isRequired() ? 'required' : null !!}
                         x-model="state"
-                        dusk="filament.{{ $getStatePath() }}"
+                        dusk="filament.forms.{{ $getStatePath() }}"
                         x-on:keyup.enter="checkForAutoInsertion"
                         x-on:file-attachment-accepted.window="
                             attachment = $event.detail?.attachments?.[0]

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -179,7 +179,7 @@
                         {!! ($placeholder = $getPlaceholder()) ? "placeholder=\"{$placeholder}\"" : null !!}
                         {!! $isRequired() ? 'required' : null !!}
                         x-model="state"
-                        dusk="{{ $getStatePath() }}"
+                        dusk="filament.{{ $getStatePath() }}"
                         x-on:keyup.enter="checkForAutoInsertion"
                         x-on:file-attachment-accepted.window="
                             attachment = $event.detail?.attachments?.[0]

--- a/packages/forms/resources/views/components/multi-select.blade.php
+++ b/packages/forms/resources/views/components/multi-select.blade.php
@@ -36,6 +36,7 @@
                 x-on:blur="closeListbox()"
                 x-on:keydown.escape.stop="closeListbox()"
                 class="relative"
+                dusk="{{ $getStatePath() }}.close"
             >
                 <div
                     x-ref="button"
@@ -60,6 +61,7 @@
                         placeholder="{{ $getPlaceholder() }}"
                         type="text"
                         autocomplete="off"
+                        dusk="{{ $getStatePath() }}"
                         @class([
                             'block w-full border-0',
                             'dark:bg-gray-700 dark:placeholder-gray-400' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/multi-select.blade.php
+++ b/packages/forms/resources/views/components/multi-select.blade.php
@@ -36,7 +36,7 @@
                 x-on:blur="closeListbox()"
                 x-on:keydown.escape.stop="closeListbox()"
                 class="relative"
-                dusk="filament.{{ $getStatePath() }}.close"
+                dusk="filament.forms.{{ $getStatePath() }}.close"
             >
                 <div
                     x-ref="button"
@@ -61,7 +61,7 @@
                         placeholder="{{ $getPlaceholder() }}"
                         type="text"
                         autocomplete="off"
-                        dusk="filament.{{ $getStatePath() }}"
+                        dusk="filament.forms.{{ $getStatePath() }}"
                         @class([
                             'block w-full border-0',
                             'dark:bg-gray-700 dark:placeholder-gray-400' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/multi-select.blade.php
+++ b/packages/forms/resources/views/components/multi-select.blade.php
@@ -36,7 +36,7 @@
                 x-on:blur="closeListbox()"
                 x-on:keydown.escape.stop="closeListbox()"
                 class="relative"
-                dusk="{{ $getStatePath() }}.close"
+                dusk="filament.{{ $getStatePath() }}.close"
             >
                 <div
                     x-ref="button"
@@ -61,7 +61,7 @@
                         placeholder="{{ $getPlaceholder() }}"
                         type="text"
                         autocomplete="off"
-                        dusk="{{ $getStatePath() }}"
+                        dusk="filament.{{ $getStatePath() }}"
                         @class([
                             'block w-full border-0',
                             'dark:bg-gray-700 dark:placeholder-gray-400' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -104,7 +104,7 @@
                                 id="{{ $getId() }}-{{ $value }}"
                                 type="radio"
                                 value="{{ $value }}"
-                                dusk="{{ $getStatePath() }}"
+                                dusk="filament.{{ $getStatePath() }}"
                                 {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
                                 {{ $getExtraInputAttributeBag()->class([
                                     'focus:ring-primary-500 h-4 w-4 text-primary-600',

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -104,6 +104,7 @@
                                 id="{{ $getId() }}-{{ $value }}"
                                 type="radio"
                                 value="{{ $value }}"
+                                dusk="{{ $getStatePath() }}"
                                 {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
                                 {{ $getExtraInputAttributeBag()->class([
                                     'focus:ring-primary-500 h-4 w-4 text-primary-600',

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -104,7 +104,7 @@
                                 id="{{ $getId() }}-{{ $value }}"
                                 type="radio"
                                 value="{{ $value }}"
-                                dusk="filament.{{ $getStatePath() }}"
+                                dusk="filament.forms.{{ $getStatePath() }}"
                                 {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
                                 {{ $getExtraInputAttributeBag()->class([
                                     'focus:ring-primary-500 h-4 w-4 text-primary-600',

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -282,6 +282,7 @@
                 placeholder="{{ $getPlaceholder() }}"
                 toolbar="trix-toolbar-{{ $getId() }}"
                 x-ref="trix"
+                dusk="{{ $getStatePath() }}"
                 @class([
                     'bg-white block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-600 prose max-w-none',
                     'dark:prose-invert dark:bg-gray-700' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -282,7 +282,7 @@
                 placeholder="{{ $getPlaceholder() }}"
                 toolbar="trix-toolbar-{{ $getId() }}"
                 x-ref="trix"
-                dusk="{{ $getStatePath() }}"
+                dusk="filament.{{ $getStatePath() }}"
                 @class([
                     'bg-white block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-600 prose max-w-none',
                     'dark:prose-invert dark:bg-gray-700' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -282,7 +282,7 @@
                 placeholder="{{ $getPlaceholder() }}"
                 toolbar="trix-toolbar-{{ $getId() }}"
                 x-ref="trix"
-                dusk="filament.{{ $getStatePath() }}"
+                dusk="filament.forms.{{ $getStatePath() }}"
                 @class([
                     'bg-white block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-600 prose max-w-none',
                     'dark:prose-invert dark:bg-gray-700' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -31,6 +31,7 @@
                     id="{{ $getId() }}"
                     {!! $isRequired() ? 'required' : null !!}
                     {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
+                    dusk="{{ $getStatePath() }}"
                     {{ $attributes->merge($getExtraInputAttributes())->merge($getExtraAttributes())->class([
                         'text-gray-900 block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600 disabled:opacity-70',
                         'dark:bg-gray-700 dark:text-white' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -31,7 +31,7 @@
                     id="{{ $getId() }}"
                     {!! $isRequired() ? 'required' : null !!}
                     {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
-                    dusk="filament.{{ $getStatePath() }}"
+                    dusk="filament.forms.{{ $getStatePath() }}"
                     {{ $attributes->merge($getExtraInputAttributes())->merge($getExtraAttributes())->class([
                         'text-gray-900 block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600 disabled:opacity-70',
                         'dark:bg-gray-700 dark:text-white' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -31,7 +31,7 @@
                     id="{{ $getId() }}"
                     {!! $isRequired() ? 'required' : null !!}
                     {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
-                    dusk="{{ $getStatePath() }}"
+                    dusk="filament.{{ $getStatePath() }}"
                     {{ $attributes->merge($getExtraInputAttributes())->merge($getExtraAttributes())->class([
                         'text-gray-900 block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600 disabled:opacity-70',
                         'dark:bg-gray-700 dark:text-white' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -35,6 +35,7 @@
                         list="{{ $getId() }}-suggestions"
                         {!! $getPlaceholder() ? 'placeholder="' . $getPlaceholder() . '"' : null !!}
                         type="text"
+                        dusk="{{ $getStatePath() }}"
                         x-on:keydown.enter.stop.prevent="createTag()"
                         x-on:keydown.,.stop.prevent="createTag()"
                         x-on:blur="createTag()"
@@ -67,6 +68,7 @@
                                 x-on:click="deleteTag(tag)"
                             @endunless
                             type="button"
+                            x-bind:dusk="'{{ $getStatePath() }}' + '.tag.' + tag + '.delete'"
                             @class([
                                 'inline-flex items-center justify-center min-h-6 px-2 py-0.5 text-sm font-medium tracking-tight text-primary-700 rounded-xl bg-primary-500/10 space-x-1 rtl:space-x-reverse',
                                 'dark:text-primary-500' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -35,7 +35,7 @@
                         list="{{ $getId() }}-suggestions"
                         {!! $getPlaceholder() ? 'placeholder="' . $getPlaceholder() . '"' : null !!}
                         type="text"
-                        dusk="filament.{{ $getStatePath() }}"
+                        dusk="filament.forms.{{ $getStatePath() }}"
                         x-on:keydown.enter.stop.prevent="createTag()"
                         x-on:keydown.,.stop.prevent="createTag()"
                         x-on:blur="createTag()"
@@ -68,7 +68,7 @@
                                 x-on:click="deleteTag(tag)"
                             @endunless
                             type="button"
-                            x-bind:dusk="filament.'{{ $getStatePath() }}' + '.tag.' + tag + '.delete'"
+                            x-bind:dusk="filament.forms.'{{ $getStatePath() }}' + '.tag.' + tag + '.delete'"
                             @class([
                                 'inline-flex items-center justify-center min-h-6 px-2 py-0.5 text-sm font-medium tracking-tight text-primary-700 rounded-xl bg-primary-500/10 space-x-1 rtl:space-x-reverse',
                                 'dark:text-primary-500' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -35,7 +35,7 @@
                         list="{{ $getId() }}-suggestions"
                         {!! $getPlaceholder() ? 'placeholder="' . $getPlaceholder() . '"' : null !!}
                         type="text"
-                        dusk="{{ $getStatePath() }}"
+                        dusk="filament.{{ $getStatePath() }}"
                         x-on:keydown.enter.stop.prevent="createTag()"
                         x-on:keydown.,.stop.prevent="createTag()"
                         x-on:blur="createTag()"
@@ -68,7 +68,7 @@
                                 x-on:click="deleteTag(tag)"
                             @endunless
                             type="button"
-                            x-bind:dusk="'{{ $getStatePath() }}' + '.tag.' + tag + '.delete'"
+                            x-bind:dusk="filament.'{{ $getStatePath() }}' + '.tag.' + tag + '.delete'"
                             @class([
                                 'inline-flex items-center justify-center min-h-6 px-2 py-0.5 text-sm font-medium tracking-tight text-primary-700 rounded-xl bg-primary-500/10 space-x-1 rtl:space-x-reverse',
                                 'dark:text-primary-500' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -39,7 +39,7 @@
                     wire:ignore
                     {{ $getExtraAlpineAttributeBag() }}
                 @endunless
-                dusk="filament.{{ $getStatePath() }}"
+                dusk="filament.forms.{{ $getStatePath() }}"
                 {!! ($autocapitalize = $getAutocapitalize()) ? "autocapitalize=\"{$autocapitalize}\"" : null !!}
                 {!! ($autocomplete = $getAutocomplete()) ? "autocomplete=\"{$autocomplete}\"" : null !!}
                 {!! $isAutofocused() ? 'autofocus' : null !!}

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -39,6 +39,7 @@
                     wire:ignore
                     {{ $getExtraAlpineAttributeBag() }}
                 @endunless
+                dusk="{{ $getStatePath() }}"
                 {!! ($autocapitalize = $getAutocapitalize()) ? "autocapitalize=\"{$autocapitalize}\"" : null !!}
                 {!! ($autocomplete = $getAutocomplete()) ? "autocomplete=\"{$autocomplete}\"" : null !!}
                 {!! $isAutofocused() ? 'autofocus' : null !!}

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -39,7 +39,7 @@
                     wire:ignore
                     {{ $getExtraAlpineAttributeBag() }}
                 @endunless
-                dusk="{{ $getStatePath() }}"
+                dusk="filament.{{ $getStatePath() }}"
                 {!! ($autocapitalize = $getAutocapitalize()) ? "autocapitalize=\"{$autocapitalize}\"" : null !!}
                 {!! ($autocomplete = $getAutocomplete()) ? "autocomplete=\"{$autocomplete}\"" : null !!}
                 {!! $isAutofocused() ? 'autofocus' : null !!}

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -15,7 +15,7 @@
         {!! ($cols = $getCols()) ? "cols=\"{$cols}\"" : null !!}
         {!! $isDisabled() ? 'disabled' : null !!}
         id="{{ $getId() }}"
-        dusk="filament.{{ $getStatePath() }}"
+        dusk="filament.forms.{{ $getStatePath() }}"
         {!! filled($length = $getMaxLength()) ? "maxlength=\"{$length}\"" : null !!}
         {!! filled($length = $getMinLength()) ? "minlength=\"{$length}\"" : null !!}
         {!! ($placeholder = $getPlaceholder()) ? "placeholder=\"{$placeholder}\"" : null !!}

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -15,7 +15,7 @@
         {!! ($cols = $getCols()) ? "cols=\"{$cols}\"" : null !!}
         {!! $isDisabled() ? 'disabled' : null !!}
         id="{{ $getId() }}"
-        dusk="{{ $getStatePath() }}"
+        dusk="filament.{{ $getStatePath() }}"
         {!! filled($length = $getMaxLength()) ? "maxlength=\"{$length}\"" : null !!}
         {!! filled($length = $getMinLength()) ? "minlength=\"{$length}\"" : null !!}
         {!! ($placeholder = $getPlaceholder()) ? "placeholder=\"{$placeholder}\"" : null !!}

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -15,6 +15,7 @@
         {!! ($cols = $getCols()) ? "cols=\"{$cols}\"" : null !!}
         {!! $isDisabled() ? 'disabled' : null !!}
         id="{{ $getId() }}"
+        dusk="{{ $getStatePath() }}"
         {!! filled($length = $getMaxLength()) ? "maxlength=\"{$length}\"" : null !!}
         {!! filled($length = $getMinLength()) ? "minlength=\"{$length}\"" : null !!}
         {!! ($placeholder = $getPlaceholder()) ? "placeholder=\"{$placeholder}\"" : null !!}

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -24,7 +24,7 @@
                 {!! $isAutofocused() ? 'autofocus' : null !!}
                 {!! $isDisabled() ? 'disabled' : null !!}
                 id="{{ $getId() }}"
-                dusk="{{ $getStatePath() }}"
+                dusk="filament.{{ $getStatePath() }}"
                 type="button"
                 {{ $attributes->merge($getExtraAttributes())->class([
                     'relative inline-flex shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-500 filament-forms-toggle-component',

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -24,7 +24,7 @@
                 {!! $isAutofocused() ? 'autofocus' : null !!}
                 {!! $isDisabled() ? 'disabled' : null !!}
                 id="{{ $getId() }}"
-                dusk="filament.{{ $getStatePath() }}"
+                dusk="filament.forms.{{ $getStatePath() }}"
                 type="button"
                 {{ $attributes->merge($getExtraAttributes())->class([
                     'relative inline-flex shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-500 filament-forms-toggle-component',

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -24,6 +24,7 @@
                 {!! $isAutofocused() ? 'autofocus' : null !!}
                 {!! $isDisabled() ? 'disabled' : null !!}
                 id="{{ $getId() }}"
+                dusk="{{ $getStatePath() }}"
                 type="button"
                 {{ $attributes->merge($getExtraAttributes())->class([
                     'relative inline-flex shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-500 filament-forms-toggle-component',


### PR DESCRIPTION
This adds `dusk="{{ $getStatePath() }}"` selectors to most form components, so that developers can more easily use the components in Dusk tests.

Below are a few examples:

```php
$browser
    // TextInputs & TextArea..
    ->type('@data.code', 'CODE')
    ->type('@data.description', 'Description.')
    ->type('@data.reuse_count', 2)
    // DatePicker...
    ->click('@data.start_at.open')
    ->screenshot('Opening picker')
    // January is month '0', so month '1' is February.
    ->select('@data.start_at.focusedMonth', '1')
    ->type('@data.start_at.focusedYear', '2023')
    ->click('@data.start_at.focusedDate.28')
    ->screenshot('After picking date')
    // Closing DatePicker by clicking somewhere..
    ->clickAtPoint(1, 1)
```

I must admit that I haven't been able to test every selector yet (though I tested most of them). That's why I didn't add anything to the docs about it yet. Most likely I'll be doing some more browser testing the coming weeks, so if I find a selector that needs an update, of course I'll PR that.

I choose for using the statepath, because the statepath maps directly to how the values of an input are stored in Livewire. Theoretically, if two components have the same statepath, their values in Livewire must always be the same. For the other part, developers should be smart enough to open up their browser inspector and figure out that everything starts with `data.` or whatever statepath they had choosen.