### PR TITLE
fix: border contrast

### DIFF
--- a/packages/tables/resources/views/components/pagination/records-per-page-selector.blade.php
+++ b/packages/tables/resources/views/components/pagination/records-per-page-selector.blade.php
@@ -4,7 +4,7 @@
 
 <div class="flex items-center space-x-2 rtl:space-x-reverse filament-tables-pagination-records-per-page-selector">
     <select wire:model="tableRecordsPerPage" id="tableRecordsPerPageSelect" @class([
-        'h-8 text-sm pr-8 leading-none transition duration-75 border-gray-200 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600',
+        'h-8 text-sm pr-8 leading-none transition duration-75 border-gray-300 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600',
         'dark:text-white dark:bg-gray-700 dark:border-gray-600' => config('tables.dark_mode'),
     ])>
         @foreach ($options as $option)

--- a/packages/tables/resources/views/components/search-input.blade.php
+++ b/packages/tables/resources/views/components/search-input.blade.php
@@ -15,7 +15,7 @@
             type="search"
             autocomplete="off"
             @class([
-                'block w-full h-9 pl-9 placeholder-gray-400 transition duration-75 border-gray-200 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600',
+                'block w-full h-9 pl-9 placeholder-gray-400 transition duration-75 border-gray-300 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600',
                 'dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400' => config('tables.dark_mode'),
             ])
         >


### PR DESCRIPTION
The table search and paginator select didn't use `border-gray-300`, instead they used `border-gray-200` which isn't consistent with other UI elements