### PR TITLE
Only show navigation tooltips on when collapsable navigation is active.

### DIFF
--- a/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
@@ -11,21 +11,23 @@
         href="{{ $url }}"
         {!! $shouldOpenUrlInNewTab ? 'target="_blank"' : '' !!}
         x-on:click="window.matchMedia(`(max-width: 1024px)`).matches && $store.sidebar.close()"
-        x-data="{ tooltip: {} }"
-        x-init="
-            Alpine.effect(() => {
-                if (Alpine.store('sidebar').isOpen) {
-                    tooltip = false
-                } else {
-                    tooltip = {
-                        content: @js($slot->toHtml()),
-                        theme: Alpine.store('theme') === 'light' ? 'dark' : 'light',
-                        placement: document.dir === 'rtl' ? 'left' : 'right',
+        @if (config('filament.layout.sidebar.is_collapsible_on_desktop'))
+            x-data="{ tooltip: {} }"
+            x-init="
+                Alpine.effect(() => {
+                    if (Alpine.store('sidebar').isOpen) {
+                        tooltip = false
+                    } else {
+                        tooltip = {
+                            content: @js($slot->toHtml()),
+                            theme: Alpine.store('theme') === 'light' ? 'dark' : 'light',
+                            placement: document.dir === 'rtl' ? 'left' : 'right',
+                        }
                     }
-                }
-            })
-        "
-        x-tooltip="tooltip"
+                })
+            "
+            x-tooltip="tooltip"
+        @endif
         @class([
             'flex items-center justify-center gap-3 px-3 py-2 rounded-lg font-medium transition',
             'hover:bg-gray-500/5 focus:bg-gray-500/5' => ! $active,


### PR DESCRIPTION
Fixes an issue where navigation tooltips were shown on non-collapsed toolbar.