### PR TITLE
Update filter query string

### DIFF
--- a/packages/admin/src/Resources/Pages/ListRecords.php
+++ b/packages/admin/src/Resources/Pages/ListRecords.php
@@ -20,11 +20,33 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
 
     protected ?Table $resourceTable = null;
 
-    protected $queryString = [
-        'tableSortColumn',
-        'tableSortDirection',
-        'tableSearchQuery' => ['except' => ''],
-    ];
+    public function queryString()
+    {
+        $formQuery = collect($this->getTableFilters())
+            ->mapWithKeys(function (Tables\Filters\Filter $filter) {
+                return [
+                    $filter->getName() => [
+                        'value' => ['except' => '']
+                    ]
+                ];
+            })
+            ->all();
+        
+        // Init per page
+        if (request()->has('tableRecordsPerPage')) {
+            $this->tableRecordsPerPage = request()->get('tableRecordsPerPage');
+        }
+
+        return [
+            'tableFilters' => [
+                'form' => $formQuery,
+            ],
+            'tableRecordsPerPage',
+            'tableSortColumn',
+            'tableSortDirection',
+            'tableSearchQuery' => ['except' => ''],
+        ];
+    }
 
     public function mount(): void
     {


### PR DESCRIPTION
With these changes filament will be able to update the query string based on the filters. 
It also includes the tableRecordsPerPage, therefore the page link can be passed on to someone with the correct pagination.