### PR TITLE
Fix: Add missing disabled classes to toggle.blade.php

### DIFF
--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -28,7 +28,7 @@
                 dusk="filament.forms.{{ $getStatePath() }}"
                 type="button"
                 {{ $attributes->merge($getExtraAttributes())->class([
-                    'relative inline-flex shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-500 filament-forms-toggle-component',
+                    'relative inline-flex shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-500 disabled:opacity-70 disabled:cursor-not-allowed filament-forms-toggle-component',
                     'border-gray-300' => ! $errors->has($getStatePath()),
                     'border-danger-300 ring-danger-500' => $errors->has($getStatePath()),
                 ]) }}


### PR DESCRIPTION
Currently when a toggle is disabled, it still shows the `cursor-pointer` class. I've added a fix for that specifically and also included a lower opacity to match the `TextInput` disabled classes.