### PR TITLE
Forms\Components\Hidden: CanBeAutocompleted

### DIFF
--- a/packages/forms/resources/views/components/hidden.blade.php
+++ b/packages/forms/resources/views/components/hidden.blade.php
@@ -2,6 +2,7 @@
     id="{{ $getId() }}"
     {!! $isRequired() ? 'required' : null !!}
     type="hidden"
+    {!! ($autocomplete = $getAutocomplete()) ? "autocomplete=\"{$autocomplete}\"" : null !!}
     {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
     {{ $attributes->merge($getExtraAttributes())->class(['filament-forms-hidden-component']) }}
     dusk="filament.forms.{{ $getStatePath() }}"

--- a/packages/forms/src/Components/Hidden.php
+++ b/packages/forms/src/Components/Hidden.php
@@ -4,6 +4,8 @@ namespace Filament\Forms\Components;
 
 class Hidden extends Field
 {
+    use Concerns\CanBeAutocompleted;
+
     protected string $view = 'forms::components.hidden';
 
     protected function setUp(): void


### PR DESCRIPTION
Useful for hidden field as `username` field on password change forms (https://goo.gl/9p2vKq)