### PR TITLE
fix modal component taking empty space

### DIFF
--- a/packages/admin/resources/views/components/dropdown/item.blade.php
+++ b/packages/admin/resources/views/components/dropdown/item.blade.php
@@ -3,7 +3,7 @@
 ])
 
 <x-filament-support::dropdown.item
-    :attributes="$attributes->merge($slots)"
+    :attributes="\Filament\Support\prepare_inherited_attributes($attributes)->merge($slots)"
     :dark-mode="config('filament.dark_mode')"
 >
     {{ $slot }}

--- a/packages/admin/resources/views/components/modal/index.blade.php
+++ b/packages/admin/resources/views/components/modal/index.blade.php
@@ -4,6 +4,7 @@
     'header',
     'heading',
     'subheading',
+    'displayClasses',
 ])
 
 <x-filament-support::modal

--- a/packages/admin/resources/views/components/modal/index.blade.php
+++ b/packages/admin/resources/views/components/modal/index.blade.php
@@ -4,11 +4,10 @@
     'header',
     'heading',
     'subheading',
-    'displayClasses',
 ])
 
 <x-filament-support::modal
-    :attributes="$attributes->merge($slots)"
+    :attributes="\Filament\Support\prepare_inherited_attributes($attributes)->merge($slots)"
     :dark-mode="config('filament.dark_mode')"
     heading-component="filament::modal.heading"
     hr-component="filament::hr"

--- a/packages/forms/resources/views/components/dropdown/item.blade.php
+++ b/packages/forms/resources/views/components/dropdown/item.blade.php
@@ -3,7 +3,7 @@
 ])
 
 <x-filament-support::dropdown.item
-    :attributes="$attributes->merge($slots)"
+    :attributes="\Filament\Support\prepare_inherited_attributes($attributes)->merge($slots)"
     :dark-mode="config('forms.dark_mode')"
 >
     {{ $slot }}

--- a/packages/forms/resources/views/components/modal/index.blade.php
+++ b/packages/forms/resources/views/components/modal/index.blade.php
@@ -4,6 +4,7 @@
     'header',
     'heading',
     'subheading',
+    'displayClasses',
 ])
 
 <x-filament-support::modal

--- a/packages/forms/resources/views/components/modal/index.blade.php
+++ b/packages/forms/resources/views/components/modal/index.blade.php
@@ -4,11 +4,10 @@
     'header',
     'heading',
     'subheading',
-    'displayClasses',
 ])
 
 <x-filament-support::modal
-    :attributes="$attributes->merge($slots)"
+    :attributes="\Filament\Support\prepare_inherited_attributes($attributes)->merge($slots)"
     :dark-mode="config('forms.dark_mode')"
     heading-component="forms::modal.heading"
     hr-component="forms::hr"

--- a/packages/tables/resources/views/components/dropdown/item.blade.php
+++ b/packages/tables/resources/views/components/dropdown/item.blade.php
@@ -3,7 +3,7 @@
 ])
 
 <x-filament-support::dropdown.item
-    :attributes="$attributes->merge($slots)"
+    :attributes="\Filament\Support\prepare_inherited_attributes($attributes)->merge($slots)"
     :dark-mode="config('tables.dark_mode')"
 >
     {{ $slot }}

--- a/packages/tables/resources/views/components/modal/index.blade.php
+++ b/packages/tables/resources/views/components/modal/index.blade.php
@@ -4,11 +4,10 @@
     'header',
     'heading',
     'subheading',
-    'displayClasses',
 ])
 
 <x-filament-support::modal
-    :attributes="$attributes->merge($slots)"
+    :attributes="\Filament\Support\prepare_inherited_attributes($attributes)->merge($slots)"
     :dark-mode="config('tables.dark_mode')"
     heading-component="tables::modal.heading"
     hr-component="tables::hr"

--- a/packages/tables/resources/views/components/modal/index.blade.php
+++ b/packages/tables/resources/views/components/modal/index.blade.php
@@ -4,6 +4,7 @@
     'header',
     'heading',
     'subheading',
+    'displayClasses',
 ])
 
 <x-filament-support::modal


### PR DESCRIPTION
i'm using the modal in custom blade file 
```php
<x-filament::modal id="page-action" display-classes="block" width="2xl">
```
recent extraction to Support package causes missing attributes to pass into components

**Before**
![image](https://user-images.githubusercontent.com/67364036/167901041-1727b4fd-c76e-40e4-87a9-1a3603eaeb2c.png)

**After**
![image](https://user-images.githubusercontent.com/67364036/167901111-67dc2638-fd8e-4564-ad70-1887d1c0491d.png)

p/s: only notice `displayClasses` is missing for now