### PR TITLE
docs: Update StatsOverviewWidget command

### DIFF
--- a/packages/admin/docs/04-dashboard.md
+++ b/packages/admin/docs/04-dashboard.md
@@ -44,7 +44,7 @@ Filament comes with a "stats overview" widget template, which you can use to dis
 Start by creating a widget with the command:
 
 ```bash
-php artisan make:filament-widget StatsOverview
+php artisan make:filament-widget StatsOverviewWidget
 ```
 
 You can delete the generated view file, as we're using a template.


### PR DESCRIPTION
`php artisan make:filament-widget StatsOverview` will create `StatsOverview.php` but the example class is named `StatsOverviewWidget` so it causes an issue with autoloading.