### PR TITLE
Auto detect redirect from Livewire response

### DIFF
--- a/packages/admin/docs/03-pages.md
+++ b/packages/admin/docs/03-pages.md
@@ -194,12 +194,6 @@ There are four types of notifications available, each with a different color and
  - `success` - for success messages.
  - `warning` - for reporting non-critical issues.
 
-By default, notifications will be sent to the user immediately. If you'd like to wait until a redirect is complete, you can use the `isAfterRedirect` argument:
-
-```php
-$this->notify('success', 'Created', isAfterRedirect: true);
-```
-
 Alternatively, you can call `Filament::notify()` from anywhere in your app, and pass the same arguments:
 
 ```php

--- a/packages/admin/resources/views/components/notification-manager.blade.php
+++ b/packages/admin/resources/views/components/notification-manager.blade.php
@@ -1,6 +1,6 @@
 <div
     x-data="{
-        notifications: {{ Js::from(session()->pull('notifications', [])) }},
+        notifications: @js(session()->pull('notifications', [])),
         add (event) {
             this.notifications = this.notifications.concat(event.detail)
         },

--- a/packages/admin/resources/views/components/notification-manager.blade.php
+++ b/packages/admin/resources/views/components/notification-manager.blade.php
@@ -2,13 +2,7 @@
     x-data="{
         notifications: {{ Js::from(session()->pull('notifications', [])) }},
         add (event) {
-            for (let notification of event.detail) {
-                this.notifications.push({
-                    id: notification.id,
-                    status: notification.status,
-                    message: notification.message,
-                })
-            }
+            this.notifications = this.notifications.concat(event.detail)
         },
         remove: function (notification) {
             this.notifications = this.notifications.filter(i => i.id !== notification.id)

--- a/packages/admin/resources/views/components/notification-manager.blade.php
+++ b/packages/admin/resources/views/components/notification-manager.blade.php
@@ -1,8 +1,14 @@
 <div
     x-data="{
-        notifications: {{ json_encode(session()->pull('notifications', [])) }},
-        add: function (event) {
-            this.notifications.push(event.detail)
+        notifications: {{ Js::from(session()->pull('notifications', [])) }},
+        add (event) {
+            for (let notification of event.detail) {
+                this.notifications.push({
+                    id: notification.id,
+                    status: notification.status,
+                    message: notification.message,
+                })
+            }
         },
         remove: function (notification) {
             this.notifications = this.notifications.filter(i => i.id !== notification.id)

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -11,11 +11,9 @@ use Filament\Models\Contracts\HasAvatar;
 use Filament\Models\Contracts\HasName;
 use Filament\Navigation\UserMenuItem;
 use Illuminate\Contracts\Auth\Guard;
-use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
-use Livewire\Component;
 
 class FilamentManager
 {

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -15,7 +15,6 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Str;
 use Livewire\Component;
 
 class FilamentManager
@@ -163,28 +162,7 @@ class FilamentManager
 
     public function notify(string $status, string $message, bool $isAfterRedirect = false): void
     {
-        if ($isAfterRedirect) {
-            session()->push('notifications', [
-                'id' => Str::random(),
-                'status' => $status,
-                'message' => $message,
-            ]);
-
-            return;
-        }
-
-        try {
-            /** @var \Livewire\Component $component */
-            $component = app(Component::class);
-        } catch (BindingResolutionException $exception) {
-            return;
-        }
-
-        $component->dispatchBrowserEvent('notify', [
-            'id' => Str::random(),
-            'status' => $status,
-            'message' => $message,
-        ]);
+        NotificationManager::notify($status, $message);
     }
 
     public function getGlobalSearchProvider(): GlobalSearchProvider

--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -104,6 +104,8 @@ class FilamentServiceProvider extends PackageServiceProvider
             $this->app->singleton(Component::class, fn () => $component);
         });
 
+        Livewire::listen('component.dehydrate', [NotificationManager::class, 'handleLivewireResponses']);
+
         Livewire::component('filament.core.auth.login', Login::class);
         Livewire::component('filament.core.global-search', GlobalSearch::class);
         Livewire::component('filament.core.pages.dashboard', Dashboard::class);

--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -100,10 +100,6 @@ class FilamentServiceProvider extends PackageServiceProvider
             MirrorConfigToSubpackages::class,
         ]);
 
-        Livewire::listen('component.hydrate', function ($component) {
-            $this->app->singleton(Component::class, fn () => $component);
-        });
-
         Livewire::listen('component.dehydrate', [NotificationManager::class, 'handleLivewireResponses']);
 
         Livewire::component('filament.core.auth.login', Login::class);

--- a/packages/admin/src/Http/Livewire/Concerns/CanNotify.php
+++ b/packages/admin/src/Http/Livewire/Concerns/CanNotify.php
@@ -8,6 +8,6 @@ trait CanNotify
 {
     public function notify(string $status, string $message, bool $isAfterRedirect = false): void
     {
-        Filament::notify($status, $message, $isAfterRedirect);
+        Filament::notify($status, $message);
     }
 }

--- a/packages/admin/src/NotificationManager.php
+++ b/packages/admin/src/NotificationManager.php
@@ -3,10 +3,11 @@
 namespace Filament;
 
 use Livewire\Response;
+use Livewire\Component;
 
 class NotificationManager
 {
-    protected static $notifications = [];
+    protected static array $notifications = [];
 
     public static function notify(string $status, string $message): void
     {
@@ -16,16 +17,16 @@ class NotificationManager
             'message' => $message,
         ]);
 
-        self::$notifications = session()->get('notifications');
+        static::$notifications = session()->get('notifications');
     }
 
-    public static function handleLivewireResponses($component, Response $response): Response
+    public static function handleLivewireResponses(Component $component, Response $response): Response
     {
         if ($component->redirectTo !== null) {
             return $response;
         }
 
-        $notifications = self::$notifications;
+        $notifications = static::$notifications;
 
         if (count($notifications) > 0) {
             $component->dispatchBrowserEvent('notify', $notifications);

--- a/packages/admin/src/NotificationManager.php
+++ b/packages/admin/src/NotificationManager.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Filament;
+
+use Livewire\Response;
+
+class NotificationManager
+{
+    protected static $notifications = [];
+
+    public static function notify(string $status, string $message): void
+    {
+        session()->push('notifications', [
+            'id' => uniqid(),
+            'status' => $status,
+            'message' => $message,
+        ]);
+
+        self::$notifications = session()->get('notifications');
+    }
+
+    public static function handleLivewireResponses($component, Response $response): Response
+    {
+        if ($component->redirectTo !== null) {
+            return $response;
+        }
+
+        $notifications = self::$notifications;
+
+        if (count($notifications) > 0) {
+            $component->dispatchBrowserEvent('notify', $notifications);
+        }
+
+        return $response;
+    }
+}

--- a/packages/admin/src/NotificationManager.php
+++ b/packages/admin/src/NotificationManager.php
@@ -2,8 +2,8 @@
 
 namespace Filament;
 
-use Livewire\Response;
 use Livewire\Component;
+use Livewire\Response;
 
 class NotificationManager
 {

--- a/tests/src/Admin/Fixtures/Pages/Settings.php
+++ b/tests/src/Admin/Fixtures/Pages/Settings.php
@@ -7,4 +7,13 @@ use Filament\Pages\Page;
 class Settings extends Page
 {
     protected static string $view = 'fixtures.pages.settings';
+
+    public function notificationManager(bool $redirect = false)
+    {
+        if ($redirect) {
+            $this->redirect('/');
+        }
+
+        $this->notify('success', 'Foobar!');
+    }
 }

--- a/tests/src/Admin/NotificationManager/NotificationManagerServiceProvider.php
+++ b/tests/src/Admin/NotificationManager/NotificationManagerServiceProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Filament\Tests\Admin\NotificationManager;
+
+use Filament\PluginServiceProvider;
+use Filament\Tests\Admin\Fixtures\Pages\Settings;
+
+class NotificationManagerServiceProvider extends PluginServiceProvider
+{
+    public static string $name = 'notification-manager';
+
+    protected function getPages(): array
+    {
+        return [
+            Settings::class,
+        ];
+    }
+}

--- a/tests/src/Admin/NotificationManager/NotificationManagerTest.php
+++ b/tests/src/Admin/NotificationManager/NotificationManagerTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Livewire\Livewire;
 use Filament\Tests\Admin\Fixtures\Pages\Settings;
 use Filament\Tests\Admin\NotificationManager\TestCase;
 use Illuminate\Support\Facades\Session;
+use Livewire\Livewire;
 
 uses(TestCase::class);
 

--- a/tests/src/Admin/NotificationManager/NotificationManagerTest.php
+++ b/tests/src/Admin/NotificationManager/NotificationManagerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Livewire\Livewire;
+use Filament\Tests\Admin\Fixtures\Pages\Settings;
+use Filament\Tests\Admin\NotificationManager\TestCase;
+use Illuminate\Support\Facades\Session;
+
+uses(TestCase::class);
+
+it('adds notifications to the session', function () {
+    Livewire::test(Settings::class)
+        ->call('notificationManager');
+
+    expect(Session::get('notifications'))
+        ->toBeArray()
+        ->toHaveLength(1)
+        ->sequence(
+            fn ($notification) => $notification->message->toBe('Foobar!')
+        );
+});
+
+it('can automatically dispatch notify event to browser', function () {
+    Livewire::test(Settings::class)
+        ->call('notificationManager')
+        ->assertDispatchedBrowserEvent('notify');
+});
+
+it('will not dispatch notify event if Livewire component redirects', function () {
+    Livewire::test(Settings::class)
+        ->call('notificationManager', redirect: true)
+        ->assertNotDispatchedBrowserEvent('notify');
+});

--- a/tests/src/Admin/NotificationManager/NotificationManagerTest.php
+++ b/tests/src/Admin/NotificationManager/NotificationManagerTest.php
@@ -19,7 +19,7 @@ it('adds notifications to the session', function () {
         );
 });
 
-it('can automatically dispatch notify event to browser', function () {
+it('can immediately dispatch notify event to browser', function () {
     Livewire::test(Settings::class)
         ->call('notificationManager')
         ->assertDispatchedBrowserEvent('notify');

--- a/tests/src/Admin/NotificationManager/TestCase.php
+++ b/tests/src/Admin/NotificationManager/TestCase.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Tests\Admin\NotificationManager;
 
-use Filament\Tests\Admin\NotificationManager\NotificationManagerServiceProvider;
 use Filament\Tests\Models\User;
 use Filament\Tests\TestCase as BaseTestCase;
 

--- a/tests/src/Admin/NotificationManager/TestCase.php
+++ b/tests/src/Admin/NotificationManager/TestCase.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Filament\Tests\Admin\NotificationManager;
+
+use Filament\Tests\Admin\NotificationManager\NotificationManagerServiceProvider;
+use Filament\Tests\Models\User;
+use Filament\Tests\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->actingAs(User::factory()->create());
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return array_merge(parent::getPackageProviders($app), [
+            NotificationManagerServiceProvider::class,
+        ]);
+    }
+}


### PR DESCRIPTION
The solution I came up with for auto-detecting redirects for notification. It checks the Livewire response for a redirect. 
I tested this with the demo app with saving, saving with redirect and saving from a modal.

Disclaimer: I have no idea why this doesn't flash messages sent via Browserevent two times, but it somehow works 😅

What do you think? And would you want to deprecate that `isAfterRedirect` param? I thought about `#[Deprecated]` but that is PhpStorm specific. Alternatively we could trigger a deprecation error.
