### PR TITLE
TextInput field tel() method to have basic phone number validation

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -12,6 +12,8 @@ trait CanBeValidated
 {
     protected bool | Closure $isRequired = false;
 
+    protected string | Closure | null $regexPattern = null;
+
     protected array $rules = [];
 
     protected string | Closure | null $validationAttribute = null;
@@ -52,9 +54,9 @@ trait CanBeValidated
         return $this;
     }
 
-    public function regex(string $regex, bool | Closure $condition = true): static
+    public function regex(string | Closure | null $pattern): static
     {
-        $this->rule('regex:' . $regex, $condition);
+        $this->regexPattern = $pattern;
 
         return $this;
     }
@@ -170,6 +172,11 @@ trait CanBeValidated
         return $this;
     }
 
+    public function getRegexPattern(): ?string
+    {
+        return $this->evaluate($this->regexPattern);
+    }
+
     public function getRequiredValidationRule(): string
     {
         return $this->isRequired() ? 'required' : 'nullable';
@@ -185,6 +192,10 @@ trait CanBeValidated
         $rules = [
             $this->getRequiredValidationRule(),
         ];
+
+        if (filled($regexPattern = $this->getRegexPattern())) {
+            $rules[] = "regex:{$regexPattern}";
+        }
 
         foreach ($this->rules as [$rule, $condition]) {
             if (is_numeric($rule)) {

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -52,6 +52,12 @@ trait CanBeValidated
         return $this;
     }
 
+    public function regex(string $regex, bool | Closure $condition = true): static
+    {
+        $this->rule('regex:' . $regex, $condition);
+        return $this;
+    }
+
     public function rule(string | object $rule, bool | Closure $condition = true): static
     {
         $this->rules = array_merge(

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -55,6 +55,7 @@ trait CanBeValidated
     public function regex(string $regex, bool | Closure $condition = true): static
     {
         $this->rule('regex:' . $regex, $condition);
+
         return $this;
     }
 

--- a/packages/forms/src/Components/TextInput.php
+++ b/packages/forms/src/Components/TextInput.php
@@ -144,7 +144,7 @@ class TextInput extends Field implements CanHaveNumericState
     {
         $this->isTel = $condition;
 
-        $this->regex('/^[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\.\/0-9]*$/', $condition);
+        $this->regex(fn (TextInput $component) => $component->evaluate($condition) ? '/^[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\.\/0-9]*$/' : null);
 
         return $this;
     }

--- a/packages/forms/src/Components/TextInput.php
+++ b/packages/forms/src/Components/TextInput.php
@@ -144,6 +144,8 @@ class TextInput extends Field implements CanHaveNumericState
     {
         $this->isTel = $condition;
 
+        $this->regex('/^[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\.\/0-9]*$/', $condition);
+
         return $this;
     }
 


### PR DESCRIPTION
as suggested on dicord https://discord.com/channels/883083792112300104/883085267383226478/956839096075051008

currently `tel()` does no validation
now it will be using a basic check `/^[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\.\/0-9]*$/`

if a more specific regex for a country, can override with `regex()`
```php
Forms\Components\TextInput::make('mobile_phone')
             ->tel()
            ->regex('/\(?\d{3}\)?-? *\d{3}-? *-?\d{4}/')
```

