### PR TITLE
Raise z-index for select dropdown

### DIFF
--- a/packages/forms/resources/css/components/select.css
+++ b/packages/forms/resources/css/components/select.css
@@ -111,7 +111,7 @@
 }
 
 .is-active.choices__list--dropdown, .is-active.choices__list[aria-expanded] {
-    @apply visible;
+    @apply visible z-[2];
 }
 
 .choices__list--dropdown .choices__list, .choices__list[aria-expanded] .choices__list {

--- a/packages/forms/resources/css/components/select.css
+++ b/packages/forms/resources/css/components/select.css
@@ -111,7 +111,7 @@
 }
 
 .is-active.choices__list--dropdown, .is-active.choices__list[aria-expanded] {
-    @apply visible z-[2];
+    @apply visible z-10;
 }
 
 .choices__list--dropdown .choices__list, .choices__list[aria-expanded] .choices__list {


### PR DESCRIPTION
This is because sometimes 3rd party plugins will work with `z-index` and have this as a higher value than `1` which choices does now. You will also always want to have the choices dropdown at first on the layers (always on top)

**Broken:**
![CleanShot 2022-05-10 at 15 50 22](https://user-images.githubusercontent.com/3110750/167645468-cc214027-8364-4757-a6a7-0cd9f08b5d60.png)

**Fixed:**
![CleanShot 2022-05-10 at 15 50 36](https://user-images.githubusercontent.com/3110750/167645525-7708d6ef-200c-4e89-9eaf-2706b866eb0c.png)

I'm also open for a z-index 10 so you're even more sure the choices list will overlap other forms/tools.