### PR TITLE
Update TextColumn.php

### DIFF
--- a/packages/tables/docs/03-columns.md
+++ b/packages/tables/docs/03-columns.md
@@ -218,7 +218,7 @@ use Filament\Tables\Columns\TextColumn;
 TextColumn::make('description')->limit('50')
 ```
 
-You may output the rendered `html()` display of the text content:
+If your column value is HTML, you may render it using `html()`:
 
 ```php
 use Filament\Tables\Columns\TextColumn;

--- a/packages/tables/docs/03-columns.md
+++ b/packages/tables/docs/03-columns.md
@@ -218,6 +218,14 @@ use Filament\Tables\Columns\TextColumn;
 TextColumn::make('description')->limit('50')
 ```
 
+You may output the rendered `html()` display of the text content:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('description')->html()
+```
+
 You may also transform a set of known cell values using the `enum()` method:
 
 ```php

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -54,9 +54,9 @@ trait CanFormatState
         return $this;
     }
 
-    public function html() : static
+    public function html(): static
     {
-        return $this->formatStateUsing(fn ($state) => new HtmlString($state));
+        return $this->formatStateUsing(fn ($state): HtmlString => new HtmlString($state));
     }
 
     public function formatStateUsing(?Closure $callback): static

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -8,6 +8,7 @@ use Filament\Tables\Columns\Column;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
+use \Illuminate\Support\HtmlString;
 
 trait CanFormatState
 {
@@ -51,6 +52,11 @@ trait CanFormatState
         });
 
         return $this;
+    }
+
+    public function html() : static
+    {
+        return $this->formatStateUsing(fn ($state) => new HtmlString($state));
     }
 
     public function formatStateUsing(?Closure $callback): static

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -28,5 +28,4 @@ class TextColumn extends Column
     {
         return implode(', ', $state);
     }
-    
 }

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -28,4 +28,9 @@ class TextColumn extends Column
     {
         return implode(', ', $state);
     }
+    
+    public function html() : static
+    {
+        return $this->formatStateUsing(fn ($state) => new \Illuminate\Support\HtmlString($state));
+    }
 }

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -29,8 +29,4 @@ class TextColumn extends Column
         return implode(', ', $state);
     }
     
-    public function html() : static
-    {
-        return $this->formatStateUsing(fn ($state) => new \Illuminate\Support\HtmlString($state));
-    }
 }


### PR DESCRIPTION
Addition of ->html() modifier. Purpose of this is to display the returned text from the database with HTML intact (rich text) rather than outputting raw data.

Sample usage in a Resource:

```
public static function table(Table $table): Table
    {
        return $table
            ->columns([
                Tables\Columns\TextColumn::make('name'),
                Tables\Columns\TextColumn::make('description')->html()
            ])
            ->filters([
                //
            ]);
    }
```