### PR TITLE
View Page Title Improvement

### DIFF
--- a/packages/admin/resources/lang/ar/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/ar/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'عرض :label',
+
     'breadcrumb' => 'عرض',
 
     'actions' => [

--- a/packages/admin/resources/lang/cs/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/cs/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'Zobrazit :label',
+
     'breadcrumb' => 'Zobrazit',
 
     'actions' => [

--- a/packages/admin/resources/lang/de/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/de/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => ':label ansehen',
+
     'breadcrumb' => 'Ansehen',
 
     'actions' => [

--- a/packages/admin/resources/lang/en/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/en/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'View :label',
+
     'breadcrumb' => 'View',
 
     'actions' => [

--- a/packages/admin/resources/lang/es/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/es/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'Ver :label',
+
     'breadcrumb' => 'Ver',
 
     'actions' => [

--- a/packages/admin/resources/lang/fa/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/fa/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'مشاهده :label',
+
     'breadcrumb' => 'مشاهده',
 
     'actions' => [

--- a/packages/admin/resources/lang/fr/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/fr/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'Afficher :label',
+
     'breadcrumb' => 'Afficher',
 
     'actions' => [

--- a/packages/admin/resources/lang/hi/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/hi/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => ':label देखें',
+
     'breadcrumb' => 'देखें',
 
     'actions' => [

--- a/packages/admin/resources/lang/id/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/id/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'Lihat :label',
+
     'breadcrumb' => 'Lihat',
 
     'actions' => [

--- a/packages/admin/resources/lang/it/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/it/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'Guarda :label',
+
     'breadcrumb' => 'Guarda',
 
     'actions' => [

--- a/packages/admin/resources/lang/kh/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/kh/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'ស្លាក​សញ្ញា :label',
+
     'breadcrumb' => 'ស្លាក​សញ្ញា',
 
     'actions' => [

--- a/packages/admin/resources/lang/ko/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/ko/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => ':label 보기',
+
     'breadcrumb' => '보기',
 
     'actions' => [

--- a/packages/admin/resources/lang/ku/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/ku/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'سەیرکردن :label',
+
     'breadcrumb' => 'سەیرکردن',
 
     'actions' => [

--- a/packages/admin/resources/lang/ms/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/ms/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'Lihat :label',
+
     'breadcrumb' => 'Lihat',
 
     'actions' => [

--- a/packages/admin/resources/lang/nl/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/nl/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => ':Label bekijken',
+
     'breadcrumb' => 'Bekijken',
 
     'actions' => [

--- a/packages/admin/resources/lang/pl/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/pl/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'Podgląd :label',
+
     'breadcrumb' => 'Podgląd',
 
     'actions' => [

--- a/packages/admin/resources/lang/pt_BR/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/pt_BR/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'Mostrar :label',
+
     'breadcrumb' => 'Mostrar',
 
     'actions' => [

--- a/packages/admin/resources/lang/pt_PT/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/pt_PT/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'Mostrar :label',
+
     'breadcrumb' => 'Mostrar',
 
     'actions' => [

--- a/packages/admin/resources/lang/ru/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/ru/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'Просмотр :label',
+
     'breadcrumb' => 'Просмотр',
 
     'actions' => [

--- a/packages/admin/resources/lang/sv/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/sv/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'Visa :label',
+
     'breadcrumb' => 'Visa',
 
     'actions' => [

--- a/packages/admin/resources/lang/tr/resources/pages/edit-record.php
+++ b/packages/admin/resources/lang/tr/resources/pages/edit-record.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'title' => 'Düzenle: :label',
+    'title' => 'Düzenle :label',
 
     'breadcrumb' => 'Düzenle',
 

--- a/packages/admin/resources/lang/tr/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/tr/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'Görüntüle :label',
+
     'breadcrumb' => 'Görüntüle',
 
     'actions' => [

--- a/packages/admin/resources/lang/vi/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/vi/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => 'Xem :label',
+
     'breadcrumb' => 'Xem',
 
     'actions' => [

--- a/packages/admin/resources/lang/zh_CN/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/zh_CN/resources/pages/view-record.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'title' => '详情 :label',
+
     'breadcrumb' => '详情',
 
     'actions' => [

--- a/packages/admin/src/Resources/Pages/ViewRecord.php
+++ b/packages/admin/src/Resources/Pages/ViewRecord.php
@@ -82,10 +82,14 @@ class ViewRecord extends Page
         }
 
         if (filled($recordTitle = $this->getRecordTitle())) {
-            return $recordTitle;
+            return __('filament::resources/pages/view-record.title', [
+                'label' => $recordTitle,
+            ]);
         }
 
-        return Str::title(static::getResource()::getLabel());
+        return __('filament::resources/pages/view-record.title', [
+            'label' => Str::title(static::getResource()::getLabel()),
+        ]);
     }
 
     protected function getForms(): array


### PR DESCRIPTION
This PR makes the formatting of the title for the view page consistent with the formatting of the title for the create and edit pages. For the examples below, let's assume we have a Registrant Record with a title of Craig Anderson. Currently, the page titles for these three pages would be as follows:

- _Create Page:_ Create Registrant
- _Edit Page:_ Edit Craig Anderson
- _View Page:_ Craig Anderson

I found this to be confusing for the user experience, especially in situations when some resources have a View page only, some have an Edit page only, and some have both.

This PR changes the View page to be consistent with the formatting of the other two, as follows:

- _Create Page:_ Create Registrant
- _Edit Page:_ Edit Craig Anderson
- _View Page:_ View Craig Anderson