### PR TITLE
fix: Notifications not showing after redirect.

### DIFF
--- a/packages/admin/resources/views/components/notification-manager.blade.php
+++ b/packages/admin/resources/views/components/notification-manager.blade.php
@@ -1,6 +1,6 @@
 <div
     x-data="{
-        notifications: {{ Illuminate\Support\Js::from(session()->pull('notifications', [])) }},
+        notifications: {{ \Illuminate\Support\Js::from(session()->pull('notifications', [])) }},
         add (event) {
             this.notifications = this.notifications.concat(event.detail)
         },

--- a/packages/admin/resources/views/components/notification-manager.blade.php
+++ b/packages/admin/resources/views/components/notification-manager.blade.php
@@ -1,6 +1,6 @@
 <div
     x-data="{
-        notifications: @js(session()->pull('notifications', [])),
+        notifications: {{ Illuminate\Support\Js::from(session()->pull('notifications', [])) }},
         add (event) {
             this.notifications = this.notifications.concat(event.detail)
         },


### PR DESCRIPTION
In the original PR (https://github.com/laravel-filament/filament/pull/1868) we switched from `Js::from()` to `@js()`. I thought they are similar and they should produce the same data after `JSON.parse()`, but `@js()` uses `btoa()` to encode the data and somehow this messes with the notifications (and maybe Alpine).

I have no idea what the difference is, but apparently one works in this case and the other doesnt.
What makes it even weirder: When I tried a static array for testing, both solutions worked 🤷🏼‍♂️

You can test this PR with create action after the redirect.