### PR TITLE
Update dynamically the locale's selector in Edit, Create, View record

### DIFF
--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/Concerns/HasActiveFormLocaleSelect.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/Concerns/HasActiveFormLocaleSelect.php
@@ -8,6 +8,8 @@ trait HasActiveFormLocaleSelect
 {
     public $activeFormLocale = null;
 
+    public ?array $translatableLocales = null;
+
     protected function getActiveFormLocaleSelectAction(): SelectAction
     {
         return SelectAction::make('activeFormLocale')
@@ -28,5 +30,15 @@ trait HasActiveFormLocaleSelect
         }
 
         return parent::getRecordTitle();
+    }
+
+    public function setTranslatableLocales(array $locales): void
+    {
+        $this->translatableLocales = $locales;
+    }
+
+    protected function getTranslatableLocales(): array
+    {
+        return $this->translatableLocales ?? static::getResource()::getTranslatableLocales();
     }
 }

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/Concerns/HasActiveFormLocaleSelect.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/Concerns/HasActiveFormLocaleSelect.php
@@ -13,7 +13,7 @@ trait HasActiveFormLocaleSelect
         return SelectAction::make('activeFormLocale')
             ->label(__('filament-spatie-laravel-translatable-plugin::actions.active_form_locale.label'))
             ->options(
-                collect(static::getResource()::getTranslatableLocales())
+                collect($this->getTranslatableLocales())
                     ->mapWithKeys(function (string $locale): array {
                         return [$locale => $locale];
                     })

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
@@ -9,6 +9,17 @@ trait Translatable
 {
     use HasActiveFormLocaleSelect;
 
+    public array $locales = [];
+    public function setTranslatableLocales(array $locales): void
+    {
+        $this->locales = $locales;
+    }
+
+    protected function getTranslatableLocales(): array
+    {
+        return count($this->locales)?$this->locales:static::getResource()::getTranslatableLocales();
+    }
+
     public function mount(): void
     {
         static::authorizeResourceAccess();

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
@@ -9,17 +9,6 @@ trait Translatable
 {
     use HasActiveFormLocaleSelect;
 
-    public array $locales = [];
-    public function setTranslatableLocales(array $locales): void
-    {
-        $this->locales = $locales;
-    }
-
-    protected function getTranslatableLocales(): array
-    {
-        return count($this->locales)?$this->locales:static::getResource()::getTranslatableLocales();
-    }
-
     public function mount(): void
     {
         static::authorizeResourceAccess();

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
@@ -9,8 +9,19 @@ trait Translatable
 {
     use HasActiveFormLocaleSelect;
 
+    public array $locales = [];
+
     public $activeFormLocale = null;
 
+    public function setTranslatableLocales(array $locales): void
+    {
+        $this->locales = $locales;
+    }
+
+    protected function getTranslatableLocales(): array
+    {
+        return count($this->locales)?$this->locales:static::getResource()::getTranslatableLocales();
+    }
     protected function fillForm(): void
     {
         $this->callHook('beforeFill');
@@ -35,7 +46,7 @@ trait Translatable
         $resource = static::getResource();
 
         $availableLocales = array_keys($this->record->getTranslations($resource::getTranslatableAttributes()[0]));
-        $resourceLocales = $resource::getTranslatableLocales();
+        $resourceLocales = $this->getTranslatableLocales();
         $defaultLocale = $resource::getDefaultTranslatableLocale();
 
         $this->activeFormLocale = in_array($defaultLocale, $availableLocales) ? $defaultLocale : array_intersect($availableLocales, $resourceLocales)[0] ?? $defaultLocale;

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
@@ -9,19 +9,8 @@ trait Translatable
 {
     use HasActiveFormLocaleSelect;
 
-    public array $locales = [];
-
     public $activeFormLocale = null;
 
-    public function setTranslatableLocales(array $locales): void
-    {
-        $this->locales = $locales;
-    }
-
-    protected function getTranslatableLocales(): array
-    {
-        return count($this->locales)?$this->locales:static::getResource()::getTranslatableLocales();
-    }
     protected function fillForm(): void
     {
         $this->callHook('beforeFill');

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/ViewRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/ViewRecord/Concerns/Translatable.php
@@ -7,16 +7,6 @@ use Filament\Resources\Pages\Concerns\HasActiveFormLocaleSelect;
 trait Translatable
 {
     use HasActiveFormLocaleSelect;
-    public array $locales = [];
-    public function setTranslatableLocales(array $locales): void
-    {
-        $this->locales = $locales;
-    }
-
-    protected function getTranslatableLocales(): array
-    {
-        return count($this->locales)?$this->locales:static::getResource()::getTranslatableLocales();
-    }
 
     protected function fillForm(): void
     {

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/ViewRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/ViewRecord/Concerns/Translatable.php
@@ -7,6 +7,16 @@ use Filament\Resources\Pages\Concerns\HasActiveFormLocaleSelect;
 trait Translatable
 {
     use HasActiveFormLocaleSelect;
+    public array $locales = [];
+    public function setTranslatableLocales(array $locales): void
+    {
+        $this->locales = $locales;
+    }
+
+    protected function getTranslatableLocales(): array
+    {
+        return count($this->locales)?$this->locales:static::getResource()::getTranslatableLocales();
+    }
 
     protected function fillForm(): void
     {
@@ -32,7 +42,7 @@ trait Translatable
         $resource = static::getResource();
 
         $availableLocales = array_keys($this->record->getTranslations($resource::getTranslatableAttributes()[0]));
-        $resourceLocales = $resource::getTranslatableLocales();
+        $resourceLocales = $this->getTranslatableLocales();
         $defaultLocale = $resource::getDefaultTranslatableLocale();
 
         $this->activeFormLocale = in_array($defaultLocale, $availableLocales) ? $defaultLocale : array_intersect($availableLocales, $resourceLocales)[0] ?? $defaultLocale;


### PR DESCRIPTION
Now you can set the locales from the views (Create/Edit/View) by calling setTranslatableLocales(array locales)
This method is public so it can be called from the form :
`
Forms\Components\MultiSelect::make('languages')
                                        ->label(__('Languages'))
                                        ->options(['en' => 'EN', 'fr' => 'FR', 'de' => 'DE', 'it' => 'IT', 'es' => 'ES'])
                                        ->reactive()
                                        ->required()
                                        ->afterStateUpdated(function (Closure $set, $state, $livewire) {
                                            $livewire->setTranslatableLocales($state);
                                        }),
`