### PR TITLE
feature: support calling `hidden()`/`visible()` with FQN class name

### DIFF
--- a/packages/admin/docs/02-resources.md
+++ b/packages/admin/docs/02-resources.md
@@ -105,6 +105,17 @@ Forms\Components\TextInput::make('password')
     ->hidden(fn (Component $livewire): bool => $livewire instanceof Pages\EditUser),
 ```
 
+Alternatively, we have a `hiddenOn()` shortcut method for this case:
+
+```php
+use Livewire\Component;
+
+Forms\Components\TextInput::make('password')
+    ->password()
+    ->required()
+    ->hiddenOn(Pages\EditUser::class),
+```
+
 You may instead use the `visible` to check if a component should be visible or not:
 
 ```php
@@ -114,6 +125,17 @@ Forms\Components\TextInput::make('password')
     ->password()
     ->required()
     ->visible(fn (Component $livewire): bool => $livewire instanceof Pages\CreateUser),
+```
+
+Alternatively, we have a `visibleOn()` shortcut method for this case:
+
+```php
+use Livewire\Component;
+
+Forms\Components\TextInput::make('password')
+    ->password()
+    ->required()
+    ->visibleOn(Pages\CreateUser::class),
 ```
 
 For more information about closure customization, see the [form builder documentation](/docs/forms/advanced#using-closure-customisation).

--- a/packages/forms/src/Components/Concerns/CanBeHidden.php
+++ b/packages/forms/src/Components/Concerns/CanBeHidden.php
@@ -3,7 +3,9 @@
 namespace Filament\Forms\Components\Concerns;
 
 use Closure;
+use Filament\Forms\Contracts\HasForms;
 use Illuminate\Support\Arr;
+use Livewire\Component;
 
 trait CanBeHidden
 {
@@ -18,9 +20,9 @@ trait CanBeHidden
         return $this;
     }
 
-    public function hiddenFor(string $page): static
+    public function hiddenFor(string $livewireClass): static
     {
-        $this->hidden(fn ($livewire) => $livewire instanceof $page);
+        $this->hidden(static fn (HasForms $livewire): bool => $livewire instanceof $livewireClass);
 
         return $this;
     }
@@ -73,9 +75,9 @@ trait CanBeHidden
         return $this;
     }
 
-    public function visibleFor(string $page): static
+    public function visibleFor(string $livewireClass): static
     {
-        $this->visible(fn ($livewire) => $livewire instanceof $page);
+        $this->visible(static fn (HasForms $livewire): bool => $livewire instanceof $livewireClass);
 
         return $this;
     }

--- a/packages/forms/src/Components/Concerns/CanBeHidden.php
+++ b/packages/forms/src/Components/Concerns/CanBeHidden.php
@@ -11,14 +11,18 @@ trait CanBeHidden
 
     protected bool | Closure $isVisible = true;
 
-    public function hidden(bool | Closure $condition = true): static
+    public function hidden(bool | Closure | string $condition = true): static
     {
+        $condition = is_string($condition) && class_exists($condition)
+            ? fn ($livewire) => $livewire instanceof $condition
+            : $condition;
+
         $this->isHidden = $condition;
 
         return $this;
     }
 
-    public function when(bool | Closure $condition = true): static
+    public function when(bool | Closure | string $condition = true): static
     {
         $this->visible($condition);
 
@@ -59,8 +63,12 @@ trait CanBeHidden
         return $this;
     }
 
-    public function visible(bool | Closure $condition = true): static
+    public function visible(bool | Closure | string $condition = true): static
     {
+        $condition = is_string($condition) && class_exists($condition)
+            ? fn ($livewire) => $livewire instanceof $condition
+            : $condition;
+
         $this->isVisible = $condition;
 
         return $this;

--- a/packages/forms/src/Components/Concerns/CanBeHidden.php
+++ b/packages/forms/src/Components/Concerns/CanBeHidden.php
@@ -11,21 +11,21 @@ trait CanBeHidden
 
     protected bool | Closure $isVisible = true;
 
-    public function hidden(bool | Closure | string $condition = true): static
+    public function hidden(bool | Closure $condition = true): static
     {
         $this->isHidden = $condition;
 
         return $this;
     }
 
-    public function hiddenFor(string $target): static
+    public function hiddenFor(string $page): static
     {
-        $this->hidden(fn ($livewire) => $livewire instanceof $target);
+        $this->hidden(fn ($livewire) => $livewire instanceof $page);
 
         return $this;
     }
 
-    public function when(bool | Closure | string $condition = true): static
+    public function when(bool | Closure $condition = true): static
     {
         $this->visible($condition);
 
@@ -66,20 +66,16 @@ trait CanBeHidden
         return $this;
     }
 
-    public function visible(bool | Closure | string $condition = true): static
+    public function visible(bool | Closure $condition = true): static
     {
-        $condition = is_string($condition) && class_exists($condition)
-            ? fn ($livewire) => $livewire instanceof $condition
-            : $condition;
-
         $this->isVisible = $condition;
 
         return $this;
     }
 
-    public function visibleFor(string $target): static
+    public function visibleFor(string $page): static
     {
-        $this->visible(fn ($livewire) => $livewire instanceof $target);
+        $this->visible(fn ($livewire) => $livewire instanceof $page);
 
         return $this;
     }

--- a/packages/forms/src/Components/Concerns/CanBeHidden.php
+++ b/packages/forms/src/Components/Concerns/CanBeHidden.php
@@ -5,7 +5,6 @@ namespace Filament\Forms\Components\Concerns;
 use Closure;
 use Filament\Forms\Contracts\HasForms;
 use Illuminate\Support\Arr;
-use Livewire\Component;
 
 trait CanBeHidden
 {

--- a/packages/forms/src/Components/Concerns/CanBeHidden.php
+++ b/packages/forms/src/Components/Concerns/CanBeHidden.php
@@ -13,11 +13,14 @@ trait CanBeHidden
 
     public function hidden(bool | Closure | string $condition = true): static
     {
-        $condition = is_string($condition) && class_exists($condition)
-            ? fn ($livewire) => $livewire instanceof $condition
-            : $condition;
-
         $this->isHidden = $condition;
+
+        return $this;
+    }
+
+    public function hiddenFor(string $target): static
+    {
+        $this->hidden(fn ($livewire) => $livewire instanceof $target);
 
         return $this;
     }
@@ -70,6 +73,13 @@ trait CanBeHidden
             : $condition;
 
         $this->isVisible = $condition;
+
+        return $this;
+    }
+
+    public function visibleFor(string $target): static
+    {
+        $this->visible(fn ($livewire) => $livewire instanceof $target);
 
         return $this;
     }


### PR DESCRIPTION
This PR allows calling `->hidden()` and `->visible()` with a fully-qualified class name, acting as a shortcut for checking that the `$livewire` is an instance of some class.

**Before**

```php
TextInput::make()
	->hidden(fn ($livewire) => $livewire instanceof EditUser)
```

```php
TextInput::make()
	->hidden(EditUser::class)
```