### PR TITLE
feature: support prefixing/suffixing text columns

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -14,6 +14,10 @@ trait CanFormatState
 {
     protected ?Closure $formatStateUsing = null;
 
+    protected string | Closure | null $prefix = null;
+
+    protected string | Closure | null $suffix = null;
+
     public function date(?string $format = null, ?string $timezone = null): static
     {
         $format ??= config('tables.date_format');
@@ -50,6 +54,20 @@ trait CanFormatState
 
             return Str::limit($state, $length, $end);
         });
+
+        return $this;
+    }
+
+    public function prefix(string | Closure $prefix): static
+    {
+        $this->prefix = $prefix;
+
+        return $this;
+    }
+
+    public function suffix(string | Closure $suffix): static
+    {
+        $this->suffix = $suffix;
 
         return $this;
     }
@@ -91,6 +109,14 @@ trait CanFormatState
             $state = $this->evaluate($this->formatStateUsing, [
                 'state' => $state,
             ]);
+        }
+
+        if ($this->prefix) {
+            $state = $this->evaluate($this->prefix) . $state;
+        }
+
+        if ($this->suffix) {
+            $state = $state . $this->evaluate($this->suffix);
         }
 
         return $state;


### PR DESCRIPTION
Adds `CanFormatState::prefix()` and `CanFormatState::suffix()` methods for formatting state, similar to the `TextField`.