### PR TITLE
Fix limitation for MakeResourceCommand where model has to be in App\Models - #2028 

### DIFF
--- a/packages/admin/src/Commands/MakeResourceCommand.php
+++ b/packages/admin/src/Commands/MakeResourceCommand.php
@@ -64,14 +64,18 @@ class MakeResourceCommand extends Command
         $this->copyStubToApp($this->option('simple') ? 'SimpleResource' : 'Resource', $resourcePath, [
             'createResourcePageClass' => $createResourcePageClass,
             'editResourcePageClass' => $editResourcePageClass,
-            'formSchema' => $this->option('generate') ? $this->getResourceFormSchema("App\Models\\{$model}") : $this->indentString('//'),
+            'formSchema' => $this->option('generate') ? $this->getResourceFormSchema(
+                ($modelNamespace !== '' ? $modelNamespace : "App\Models") . "\\" . $modelClass
+            ) : $this->indentString('//'),
             'indexResourcePageClass' => $this->option('simple') ? $manageResourcePageClass : $listResourcePageClass,
             'model' => $model,
             'modelClass' => $modelClass,
             'namespace' => 'App\\Filament\\Resources' . ($resourceNamespace !== '' ? "\\{$resourceNamespace}" : ''),
             'resource' => $resource,
             'resourceClass' => $resourceClass,
-            'tableColumns' => $this->option('generate') ? $this->getResourceTableColumns("App\Models\\{$model}") : $this->indentString('//'),
+            'tableColumns' => $this->option('generate') ? $this->getResourceTableColumns(
+                ($modelNamespace !== '' ? $modelNamespace : "App\Models") . "\\" . $modelClass
+            ) : $this->indentString('//'),
         ]);
 
         if ($this->option('simple')) {

--- a/packages/admin/src/Commands/MakeResourceCommand.php
+++ b/packages/admin/src/Commands/MakeResourceCommand.php
@@ -65,7 +65,7 @@ class MakeResourceCommand extends Command
             'createResourcePageClass' => $createResourcePageClass,
             'editResourcePageClass' => $editResourcePageClass,
             'formSchema' => $this->option('generate') ? $this->getResourceFormSchema(
-                ($modelNamespace !== '' ? $modelNamespace : "App\Models") . "\\" . $modelClass
+                ($modelNamespace !== '' ? $modelNamespace : 'App\Models') . '\\' . $modelClass
             ) : $this->indentString('//'),
             'indexResourcePageClass' => $this->option('simple') ? $manageResourcePageClass : $listResourcePageClass,
             'model' => $model,
@@ -74,7 +74,7 @@ class MakeResourceCommand extends Command
             'resource' => $resource,
             'resourceClass' => $resourceClass,
             'tableColumns' => $this->option('generate') ? $this->getResourceTableColumns(
-                ($modelNamespace !== '' ? $modelNamespace : "App\Models") . "\\" . $modelClass
+                ($modelNamespace !== '' ? $modelNamespace : 'App\Models') . '\\' . $modelClass
             ) : $this->indentString('//'),
         ]);
 


### PR DESCRIPTION
Fix for bug 2028.
Check to see if ModelNamespace is given explicitly and if so, use it for getResourceFormsSchema and getResourceTablesSchema