### PR TITLE
feature: allow disabling collapsible nav groups

### DIFF
--- a/packages/admin/resources/views/components/layouts/app/sidebar/group.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/group.blade.php
@@ -1,11 +1,14 @@
 @props([
     'label' => null,
+    'collapsible' => true,
 ])
 
-<li x-data="{ label: {{ json_encode($label) }} }" class="filament-sidebar-group">
+<li x-data="{ label: @js($label) }" class="filament-sidebar-group">
     @if ($label)
         <button
-            x-on:click.prevent="$store.sidebar.toggleCollapsedGroup(label)"
+            @if($collapsible)
+                x-on:click.prevent="$store.sidebar.toggleCollapsedGroup(label)"
+            @endif
             @if (config('filament.layout.sidebar.is_collapsible_on_desktop'))
                 x-show="$store.sidebar.isOpen"
             @endif
@@ -18,15 +21,17 @@
                 {{ $label }}
             </p>
 
-            <x-heroicon-o-chevron-down :class="\Illuminate\Support\Arr::toCssClasses([
-                'w-3 h-3 text-gray-600',
-                'dark:text-gray-300' => config('filament.dark_mode'),
-            ])" x-show="$store.sidebar.groupIsCollapsed(label)" x-cloak />
+            @if($collapsible)
+                <x-heroicon-o-chevron-down :class="\Illuminate\Support\Arr::toCssClasses([
+                    'w-3 h-3 text-gray-600',
+                    'dark:text-gray-300' => config('filament.dark_mode'),
+                ])" x-show="$store.sidebar.groupIsCollapsed(label)" x-cloak />
 
-            <x-heroicon-o-chevron-up :class="\Illuminate\Support\Arr::toCssClasses([
-                'w-3 h-3 text-gray-600',
-                'dark:text-gray-300' => config('filament.dark_mode'),
-            ])" x-show="! $store.sidebar.groupIsCollapsed(label)" />
+                <x-heroicon-o-chevron-up :class="\Illuminate\Support\Arr::toCssClasses([
+                    'w-3 h-3 text-gray-600',
+                    'dark:text-gray-300' => config('filament.dark_mode'),
+                ])" x-show="! $store.sidebar.groupIsCollapsed(label)" />
+            @endif
         </button>
     @endif
 

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -48,8 +48,8 @@
         <x-filament::layouts.app.sidebar.start />
 
         <ul class="space-y-6 px-6">
-            @foreach (\Filament\Facades\Filament::getNavigation() as $group => $items)
-                <x-filament::layouts.app.sidebar.group :label="$group">
+            @foreach (\Filament\Facades\Filament::getNavigation() as $group => ['items' => $items, 'collapsible' => $collapsible])
+                <x-filament::layouts.app.sidebar.group :label="$group" :collapsible="$collapsible">
                     @foreach ($items as $item)
                         <x-filament::layouts.app.sidebar.item
                             :active="$item->isActive()"

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -69,7 +69,7 @@ class FilamentManager
             null => [
                 'items' => $builder->getItems(),
                 'collapsible' => false,
-            ]
+            ],
         ])
             ->merge($builder->getGroups())
             ->toArray();

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -224,7 +224,12 @@ class FilamentManager
 
         return $sortedGroups
             ->mapWithKeys(function (?string $group) use ($groupedItems): array {
-                return [$group => $groupedItems->get($group)];
+                return [
+                    $group => [
+                        'items' => $groupedItems->get($group),
+                        'collapsible' => true,
+                    ]
+                ];
             })
             ->toArray();
     }

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -228,7 +228,7 @@ class FilamentManager
                     $group => [
                         'items' => $groupedItems->get($group),
                         'collapsible' => true,
-                    ]
+                    ],
                 ];
             })
             ->toArray();

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -65,7 +65,12 @@ class FilamentManager
         /** @var \Filament\Navigation\NavigationBuilder $builder */
         $builder = app()->call($this->navigationBuilder);
 
-        return collect([null => $builder->getItems()])
+        return collect([
+            null => [
+                'items' => $builder->getItems(),
+                'collapsible' => false,
+            ]
+        ])
             ->merge($builder->getGroups())
             ->toArray();
     }

--- a/packages/admin/src/Navigation/NavigationBuilder.php
+++ b/packages/admin/src/Navigation/NavigationBuilder.php
@@ -14,11 +14,14 @@ class NavigationBuilder
     /** @var \Filament\Navigation\NavigationItem[] */
     protected array $items = [];
 
-    public function group(string $name, array $items = []): static
+    public function group(string $name, array $items = [], bool $collapsible = true): static
     {
-        $this->groups[$name] = collect($items)->map(
-            fn (NavigationItem $item, int $index) => $item->group($name)->sort($index),
-        )->toArray();
+        $this->groups[$name] = [
+            'items' => collect($items)->map(
+                fn (NavigationItem $item, int $index) => $item->group($name)->sort($index),
+            )->toArray(),
+            'collapsible' => $collapsible,
+        ];
 
         return $this;
     }


### PR DESCRIPTION
`->group()` now accepts a `$collapsible` argument that defaults to `true`. Default needs to be `true` to avoid a breaking UI/UX change.

If you set it to `false`, then the group won't be collapsible.