### PR TITLE
[BUG] focusedYear null value

### DIFF
--- a/packages/forms/resources/js/components/date-time-picker.js
+++ b/packages/forms/resources/js/components/date-time-picker.js
@@ -116,11 +116,11 @@ export default (Alpine) => {
                 })
 
                 this.$watch('focusedYear', () => {
-                    if (this.focusedYear.length > 4) {
+                    if (this.focusedYear?.length > 4) {
                         this.focusedYear = this.focusedYear.substring(0, 4)
                     }
 
-                    if ((! this.focusedYear) || (this.focusedYear.length !== 4)) {
+                    if ((! this.focusedYear) || (this.focusedYear?.length !== 4)) {
                         return
                     }
 


### PR DESCRIPTION
I don't know how to replicate bug but if you try to use datetime in form, when save ( or reload state ) 
the input trigger error in javascript like this:

```
Uncaught TypeError: Cannot read properties of null (reading 'length')
    at eval (module.esm.js?cbbd:6149:32)
    at eval (module.esm.js?027e:2724:1)
```

i've added a simple optional chaining to property.

[Option chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining)