### PR TITLE
Update select component to work with BelongsToMany

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -168,7 +168,7 @@ class Select extends Field
                 ]);
 
                 $state = $component->isMultiple() ?
-                    array_merge($component->getState(), $createdOptionKey) :
+                    array_merge($component->getState(), [$createdOptionKey]) :
                     $createdOptionKey;
 
                 $component->state($state);


### PR DESCRIPTION
When creating a record in a form (with the just-released feature) with a belongs to many relationship, an array_merge error would occur because a string(or ID) would be returned from the database. Wrapping this in an array solves it.