### PR TITLE
fix: missing polish translation

### DIFF
--- a/packages/admin/resources/lang/pl/login.php
+++ b/packages/admin/resources/lang/pl/login.php
@@ -4,6 +4,8 @@ return [
 
     'title' => 'Logowanie',
 
+    'heading' => 'Zaloguj się',
+
     'buttons' => [
 
         'submit' => [
@@ -29,10 +31,8 @@ return [
     ],
 
     'messages' => [
-        'failed' => 'Błędny login lub hasło.',
-        'throttled' => 'Za dużo nieudanych prób logowania. Proszę spróbować za :seconds sekund.',
+        'failed' => 'Nieprawidłowe poświadczenia.',
+        'throttled' => 'Zbyt wiele nieudanych prób logowania. Spróbuj ponownie za :seconds sekund.',
     ],
-
-    'heading' => 'Zaloguj się do swojego konta',
 
 ];

--- a/packages/admin/resources/lang/pl/pages/dashboard.php
+++ b/packages/admin/resources/lang/pl/pages/dashboard.php
@@ -2,6 +2,6 @@
 
 return [
 
-    'title' => 'Dashboard',
+    'title' => 'Pulpit',
 
 ];

--- a/packages/admin/resources/lang/pl/resources/pages/create-record.php
+++ b/packages/admin/resources/lang/pl/resources/pages/create-record.php
@@ -2,9 +2,9 @@
 
 return [
 
-    'title' => 'Utwórz :label',
+    'title' => 'Tworzenie :label',
 
-    'breadcrumb' => 'Utwórz',
+    'breadcrumb' => 'Tworzenie',
 
     'form' => [
 

--- a/packages/admin/resources/lang/pl/resources/pages/list-records.php
+++ b/packages/admin/resources/lang/pl/resources/pages/list-records.php
@@ -29,7 +29,7 @@ return [
             ],
 
             'messages' => [
-                'created' => 'Created',
+                'created' => 'Utworzono',
             ],
 
         ],

--- a/packages/admin/resources/lang/pl/resources/pages/view-record.php
+++ b/packages/admin/resources/lang/pl/resources/pages/view-record.php
@@ -9,7 +9,7 @@ return [
     'actions' => [
 
         'edit' => [
-            'label' => 'Edycja',
+            'label' => 'Edytuj',
         ],
 
     ],

--- a/packages/admin/resources/lang/pl/resources/relation-managers/associate.php
+++ b/packages/admin/resources/lang/pl/resources/relation-managers/associate.php
@@ -4,11 +4,11 @@ return [
 
     'action' => [
 
-        'label' => 'Dołącz',
+        'label' => 'Powiąż',
 
         'modal' => [
 
-            'heading' => 'Dołączanie :label',
+            'heading' => 'Powiązywanie :label',
 
             'fields' => [
 
@@ -20,12 +20,12 @@ return [
 
             'actions' => [
 
-                'attach' => [
-                    'label' => 'Dołącz',
+                'associate' => [
+                    'label' => 'Powiąż',
                 ],
 
-                'attach_and_attach_another' => [
-                    'label' => 'Dołącz i dołącz kolejny',
+                'associate_and_associate_another' => [
+                    'label' => 'Powiąż i powiąż kolejny',
                 ],
 
             ],
@@ -33,7 +33,7 @@ return [
         ],
 
         'messages' => [
-            'attached' => 'Dołączono',
+            'associated' => 'Powiązano',
         ],
 
     ],

--- a/packages/admin/resources/lang/pl/resources/relation-managers/create.php
+++ b/packages/admin/resources/lang/pl/resources/relation-managers/create.php
@@ -8,7 +8,7 @@ return [
 
         'modal' => [
 
-            'heading' => 'Utwórz :label',
+            'heading' => 'Tworzenie :label',
 
             'actions' => [
 

--- a/packages/admin/resources/lang/pl/resources/relation-managers/dissociate.php
+++ b/packages/admin/resources/lang/pl/resources/relation-managers/dissociate.php
@@ -1,0 +1,33 @@
+<?php
+
+return [
+
+    'action' => [
+
+        'label' => 'Usuń powiązanie',
+
+        'modal' => [
+            'heading' => 'Usuwanie powiązania :label',
+        ],
+
+        'messages' => [
+            'dissociated' => 'Usunięto powiązanie',
+        ],
+
+    ],
+
+    'bulk_action' => [
+
+        'label' => 'Usuń powiązanie zaznaczonych',
+
+        'modal' => [
+            'heading' => 'Usuwanie powiązań zaznaczonych :label',
+        ],
+
+        'messages' => [
+            'dissociated' => 'Usunięto powiązania',
+        ],
+
+    ],
+
+];


### PR DESCRIPTION
A few missing words here and there, and associate/dissociate were missing completely.
I am not confident in associate/dissociate, because I don't have any actual use case for it.

@lolen  was the last one to work on translations, so if he can opinion it, then great.
If not, it's better than having sudden English on page.