### PR TITLE
Badges for navigation items

### DIFF
--- a/packages/admin/docs/05-navigation.md
+++ b/packages/admin/docs/05-navigation.md
@@ -4,7 +4,7 @@ title: Navigation
 
 ## Getting started
 
-By default, Filament will register navigation items for each of your [resources](resources) and [custom pages](pages). These classes contain static properties that you can override, to configure that navigation item and its order:
+By default, Filament will register navigation items for each of your [resources](resources) and [custom pages](pages). These classes contain static properties and methods that you can override, to configure that navigation item and its order:
 
 ```php
 protected static ?string $navigationIcon = 'heroicon-o-document-text';
@@ -12,6 +12,11 @@ protected static ?string $navigationIcon = 'heroicon-o-document-text';
 protected static ?string $navigationLabel = 'Custom Navigation Label';
 
 protected static ?int $navigationSort = 3;
+
+protected static function getNavigationBadge(): ?string
+{
+    return self::getModel()::count();
+}
 ```
 
 The `$navigationIcon` supports the name of any Blade component, and passes a set of formatting classes to it. By default, the [Blade Heroicons](https://github.com/blade-ui-kit/blade-heroicons) package is installed, so you may use the name of any [Heroicon](https://heroicons.com) out of the box. However, you may create your own custom icon components or install an alternative library if you wish.

--- a/packages/admin/docs/05-navigation.md
+++ b/packages/admin/docs/05-navigation.md
@@ -15,7 +15,7 @@ protected static ?int $navigationSort = 3;
 
 protected static function getNavigationBadge(): ?string
 {
-    return self::getModel()::count();
+    return static::getModel()::count();
 }
 ```
 

--- a/packages/admin/docs/05-navigation.md
+++ b/packages/admin/docs/05-navigation.md
@@ -62,6 +62,7 @@ public static function getNavigationItems(): array
             ->icon($icon)
             ->isActiveWhen($closure)
             ->label($label)
+            ->badge($badge)
             ->sort($sort)
             ->url($url),
     ];

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -27,6 +27,7 @@
                             :active="$item->isActive()"
                             :icon="$item->getIcon()"
                             :url="$item->getUrl()"
+                            :badge="$item->getBadge()"
                         >
                             {{ $item->getLabel() }}
                         </x-filament::layouts.app.sidebar.item>

--- a/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
@@ -25,8 +25,9 @@
             <span
                 @class([
                     'inline-flex items-center justify-center ml-auto min-h-4 px-2 py-0.5 text-xs font-medium tracking-tight rounded-xl whitespace-normal',
-                    'text-primary-700 bg-primary-500/10',
-                    'dark:text-primary-500' => config('filament.dark_mode'),
+                    'text-primary-700 bg-primary-500/20' => ! $active,
+                    'text-white bg-white/20' => $active,
+                    'dark:text-primary-500' => (! $active) && config('filament.dark_mode'),
                 ])>
                 {{ $badge }}
             </span>

--- a/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
@@ -1,5 +1,6 @@
 @props([
     'active' => false,
+    'badge',
     'icon',
     'url',
 ])
@@ -19,5 +20,16 @@
         <span>
             {{ $slot }}
         </span>
+
+        @if(filled($badge))
+            <span
+                @class([
+                    'inline-flex items-center justify-center ml-auto min-h-4 px-2 py-0.5 text-xs font-medium tracking-tight rounded-xl whitespace-normal',
+                    'text-primary-700 bg-primary-500/10',
+                    'dark:text-primary-500' => config('filament.dark_mode'),
+                ])>
+                {{ $badge }}
+            </span>
+        @endif
     </a>
 </li>

--- a/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
@@ -21,14 +21,15 @@
             {{ $slot }}
         </span>
 
-        @if(filled($badge))
+        @if (filled($badge))
             <span
                 @class([
                     'inline-flex items-center justify-center ml-auto min-h-4 px-2 py-0.5 text-xs font-medium tracking-tight rounded-xl whitespace-normal',
                     'text-primary-700 bg-primary-500/20' => ! $active,
                     'text-white bg-white/20' => $active,
                     'dark:text-primary-500' => (! $active) && config('filament.dark_mode'),
-                ])>
+                ])
+            >
                 {{ $badge }}
             </span>
         @endif

--- a/packages/admin/src/Navigation/NavigationItem.php
+++ b/packages/admin/src/Navigation/NavigationItem.php
@@ -14,6 +14,8 @@ class NavigationItem
 
     protected string $label;
 
+    protected ?string $badge = null;
+
     protected ?int $sort = null;
 
     protected ?string $url = null;
@@ -55,6 +57,13 @@ class NavigationItem
         return $this;
     }
 
+    public function badge(?string $badge): static
+    {
+        $this->badge = $badge;
+
+        return $this;
+    }
+
     public function sort(?int $sort): static
     {
         $this->sort = $sort;
@@ -82,6 +91,11 @@ class NavigationItem
     public function getLabel(): string
     {
         return $this->label;
+    }
+
+    public function getBadge(): ?string
+    {
+        return $this->badge;
     }
 
     public function getSort(): int

--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -55,6 +55,7 @@ class Page extends Component implements Forms\Contracts\HasForms
                 ->isActiveWhen(fn (): bool => request()->routeIs(static::getRouteName()))
                 ->label(static::getNavigationLabel())
                 ->sort(static::getNavigationSort())
+                ->badge(static::getNavigationBadge())
                 ->url(static::getNavigationUrl()),
         ];
     }
@@ -121,6 +122,11 @@ class Page extends Component implements Forms\Contracts\HasForms
             ->kebab()
             ->replace('-', ' ')
             ->title();
+    }
+
+    protected static function getNavigationBadge(): ?string
+    {
+        return null;
     }
 
     protected static function getNavigationSort(): ?int

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -73,6 +73,7 @@ class Resource
                 ->icon(static::getNavigationIcon())
                 ->isActiveWhen(fn () => request()->routeIs("{$routeBaseName}.*"))
                 ->label(static::getNavigationLabel())
+                ->badge(static::getNavigationBadge())
                 ->sort(static::getNavigationSort())
                 ->url(static::getNavigationUrl()),
         ];
@@ -358,6 +359,11 @@ class Resource
     protected static function getNavigationLabel(): string
     {
         return static::$navigationLabel ?? Str::title(static::getPluralLabel());
+    }
+
+    protected static function getNavigationBadge(): ?string
+    {
+        return null;
     }
 
     protected static function getNavigationSort(): ?int


### PR DESCRIPTION
Allow users to set a badge on the navigation items. This could be helpful for showing resources that require an action like a reminder resource.

Usage on resources could look like this:
```php
    public static function getNavigationItems(): array
    {
        [$item] = parent::getNavigationItems();
        $item->badge(Reminder::where('is_open')->count());
        return [$item];
    }
```

This is how it looks. I used the styles from the badge column.

![Bildschirmfoto 2022-03-10 um 23 13 58](https://user-images.githubusercontent.com/22632550/157764209-e76edf86-7790-42f9-a39f-2924628bf808.png)

![Bildschirmfoto 2022-03-10 um 23 22 12](https://user-images.githubusercontent.com/22632550/157764768-ae709409-705a-4d8d-9b98-6e381bc73d65.png)


