### PR TITLE
fix: card consistency

### DIFF
--- a/packages/admin/resources/views/components/card/index.blade.php
+++ b/packages/admin/resources/views/components/card/index.blade.php
@@ -6,7 +6,7 @@
 ])
 
 <div {{ $attributes->class([
-    'p-2 space-y-2 bg-white rounded-xl shadow',
+    'p-2 space-y-2 bg-white rounded-xl shadow-sm border border-gray-300',
     'dark:border-gray-600 dark:bg-gray-800' => config('filament.dark_mode'),
 ]) }}>
     @if ($actions || $header || $heading)


### PR DESCRIPTION
**Before:**

![Before](https://user-images.githubusercontent.com/25669876/165582025-4af9fccc-f444-434d-ba5c-f09224d7cd7d.png)

**After:**

![After](https://user-images.githubusercontent.com/25669876/165582077-74d6d401-3add-4581-8620-473204db552c.png)

**Other card elements:**

![Table](https://user-images.githubusercontent.com/25669876/165582163-a390456e-7e5f-4b23-909f-4994a9ec48cc.png)

![Card](https://user-images.githubusercontent.com/25669876/165582216-ebeb8503-c3a4-4702-829d-af68d1985332.png)
^ _This example is still missing a `shadow-sm`_

