### PR TITLE
small ui improve for selectable column on RTL

### DIFF
--- a/packages/tables/resources/views/components/toggleable/index.blade.php
+++ b/packages/tables/resources/views/components/toggleable/index.blade.php
@@ -20,7 +20,7 @@
         x-transition:leave-start="opacity-100 translate-y-0"
         x-transition:leave-end="opacity-0 translate-y-2"
         @class([
-            'absolute right-0 rtl:right-auto rtl:left-0 z-10 w-screen pl-12 rtl:pr-12 mt-2 top-full transition',
+            'absolute right-0 rtl:right-auto rtl:left-0 z-10 w-screen pl-12 rtl:pl-0 rtl:pr-12 mt-2 top-full transition',
             match ($width) {
                 'xs' => 'max-w-xs',
                 'md' => 'max-w-md',


### PR DESCRIPTION
small ui improve to RTL version of selectable column 

just add **`rtl:pl-0`** class to reset padding from left of dropdown element on RTL version.