### PR TITLE
fix: use `resolveRouteBinding` to resolve model

### DIFF
--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -86,9 +86,8 @@ class Resource
 
     public static function resolveRecordRouteBinding($key): ?Model
     {
-        return static::getEloquentQuery()
-            ->where(static::getRecordRouteKeyName(), $key)
-            ->first();
+        return (new (static::getModel()))
+            ->resolveRouteBinding($key);
     }
 
     public static function can(string $action, ?Model $record = null): bool

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -86,7 +86,13 @@ class Resource
 
     public static function resolveRecordRouteBinding($key): ?Model
     {
-        return (new (static::getModel()))
+        if (static::shouldUseRecordRouteKeyName()) {
+            return static::getEloquentQuery()
+                ->where(static::getRecordRouteKeyName(), $key)
+                ->first();
+        }
+
+        return app(static::getModel())
             ->resolveRouteBinding($key);
     }
 
@@ -262,6 +268,11 @@ class Resource
         $slug = static::getSlug();
 
         return "filament.resources.{$slug}";
+    }
+
+    public static function shouldUseRecordRouteKeyName(): bool
+    {
+        return isset(static::$recordRouteKeyName);
     }
 
     public static function getRecordRouteKeyName(): string

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -92,8 +92,7 @@ class Resource
                 ->first();
         }
 
-        return app(static::getModel())
-            ->resolveRouteBinding($key);
+        return app(static::getModel())->resolveRouteBinding($key);
     }
 
     public static function can(string $action, ?Model $record = null): bool
@@ -272,7 +271,7 @@ class Resource
 
     public static function shouldUseRecordRouteKeyName(): bool
     {
-        return isset(static::$recordRouteKeyName);
+        return filled(static::$recordRouteKeyName);
     }
 
     public static function getRecordRouteKeyName(): string


### PR DESCRIPTION
This PR reintroduces the fix from https://github.com/laravel-filament/filament/pull/245, that was apparently lost. My use case is the same, my model uses hashid by extending `resolveRouteBinding`.