### PR TITLE
Tooltips for collapsed navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@babel/runtime": "^7.15.3",
                 "@github/file-attachment-element": "^2.0.1",
                 "@github/markdown-toolbar-element": "^1.5.1",
-                "@ryangjchandler/alpine-tooltip": "^1.1.0",
+                "@ryangjchandler/alpine-tooltip": "^1.2.0",
                 "@tailwindcss/forms": "^0.4.0",
                 "@tailwindcss/typography": "^0.5.0",
                 "alpinejs": "^3.9.0",
@@ -1847,9 +1847,9 @@
             }
         },
         "node_modules/@ryangjchandler/alpine-tooltip": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@ryangjchandler/alpine-tooltip/-/alpine-tooltip-1.1.0.tgz",
-            "integrity": "sha512-3weeDCat2jTjiXsky/JVLHHuTV+dcmRjVvJ+U5j2M5vo57+PYzKJvAkJoDHBWZ225gR84fx2JA2Hy6PTA5Y+Cw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ryangjchandler/alpine-tooltip/-/alpine-tooltip-1.2.0.tgz",
+            "integrity": "sha512-PzShzyYPoDTMvfayQRoNAnoxOkcfVYrrYrtiqX/Dg09Jp2qpNDB8IkcShs3BQwK0D4RnaYFtFXCqtXGhGU0dPA==",
             "dev": true
         },
         "node_modules/@tailwindcss/forms": {
@@ -11046,9 +11046,9 @@
             "dev": true
         },
         "@ryangjchandler/alpine-tooltip": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@ryangjchandler/alpine-tooltip/-/alpine-tooltip-1.1.0.tgz",
-            "integrity": "sha512-3weeDCat2jTjiXsky/JVLHHuTV+dcmRjVvJ+U5j2M5vo57+PYzKJvAkJoDHBWZ225gR84fx2JA2Hy6PTA5Y+Cw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ryangjchandler/alpine-tooltip/-/alpine-tooltip-1.2.0.tgz",
+            "integrity": "sha512-PzShzyYPoDTMvfayQRoNAnoxOkcfVYrrYrtiqX/Dg09Jp2qpNDB8IkcShs3BQwK0D4RnaYFtFXCqtXGhGU0dPA==",
             "dev": true
         },
         "@tailwindcss/forms": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "@babel/runtime": "^7.15.3",
         "@github/file-attachment-element": "^2.0.1",
         "@github/markdown-toolbar-element": "^1.5.1",
+        "@ryangjchandler/alpine-tooltip": "^1.2.0",
         "@tailwindcss/forms": "^0.4.0",
         "@tailwindcss/typography": "^0.5.0",
         "alpinejs": "^3.9.0",
@@ -32,7 +33,6 @@
         "marked": "^4.0.10",
         "mdhl": "^0.0.6",
         "postcss": "^8.4.4",
-        "@ryangjchandler/alpine-tooltip": "^1.1.0",
         "tailwindcss": "^3.0.0",
         "tippy.js": "^6.3.7",
         "trix": "^1.3.1"

--- a/packages/admin/resources/css/app.css
+++ b/packages/admin/resources/css/app.css
@@ -1,4 +1,5 @@
 @import '../../../forms/dist/module.esm.css';
+
 @import '~tippy.js/dist/tippy.css';
 @import '~tippy.js/themes/light.css';
 

--- a/packages/admin/resources/css/app.css
+++ b/packages/admin/resources/css/app.css
@@ -1,5 +1,6 @@
 @import '../../../forms/dist/module.esm.css';
 @import '~tippy.js/dist/tippy.css';
+@import '~tippy.js/themes/light.css';
 
 @tailwind base;
 @tailwind components;

--- a/packages/admin/resources/js/app.js
+++ b/packages/admin/resources/js/app.js
@@ -41,15 +41,14 @@ Alpine.store('sidebar', {
 
 Alpine.store(
     'theme',
-    window.matchMedia("(prefers-color-scheme: dark)").matches ? 'dark' : 'light'
+    window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light',
 );
 
 window
-    .matchMedia("(prefers-color-scheme: dark)")
-    .addEventListener("change", (e) => {
-        Alpine.store('theme', e.matches ? 'dark' : 'light')
-    });
-
+    .matchMedia('(prefers-color-scheme: dark)')
+    .addEventListener('change', (event) => {
+        Alpine.store('theme', event.matches ? 'dark' : 'light')
+    })
 
 Chart.defaults.font.family = `'DM Sans', sans-serif`
 Chart.defaults.color = '#6b7280'

--- a/packages/admin/resources/js/app.js
+++ b/packages/admin/resources/js/app.js
@@ -39,6 +39,19 @@ Alpine.store('sidebar', {
     },
 })
 
+Alpine.store(
+    'theme',
+    window.matchMedia("(prefers-color-scheme: dark)").matches ? 'dark' : 'light'
+);
+
+window
+    .matchMedia("(prefers-color-scheme: dark)")
+    .addEventListener("change", (e) => {
+        Alpine.store('theme', e.matches ? 'dark' : 'light')
+        console.log('store', Alpine.store('theme'), 'event', e);
+    });
+
+
 Chart.defaults.font.family = `'DM Sans', sans-serif`
 Chart.defaults.color = '#6b7280'
 

--- a/packages/admin/resources/js/app.js
+++ b/packages/admin/resources/js/app.js
@@ -42,7 +42,7 @@ Alpine.store('sidebar', {
 Alpine.store(
     'theme',
     window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light',
-);
+)
 
 window
     .matchMedia('(prefers-color-scheme: dark)')

--- a/packages/admin/resources/js/app.js
+++ b/packages/admin/resources/js/app.js
@@ -48,7 +48,6 @@ window
     .matchMedia("(prefers-color-scheme: dark)")
     .addEventListener("change", (e) => {
         Alpine.store('theme', e.matches ? 'dark' : 'light')
-        console.log('store', Alpine.store('theme'), 'event', e);
     });
 
 

--- a/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
@@ -11,7 +11,7 @@
         href="{{ $url }}"
         {!! $shouldOpenUrlInNewTab ? 'target="_blank"' : '' !!}
         x-on:click="window.matchMedia(`(max-width: 1024px)`).matches && $store.sidebar.close()"
-        x-data="{tooltip: {}}"
+        x-data="{ tooltip: {} }"
         x-init="
             Alpine.effect(() => {
                 if (Alpine.store('sidebar').isOpen) {
@@ -19,11 +19,11 @@
                 } else {
                     tooltip = {
                         content: @js($slot->toHtml()),
-                        theme:  Alpine.store('theme') === 'light' ? 'dark' : 'light',
-                        placement: document.dir === 'rtl' ? 'left' : 'right'
+                        theme: Alpine.store('theme') === 'light' ? 'dark' : 'light',
+                        placement: document.dir === 'rtl' ? 'left' : 'right',
                     }
                 }
-            });
+            })
         "
         x-tooltip="tooltip"
         @class([

--- a/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
@@ -18,7 +18,7 @@
                     tooltip = false
                 } else {
                     tooltip = {
-                        content: '{{ $slot }}',
+                        content: @js($slot->toHtml()),
                         theme:  Alpine.store('theme') === 'light' ? 'dark' : 'light',
                         placement: document.dir === 'rtl' ? 'left' : 'right'
                     }

--- a/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
@@ -11,6 +11,21 @@
         href="{{ $url }}"
         {!! $shouldOpenUrlInNewTab ? 'target="_blank"' : '' !!}
         x-on:click="window.matchMedia(`(max-width: 1024px)`).matches && $store.sidebar.close()"
+        x-data="{tooltip: {}}"
+        x-init="
+            Alpine.effect(() => {
+                if (Alpine.store('sidebar').isOpen) {
+                    tooltip = false
+                } else {
+                    tooltip = {
+                        content: '{{ $slot }}',
+                        theme:  Alpine.store('theme') === 'light' ? 'dark' : 'light',
+                        placement: document.dir === 'rtl' ? 'left' : 'right'
+                    }
+                }
+            });
+        "
+        x-tooltip="tooltip"
         @class([
             'flex items-center justify-center gap-3 px-3 py-2 rounded-lg font-medium transition',
             'hover:bg-gray-500/5 focus:bg-gray-500/5' => ! $active,


### PR DESCRIPTION
Add tooltips to navigation items when it is collapsed.

https://user-images.githubusercontent.com/22632550/159532733-9b5d496e-b13a-4a5f-93e3-d893dd4f3c7f.mov

Should we have light tooltips on dark theme and dark tooltips on light theme for better contrast or the other way around?
