### PR TITLE
Fix custom order in HasManyRepeater

### DIFF
--- a/packages/forms/src/Components/RelationshipRepeater.php
+++ b/packages/forms/src/Components/RelationshipRepeater.php
@@ -40,7 +40,7 @@ class RelationshipRepeater extends Repeater
             $recordsToDelete = [];
 
             foreach ($existingRecords->pluck($localKeyName) as $keyToCheckForDeletion) {
-                if (array_key_exists('id-'.$keyToCheckForDeletion, $state)) {
+                if (array_key_exists("record-{$keyToCheckForDeletion}", $state)) {
                     continue;
                 }
 
@@ -136,7 +136,7 @@ class RelationshipRepeater extends Repeater
         $localKeyName = $relationship->getLocalKeyName();
 
         return $this->cachedExistingRecords = $relationship->getResults()->mapWithKeys(
-            fn ($item) => ['id-'.$item[$localKeyName] => $item],
+            fn (Model $item): array => ["record-{$item[$localKeyName]}" => $item],
         );
     }
 

--- a/packages/forms/src/Components/RelationshipRepeater.php
+++ b/packages/forms/src/Components/RelationshipRepeater.php
@@ -40,7 +40,7 @@ class RelationshipRepeater extends Repeater
             $recordsToDelete = [];
 
             foreach ($existingRecords->pluck($localKeyName) as $keyToCheckForDeletion) {
-                if (array_key_exists($keyToCheckForDeletion, $state)) {
+                if (array_key_exists('id-'.$keyToCheckForDeletion, $state)) {
                     continue;
                 }
 
@@ -133,9 +133,10 @@ class RelationshipRepeater extends Repeater
         }
 
         $relationship = $this->getRelationship();
+        $localKeyName = $relationship->getLocalKeyName();
 
-        return $this->cachedExistingRecords = $relationship->getResults()->keyBy(
-            $relationship->getLocalKeyName(),
+        return $this->cachedExistingRecords = $relationship->getResults()->mapWithKeys(
+            fn ($item) => ['id-'.$item[$localKeyName] => $item],
         );
     }
 


### PR DESCRIPTION
Possible fix for https://github.com/laravel-filament/filament/issues/1816

Livewire re-orders numerically indexed array keys, breaking the order of repeater items that aren't ordered by ascending ID. This changes the array to an associative array, preventing that. See https://github.com/laravel-filament/filament/issues/1816#issuecomment-1060925406

From initial testing this appears to be all that's necessary to fix this with no side effects that I can see. Creating, updating and deleting items all work as expected. But I may well have missed something!