### PR TITLE
Fix error in global search when user can not view or edit record.

### DIFF
--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -198,11 +198,20 @@ class Resource
         return $query
             ->limit(50)
             ->get()
-            ->map(fn (Model $record): GlobalSearchResult => new GlobalSearchResult(
-                title: static::getGlobalSearchResultTitle($record),
-                url: static::getGlobalSearchResultUrl($record),
-                details: static::getGlobalSearchResultDetails($record),
-            ));
+            ->map(function (Model $record): ?GlobalSearchResult {
+                $url = static::getGlobalSearchResultUrl($record);
+
+                if (blank($url)) {
+                    return null;
+                }
+
+                return new GlobalSearchResult(
+                    title: static::getGlobalSearchResultTitle($record),
+                    url: $url,
+                    details: static::getGlobalSearchResultDetails($record),
+                );
+            })
+            ->filter();
     }
 
     public static function getLabel(): string


### PR DESCRIPTION
@ryangjchandler Can you give feedback on this one?

Ideally data is filtered by `getEloquentQuery()` before, but you cannot rely on that entirely I think.

Fixes https://github.com/laravel-filament/filament/issues/2031