### PR TITLE
Remove drag and drop behaviour from repeater and builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
         "marked": "^4.0.10",
         "mdhl": "^0.0.6",
         "postcss": "^8.4.4",
-        "sortablejs": "^1.15.0",
         "tailwindcss": "^3.0.0",
         "tippy.js": "^6.3.7",
         "trix": "^1.3.1"

--- a/packages/forms/resources/js/index.js
+++ b/packages/forms/resources/js/index.js
@@ -9,7 +9,6 @@ import SelectFormComponentAlpinePlugin from './components/select'
 import TagsInputFormComponentAlpinePlugin from './components/tags-input'
 import TextInputFormComponentAlpinePlugin from './components/text-input'
 import TextareaFormComponentAlpinePlugin from './components/textarea'
-import './sortable'
 
 export default (Alpine) => {
     Alpine.plugin(ColorPickerFormComponentAlpinePlugin)

--- a/packages/forms/resources/js/sortable.js
+++ b/packages/forms/resources/js/sortable.js
@@ -1,9 +1,0 @@
-import Sortable from 'sortablejs';
-
-window.Livewire.directive('sortable', (el) => {
-    el.sortable = Sortable.create(el, {
-        draggable: '[wire\\:sortable\\.item]',
-        handle: '[wire\\:sortable\\.handle]',
-        dataIdAttr: 'wire:sortable.item',
-    });
-});

--- a/packages/forms/resources/lang/en/components.php
+++ b/packages/forms/resources/lang/en/components.php
@@ -18,10 +18,6 @@ return [
                 'label' => 'Delete',
             ],
 
-            'move_item' => [
-                'label' => 'Move',
-            ],
-
             'move_item_down' => [
                 'label' => 'Move down',
             ],

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -11,11 +11,7 @@
 >
     <div {{ $attributes->merge($getExtraAttributes())->class(['space-y-2 filament-forms-builder-component']) }}>
         @if (count($containers = $getChildComponentContainers()))
-            <ul
-                class="space-y-2"
-                wire:sortable
-                wire:end="dispatchFormEvent('builder::moveItems', '{{ $getStatePath() }}', $event.target.sortable.toArray())"
-            >
+            <ul class="space-y-2">
                 @foreach ($containers as $uuid => $item)
                     @php($withBlockLabels = $shouldShowBlockLabels())
 
@@ -24,7 +20,6 @@
                         x-on:click="isCreateButtonVisible = true"
                         x-on:click.away="isCreateButtonVisible = false"
                         wire:key="{{ $item->getStatePath() }}"
-                        wire:sortable.item="{{ $uuid }}"
                         @class([
                             'relative bg-white shadow-sm rounded-lg border border-gray-300',
                             'dark:bg-gray-700 dark:border-gray-600' => config('forms.dark_mode'),
@@ -48,25 +43,37 @@
                                 'absolute top-0 right-0 h-6 flex divide-x rounded-bl-lg rounded-tr-lg border-gray-300 border-b border-l overflow-hidden rtl:border-l-0 rtl:border-r rtl:right-auto rtl:left-0 rtl:rounded-bl-none rtl:rounded-br-lg rtl:rounded-tr-none rtl:rounded-tl-lg',
                                 'dark:border-gray-600 dark:divide-gray-600' => config('forms.dark_mode'),
                             ])>
-                                @unless ($isItemMovementDisabled())
+                                @unless ($loop->first || $isItemMovementDisabled())
                                     <button
-                                        wire:sortable.handle
-                                        wire:keydown.prevent.arrow-up="dispatchFormEvent('builder::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
-                                        wire:keydown.prevent.arrow-down="dispatchFormEvent('builder::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                        wire:click="dispatchFormEvent('builder::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
                                         type="button"
                                         @class([
-                                            'flex items-center justify-center w-6 text-gray-800 cursor-grab hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600',
-                                            'dark:text-gray-200 dark:hover:bg-gray-600 dark:focus:text-primary-600' => config('forms.dark_mode'),
+                                            'flex items-center justify-center w-6 text-gray-800 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600',
+                                            'dark:text-gray-200 dark:hover:bg-gray-600' => config('forms.dark_mode'),
+                                        ])
+                                    >
+                                        <span class="sr-only">
+                                            {{ __('forms::components.repeater.buttons.move_item_up.label') }}
+                                        </span>
+
+                                        <x-heroicon-s-chevron-up class="w-4 h-4" />
+                                    </button>
+                                @endunless
+
+                                @unless ($loop->last || $isItemMovementDisabled())
+                                    <button
+                                        wire:click="dispatchFormEvent('builder::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                        type="button"
+                                        @class([
+                                            'flex items-center justify-center w-6 text-gray-800 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600',
+                                            'dark:text-gray-200 dark:hover:bg-gray-600' => config('forms.dark_mode'),
                                         ])
                                     >
                                         <span class="sr-only">
                                             {{ __('forms::components.repeater.buttons.move_item_down.label') }}
                                         </span>
 
-                                        <div class="flex flex-col">
-                                            <x-heroicon-o-dots-horizontal class="w-4 h-4" />
-                                            <x-heroicon-o-dots-horizontal class="w-4 h-4 -mt-[0.6875rem]" />
-                                        </div>
+                                        <x-heroicon-s-chevron-down class="w-4 h-4" />
                                     </button>
                                 @endunless
 

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -9,17 +9,12 @@
     :required="$isRequired()"
     :state-path="$getStatePath()"
 >
-    <div {{ $attributes->merge($getExtraAttributes())->class(['space-y-2 filament-forms-repeater-component']) }}>
+    <div wire:key="{{ $getStatePath() }}" {{ $attributes->merge($getExtraAttributes())->class(['space-y-2 filament-forms-repeater-component']) }}>
         @if (count($containers = $getChildComponentContainers()))
-            <ul
-                class="space-y-2"
-                wire:sortable
-                wire:end="dispatchFormEvent('repeater::moveItems', '{{ $getStatePath() }}', $event.target.sortable.toArray())"
-            >
+            <ul class="space-y-2">
                 @foreach ($containers as $uuid => $item)
                     <li
                         wire:key="{{ $item->getStatePath() }}"
-                        wire:sortable.item="{{ $uuid }}"
                         @class([
                             'relative p-6 bg-white shadow-sm rounded-lg border border-gray-300',
                             'dark:bg-gray-700 dark:border-gray-600' => config('forms.dark_mode'),
@@ -32,25 +27,37 @@
                                 'absolute top-0 right-0 h-6 flex divide-x rounded-bl-lg rounded-tr-lg border-gray-300 border-b border-l overflow-hidden rtl:border-l-0 rtl:border-r rtl:right-auto rtl:left-0 rtl:rounded-bl-none rtl:rounded-br-lg rtl:rounded-tr-none rtl:rounded-tl-lg',
                                 'dark:border-gray-600 dark:divide-gray-600' => config('forms.dark_mode'),
                             ])>
-                                @unless ($isItemMovementDisabled())
+                                @unless ($loop->first || $isItemMovementDisabled())
                                     <button
-                                        wire:sortable.handle
-                                        wire:keydown.prevent.arrow-up="dispatchFormEvent('repeater::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
-                                        wire:keydown.prevent.arrow-down="dispatchFormEvent('repeater::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                        wire:click="dispatchFormEvent('repeater::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
                                         type="button"
                                         @class([
-                                            'flex items-center justify-center w-6 text-gray-800 cursor-grab hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600',
-                                            'dark:text-gray-200 dark:hover:bg-gray-600 dark:focus:text-primary-600' => config('forms.dark_mode'),
+                                            'flex items-center justify-center w-6 text-gray-800 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600',
+                                            'dark:text-gray-200 dark:hover:bg-gray-600' => config('forms.dark_mode'),
+                                        ])
+                                    >
+                                        <span class="sr-only">
+                                            {{ __('forms::components.repeater.buttons.move_item_up.label') }}
+                                        </span>
+
+                                        <x-heroicon-s-chevron-up class="w-4 h-4" />
+                                    </button>
+                                @endunless
+
+                                @unless ($loop->last || $isItemMovementDisabled())
+                                    <button
+                                        wire:click="dispatchFormEvent('repeater::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                        type="button"
+                                        @class([
+                                            'flex items-center justify-center w-6 text-gray-800 hover:bg-gray-50 focus:outline-none focus:ring-offset-2 focus:ring-2 focus:ring-inset focus:ring-white focus:ring-primary-600 focus:text-primary-600 focus:bg-primary-50 focus:border-primary-600',
+                                            'dark:text-gray-200 dark:hover:bg-gray-600' => config('forms.dark_mode'),
                                         ])
                                     >
                                         <span class="sr-only">
                                             {{ __('forms::components.repeater.buttons.move_item_down.label') }}
                                         </span>
 
-                                        <div class="flex flex-col">
-                                            <x-heroicon-o-dots-horizontal class="w-4 h-4" />
-                                            <x-heroicon-o-dots-horizontal class="w-4 h-4 -mt-[0.6875rem]" />
-                                        </div>
+                                        <x-heroicon-s-chevron-down class="w-4 h-4" />
                                     </button>
                                 @endunless
 

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -148,26 +148,6 @@ class Builder extends Field
                     data_set($livewire, $statePath, $items);
                 },
             ],
-            'builder::moveItems' => [
-                function (Builder $component, string $statePath, array $uuids): void {
-                    if ($component->isDisabled()) {
-                        return;
-                    }
-
-                    if ($component->isItemMovementDisabled()) {
-                        return;
-                    }
-
-                    if ($statePath !== $component->getStatePath()) {
-                        return;
-                    }
-
-                    $items = array_merge(array_flip($uuids), $component->getState());
-
-                    $livewire = $component->getLivewire();
-                    data_set($livewire, $statePath, $items);
-                },
-            ],
         ]);
 
         $this->createItemBetweenButtonLabel(__('forms::components.builder.buttons.create_item_between.label'));

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -115,26 +115,6 @@ class Repeater extends Field
                     data_set($livewire, $statePath, $items);
                 },
             ],
-            'repeater::moveItems' => [
-                function (Repeater $component, string $statePath, array $uuids): void {
-                    if ($component->isDisabled()) {
-                        return;
-                    }
-
-                    if ($component->isItemMovementDisabled()) {
-                        return;
-                    }
-
-                    if ($statePath !== $component->getStatePath()) {
-                        return;
-                    }
-
-                    $items = array_merge(array_flip($uuids), $component->getState());
-
-                    $livewire = $component->getLivewire();
-                    data_set($livewire, $statePath, $items);
-                },
-            ],
         ]);
 
         $this->createItemButtonLabel(function (Repeater $component) {

--- a/packages/forms/src/helpers.php
+++ b/packages/forms/src/helpers.php
@@ -10,10 +10,6 @@ if (! function_exists('Filament\Forms\array_move_after')) {
         $indexToMoveAfter = array_search($keyToMoveAfter, $keys);
         $keyToMoveBefore = $keys[$indexToMoveAfter + 1] ?? null;
 
-        if (filled($keyToMoveBefore)) {
-            return $array;
-        }
-
         $keys[$indexToMoveAfter + 1] = $keyToMoveAfter;
         $keys[$indexToMoveAfter] = $keyToMoveBefore;
 
@@ -35,10 +31,6 @@ if (! function_exists('Filament\Forms\array_move_before')) {
 
         $indexToMoveBefore = array_search($keyToMoveBefore, $keys);
         $keyToMoveAfter = $keys[$indexToMoveBefore - 1] ?? null;
-
-        if (filled($keyToMoveAfter)) {
-            return $array;
-        }
 
         $keys[$indexToMoveBefore - 1] = $keyToMoveBefore;
         $keys[$indexToMoveBefore] = $keyToMoveAfter;


### PR DESCRIPTION
Fixes #2105, #2141.

Reverses #2017.

I regret to make such a change, but the PR introduced a large bug when sorting nested repeaters and I am struggling to find the solution.