### PR TITLE
Tweak forms validation attribute generation

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -170,7 +170,7 @@ trait CanBeValidated
 
     public function getValidationAttribute(): string
     {
-        return $this->evaluate($this->validationAttribute) ?? lcfirst($this->getLabel());
+        return $this->evaluate($this->validationAttribute) ?? strtolower($this->getLabel());
     }
 
     public function getValidationRules(): array


### PR DESCRIPTION
This commit tweaks the behaviour of the `getValidationAttribute` method for fields, to use the entire lowercased version of the field label (and therefore name, if not explicitly set) as a fallback, rather than simply lowercasing the first character.

For a label consisting of a single word, this wouldn't normally be a problem, however for labels with multiple words, aesthetically it looks better to have all words lowercased when used for error messages.

Before:
<img width="348" alt="Screen Shot 2022-03-28 at 11 38 01 am" src="https://user-images.githubusercontent.com/3736774/160312591-56cde70d-820d-4193-b9a5-2d15322871fa.png">

After:
<img width="348" alt="Screen Shot 2022-03-28 at 11 38 13 am" src="https://user-images.githubusercontent.com/3736774/160312611-16b0ae81-22a4-4169-a131-747b034fdcc0.png">