### PR TITLE
Fix: str() helper not compatible with L8

### DIFF
--- a/packages/admin/resources/views/components/brand-icon.blade.php
+++ b/packages/admin/resources/views/components/brand-icon.blade.php
@@ -8,7 +8,7 @@
                 ->snake()
                 ->upper()
                 ->explode('_')
-                ->map(fn (string $string) => substr($string, 0, 1))
+                ->map(fn (string $string) => \Illuminate\Support\Str::substr($string, 0, 1))
                 ->take(2)
                 ->implode('')
         }}

--- a/packages/admin/resources/views/components/brand-icon.blade.php
+++ b/packages/admin/resources/views/components/brand-icon.blade.php
@@ -4,11 +4,11 @@
         'dark:text-white' => config('filament.dark_mode'),
     ])>
         {{
-            str($brand)
+            \Illuminate\Support\Str::of($brand)
                 ->snake()
                 ->upper()
                 ->explode('_')
-                ->map(fn (string $string) => str($string)->substr(0, 1))
+                ->map(fn (string $string) => substr($string, 0, 1))
                 ->take(2)
                 ->implode('')
         }}


### PR DESCRIPTION
`str()` was introduced with L9 and causes issues with L8. 