### PR TITLE
FIX: SpatieMediaLibraryFileUpload should use existing `getUploadedFil…

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -81,7 +81,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             /** @var FileAdder $mediaAdder */
             $mediaAdder = $record->addMediaFromString($file->get());
 
-            $filename = $component->shouldPreserveFilenames() ? $file->getClientOriginalName() : $file->getFilename();
+            $filename = $component->getUploadedFileNameForStorage($file);
 
             $media = $mediaAdder
                 ->usingFileName($filename)


### PR DESCRIPTION
…eNameForStorageUsing` and not copy+paste code ;)

Otherwise `getUploadedFileNameForStorageUsing` will not work.