### PR TITLE
fix: [forms] block builder when block non-existant

### DIFF
--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -242,15 +242,14 @@ class Builder extends Field
     public function getChildComponentContainers(bool $withHidden = false): array
     {
         return collect($this->getState())
+            ->filter(fn (array $itemData): ?Block => $this->hasBlock($itemData['type']))
             ->map(
-                fn ($itemData, $itemIndex): ?Block =>  $this->getBlock($itemData['type'])
-                )
-            ->filter()
-            ->map(
-                fn (Block $block, $itemIndex): ComponentContainer  =>  $block->getChildComponentContainer()
+                fn (array $itemData, $itemIndex): ComponentContainer => $this
+                    ->getBlock($itemData['type'])
+                    ->getChildComponentContainer()
                     ->getClone()
                     ->statePath("{$itemIndex}.data")
-                    ->inlineLabel(false)
+                    ->inlineLabel(false),
             )
             ->toArray();
     }

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -242,7 +242,7 @@ class Builder extends Field
     public function getChildComponentContainers(bool $withHidden = false): array
     {
         return collect($this->getState())
-            ->filter(fn (array $itemData): ?Block => $this->hasBlock($itemData['type']))
+            ->filter(fn (array $itemData): bool => $this->hasBlock($itemData['type']))
             ->map(
                 fn (array $itemData, $itemIndex): ComponentContainer => $this
                     ->getBlock($itemData['type'])

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -243,11 +243,11 @@ class Builder extends Field
     {
         return collect($this->getState())
             ->map(
-                fn ($itemData, $itemIndex): ?ComponentContainer =>  $this->getBlock($itemData['type'])
+                fn ($itemData, $itemIndex): ?Block =>  $this->getBlock($itemData['type'])
                 )
             ->filter()
             ->map(
-                fn ($block, $itemIndex): ComponentContainer  =>  $block->getChildComponentContainer()
+                fn (Block $block, $itemIndex): ComponentContainer  =>  $block->getChildComponentContainer()
                     ->getClone()
                     ->statePath("{$itemIndex}.data")
                     ->inlineLabel(false)

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -242,13 +242,16 @@ class Builder extends Field
     public function getChildComponentContainers(bool $withHidden = false): array
     {
         return collect($this->getState())
-            ->map(function ($itemData, $itemIndex): ComponentContainer {
-                return $this->getBlock($itemData['type'])
-                    ->getChildComponentContainer()
+            ->map(
+                fn ($itemData, $itemIndex): ?ComponentContainer =>  $this->getBlock($itemData['type'])
+                )
+            ->filter()
+            ->map(
+                fn ($block, $itemIndex): ComponentContainer  =>  $block->getChildComponentContainer()
                     ->getClone()
                     ->statePath("{$itemIndex}.data")
-                    ->inlineLabel(false);
-            })
+                    ->inlineLabel(false)
+            )
             ->toArray();
     }
 


### PR DESCRIPTION
Fixes an issue - though rare as it might be -- could be only during development of a resource Block:

How to replicate:
- Using Block builder - create an record
- Change the Block Builder and try and edit the record - Throws exception

To Fix:
Updated the GetChildComponentContainers method to filter our null blocks