### PR TITLE
Fix BelongsToSelect key with custom OptionLabel

### DIFF
--- a/packages/forms/src/Components/BelongsToManyCheckboxList.php
+++ b/packages/forms/src/Components/BelongsToManyCheckboxList.php
@@ -65,7 +65,9 @@ class BelongsToManyCheckboxList extends CheckboxList
             if ($component->hasOptionLabelFromRecordUsingCallback()) {
                 return $relationshipQuery
                     ->get()
-                    ->map(fn (Model $record) => $component->getOptionLabelFromRecord($record))
+                    ->map(fn (Model $record) => [
+                        $record->getKey() => $component->getOptionLabelFromRecord($record)
+                    ])
                     ->toArray();
             }
 

--- a/packages/forms/src/Components/BelongsToManyCheckboxList.php
+++ b/packages/forms/src/Components/BelongsToManyCheckboxList.php
@@ -65,8 +65,8 @@ class BelongsToManyCheckboxList extends CheckboxList
             if ($component->hasOptionLabelFromRecordUsingCallback()) {
                 return $relationshipQuery
                     ->get()
-                    ->map(fn (Model $record) => [
-                        $record->getKey() => $component->getOptionLabelFromRecord($record)
+                    ->mapWithKeys(fn (Model $record) => [
+                        $record->{$relationship->getRelatedKeyName()} => $component->getOptionLabelFromRecord($record)
                     ])
                     ->toArray();
             }

--- a/packages/forms/src/Components/BelongsToManyMultiSelect.php
+++ b/packages/forms/src/Components/BelongsToManyMultiSelect.php
@@ -71,7 +71,9 @@ class BelongsToManyMultiSelect extends MultiSelect
             if ($component->hasOptionLabelFromRecordUsingCallback()) {
                 return $relationshipQuery
                     ->get()
-                    ->map(fn (Model $record) => $component->getOptionLabelFromRecord($record))
+                    ->mapWithKeys(fn (Model $record) => [
+                        $record->{$relatedKeyName} => $component->getOptionLabelFromRecord($record)
+                    ])
                     ->toArray();
             }
 
@@ -108,7 +110,9 @@ class BelongsToManyMultiSelect extends MultiSelect
             if ($component->hasOptionLabelFromRecordUsingCallback()) {
                 return $relationshipQuery
                     ->get()
-                    ->map(fn (Model $record) => $component->getOptionLabelFromRecord($record))
+                    ->map(fn (Model $record) => [
+                        $record->getKey() => $component->getOptionLabelFromRecord($record)
+                    ])
                     ->toArray();
             }
 
@@ -135,7 +139,9 @@ class BelongsToManyMultiSelect extends MultiSelect
             if ($component->hasOptionLabelFromRecordUsingCallback()) {
                 return $relationshipQuery
                     ->get()
-                    ->map(fn (Model $record) => $component->getOptionLabelFromRecord($record))
+                    ->map(fn (Model $record) => [
+                        $record->getKey() => $component->getOptionLabelFromRecord($record)
+                    ])
                     ->toArray();
             }
 

--- a/packages/forms/src/Components/BelongsToManyMultiSelect.php
+++ b/packages/forms/src/Components/BelongsToManyMultiSelect.php
@@ -72,7 +72,7 @@ class BelongsToManyMultiSelect extends MultiSelect
                 return $relationshipQuery
                     ->get()
                     ->mapWithKeys(fn (Model $record) => [
-                        $record->getKey() => $component->getOptionLabelFromRecord($record)
+                        $record->{$relatedKeyName} => $component->getOptionLabelFromRecord($record)
                     ])
                     ->toArray();
             }

--- a/packages/forms/src/Components/BelongsToManyMultiSelect.php
+++ b/packages/forms/src/Components/BelongsToManyMultiSelect.php
@@ -72,7 +72,7 @@ class BelongsToManyMultiSelect extends MultiSelect
                 return $relationshipQuery
                     ->get()
                     ->mapWithKeys(fn (Model $record) => [
-                        $record->{$relatedKeyName} => $component->getOptionLabelFromRecord($record)
+                        $record->getKey() => $component->getOptionLabelFromRecord($record)
                     ])
                     ->toArray();
             }

--- a/packages/forms/src/Components/BelongsToSelect.php
+++ b/packages/forms/src/Components/BelongsToSelect.php
@@ -100,7 +100,7 @@ class BelongsToSelect extends Select
                 return $relationshipQuery
                     ->get()
                     ->mapWithKeys(fn (Model $record) => [
-                        $record->getKey() => $component->getOptionLabelFromRecord($record)
+                        $record->{$relationship->getOwnerKeyName()} => $component->getOptionLabelFromRecord($record)
                     ])
                     ->toArray();
             }

--- a/packages/forms/src/Components/BelongsToSelect.php
+++ b/packages/forms/src/Components/BelongsToSelect.php
@@ -99,7 +99,9 @@ class BelongsToSelect extends Select
             if ($component->hasOptionLabelFromRecordUsingCallback()) {
                 return $relationshipQuery
                     ->get()
-                    ->map(fn (Model $record) => $component->getOptionLabelFromRecord($record))
+                    ->mapWithKeys(fn (Model $record) => [
+                        $record->{$relationship->getOwnerKeyName()} => $component->getOptionLabelFromRecord($record)
+                    ])
                     ->toArray();
             }
 
@@ -126,7 +128,9 @@ class BelongsToSelect extends Select
             if ($component->hasOptionLabelFromRecordUsingCallback()) {
                 return $relationshipQuery
                     ->get()
-                    ->map(fn (Model $record) => $component->getOptionLabelFromRecord($record))
+                    ->mapWithKeys(fn (Model $record) => [
+                        $record->{$relationship->getOwnerKeyName()} => $component->getOptionLabelFromRecord($record)
+                    ])
                     ->toArray();
             }
 

--- a/packages/forms/src/Components/BelongsToSelect.php
+++ b/packages/forms/src/Components/BelongsToSelect.php
@@ -100,7 +100,7 @@ class BelongsToSelect extends Select
                 return $relationshipQuery
                     ->get()
                     ->mapWithKeys(fn (Model $record) => [
-                        $record->{$relationship->getOwnerKeyName()} => $component->getOptionLabelFromRecord($record)
+                        $record->getKey() => $component->getOptionLabelFromRecord($record)
                     ])
                     ->toArray();
             }


### PR DESCRIPTION
When using a custom OptionLabelFromRecord it used the collection id instead of model's id, fixed with mapWithKeys.