### PR TITLE
fix: Default sort with anonymous column

### DIFF
--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -64,13 +64,15 @@ trait CanSortRecords
             return $query;
         }
 
+        $direction = $this->tableSortDirection ?? 'asc';
+
         $column = $this->getCachedTableColumn($columnName);
 
         if (! $column) {
-            return $query;
+            return $query->orderBy($columnName, $direction);
         }
 
-        $column->applySort($query, $this->tableSortDirection ?? 'asc');
+        $column->applySort($query, $direction);
 
         return $query;
     }


### PR DESCRIPTION
You can now apply a `defaultSort()` with a column that does not exist in the table.