### PR TITLE
Feature: Add visible method to Table Filters

### DIFF
--- a/packages/tables/src/Filters/Concerns/CanBeHidden.php
+++ b/packages/tables/src/Filters/Concerns/CanBeHidden.php
@@ -8,6 +8,8 @@ trait CanBeHidden
 {
     protected bool | Closure $isHidden = false;
 
+    protected bool | Closure $isVisible = true;
+
     public function hidden(bool | Closure $condition = true): static
     {
         $this->isHidden = $condition;
@@ -15,8 +17,19 @@ trait CanBeHidden
         return $this;
     }
 
+    public function visible(bool | Closure $condition = true): static
+    {
+        $this->isVisible = $condition;
+
+        return $this;
+    }
+
     public function isHidden(): bool
     {
-        return $this->evaluate($this->isHidden);
+        if ($this->evaluate($this->isHidden)) {
+            return true;
+        }
+
+        return ! $this->evaluate($this->isVisible);
     }
 }


### PR DESCRIPTION
This adds the missing `visible()` method to` Filament\Tables\Filters\Concerns\CanBeHidden`

I have implemented it same as [Filament\Tables\Actions\Concerns\CanBeHidden](https://github.com/laravel-filament/filament/blob/4d6826132158a59ed880819c291494edee7de024/packages/tables/src/Actions/Concerns/CanBeHidden.php)