### PR TITLE
Improved search variable name for selects

### DIFF
--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanAssociateRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanAssociateRecords.php
@@ -61,7 +61,7 @@ trait CanAssociateRecords
         return Select::make('recordId')
             ->label(__('filament::resources/relation-managers/associate.action.modal.fields.record_id.label'))
             ->searchable()
-            ->getSearchResultsUsing(function (Select $component, RelationManager $livewire, string $query): array {
+            ->getSearchResultsUsing(function (Select $component, RelationManager $livewire, string $search): array {
                 $relationship = $livewire->getRelationship();
 
                 $displayColumnName = static::getRecordTitleAttribute();
@@ -69,7 +69,7 @@ trait CanAssociateRecords
                 /** @var Builder $relationshipQuery */
                 $relationshipQuery = $relationship->getRelated()->query()->orderBy($displayColumnName);
 
-                $query = strtolower($query);
+                $search = strtolower($search);
 
                 /** @var Connection $databaseConnection */
                 $databaseConnection = $relationshipQuery->getConnection();
@@ -88,7 +88,7 @@ trait CanAssociateRecords
                     $relationshipQuery->{$whereClause}(
                         $searchColumnName,
                         $searchOperator,
-                        "%{$query}%",
+                        "%{$search}%",
                     );
 
                     $isFirst = false;

--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanAssociateRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanAssociateRecords.php
@@ -61,7 +61,7 @@ trait CanAssociateRecords
         return Select::make('recordId')
             ->label(__('filament::resources/relation-managers/associate.action.modal.fields.record_id.label'))
             ->searchable()
-            ->getSearchResultsUsing(function (Select $component, RelationManager $livewire, string $search): array {
+            ->getSearchResultsUsing(function (Select $component, RelationManager $livewire, string $searchQuery): array {
                 $relationship = $livewire->getRelationship();
 
                 $displayColumnName = static::getRecordTitleAttribute();
@@ -69,7 +69,7 @@ trait CanAssociateRecords
                 /** @var Builder $relationshipQuery */
                 $relationshipQuery = $relationship->getRelated()->query()->orderBy($displayColumnName);
 
-                $search = strtolower($search);
+                $searchQuery = strtolower($searchQuery);
 
                 /** @var Connection $databaseConnection */
                 $databaseConnection = $relationshipQuery->getConnection();
@@ -88,7 +88,7 @@ trait CanAssociateRecords
                     $relationshipQuery->{$whereClause}(
                         $searchColumnName,
                         $searchOperator,
-                        "%{$search}%",
+                        "%{$searchQuery}%",
                     );
 
                     $isFirst = false;

--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanAttachRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanAttachRecords.php
@@ -54,7 +54,7 @@ trait CanAttachRecords
         return Select::make('recordId')
             ->label(__('filament::resources/relation-managers/attach.action.modal.fields.record_id.label'))
             ->searchable()
-            ->getSearchResultsUsing(function (Select $component, RelationManager $livewire, string $search): array {
+            ->getSearchResultsUsing(function (Select $component, RelationManager $livewire, string $searchQuery): array {
                 $relationship = $livewire->getRelationship();
 
                 $displayColumnName = static::getRecordTitleAttribute();
@@ -62,7 +62,7 @@ trait CanAttachRecords
                 /** @var Builder $relationshipQuery */
                 $relationshipQuery = $relationship->getRelated()->query()->orderBy($displayColumnName);
 
-                $search = strtolower($search);
+                $searchQuery = strtolower($searchQuery);
 
                 /** @var Connection $databaseConnection */
                 $databaseConnection = $relationshipQuery->getConnection();
@@ -81,7 +81,7 @@ trait CanAttachRecords
                     $relationshipQuery->{$whereClause}(
                         $searchColumnName,
                         $searchOperator,
-                        "%{$search}%",
+                        "%{$searchQuery}%",
                     );
 
                     $isFirst = false;

--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanAttachRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanAttachRecords.php
@@ -54,7 +54,7 @@ trait CanAttachRecords
         return Select::make('recordId')
             ->label(__('filament::resources/relation-managers/attach.action.modal.fields.record_id.label'))
             ->searchable()
-            ->getSearchResultsUsing(function (Select $component, RelationManager $livewire, string $query): array {
+            ->getSearchResultsUsing(function (Select $component, RelationManager $livewire, string $search): array {
                 $relationship = $livewire->getRelationship();
 
                 $displayColumnName = static::getRecordTitleAttribute();
@@ -62,7 +62,7 @@ trait CanAttachRecords
                 /** @var Builder $relationshipQuery */
                 $relationshipQuery = $relationship->getRelated()->query()->orderBy($displayColumnName);
 
-                $query = strtolower($query);
+                $search = strtolower($search);
 
                 /** @var Connection $databaseConnection */
                 $databaseConnection = $relationshipQuery->getConnection();
@@ -81,7 +81,7 @@ trait CanAttachRecords
                     $relationshipQuery->{$whereClause}(
                         $searchColumnName,
                         $searchOperator,
-                        "%{$query}%",
+                        "%{$search}%",
                     );
 
                     $isFirst = false;

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -437,7 +437,7 @@ The `getOptionLabelUsing()` method accepts a callback that transforms the select
 ```php
 Select::make('authorId')
     ->searchable()
-    ->getSearchResultsUsing(fn (string $search) => User::where('name', 'like', "%{$search}%")->limit(50)->pluck('name', 'id'))
+    ->getSearchResultsUsing(fn (string $searchQuery) => User::where('name', 'like', "%{$searchQuery}%")->limit(50)->pluck('name', 'id'))
     ->getOptionLabelUsing(fn ($value): ?string => User::find($value)?->name),
 ```
 
@@ -554,7 +554,7 @@ The `getOptionLabelsUsing()` method accepts a callback that transforms the selec
 use Filament\Forms\Components\MultiSelect;
 
 MultiSelect::make('technologies')
-    ->getSearchResultsUsing(fn (string $search) => Technology::where('name', 'like', "%{$search}%")->limit(50)->pluck('name', 'id'))
+    ->getSearchResultsUsing(fn (string $searchQuery) => Technology::where('name', 'like', "%{$searchQuery}%")->limit(50)->pluck('name', 'id'))
     ->getOptionLabelsUsing(fn (array $values) => Technology::find($values)->pluck('name')),
 ```
 

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -437,7 +437,7 @@ The `getOptionLabelUsing()` method accepts a callback that transforms the select
 ```php
 Select::make('authorId')
     ->searchable()
-    ->getSearchResultsUsing(fn (string $query) => User::where('name', 'like', "%{$query}%")->limit(50)->pluck('name', 'id'))
+    ->getSearchResultsUsing(fn (string $search) => User::where('name', 'like', "%{$search}%")->limit(50)->pluck('name', 'id'))
     ->getOptionLabelUsing(fn ($value): ?string => User::find($value)?->name),
 ```
 
@@ -554,7 +554,7 @@ The `getOptionLabelsUsing()` method accepts a callback that transforms the selec
 use Filament\Forms\Components\MultiSelect;
 
 MultiSelect::make('technologies')
-    ->getSearchResultsUsing(fn (string $query) => Technology::where('name', 'like', "%{$query}%")->limit(50)->pluck('name', 'id'))
+    ->getSearchResultsUsing(fn (string $search) => Technology::where('name', 'like', "%{$search}%")->limit(50)->pluck('name', 'id'))
     ->getOptionLabelsUsing(fn (array $values) => Technology::find($values)->pluck('name')),
 ```
 

--- a/packages/forms/resources/views/components/multi-select.blade.php
+++ b/packages/forms/resources/views/components/multi-select.blade.php
@@ -17,8 +17,8 @@
             getOptionsUsing: async () => {
                 return await $wire.getMultiSelectOptions('{{ $getStatePath() }}')
             },
-            getSearchResultsUsing: async (query) => {
-                return await $wire.getMultiSelectSearchResults('{{ $getStatePath() }}', query)
+            getSearchResultsUsing: async (search) => {
+                return await $wire.getMultiSelectSearchResults('{{ $getStatePath() }}', search)
             },
             isAutofocused: {{ $isAutofocused() ? 'true' : 'false' }},
             hasDynamicOptions: {{ $hasDynamicOptions() ? 'true' : 'false' }},

--- a/packages/forms/resources/views/components/multi-select.blade.php
+++ b/packages/forms/resources/views/components/multi-select.blade.php
@@ -17,8 +17,8 @@
             getOptionsUsing: async () => {
                 return await $wire.getMultiSelectOptions('{{ $getStatePath() }}')
             },
-            getSearchResultsUsing: async (search) => {
-                return await $wire.getMultiSelectSearchResults('{{ $getStatePath() }}', search)
+            getSearchResultsUsing: async (searchQuery) => {
+                return await $wire.getMultiSelectSearchResults('{{ $getStatePath() }}', searchQuery)
             },
             isAutofocused: {{ $isAutofocused() ? 'true' : 'false' }},
             hasDynamicOptions: {{ $hasDynamicOptions() ? 'true' : 'false' }},

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -63,8 +63,8 @@
                         getOptionsUsing: async (query) => {
                             return await $wire.getSelectOptions('{{ $getStatePath() }}')
                         },
-                        getSearchResultsUsing: async (search) => {
-                            return await $wire.getSelectSearchResults('{{ $getStatePath() }}', search)
+                        getSearchResultsUsing: async (searchQuery) => {
+                            return await $wire.getSelectSearchResults('{{ $getStatePath() }}', searchQuery)
                         },
                         isAutofocused: {{ $isAutofocused() ? 'true' : 'false' }},
                         hasDynamicOptions: {{ $hasDynamicOptions() ? 'true' : 'false' }},

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -63,8 +63,8 @@
                         getOptionsUsing: async (query) => {
                             return await $wire.getSelectOptions('{{ $getStatePath() }}')
                         },
-                        getSearchResultsUsing: async (query) => {
-                            return await $wire.getSelectSearchResults('{{ $getStatePath() }}', query)
+                        getSearchResultsUsing: async (search) => {
+                            return await $wire.getSelectSearchResults('{{ $getStatePath() }}', search)
                         },
                         isAutofocused: {{ $isAutofocused() ? 'true' : 'false' }},
                         hasDynamicOptions: {{ $hasDynamicOptions() ? 'true' : 'false' }},

--- a/packages/forms/src/Components/BelongsToManyMultiSelect.php
+++ b/packages/forms/src/Components/BelongsToManyMultiSelect.php
@@ -82,7 +82,7 @@ class BelongsToManyMultiSelect extends MultiSelect
                 ->toArray();
         });
 
-        $this->getSearchResultsUsing(static function (BelongsToManyMultiSelect $component, ?string $search) use ($callback): array {
+        $this->getSearchResultsUsing(static function (BelongsToManyMultiSelect $component, ?string $searchQuery) use ($callback): array {
             $relationship = $component->getRelationship();
 
             $relationshipQuery = $relationship->getRelated()->query()->orderBy($component->getDisplayColumnName());
@@ -93,7 +93,7 @@ class BelongsToManyMultiSelect extends MultiSelect
                 ]);
             }
 
-            $search = strtolower($search);
+            $searchQuery = strtolower($searchQuery);
 
             /** @var Connection $databaseConnection */
             $databaseConnection = $relationshipQuery->getConnection();
@@ -104,7 +104,7 @@ class BelongsToManyMultiSelect extends MultiSelect
             };
 
             $relationshipQuery = $relationshipQuery
-                ->where($component->getDisplayColumnName(), $searchOperator, "%{$search}%")
+                ->where($component->getDisplayColumnName(), $searchOperator, "%{$searchQuery}%")
                 ->limit(50);
 
             if ($component->hasOptionLabelFromRecordUsingCallback()) {

--- a/packages/forms/src/Components/BelongsToManyMultiSelect.php
+++ b/packages/forms/src/Components/BelongsToManyMultiSelect.php
@@ -82,7 +82,7 @@ class BelongsToManyMultiSelect extends MultiSelect
                 ->toArray();
         });
 
-        $this->getSearchResultsUsing(static function (BelongsToManyMultiSelect $component, ?string $query) use ($callback): array {
+        $this->getSearchResultsUsing(static function (BelongsToManyMultiSelect $component, ?string $search) use ($callback): array {
             $relationship = $component->getRelationship();
 
             $relationshipQuery = $relationship->getRelated()->query()->orderBy($component->getDisplayColumnName());
@@ -93,7 +93,7 @@ class BelongsToManyMultiSelect extends MultiSelect
                 ]);
             }
 
-            $query = strtolower($query);
+            $search = strtolower($search);
 
             /** @var Connection $databaseConnection */
             $databaseConnection = $relationshipQuery->getConnection();
@@ -104,7 +104,7 @@ class BelongsToManyMultiSelect extends MultiSelect
             };
 
             $relationshipQuery = $relationshipQuery
-                ->where($component->getDisplayColumnName(), $searchOperator, "%{$query}%")
+                ->where($component->getDisplayColumnName(), $searchOperator, "%{$search}%")
                 ->limit(50);
 
             if ($component->hasOptionLabelFromRecordUsingCallback()) {

--- a/packages/forms/src/Components/BelongsToSelect.php
+++ b/packages/forms/src/Components/BelongsToSelect.php
@@ -81,7 +81,7 @@ class BelongsToSelect extends Select
             return $record->getAttributeValue($component->getDisplayColumnName());
         });
 
-        $this->getSearchResultsUsing(static function (BelongsToSelect $component, ?string $query) use ($callback): array {
+        $this->getSearchResultsUsing(static function (BelongsToSelect $component, ?string $search) use ($callback): array {
             $relationship = $component->getRelationship();
 
             $relationshipQuery = $relationship->getRelated()->query()->orderBy($component->getDisplayColumnName());
@@ -92,9 +92,9 @@ class BelongsToSelect extends Select
                 ]);
             }
 
-            $query = strtolower($query);
+            $search = strtolower($search);
 
-            $relationshipQuery = $component->applySearchConstraint($relationshipQuery, $query)->limit(50);
+            $relationshipQuery = $component->applySearchConstraint($relationshipQuery, $search)->limit(50);
 
             if ($component->hasOptionLabelFromRecordUsingCallback()) {
                 return $relationshipQuery

--- a/packages/forms/src/Components/BelongsToSelect.php
+++ b/packages/forms/src/Components/BelongsToSelect.php
@@ -81,7 +81,7 @@ class BelongsToSelect extends Select
             return $record->getAttributeValue($component->getDisplayColumnName());
         });
 
-        $this->getSearchResultsUsing(static function (BelongsToSelect $component, ?string $search) use ($callback): array {
+        $this->getSearchResultsUsing(static function (BelongsToSelect $component, ?string $searchQuery) use ($callback): array {
             $relationship = $component->getRelationship();
 
             $relationshipQuery = $relationship->getRelated()->query()->orderBy($component->getDisplayColumnName());
@@ -92,9 +92,9 @@ class BelongsToSelect extends Select
                 ]);
             }
 
-            $search = strtolower($search);
+            $searchQuery = strtolower($searchQuery);
 
-            $relationshipQuery = $component->applySearchConstraint($relationshipQuery, $search)->limit(50);
+            $relationshipQuery = $component->applySearchConstraint($relationshipQuery, $searchQuery)->limit(50);
 
             if ($component->hasOptionLabelFromRecordUsingCallback()) {
                 return $relationshipQuery

--- a/packages/forms/src/Components/MultiSelect.php
+++ b/packages/forms/src/Components/MultiSelect.php
@@ -111,7 +111,7 @@ class MultiSelect extends Field
 
         $results = $this->evaluate($this->getSearchResultsUsing, [
             'query' => $searchQuery,
-            'search' => $searchQuery,
+            'searchQuery' => $searchQuery,
         ]);
 
         if ($results instanceof Arrayable) {

--- a/packages/forms/src/Components/MultiSelect.php
+++ b/packages/forms/src/Components/MultiSelect.php
@@ -103,14 +103,15 @@ class MultiSelect extends Field
         return $this->evaluate($this->searchPrompt);
     }
 
-    public function getSearchResults(string $query): array
+    public function getSearchResults(string $search): array
     {
         if (! $this->getSearchResultsUsing) {
             return [];
         }
 
         $results = $this->evaluate($this->getSearchResultsUsing, [
-            'query' => $query,
+            'query' => $search,
+            'search' => $search,
         ]);
 
         if ($results instanceof Arrayable) {

--- a/packages/forms/src/Components/MultiSelect.php
+++ b/packages/forms/src/Components/MultiSelect.php
@@ -103,15 +103,15 @@ class MultiSelect extends Field
         return $this->evaluate($this->searchPrompt);
     }
 
-    public function getSearchResults(string $search): array
+    public function getSearchResults(string $searchQuery): array
     {
         if (! $this->getSearchResultsUsing) {
             return [];
         }
 
         $results = $this->evaluate($this->getSearchResultsUsing, [
-            'query' => $search,
-            'search' => $search,
+            'query' => $searchQuery,
+            'search' => $searchQuery,
         ]);
 
         if ($results instanceof Arrayable) {

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -138,14 +138,15 @@ class Select extends Field
         return $this->searchColumns;
     }
 
-    public function getSearchResults(string $query): array
+    public function getSearchResults(string $search): array
     {
         if (! $this->getSearchResultsUsing) {
             return [];
         }
 
         $results = $this->evaluate($this->getSearchResultsUsing, [
-            'query' => $query,
+            'query' => $search,
+            'search' => $search,
         ]);
 
         if ($results instanceof Arrayable) {

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -146,7 +146,7 @@ class Select extends Field
 
         $results = $this->evaluate($this->getSearchResultsUsing, [
             'query' => $searchQuery,
-            'search' => $searchQuery,
+            'searchQuery' => $searchQuery,
         ]);
 
         if ($results instanceof Arrayable) {

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -138,15 +138,15 @@ class Select extends Field
         return $this->searchColumns;
     }
 
-    public function getSearchResults(string $search): array
+    public function getSearchResults(string $searchQuery): array
     {
         if (! $this->getSearchResultsUsing) {
             return [];
         }
 
         $results = $this->evaluate($this->getSearchResultsUsing, [
-            'query' => $search,
-            'search' => $search,
+            'query' => $searchQuery,
+            'search' => $searchQuery,
         ]);
 
         if ($results instanceof Arrayable) {

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -72,10 +72,10 @@ trait InteractsWithForms
         return [];
     }
 
-    public function getMultiSelectSearchResults(string $statePath, string $query): array
+    public function getMultiSelectSearchResults(string $statePath, string $search): array
     {
         foreach ($this->getCachedForms() as $form) {
-            if ($results = $form->getMultiSelectSearchResults($statePath, $query)) {
+            if ($results = $form->getMultiSelectSearchResults($statePath, $search)) {
                 return $results;
             }
         }
@@ -105,10 +105,10 @@ trait InteractsWithForms
         return [];
     }
 
-    public function getSelectSearchResults(string $statePath, string $query): array
+    public function getSelectSearchResults(string $statePath, string $search): array
     {
         foreach ($this->getCachedForms() as $form) {
-            if ($results = $form->getSelectSearchResults($statePath, $query)) {
+            if ($results = $form->getSelectSearchResults($statePath, $search)) {
                 return $results;
             }
         }

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -72,10 +72,10 @@ trait InteractsWithForms
         return [];
     }
 
-    public function getMultiSelectSearchResults(string $statePath, string $search): array
+    public function getMultiSelectSearchResults(string $statePath, string $searchQuery): array
     {
         foreach ($this->getCachedForms() as $form) {
-            if ($results = $form->getMultiSelectSearchResults($statePath, $search)) {
+            if ($results = $form->getMultiSelectSearchResults($statePath, $searchQuery)) {
                 return $results;
             }
         }
@@ -105,10 +105,10 @@ trait InteractsWithForms
         return [];
     }
 
-    public function getSelectSearchResults(string $statePath, string $search): array
+    public function getSelectSearchResults(string $statePath, string $searchQuery): array
     {
         foreach ($this->getCachedForms() as $form) {
-            if ($results = $form->getSelectSearchResults($statePath, $search)) {
+            if ($results = $form->getSelectSearchResults($statePath, $searchQuery)) {
                 return $results;
             }
         }

--- a/packages/forms/src/Concerns/SupportsMultiSelectFields.php
+++ b/packages/forms/src/Concerns/SupportsMultiSelectFields.php
@@ -48,11 +48,11 @@ trait SupportsMultiSelectFields
         return [];
     }
 
-    public function getMultiSelectSearchResults(string $statePath, string $search): array
+    public function getMultiSelectSearchResults(string $statePath, string $searchQuery): array
     {
         foreach ($this->getComponents() as $component) {
             if ($component instanceof MultiSelect && $component->getStatePath() === $statePath) {
-                return $component->getSearchResults($search);
+                return $component->getSearchResults($searchQuery);
             }
 
             foreach ($component->getChildComponentContainers() as $container) {
@@ -60,7 +60,7 @@ trait SupportsMultiSelectFields
                     continue;
                 }
 
-                if ($results = $container->getMultiSelectSearchResults($statePath, $search)) {
+                if ($results = $container->getMultiSelectSearchResults($statePath, $searchQuery)) {
                     return $results;
                 }
             }

--- a/packages/forms/src/Concerns/SupportsMultiSelectFields.php
+++ b/packages/forms/src/Concerns/SupportsMultiSelectFields.php
@@ -48,11 +48,11 @@ trait SupportsMultiSelectFields
         return [];
     }
 
-    public function getMultiSelectSearchResults(string $statePath, string $query): array
+    public function getMultiSelectSearchResults(string $statePath, string $search): array
     {
         foreach ($this->getComponents() as $component) {
             if ($component instanceof MultiSelect && $component->getStatePath() === $statePath) {
-                return $component->getSearchResults($query);
+                return $component->getSearchResults($search);
             }
 
             foreach ($component->getChildComponentContainers() as $container) {
@@ -60,7 +60,7 @@ trait SupportsMultiSelectFields
                     continue;
                 }
 
-                if ($results = $container->getMultiSelectSearchResults($statePath, $query)) {
+                if ($results = $container->getMultiSelectSearchResults($statePath, $search)) {
                     return $results;
                 }
             }

--- a/packages/forms/src/Concerns/SupportsSelectFields.php
+++ b/packages/forms/src/Concerns/SupportsSelectFields.php
@@ -48,11 +48,11 @@ trait SupportsSelectFields
         return [];
     }
 
-    public function getSelectSearchResults(string $statePath, string $query): array
+    public function getSelectSearchResults(string $statePath, string $search): array
     {
         foreach ($this->getComponents() as $component) {
             if ($component instanceof Select && $component->getStatePath() === $statePath) {
-                return $component->getSearchResults($query);
+                return $component->getSearchResults($search);
             }
 
             foreach ($component->getChildComponentContainers() as $container) {
@@ -60,7 +60,7 @@ trait SupportsSelectFields
                     continue;
                 }
 
-                if ($results = $container->getSelectSearchResults($statePath, $query)) {
+                if ($results = $container->getSelectSearchResults($statePath, $search)) {
                     return $results;
                 }
             }

--- a/packages/forms/src/Concerns/SupportsSelectFields.php
+++ b/packages/forms/src/Concerns/SupportsSelectFields.php
@@ -48,11 +48,11 @@ trait SupportsSelectFields
         return [];
     }
 
-    public function getSelectSearchResults(string $statePath, string $search): array
+    public function getSelectSearchResults(string $statePath, string $searchQuery): array
     {
         foreach ($this->getComponents() as $component) {
             if ($component instanceof Select && $component->getStatePath() === $statePath) {
-                return $component->getSearchResults($search);
+                return $component->getSearchResults($searchQuery);
             }
 
             foreach ($component->getChildComponentContainers() as $container) {
@@ -60,7 +60,7 @@ trait SupportsSelectFields
                     continue;
                 }
 
-                if ($results = $container->getSelectSearchResults($statePath, $search)) {
+                if ($results = $container->getSelectSearchResults($statePath, $searchQuery)) {
                     return $results;
                 }
             }

--- a/packages/forms/src/Contracts/HasForms.php
+++ b/packages/forms/src/Contracts/HasForms.php
@@ -16,13 +16,13 @@ interface HasForms
 
     public function getMultiSelectOptions(string $statePath): array;
 
-    public function getMultiSelectSearchResults(string $statePath, string $query): array;
+    public function getMultiSelectSearchResults(string $statePath, string $search): array;
 
     public function getSelectOptionLabel(string $statePath): ?string;
 
     public function getSelectOptions(string $statePath): array;
 
-    public function getSelectSearchResults(string $statePath, string $query): array;
+    public function getSelectSearchResults(string $statePath, string $search): array;
 
     public function getUploadedFileUrls(string $statePath): ?array;
 

--- a/packages/forms/src/Contracts/HasForms.php
+++ b/packages/forms/src/Contracts/HasForms.php
@@ -16,13 +16,13 @@ interface HasForms
 
     public function getMultiSelectOptions(string $statePath): array;
 
-    public function getMultiSelectSearchResults(string $statePath, string $search): array;
+    public function getMultiSelectSearchResults(string $statePath, string $searchQuery): array;
 
     public function getSelectOptionLabel(string $statePath): ?string;
 
     public function getSelectOptions(string $statePath): array;
 
-    public function getSelectSearchResults(string $statePath, string $search): array;
+    public function getSelectSearchResults(string $statePath, string $searchQuery): array;
 
     public function getUploadedFileUrls(string $statePath): ?array;
 


### PR DESCRIPTION
Per [this discussion](https://github.com/laravel-filament/filament/discussions/2007), this PR improves the default search string variable for the Form Select Components. Previously, the variable had to be `$query`, which could sometimes be confusing when the Laravel Query builder was also used. This PR allows either `$search` or `$query` to be used, and updates the docs to default to `$search`.

I also changed the variable name in a few other related methods for the sake of consistency.