### PR TITLE
Can format date/datetime/time column with tz

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -13,22 +13,22 @@ trait CanFormatState
     protected ?Closure $formatStateUsing = null;
 
 
-    public function date(?string $format = null,?string $tz = null): static
+    public function date(?string $format = null, ?string $timezone = null): static
     {
         $format ??= config('tables.date_format');
 
-        $tz ??= config('app.timezone');
+        $timezone ??= config('app.timezone');
 
-        $this->formatStateUsing(fn ($state): ?string => $state ? Carbon::parse($state)->setTimezone($tz)->translatedFormat($format) : null);
+        $this->formatStateUsing(fn ($state): ?string => $state ? Carbon::parse($state)->setTimezone($timezone)->translatedFormat($format) : null);
 
         return $this;
     }
 
-    public function dateTime(?string $format = null,?string $tz = null): static
+    public function dateTime(?string $format = null, ?string $timezone = null): static
     {
         $format ??= config('tables.date_time_format');
 
-        $this->date($format,$tz);
+        $this->date($format, $timezone);
 
         return $this;
     }
@@ -90,11 +90,11 @@ trait CanFormatState
         return $state;
     }
 
-    public function time(?string $format = null,?string $tz = null): static
+    public function time(?string $format = null, ?string $timezone = null): static
     {
         $format ??= config('tables.time_format');
 
-        $this->date($format,$tz);
+        $this->date($format, $timezone);
 
         return $this;
     }

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -12,20 +12,23 @@ trait CanFormatState
 {
     protected ?Closure $formatStateUsing = null;
 
-    public function date(?string $format = null): static
+
+    public function date(?string $format = null,?string $tz = null): static
     {
         $format ??= config('tables.date_format');
 
-        $this->formatStateUsing(fn ($state): ?string => $state ? Carbon::parse($state)->translatedFormat($format) : null);
+        $tz ??= config('app.timezone');
+
+        $this->formatStateUsing(fn ($state): ?string => $state ? Carbon::parse($state)->setTimezone($tz)->translatedFormat($format) : null);
 
         return $this;
     }
 
-    public function dateTime(?string $format = null): static
+    public function dateTime(?string $format = null,?string $tz = null): static
     {
         $format ??= config('tables.date_time_format');
 
-        $this->date($format);
+        $this->date($format,$tz);
 
         return $this;
     }
@@ -87,11 +90,11 @@ trait CanFormatState
         return $state;
     }
 
-    public function time(?string $format = null): static
+    public function time(?string $format = null,?string $tz = null): static
     {
         $format ??= config('tables.time_format');
 
-        $this->date($format);
+        $this->date($format,$tz);
 
         return $this;
     }


### PR DESCRIPTION
This enable format column with custom timezone or if not defined used config app.timezone ( default at UTC) 

```
    TextColumn::make('updated_at')
                ->label("Updated at")              
                ->dateTime('d/m/Y H:i:s','Europe/Rome')
```