### PR TITLE
Add spacing for navigation badges on RTL mode

### DIFF
--- a/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
@@ -33,7 +33,7 @@
             @if (filled($badge))
                 <span
                     @class([
-                        'inline-flex items-center justify-center ml-auto min-h-4 px-2 py-0.5 text-xs font-medium tracking-tight rounded-xl whitespace-normal',
+                        'inline-flex items-center justify-center ml-auto rtl:ml-0 rtl:mr-auto min-h-4 px-2 py-0.5 text-xs font-medium tracking-tight rounded-xl whitespace-normal',
                         'text-primary-700 bg-primary-500/20' => ! $active,
                         'text-white bg-white/20' => $active,
                         'dark:text-primary-500' => (! $active) && config('filament.dark_mode'),


### PR DESCRIPTION
**Before:**
<img width="319" alt="Bildschirmfoto 2022-03-21 um 15 46 00" src="https://user-images.githubusercontent.com/22632550/159286123-2c8940c5-9c91-4e95-ae84-8754a02c9a7f.png">

**After:**
<img width="309" alt="Bildschirmfoto 2022-03-21 um 15 45 27" src="https://user-images.githubusercontent.com/22632550/159286015-ff51c78c-93f0-4d67-ba70-85340a5783e0.png">
