### PR TITLE
Laravel Octane Support: Scoped service binding

### DIFF
--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -72,7 +72,13 @@ class FilamentServiceProvider extends PackageServiceProvider
 
     public function packageRegistered(): void
     {
-        $this->app->singleton('filament', function (): FilamentManager {
+        $this->app->resolving('filament', function () {
+            $this->discoverPages();
+            $this->discoverResources();
+            $this->discoverWidgets();
+        });
+
+        $this->app->scoped('filament', function (): FilamentManager {
             return app(FilamentManager::class);
         });
 
@@ -80,10 +86,6 @@ class FilamentServiceProvider extends PackageServiceProvider
         $this->app->bind(LogoutResponseContract::class, LogoutResponse::class);
 
         $this->mergeConfigFrom(__DIR__ . '/../config/filament.php', 'filament');
-
-        $this->discoverPages();
-        $this->discoverResources();
-        $this->discoverWidgets();
     }
 
     public function packageBooted(): void

--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -72,7 +72,7 @@ class FilamentServiceProvider extends PackageServiceProvider
 
     public function packageRegistered(): void
     {
-        $this->app->resolving('filament', function () {
+        $this->app->resolving('filament', function (): void {
             $this->discoverPages();
             $this->discoverResources();
             $this->discoverWidgets();


### PR DESCRIPTION
See https://github.com/laravel-filament/filament/issues/2010

@danharrin As I was working on this I found there is an issue with octane itself where scoped services aren't being flushed correctly because of a discrepancy between octane and laravel itself. https://github.com/laravel/octane/issues/500

There is a workaround where after this pull request is submitted you can add the filament service to octane's flush services in the config like so:

config/octane.php:
```php
<?php

...

return [

   ...

    /*
    |--------------------------------------------------------------------------
    | Warm / Flush Bindings
    |--------------------------------------------------------------------------
    |
    | The bindings listed below will either be pre-warmed when a worker boots
    | or they will be flushed before every new request. Flushing a binding
    | will force the container to resolve that binding again when asked.
    |
    */

    'warm' => [
        ...Octane::defaultServicesToWarm(),
    ],

    'flush' => [
        'filament'
    ],

  ...

];

```

Is that something that should be added to the documentation or do you want to just refer people here? Once the issue in the octane package is resolved we won't need to add that item to the flush in the config