### PR TITLE
fix: Anonymous column sort

### DIFF
--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -13,19 +13,17 @@ trait CanSortRecords
     public function sortTable(?string $column = null): void
     {
         if ($column === $this->tableSortColumn) {
-            if ($this->tableSortDirection === 'asc') {
-                $direction = 'desc';
-            } elseif ($this->tableSortDirection === 'desc') {
-                $column = null;
-                $direction = null;
-            } else {
-                $direction = 'asc';
-            }
+            $direction = match ($this->tableSortDirection) {
+                'asc' => 'desc',
+                'desc' => null,
+                default => 'asc',
+            };
         } else {
             $direction = 'asc';
         }
 
         $this->tableSortColumn = $column;
+        $this->tableSortColumn = $direction ? $column : null;
         $this->tableSortDirection = $direction;
 
         $this->updatedTableSort();

--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -66,13 +66,15 @@ trait CanSortRecords
 
         $direction = $this->tableSortDirection ?? 'asc';
 
-        $column = $this->getCachedTableColumn($columnName);
+        if ($column = $this->getCachedTableColumn($columnName)) {
+            $column->applySort($query, $direction);
 
-        if (! $column) {
-            return $query->orderBy($columnName, $direction);
+            return $query;
         }
 
-        $column->applySort($query, $direction);
+        if ($columnName === $this->getDefaultTableSortColumn()) {
+            return $query->orderBy($columnName, $direction);
+        }
 
         return $query;
     }

--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -22,7 +22,6 @@ trait CanSortRecords
             $direction = 'asc';
         }
 
-        $this->tableSortColumn = $column;
         $this->tableSortColumn = $direction ? $column : null;
         $this->tableSortDirection = $direction;
 
@@ -62,7 +61,6 @@ trait CanSortRecords
             return $query;
         }
 
-        $direction = $this->tableSortDirection ?? 'asc';
         $direction = $this->tableSortDirection === 'desc' ? 'desc' : 'asc';
 
         if ($column = $this->getCachedTableColumn($columnName)) {

--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -65,6 +65,7 @@ trait CanSortRecords
         }
 
         $direction = $this->tableSortDirection ?? 'asc';
+        $direction = $this->tableSortDirection === 'desc' ? 'desc' : 'asc';
 
         if ($column = $this->getCachedTableColumn($columnName)) {
             $column->applySort($query, $direction);


### PR DESCRIPTION
Previously, users could sort tables via any column. This feature was requested in #1795, and I implemented it in #1802.

Altering the query string / Livewire `serverMemo` payload to sort through custom column that did not exist in the database threw a harmless internal error. However, since the error indicated the existence of the column in the table, this could be classified as a low-risk information disclosure vulnerability.

As a fix, we now only allow anonymous column sorting if the column is explicitly default (as per `getDefaultTableSortColumn()`).

/cc @DSpeichert