### PR TITLE
remove extra `!` from pt_BR translation

### DIFF
--- a/packages/admin/resources/lang/pt_BR/resources/pages/list-records.php
+++ b/packages/admin/resources/lang/pt_BR/resources/pages/list-records.php
@@ -61,7 +61,7 @@ return [
                     'actions' => [
 
                         'save' => [
-                            'label' => 'Salvar!',
+                            'label' => 'Salvar',
                         ],
 
                     ],


### PR DESCRIPTION
not needed and to keep consistency between other labels