### PR TITLE
Clear icon mirroring class

### DIFF
--- a/packages/admin/resources/views/components/dropdown/item.blade.php
+++ b/packages/admin/resources/views/components/dropdown/item.blade.php
@@ -29,7 +29,7 @@
     $labelClasses = 'truncate';
 
     $iconClasses = \Illuminate\Support\Arr::toCssClasses([
-        'mr-2 -ml-1 w-6 h-6 flex-shrink-0 rtl:ml-2 rtl:-mr-1 rtl:scale-x-[-1]',
+        'mr-2 -ml-1 w-6 h-6 flex-shrink-0 rtl:ml-2 rtl:-mr-1',
         'group-hover:text-white group-focus:text-white' => $hasHoverAndFocusState,
         'text-primary-500' => $color === 'primary',
         'text-danger-500' => $color === 'danger',

--- a/packages/tables/resources/views/components/dropdown/item.blade.php
+++ b/packages/tables/resources/views/components/dropdown/item.blade.php
@@ -29,7 +29,7 @@
     $labelClasses = 'truncate';
 
     $iconClasses = \Illuminate\Support\Arr::toCssClasses([
-        'mr-2 -ml-1 w-6 h-6 flex-shrink-0 rtl:ml-2 rtl:-mr-1 rtl:scale-x-[-1]',
+        'mr-2 -ml-1 w-6 h-6 flex-shrink-0 rtl:ml-2 rtl:-mr-1',
         'group-hover:text-white group-focus:text-white' => $hasHoverAndFocusState,
         'text-primary-500' => $color === 'primary',
         'text-danger-500' => $color === 'danger',


### PR DESCRIPTION
As mirroring icons can be great for some classes on RTL direction, others are not. For that, this PR clear mirroring class except that one related to pagination which only uses **left/right** arrows icon