### PR TITLE
Added custom validation rule for minLength() and maxLength()

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeLengthConstrained.php
+++ b/packages/forms/src/Components/Concerns/CanBeLengthConstrained.php
@@ -3,6 +3,7 @@
 namespace Filament\Forms\Components\Concerns;
 
 use Closure;
+use Illuminate\Support\Facades\Validator;
 
 trait CanBeLengthConstrained
 {
@@ -12,12 +13,15 @@ trait CanBeLengthConstrained
 
     public function maxLength(int | Closure $length): static
     {
+        Validator::extend('max_length', fn ($attribute, $value, $parameters) =>  strlen((string) $value) <= $parameters[0], __('validation.max.string'));
+        Validator::replacer('max_length', fn ($message, $attribute, $rule, $parameters) =>  str_replace(':max', $parameters[0], $message));
+
         $this->maxLength = $length;
 
         $this->rule(function (): string {
             $length = $this->getMaxLength();
 
-            return "max:{$length}";
+            return "max_length:{$length}";
         });
 
         return $this;
@@ -25,12 +29,15 @@ trait CanBeLengthConstrained
 
     public function minLength(int | Closure $length): static
     {
+        Validator::extend('min_length', fn ($attribute, $value, $parameters) =>  strlen((string) $value) >= $parameters[0], __('validation.min.string'));
+        Validator::replacer('min_length', fn ($message, $attribute, $rule, $parameters) =>  str_replace(':min', $parameters[0], $message));
+
         $this->minLength = $length;
 
         $this->rule(function (): string {
             $length = $this->getMinLength();
 
-            return "min:{$length}";
+            return "min_length:{$length}";
         });
 
         return $this;


### PR DESCRIPTION
As you specified on the [documentation](https://filamentphp.com/docs/2.x/forms/fields#text-input) "min" and "max" rules behave differently for numeric inputs. So in order to fix that we can use the "digits_between" rule but it needs minimum and maximum values together. To solve this problem, we can extend the validator with a custom rule that parses value to a string and checks the length of it which is what actually laravel does in [validateDigitsBetween function.](https://github.com/laravel/framework/blob/c0f3ee8c8779d5cfb6bb3c37c93b84672e67f236/src/Illuminate/Validation/Concerns/ValidatesAttributes.php#L578) And for the message we can use the validation messages for "min" and "mix" rules not to add any message for all the languages. You may think it's laravel's behavior but we also have minValue() and maxValue() for inputs so it makes it confusing.