### PR TITLE
Fix issue with from() method in Input Mask

### DIFF
--- a/packages/forms/src/Components/TextInput/Mask.php
+++ b/packages/forms/src/Components/TextInput/Mask.php
@@ -280,7 +280,7 @@ class Mask implements Jsonable
         }
 
         if ($this->fromValue !== null) {
-            $configuration['from'] = $this->toValue;
+            $configuration['from'] = $this->fromValue;
         }
 
         if (! $this->hasLazyPlaceholder) {


### PR DESCRIPTION
Fixing a typo that was preventing the `from()` method from working properly in an Input Mask range.