### PR TITLE
Added length() function for inputs

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -240,7 +240,7 @@ TextInput::make('domain')
 
 <img src="https://user-images.githubusercontent.com/41773797/147612784-5eb58d0f-5111-4db8-8f54-3b5c3e2cc80a.png">
 
-You may limit the length of the string by setting the `minLength()` and `maxLength()` methods. These methods add both frontend and backend validation:
+You may limit the length of the input by setting the `minLength()` and `maxLength()` methods. These methods add both frontend and backend validation:
 
 ```php
 use Filament\Forms\Components\TextInput;
@@ -251,6 +251,16 @@ TextInput::make('name')
 ```
 
 > When using `minLength()` or `maxLength()` with `numeric()`, be aware that the validation will apply to the value of the input instead of its length. This is in line with the behaviour of Laravel's `min` and `max` validation rules.
+
+You may also specify the exact length of the input by setting the `length()`. This method adds both frontend and backend validation:
+
+```php
+use Filament\Forms\Components\TextInput;
+
+TextInput::make('code')->length(8)
+```
+
+Internally, this uses the `size` rule by default, and the `digits` rule for numeric inputs.
 
 In addition, you may validate the minimum and maximum value of the input by setting the `minValue()` and `maxValue()` methods:
 

--- a/packages/forms/src/Components/Concerns/CanBeLengthConstrained.php
+++ b/packages/forms/src/Components/Concerns/CanBeLengthConstrained.php
@@ -4,11 +4,32 @@ namespace Filament\Forms\Components\Concerns;
 
 use Closure;
 
+
 trait CanBeLengthConstrained
 {
+    protected int | Closure | null $length = null;
+
     protected int | Closure | null $maxLength = null;
 
     protected int | Closure | null $minLength = null;
+
+    public function length(int | Closure $length): static
+    {
+        $this->length = $length;
+        $this->maxLength = $length;
+        $this->minLength = $length;
+
+        $this->rule(function (): string {
+            $length = $this->getLength();
+
+            if (method_exists($this, 'isNumeric') && $this->isNumeric())
+                return "digits:{$length}";
+
+            return "size:{$length}";
+        });
+
+        return $this;
+    }
 
     public function maxLength(int | Closure $length): static
     {
@@ -34,6 +55,11 @@ trait CanBeLengthConstrained
         });
 
         return $this;
+    }
+
+    public function getLength(): ?int
+    {
+        return $this->evaluate($this->length);
     }
 
     public function getMaxLength(): ?int

--- a/packages/forms/src/Components/Concerns/CanBeLengthConstrained.php
+++ b/packages/forms/src/Components/Concerns/CanBeLengthConstrained.php
@@ -3,7 +3,7 @@
 namespace Filament\Forms\Components\Concerns;
 
 use Closure;
-
+use Filament\Forms\Components\Contracts\CanHaveNumericState;
 
 trait CanBeLengthConstrained
 {
@@ -22,7 +22,7 @@ trait CanBeLengthConstrained
         $this->rule(function (): string {
             $length = $this->getLength();
 
-            if (method_exists($this, 'isNumeric') && $this->isNumeric()) {
+            if ($this instanceof CanHaveNumericState && $this->isNumeric()) {
                 return "digits:{$length}";
             }
 

--- a/packages/forms/src/Components/Concerns/CanBeLengthConstrained.php
+++ b/packages/forms/src/Components/Concerns/CanBeLengthConstrained.php
@@ -22,8 +22,9 @@ trait CanBeLengthConstrained
         $this->rule(function (): string {
             $length = $this->getLength();
 
-            if (method_exists($this, 'isNumeric') && $this->isNumeric())
+            if (method_exists($this, 'isNumeric') && $this->isNumeric()) {
                 return "digits:{$length}";
+            }
 
             return "size:{$length}";
         });

--- a/packages/forms/src/Components/Contracts/CanHaveNumericState.php
+++ b/packages/forms/src/Components/Contracts/CanHaveNumericState.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Filament\Forms\Components\Contracts;
+
+interface CanHaveNumericState
+{
+    public function isNumeric(): bool;
+}

--- a/packages/forms/src/Components/TextInput.php
+++ b/packages/forms/src/Components/TextInput.php
@@ -3,10 +3,11 @@
 namespace Filament\Forms\Components;
 
 use Closure;
+use Filament\Forms\Components\Contracts\CanHaveNumericState;
 use Filament\Forms\Components\TextInput\Mask;
 use Illuminate\Contracts\Support\Arrayable;
 
-class TextInput extends Field
+class TextInput extends Field implements CanHaveNumericState
 {
     use Concerns\CanBeAutocapitalized;
     use Concerns\CanBeAutocompleted;


### PR DESCRIPTION
Sometimes we need exact length for inputs. So instead of using minLength() and maxLength() together we can call length(). To validate, it uses "digits" for numeric inputs and "size" for strings. It just sets minLength and maxLength to the given value since HTML doesn't have an attribute for exact input length. But for numeric inputs, it looks like minlength and maxlength attributes don't work. It may also be fixed with some alpine logic.