### PR TITLE
Fix  overwrite on tables w/ multiple filters using  method

### DIFF
--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -60,7 +60,7 @@ trait HasFilters
     {
         $data = $this->getTableFiltersForm()->getState();
 
-        return $query->where(function (Builder $query) use ($data) {
+        return $query->where(function () use ($query, $data) {
             foreach ($this->getCachedTableFilters() as $filter) {
                 $filter->apply(
                     $query,


### PR DESCRIPTION
Hey @danharrin I'm really enjoying Filament on a current project and thus far have only run into this one issue for which I _hope_ I've provided the proper solution.

The steps to reproduce this are: 
* Add a multiple filters to a table that each use the `->query()` method. 
* In each query, apply a join.
* With Xdebug on:
    * lines 18 and 20 of HasRecords.php 
    * line 65 of HasFilters.php
    * lines 26 and 29 of InteractsWithTableQuery.php 
    you can see that the joins are dropped once the loop is exited. 

I believe this is because the $query is re-instantiated entering the `->where()` method. I'm not 100%, but when I experimented by passing the $query object through in the `use` clause, it solved the issue. 

Hope this helps. 