### PR TITLE
Add brand-icon for collapsed navigation

### DIFF
--- a/packages/admin/docs/07-appearance.md
+++ b/packages/admin/docs/07-appearance.md
@@ -12,10 +12,10 @@ You may create a `resources/views/vendor/filament/components/brand.blade.php` fi
 <img src="{{ asset('/images/logo.svg') }}" alt="Logo" class="h-10">
 ```
 
-If you enabled the [collapsible sidebar](#collapsible-sidebar) you may also provide a brand icon (`resources/views/vendor/filament/components/brand-icon.blade.php`) which is shown when the sidebar is collapsed: 
+If you enabled the [collapsible sidebar](#collapsible-sidebar), you may also provide a brand icon (`resources/views/vendor/filament/components/brand-icon.blade.php`) which is shown when the sidebar is collapsed:
 
 ```blade
-<img src="{{ asset('/images/icon.svg') }}" alt="Icon" class="h-full w-full object-contain">
+<img src="{{ asset('/images/icon.svg') }}" alt="Icon" class="h-full w-full object-contain" />
 ```
 
 ## Dark mode

--- a/packages/admin/docs/07-appearance.md
+++ b/packages/admin/docs/07-appearance.md
@@ -15,7 +15,7 @@ You may create a `resources/views/vendor/filament/components/brand.blade.php` fi
 If you enabled the [collapsible sidebar](#collapsible-sidebar) you may also provide a brand icon (`resources/views/vendor/filament/components/brand-icon.blade.php`) which is shown when the sidebar is collapsed: 
 
 ```blade
-<img src="{{ asset('/images/icon.svg') }}" alt="Logo" class="h-full h-full object-contain">
+<img src="{{ asset('/images/icon.svg') }}" alt="Icon" class="h-full w-full object-contain">
 ```
 
 ## Dark mode

--- a/packages/admin/docs/07-appearance.md
+++ b/packages/admin/docs/07-appearance.md
@@ -12,6 +12,12 @@ You may create a `resources/views/vendor/filament/components/brand.blade.php` fi
 <img src="{{ asset('/images/logo.svg') }}" alt="Logo" class="h-10">
 ```
 
+If you enabled the [collapsible sidebar](#collapsible-sidebar) you may also provide a brand icon (`resources/views/vendor/filament/components/brand-icon.blade.php`) which is shown when the sidebar is collapsed: 
+
+```blade
+<img src="{{ asset('/images/icon.svg') }}" alt="Logo" class="h-full h-full object-contain">
+```
+
 ## Dark mode
 
 By default, Filament only includes a light theme. However, you may allow the user to switch to dark mode if they wish, using the `dark_mode` setting of the [configuration file](installation#publishing-the-configuration):

--- a/packages/admin/resources/views/components/brand-icon.blade.php
+++ b/packages/admin/resources/views/components/brand-icon.blade.php
@@ -1,0 +1,16 @@
+@if (filled($brand = config('filament.brand')))
+    <div @class([
+        'text-xl font-bold tracking-tight filament-brand',
+        'dark:text-white' => config('filament.dark_mode'),
+    ])>
+        {{
+            str($brand)
+                ->snake()
+                ->upper()
+                ->explode('_')
+                ->map(fn (string $string) => str($string)->substr(0, 1))
+                ->take(2)
+                ->implode('')
+        }}
+    </div>
+@endif

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -34,12 +34,10 @@
             <a
                 class="block w-full text-center"
                 href="{{ config('filament.home_url') }}"
-                @if (config('filament.layout.sidebar.is_collapsible_on_desktop'))
-                    x-show="! $store.sidebar.isOpen"
-                    x-transition:enter="lg:transition delay-100"
-                    x-transition:enter-start="opacity-0"
-                    x-transition:enter-end="opacity-100"
-                @endif
+                x-show="! $store.sidebar.isOpen"
+                x-transition:enter="lg:transition delay-100"
+                x-transition:enter-start="opacity-0"
+                x-transition:enter-end="opacity-100"
             >
                 <x-filament::brand-icon />
             </a>

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -21,7 +21,6 @@
         <a
             href="{{ config('filament.home_url') }}"
             @if (config('filament.layout.sidebar.is_collapsible_on_desktop'))
-                x-data="{}"
                 x-show="$store.sidebar.isOpen"
                 x-transition:enter="lg:transition delay-100"
                 x-transition:enter-start="opacity-0"
@@ -30,6 +29,21 @@
         >
             <x-filament::brand />
         </a>
+
+        @if (config('filament.layout.sidebar.is_collapsible_on_desktop'))
+            <a
+                class="block w-full text-center"
+                href="{{ config('filament.home_url') }}"
+                @if (config('filament.layout.sidebar.is_collapsible_on_desktop'))
+                    x-show="! $store.sidebar.isOpen"
+                    x-transition:enter="lg:transition delay-100"
+                    x-transition:enter-start="opacity-0"
+                    x-transition:enter-end="opacity-100"
+                @endif
+            >
+                <x-filament::brand-icon />
+            </a>
+        @endif
     </header>
 
     <nav class="flex-1 overflow-y-auto py-6 filament-sidebar-nav">


### PR DESCRIPTION
Allows a brand icon for the collapsed sidebar. Default is 2 initials of the brand name;

https://user-images.githubusercontent.com/22632550/159794380-73f37e43-f28b-4548-b215-db5778468448.mov

By overwriting the `brand-icon.blade.php` you could add nice SVG icons:

https://user-images.githubusercontent.com/22632550/159794392-e6176421-ad79-4dec-9b09-9b954996e1ab.mov

