### PR TITLE
fix: Sortable end events bubbling up to parent containers

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -14,7 +14,7 @@
             <ul
                 class="space-y-2"
                 wire:sortable
-                wire:end="dispatchFormEvent('builder::moveItems', '{{ $getStatePath() }}', $event.target.sortable.toArray())"
+                wire:end.stop="dispatchFormEvent('builder::moveItems', '{{ $getStatePath() }}', $event.target.sortable.toArray())"
             >
                 @foreach ($containers as $uuid => $item)
                     @php($withBlockLabels = $shouldShowBlockLabels())

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -14,7 +14,7 @@
             <ul
                 class="space-y-2"
                 wire:sortable
-                wire:end="dispatchFormEvent('repeater::moveItems', '{{ $getStatePath() }}', $event.target.sortable.toArray())"
+                wire:end.stop="dispatchFormEvent('repeater::moveItems', '{{ $getStatePath() }}', $event.target.sortable.toArray())"
             >
                 @foreach ($containers as $uuid => $item)
                     <li


### PR DESCRIPTION
Closes #2141 and replaces #2156.