### PR TITLE
Alpine.start() when document is fully loaded

### DIFF
--- a/packages/admin/resources/js/app.js
+++ b/packages/admin/resources/js/app.js
@@ -61,4 +61,4 @@ Chart.defaults.color = '#6b7280'
 window.Alpine = Alpine
 window.Chart = Chart
 
-Alpine.start()
+document.addEventListener('DOMContentLoaded', () => Alpine.start())


### PR DESCRIPTION
Had tons of Alpine errors with my spotlight plugin when registering the scripts via `$scripts` or `$beforeCoreScripts`.
Could solve it by delaying `Alpine.start()`. Not sure whether there's a better solution?

<img width="1439" alt="Bildschirmfoto 2022-03-23 um 18 28 37" src="https://user-images.githubusercontent.com/22632550/159760070-1cb0348c-a587-4010-a899-baf2142ef8d6.png">

