### PR TITLE
feature: add `ignoreRecord` shorthand for unique rule

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -126,12 +126,12 @@ trait CanBeValidated
         return $this->fieldComparisonRule('same', $statePath, $isStatePathAbsolute);
     }
 
-    public function unique(string | Closure | null $table = null, string | Closure | null $column = null, Model | Closure $ignorable = null, ?Closure $callback = null, bool $ignoreCurrent = false): static
+    public function unique(string | Closure | null $table = null, string | Closure | null $column = null, Model | Closure $ignorable = null, ?Closure $callback = null, bool $ignoreRecord = false): static
     {
-        $this->rule(function (Field $component, ?string $model) use ($callback, $column, $ignorable, $table, $ignoreCurrent) {
+        $this->rule(function (Field $component, ?string $model) use ($callback, $column, $ignorable, $table, $ignoreRecord) {
             $table = $component->evaluate($table) ?? $model;
             $column = $component->evaluate($column) ?? $component->getName();
-            $ignorable = ($ignoreCurrent && ! $ignorable) ?
+            $ignorable = ($ignoreRecord && ! $ignorable) ?
                 $component->evaluate(fn ($record) => $record) :
                 $component->evaluate($ignorable);
 

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -132,7 +132,7 @@ trait CanBeValidated
             $table = $component->evaluate($table) ?? $model;
             $column = $component->evaluate($column) ?? $component->getName();
             $ignorable = ($ignoreRecord && ! $ignorable) ?
-                $component->evaluate(fn ($record) => $record) :
+                $component->getRecord() :
                 $component->evaluate($ignorable);
 
             $rule = Rule::unique($table, $column)

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -126,12 +126,14 @@ trait CanBeValidated
         return $this->fieldComparisonRule('same', $statePath, $isStatePathAbsolute);
     }
 
-    public function unique(string | Closure | null $table = null, string | Closure | null $column = null, Model | Closure $ignorable = null, ?Closure $callback = null): static
+    public function unique(string | Closure | null $table = null, string | Closure | null $column = null, Model | Closure $ignorable = null, ?Closure $callback = null, bool $ignoreCurrent = false): static
     {
-        $this->rule(function (Field $component, ?string $model) use ($callback, $column, $ignorable, $table) {
+        $this->rule(function (Field $component, ?string $model) use ($callback, $column, $ignorable, $table, $ignoreCurrent) {
             $table = $component->evaluate($table) ?? $model;
             $column = $component->evaluate($column) ?? $component->getName();
-            $ignorable = $component->evaluate($ignorable);
+            $ignorable = ($ignoreCurrent && ! $ignorable) ?
+                $component->evaluate(fn ($record) => $record) :
+                $component->evaluate($ignorable);
 
             $rule = Rule::unique($table, $column)
                 ->when(


### PR DESCRIPTION
The following code:

```php
->unique(ignoreable: fn ($record) => $record)
```

Can now become:

```php
->unique(ignoreRecord: true)
```

New parameter has to go at the end to continue working with positional arguments.