### PR TITLE
feature: support statically setting nav options

### DIFF
--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -369,9 +369,19 @@ class Resource
         return static::$navigationGroup;
     }
 
+    public static function setNavigationGroup(string $group): void
+    {
+        static::$navigationGroup = $group;
+    }
+
     protected static function getNavigationIcon(): string
     {
         return static::$navigationIcon ?? 'heroicon-o-collection';
+    }
+
+    public static function setNavigationIcon(string $icon): void
+    {
+        static::$navigationIcon = $icon;
     }
 
     protected static function getNavigationLabel(): string
@@ -387,6 +397,11 @@ class Resource
     protected static function getNavigationSort(): ?int
     {
         return static::$navigationSort;
+    }
+
+    public static function setNavigationSort(int $sort): void
+    {
+        static::$navigationSort = $sort;
     }
 
     protected static function getNavigationUrl(): string

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -369,7 +369,7 @@ class Resource
         return static::$navigationGroup;
     }
 
-    public static function setNavigationGroup(string $group): void
+    public static function navigationGroup(string $group): void
     {
         static::$navigationGroup = $group;
     }
@@ -379,7 +379,7 @@ class Resource
         return static::$navigationIcon ?? 'heroicon-o-collection';
     }
 
-    public static function setNavigationIcon(string $icon): void
+    public static function navigationIcon(string $icon): void
     {
         static::$navigationIcon = $icon;
     }
@@ -399,7 +399,7 @@ class Resource
         return static::$navigationSort;
     }
 
-    public static function setNavigationSort(int $sort): void
+    public static function navigationSort(int $sort): void
     {
         static::$navigationSort = $sort;
     }

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -369,7 +369,7 @@ class Resource
         return static::$navigationGroup;
     }
 
-    public static function navigationGroup(string $group): void
+    public static function navigationGroup(?string $group): void
     {
         static::$navigationGroup = $group;
     }
@@ -379,7 +379,7 @@ class Resource
         return static::$navigationIcon ?? 'heroicon-o-collection';
     }
 
-    public static function navigationIcon(string $icon): void
+    public static function navigationIcon(?string $icon): void
     {
         static::$navigationIcon = $icon;
     }
@@ -399,7 +399,7 @@ class Resource
         return static::$navigationSort;
     }
 
-    public static function navigationSort(int $sort): void
+    public static function navigationSort(?int $sort): void
     {
         static::$navigationSort = $sort;
     }


### PR DESCRIPTION
This will allow developers to call `setNavigationX` methods on `Resource` classes without needing to extend third-party resources.

I'm doing this in a plugin at the moment but figured it would make sense to add to core as an extra point of customisation / extension for third-party plugins.