### PR TITLE
Custom modals stack

### DIFF
--- a/packages/admin/resources/views/components/page.blade.php
+++ b/packages/admin/resources/views/components/page.blade.php
@@ -72,5 +72,7 @@
 
     {{ $modals }}
 
+    @stack('modals')
+
     <x-filament::notification-manager />
 </div>


### PR DESCRIPTION
Adds modals stack to x-filament::page component to allow for pushing custom modals to the livewire component. See [related discussion](https://github.com/laravel-filament/filament/discussions/1778)