### PR TITLE
Allow mutation of settings data

### DIFF
--- a/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
+++ b/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
@@ -28,9 +28,16 @@ class SettingsPage extends Page
 
         $settings = app(static::getSettings());
 
-        $this->form->fill($settings->toArray());
+        $data = $this->mutateFormDataBeforeFill($settings->toArray());
+
+        $this->form->fill($data);
 
         $this->callHook('afterFill');
+    }
+
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        return $data;
     }
 
     public function save(): void

--- a/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
+++ b/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
@@ -41,6 +41,8 @@ class SettingsPage extends Page
 
         $this->callHook('afterValidate');
 
+        $data = $this->mutateFormDataBeforeSave($data);
+
         $this->callHook('beforeSave');
 
         $settings = app(static::getSettings());
@@ -71,6 +73,11 @@ class SettingsPage extends Page
         }
 
         $this->{$hook}();
+    }
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        return $data;
     }
 
     public static function getSettings(): string


### PR DESCRIPTION
Add `mutateFormDataBeforeFill` and `mutateFormDataBeforeSave` option as we have with EditRecord.