### PR TITLE
fix: Use the "resolving" service event in the PluginServiceProvider

### DIFF
--- a/packages/admin/src/PluginServiceProvider.php
+++ b/packages/admin/src/PluginServiceProvider.php
@@ -59,21 +59,18 @@ abstract class PluginServiceProvider extends PackageServiceProvider
 
     public function packageRegistered(): void
     {
-        $this->app->singletonIf(
-            'filament',
-            fn (): FilamentManager => app(FilamentManager::class),
-        );
+        $this->app->resolving('filament', function () {
+            Facades\Filament::registerPages($this->getPages());
+            Facades\Filament::registerResources($this->getResources());
+            Facades\Filament::registerUserMenuItems($this->getUserMenuItems());
+            Facades\Filament::registerWidgets($this->getWidgets());
 
-        Facades\Filament::registerPages($this->getPages());
-        Facades\Filament::registerResources($this->getResources());
-        Facades\Filament::registerUserMenuItems($this->getUserMenuItems());
-        Facades\Filament::registerWidgets($this->getWidgets());
-
-        Facades\Filament::serving(function () {
-            Facades\Filament::registerScripts($this->getBeforeCoreScripts(), true);
-            Facades\Filament::registerScripts($this->getScripts());
-            Facades\Filament::registerStyles($this->getStyles());
-            Facades\Filament::registerScriptData($this->getScriptData());
+            Facades\Filament::serving(function () {
+                Facades\Filament::registerScripts($this->getBeforeCoreScripts(), true);
+                Facades\Filament::registerScripts($this->getScripts());
+                Facades\Filament::registerStyles($this->getStyles());
+                Facades\Filament::registerScriptData($this->getScriptData());
+            });
         });
     }
 


### PR DESCRIPTION
Currently the plugin service provider force-resolves the filament service whenever the first filament plugin's ServiceProvider is registered. This interrupts the normal service lifecycle which allows for calls to `$app->extend()` (such as in my multi-context package).

This is also related to the changes made in https://github.com/laravel-filament/filament/pull/2055