### PR TITLE
feature: render hooks

### DIFF
--- a/packages/admin/src/Facades/Filament.php
+++ b/packages/admin/src/Facades/Filament.php
@@ -35,6 +35,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void registerNavigationGroups(array $groups)
  * @method static void registerNavigationItems(array $items)
  * @method static void registerPages(array $pages)
+ * @method static void registerRenderHook(string $name, \Closure $callback)
  * @method static void registerResources(array $resources)
  * @method static void registerBeforeCoreScripts(array $scripts)
  * @method static void registerScripts(array $scripts)
@@ -43,6 +44,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void registerTheme(string $url)
  * @method static void registerUserMenuItems(array $items)
  * @method static void registerWidgets(array $widgets)
+ * @method static ?string renderHook(string $name)
  * @method static void serving(Closure $callback)
  *
  * @see FilamentManager

--- a/packages/admin/src/Facades/Filament.php
+++ b/packages/admin/src/Facades/Filament.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\HtmlString;
 
 /**
  * @method static StatefulGuard auth()
@@ -44,7 +45,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void registerTheme(string $url)
  * @method static void registerUserMenuItems(array $items)
  * @method static void registerWidgets(array $widgets)
- * @method static ?string renderHook(string $name)
+ * @method static HtmlString renderHook(string $name)
  * @method static void serving(Closure $callback)
  *
  * @see FilamentManager

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -47,6 +47,8 @@ class FilamentManager
 
     protected ?Closure $navigationBuilder = null;
 
+    protected array $renderHooks = [];
+
     public function auth(): Guard
     {
         return auth()->guard(config('filament.auth.guard'));
@@ -109,6 +111,11 @@ class FilamentManager
         $this->pages = array_merge($this->pages, $pages);
     }
 
+    public function registerRenderHook(string $name, Closure $callback): void
+    {
+        $this->renderHooks[$name][] = $callback;
+    }
+
     public function registerResources(array $resources): void
     {
         $this->resources = array_merge($this->resources, $resources);
@@ -166,6 +173,21 @@ class FilamentManager
     public function getGlobalSearchProvider(): GlobalSearchProvider
     {
         return app($this->globalSearchProvider);
+    }
+
+    public function renderHook(string $name): ?string
+    {
+        if (! array_key_exists($name, $this->renderHooks)) {
+            return null;
+        }
+
+        $output = '';
+
+        foreach ($this->renderHooks[$name] as $renderHook) {
+            $output .= (string) app()->call($renderHook);
+        }
+
+        return $output;
     }
 
     public function getNavigation(): array

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -13,6 +13,7 @@ use Filament\Navigation\UserMenuItem;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Facades\Event;
 
 class FilamentManager
@@ -175,19 +176,13 @@ class FilamentManager
         return app($this->globalSearchProvider);
     }
 
-    public function renderHook(string $name): ?string
+    public function renderHook(string $name): HtmlString
     {
-        if (! array_key_exists($name, $this->renderHooks)) {
-            return null;
-        }
-
-        $output = '';
-
-        foreach ($this->renderHooks[$name] as $renderHook) {
-            $output .= (string) app()->call($renderHook);
-        }
-
-        return $output;
+        $output = collect($this->renderHooks[$name] ?? [])
+            ->map(fn (callable $hook): string => (string) app()->call($renderHook))
+            ->implode();
+        
+        return new HtmlString($output);
     }
 
     public function getNavigation(): array

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -178,11 +178,12 @@ class FilamentManager
 
     public function renderHook(string $name): HtmlString
     {
-        $output = collect($this->renderHooks[$name] ?? [])
-            ->map(fn (callable $hook): string => (string) app()->call($renderHook))
-            ->implode();
+        $hooks = array_map(
+            fn (callable $hook): string => (string) app()->call($hook),
+            $this->renderHooks[$name] ?? [],
+        );
 
-        return new HtmlString($output);
+        return new HtmlString(implode('', $hooks));
     }
 
     public function getNavigation(): array

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -13,8 +13,8 @@ use Filament\Navigation\UserMenuItem;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
-use Illuminate\Support\HtmlString;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\HtmlString;
 
 class FilamentManager
 {
@@ -181,7 +181,7 @@ class FilamentManager
         $output = collect($this->renderHooks[$name] ?? [])
             ->map(fn (callable $hook): string => (string) app()->call($renderHook))
             ->implode();
-        
+
         return new HtmlString($output);
     }
 

--- a/tests/resources/views/fixtures/pages/render-hooks/foo.blade.php
+++ b/tests/resources/views/fixtures/pages/render-hooks/foo.blade.php
@@ -1,0 +1,1 @@
+Hello, foo!

--- a/tests/resources/views/fixtures/pages/render-hooks/foo.blade.php
+++ b/tests/resources/views/fixtures/pages/render-hooks/foo.blade.php
@@ -1,1 +1,1 @@
-Hello, foo!
+bar

--- a/tests/src/Admin/RenderHooks/RenderHooksServiceProvider.php
+++ b/tests/src/Admin/RenderHooks/RenderHooksServiceProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Filament\Tests\Admin\RenderHooks;
+
+use Filament\PluginServiceProvider;
+
+class RenderHooksServiceProvider extends PluginServiceProvider
+{
+    public static string $name = 'render-hooks';
+}

--- a/tests/src/Admin/RenderHooks/RenderHooksTest.php
+++ b/tests/src/Admin/RenderHooks/RenderHooksTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Filament\Facades\Filament;
+use Filament\Tests\Admin\RenderHooks\TestCase;
+use Illuminate\Support\Facades\Blade;
+
+uses(TestCase::class);
+
+test('render hooks can be registered', function () {
+    Filament::registerRenderHook('foo', function () {
+        return Blade::render('foobar');
+    });
+
+    expect(Filament::renderHook('foo'))
+        ->toBeString()
+        ->toBe('foobar');
+});
+
+test('render hooks can render view files', function () {
+    Filament::registerRenderHook('view-foo', function () {
+        return view('fixtures.pages.render-hooks.foo');
+    });
+
+    expect(Filament::renderHook('view-foo'))
+        ->toBeString()
+        ->toContain('Hello, foo!');
+});

--- a/tests/src/Admin/RenderHooks/RenderHooksTest.php
+++ b/tests/src/Admin/RenderHooks/RenderHooksTest.php
@@ -3,17 +3,18 @@
 use Filament\Facades\Filament;
 use Filament\Tests\Admin\RenderHooks\TestCase;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\HtmlString;
 
 uses(TestCase::class);
 
 test('render hooks can be registered', function () {
     Filament::registerRenderHook('foo', function () {
-        return Blade::render('foobar');
+        return Blade::render('bar');
     });
 
     expect(Filament::renderHook('foo'))
-        ->toBeString()
-        ->toBe('foobar');
+        ->toBeInstanceOf(HtmlString::class)
+        ->toHtml()->toBe('bar');
 });
 
 test('render hooks can render view files', function () {
@@ -22,6 +23,6 @@ test('render hooks can render view files', function () {
     });
 
     expect(Filament::renderHook('view-foo'))
-        ->toBeString()
-        ->toContain('Hello, foo!');
+        ->toBeInstanceOf(HtmlString::class)
+        ->toHtml()->toContain('Hello, foo!');
 });

--- a/tests/src/Admin/RenderHooks/RenderHooksTest.php
+++ b/tests/src/Admin/RenderHooks/RenderHooksTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\HtmlString;
 uses(TestCase::class);
 
 test('render hooks can be registered', function () {
-    Filament::registerRenderHook('foo', function () {
+    Filament::registerRenderHook('foo', function (): string {
         return Blade::render('bar');
     });
 
@@ -18,11 +18,11 @@ test('render hooks can be registered', function () {
 });
 
 test('render hooks can render view files', function () {
-    Filament::registerRenderHook('view-foo', function () {
+    Filament::registerRenderHook('view-foo', function (): \Illuminate\Contracts\View\View {
         return view('fixtures.pages.render-hooks.foo');
     });
 
     expect(Filament::renderHook('view-foo'))
         ->toBeInstanceOf(HtmlString::class)
-        ->toHtml()->toContain('Hello, foo!');
+        ->toHtml()->toContain('bar');
 });

--- a/tests/src/Admin/RenderHooks/TestCase.php
+++ b/tests/src/Admin/RenderHooks/TestCase.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Filament\Tests\Admin\RenderHooks;
+
+use Filament\Tests\Models\User;
+use Filament\Tests\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->actingAs(User::factory()->create());
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return array_merge(parent::getPackageProviders($app), [
+            RenderHooksServiceProvider::class,
+        ]);
+    }
+}


### PR DESCRIPTION
At the moment, extending the admin panel from a third-party package is only really possible with fields/resources/pages. If somebody wanted to add a bit of text or view somewhere, the developer would need to publish a vendor Blade view and most likely modify it.

An example of where we support this already is with the global search `end` and `start` views. 

This PR introduces a new "render hook" concept. These are small hooks that we can add into our own Blade views and allow developers to register their own callbacks from packages, etc.

An example of this might be a context switcher rendered in the header of the admin panel. Registering a render hook will allow developers to render their own Blade views here without worrying about overwriting Blade views from the package.

```php
public function boot()
{
	Filament::registerRenderHook('header::start', function () {
		return view('my-package::header-start');
	});
}
```

**Inside of a Filament view**

```blade
<header>
	{{-- ... --}}

	{{ \Filament\Facades\Filament::renderHook('header::start') }}
</header>
```

Mostly looking for feedback on this, as I have a few potential plugins that would benefit from this.