### PR TITLE
Multiple image grid layout

### DIFF
--- a/packages/forms/resources/css/components/file-upload.css
+++ b/packages/forms/resources/css/components/file-upload.css
@@ -42,6 +42,7 @@
 }
 
 /* Grid styles */
+
 .filepond--root[data-style-panel-layout='grid'] .filepond--item {
     width: calc(50% - 0.5em);
 }

--- a/packages/forms/resources/css/components/file-upload.css
+++ b/packages/forms/resources/css/components/file-upload.css
@@ -40,3 +40,14 @@
     padding-top: 0.5em;
     padding-bottom: 0.5em;
 }
+
+/* Grid styles */
+.filepond--root[data-style-panel-layout='grid'] .filepond--item {
+    width: calc(50% - 0.5em);
+}
+
+@media (min-width: 50em) {
+    .filepond--root[data-style-panel-layout='grid'] .filepond--item {
+        width: calc(33.33% - 0.5em);
+    }
+}


### PR DESCRIPTION
Noted that while we have `compact`, `circle` and `compact circle`, `grid` was missing and would be nice
Simple CSS change resulting in:

![image](https://user-images.githubusercontent.com/952595/164965990-d71d7248-14ef-4bd2-b754-753f5425eee4.png)
