### PR TITLE
fix: tab.blade.php padding

### DIFF
--- a/packages/forms/resources/views/components/tabs/tab.blade.php
+++ b/packages/forms/resources/views/components/tabs/tab.blade.php
@@ -3,8 +3,8 @@
     id="{{ $getId() }}"
     role="tabpanel"
     tabindex="0"
-    x-bind:class="{ 'invisible h-0 p-0 overflow-y-hidden': tab !== '{{ $getId() }}' }"
-    {{ $attributes->merge($getExtraAttributes())->class(['p-6 focus:outline-none filament-forms-tabs-component-tab']) }}
+    x-bind:class="{ 'invisible h-0 p-0 overflow-y-hidden': tab !== '{{ $getId() }}', 'p-6': tab === '{{ $getId() }}' }"
+    {{ $attributes->merge($getExtraAttributes())->class(['focus:outline-none filament-forms-tabs-component-tab']) }}
 >
     {{ $getChildComponentContainer() }}
 </div>


### PR DESCRIPTION
Fixes issue where "p-6" class persists and overrides "p-0" class when tabs are hidden, resulting in the padding of hidden tabs adding extra white space.

E.g..

Tab 1, being the first tab, appears at the top and shows the padding from each of the other tabs below.

![DTV_Dashboard](https://user-images.githubusercontent.com/3206141/165786861-6b1b8e1e-ab40-4462-a45a-909d202d8011.png)

Tab 2, being the second tab, has the padding from tab 1 above it and the padding of the rest of the tabs below.

![DTV_Dashboard](https://user-images.githubusercontent.com/3206141/165787059-37ec438d-c7d8-4f90-812e-e55f98b847eb.png)

etc...