### PR TITLE
fix/discuss: FilePond doesn't initialize correctly when not visible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "devDependencies": {
                 "@alpinejs/collapse": "^3.8.1",
                 "@alpinejs/focus": "^3.8.1",
+                "@alpinejs/intersect": "^3.9.2",
                 "@alpinejs/persist": "^3.8.1",
                 "@babel/runtime": "^7.15.3",
                 "@github/file-attachment-element": "^2.0.1",
@@ -53,6 +54,12 @@
             "dependencies": {
                 "focus-trap": "^6.6.1"
             }
+        },
+        "node_modules/@alpinejs/intersect": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.9.2.tgz",
+            "integrity": "sha512-0Pt2OHE4LuKkGZHbj9vvkxokWtuGMSBcrM+oHBOb5ntMFrOz5nmuHaN26SilwlV3mrwGS9J83kskUrF5mcHZkg==",
+            "dev": true
         },
         "node_modules/@alpinejs/persist": {
             "version": "3.9.2",
@@ -9737,6 +9744,12 @@
             "requires": {
                 "focus-trap": "^6.6.1"
             }
+        },
+        "@alpinejs/intersect": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.9.2.tgz",
+            "integrity": "sha512-0Pt2OHE4LuKkGZHbj9vvkxokWtuGMSBcrM+oHBOb5ntMFrOz5nmuHaN26SilwlV3mrwGS9J83kskUrF5mcHZkg==",
+            "dev": true
         },
         "@alpinejs/persist": {
             "version": "3.9.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "devDependencies": {
         "@alpinejs/collapse": "^3.8.1",
         "@alpinejs/focus": "^3.8.1",
+        "@alpinejs/intersect": "^3.9.2",
         "@alpinejs/persist": "^3.8.1",
         "@babel/runtime": "^7.15.3",
         "@github/file-attachment-element": "^2.0.1",

--- a/packages/admin/resources/js/app.js
+++ b/packages/admin/resources/js/app.js
@@ -6,12 +6,14 @@ import Chart from 'chart.js/auto'
 import Collapse from '@alpinejs/collapse'
 import FormsAlpinePlugin from '../../../forms/dist/module.esm'
 import Focus from '@alpinejs/focus'
+import Intersect from '@alpinejs/intersect'
 import Persist from '@alpinejs/persist'
 import Tooltip from '@ryangjchandler/alpine-tooltip'
 
 Alpine.plugin(Collapse)
 Alpine.plugin(FormsAlpinePlugin)
 Alpine.plugin(Focus)
+Alpine.plugin(Intersect)
 Alpine.plugin(Persist)
 Alpine.plugin(Tooltip)
 

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -61,7 +61,7 @@ export default (Alpine) => {
 
             uploadedFileUrlIndex: {},
 
-            init: async function () {
+            initDefer: async function () {
                 this.pond = FilePond.create(this.$refs.input, {
                     acceptedFileTypes,
                     allowReorder: canReorder,

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -67,6 +67,7 @@
                 }, error, progress)
             },
         })"
+        x-intersect.once="initDefer"
         wire:ignore
         {!! ($id = $getId()) ? "id=\"{$id}\"" : null !!}
         style="min-height: {{ $isAvatar() ? '8em' : ($getPanelLayout() === 'compact' ? '2.625em' : '4.75em') }}"


### PR DESCRIPTION
This is a potential fix for https://github.com/laravel-filament/filament/issues/1967.

This issue occurs when FilePond is in a secondary tab. In my testing I've found it happens when FilePond initializes inside any element set to `display: none`. I feel like this may actually be a FilePond bug rather than something that should be fixed in Filament, but I came up with this potential solution anyway.

This change uses Alpine's `x-intersect` directive to defer the FilePond initialisation until the element is actually visible. it works, but the delayed initialisation does mean that FilePond doesn't kick in until you switch to the tab, which doesn't look very slick. It also unnecessarily defers fields further down the page until they're scrolled into view.

Not ideal, but something for discussion.