### PR TITLE
fix: table search problem when use translatable package

### DIFF
--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -52,8 +52,15 @@ trait InteractsWithTableQuery
             default => 'like',
         };
 
+        $model = $query->getModel();
+        $isTranslatableModel = method_exists($model, 'isTranslatableAttribute');
+
         foreach ($this->getSearchColumns() as $searchColumnName) {
             $whereClause = $isFirst ? 'where' : 'orWhere';
+
+            if ($isTranslatableModel && $model->isTranslatableAttribute($searchColumnName)) {
+                $searchColumnName = $searchColumnName . '->' . app()->getLocale();
+            }
 
             $query->when(
                 $this->queriesRelationships(),

--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -53,12 +53,11 @@ trait InteractsWithTableQuery
         };
 
         $model = $query->getModel();
-        $isTranslatableModel = method_exists($model, 'isTranslatableAttribute');
 
         foreach ($this->getSearchColumns() as $searchColumnName) {
             $whereClause = $isFirst ? 'where' : 'orWhere';
 
-            if ($isTranslatableModel && $model->isTranslatableAttribute($searchColumnName)) {
+            if (method_exists($model, 'isTranslatableAttribute') && $model->isTranslatableAttribute($searchColumnName)) {
                 $searchColumnName = $searchColumnName . '->' . app()->getLocale();
             }
 


### PR DESCRIPTION
When use spatie/translatable package, table search not working because LIKE operator is not correctly working when column type is json.

Query;

before:
select count(*) as aggregate from `collections` where (`name` like '%more%')

after:
select count(*) as aggregate from `collections` where (json_unquote(json_extract(`name`, '$."tr"')) like '%more%')
