### PR TITLE
Specify pluralization intervals

### DIFF
--- a/packages/tables/resources/lang/ms/table.php
+++ b/packages/tables/resources/lang/ms/table.php
@@ -107,7 +107,7 @@ return [
 
     'selection_indicator' => [
 
-        'selected_count' => '1 rekod dipilih.|:count rekod yang dipilih.',
+        'selected_count' => '{1} 1 rekod dipilih.|[2,*] :count rekod yang dipilih.',
 
         'buttons' => [
 

--- a/packages/tables/resources/lang/tr/table.php
+++ b/packages/tables/resources/lang/tr/table.php
@@ -107,7 +107,7 @@ return [
 
     'selection_indicator' => [
 
-        'selected_count' => '1 kayıt seçildi.|:count kayıt seçildi.',
+        'selected_count' => '{1} 1 kayıt seçildi.|[2,*] :count kayıt seçildi.',
 
         'buttons' => [
 


### PR DESCRIPTION
Languages that don't exist in Symfony's [getPluralizationRule function](https://github.com/symfony/translation-contracts/blob/main/TranslatorTrait.php#L139) always return the singular translation for trans_choice() function. So it's needed to specify intervals.