### PR TITLE
feature: allow `Closure` values for stats cards

### DIFF
--- a/packages/admin/src/Widgets/StatsOverviewWidget/Card.php
+++ b/packages/admin/src/Widgets/StatsOverviewWidget/Card.php
@@ -187,7 +187,7 @@ class Card extends Component implements Htmlable
 
     public function getValue()
     {
-        return $this->value;
+        return value($this->value);
     }
 
     public function toHtml(): string


### PR DESCRIPTION
Currently only allows literal values, i.e. scalars.