### PR TITLE
Added $record parameter to colors callback

### DIFF
--- a/packages/tables/src/Columns/Concerns/HasColors.php
+++ b/packages/tables/src/Columns/Concerns/HasColors.php
@@ -23,7 +23,7 @@ trait HasColors
         foreach ($this->getColors() as $color => $condition) {
             if (is_numeric($color)) {
                 $stateColor = $condition;
-            } elseif ($condition instanceof Closure && $condition($state)) {
+            } elseif ($condition instanceof Closure && $condition($state, $this->getRecord())) {
                 $stateColor = $color;
             } elseif ($condition === $state) {
                 $stateColor = $color;


### PR DESCRIPTION
Small change in the callback to activate a color, so you are able to set a color based on a value of an other column, something like:

```
BadgeColumn::make('sum')
    ->colors([
        'success' => fn ($state, $record) => $state < $record['budget'],
        'danger' => fn ($state, $record) => $state >= $record['budget']
     ])
```
