### PR TITLE
Add HasExtraInputAttributes to rich editor

### DIFF
--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -289,17 +289,13 @@
                 toolbar="trix-toolbar-{{ $getId() }}"
                 x-ref="trix"
                 dusk="filament.forms.{{ $getStatePath() }}"
-                {{
-                    $attributes
-                        ->merge($getExtraInputAttributeBag()->getAttributes())
-                        ->class([
-                            'bg-white block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-600 prose max-w-none',
-                            'dark:prose-invert dark:bg-gray-700' => config('forms.dark_mode'),
-                            'border-gray-300' => ! $errors->has($getStatePath()),
-                            'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
-                            'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
-                        ])
-                }}
+                {{ $getExtraInputAttributeBag()->class([
+                    'bg-white block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-600 prose max-w-none',
+                    'dark:prose-invert dark:bg-gray-700' => config('forms.dark_mode'),
+                    'border-gray-300' => ! $errors->has($getStatePath()),
+                    'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
+                    'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
+                ]) }}
             ></trix-editor>
         @else
             <div x-html="state" @class([

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -289,13 +289,17 @@
                 toolbar="trix-toolbar-{{ $getId() }}"
                 x-ref="trix"
                 dusk="filament.forms.{{ $getStatePath() }}"
-                @class([
-                    'bg-white block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-600 prose max-w-none',
-                    'dark:prose-invert dark:bg-gray-700' => config('forms.dark_mode'),
-                    'border-gray-300' => ! $errors->has($getStatePath()),
-                    'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
-                    'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
-                ])
+                {{
+                    $attributes
+                        ->merge($getExtraInputAttributeBag()->getAttributes())
+                        ->class([
+                            'bg-white block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-600 prose max-w-none',
+                            'dark:prose-invert dark:bg-gray-700' => config('forms.dark_mode'),
+                            'border-gray-300' => ! $errors->has($getStatePath()),
+                            'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
+                            'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
+                        ])
+                }}
             ></trix-editor>
         @else
             <div x-html="state" @class([

--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -8,6 +8,7 @@ class RichEditor extends Field implements Contracts\HasFileAttachments
 {
     use Concerns\CanBeLengthConstrained;
     use Concerns\HasExtraAlpineAttributes;
+    use Concerns\HasExtraInputAttributes;
     use Concerns\HasFileAttachments;
     use Concerns\HasPlaceholder;
     use Concerns\InteractsWithToolbarButtons;


### PR DESCRIPTION
this allows to use classes in trix editor

```php
Forms\Components\RichEditor::make('summary')
       ->extraInputAttributes(['class' => 'min-h-[200px]'])
```
