### PR TITLE
Fix stats widget spacing

### DIFF
--- a/packages/admin/resources/views/components/stats/index.blade.php
+++ b/packages/admin/resources/views/components/stats/index.blade.php
@@ -7,7 +7,7 @@
 @endphp
 
 <div {{ $attributes->class([
-    'grid gap-6 filament-stats',
+    'grid gap-4 lg:gap-8 filament-stats',
     'md:grid-cols-3' => $columns === 3,
     'md:grid-cols-1' => $columns === 1,
     'md:grid-cols-2' => $columns === 2,


### PR DESCRIPTION
The main widget grid has spacing of `4` on small screens and `8` on large. Stats widgets have a fixed spacing of `6`. This PR sets stats widget spacing to the same as the main grid.

Before:
![Screenshot 2022-03-15 at 16 29 45](https://user-images.githubusercontent.com/126740/158426352-2af6accd-91e8-428d-a9a5-72aed0959c33.png)

After:
![Screenshot 2022-03-15 at 16 29 36](https://user-images.githubusercontent.com/126740/158426366-495bd4a5-53a0-473d-8b87-39eb2e69e95a.png)

