### PR TITLE
Use evaluate for HasColor and HasLabel

### DIFF
--- a/packages/support/src/Actions/Concerns/HasColor.php
+++ b/packages/support/src/Actions/Concerns/HasColor.php
@@ -2,11 +2,13 @@
 
 namespace Filament\Support\Actions\Concerns;
 
+use Closure;
+
 trait HasColor
 {
-    protected ?string $color = null;
+    protected string | Closure | null $color = null;
 
-    public function color(?string $color): static
+    public function color(string | Closure | null $color): static
     {
         $this->color = $color;
 
@@ -15,6 +17,6 @@ trait HasColor
 
     public function getColor(): ?string
     {
-        return $this->color;
+        return $this->evaluate($this->color);
     }
 }

--- a/packages/support/src/Actions/Concerns/HasLabel.php
+++ b/packages/support/src/Actions/Concerns/HasLabel.php
@@ -2,13 +2,14 @@
 
 namespace Filament\Support\Actions\Concerns;
 
+use Closure;
 use Illuminate\Support\Str;
 
 trait HasLabel
 {
-    protected ?string $label = null;
+    protected string | Closure | null $label = null;
 
-    public function label(string $label): static
+    public function label(string | Closure | null $label): static
     {
         $this->label = $label;
 
@@ -17,7 +18,7 @@ trait HasLabel
 
     public function getLabel(): string
     {
-        return $this->label ?? (string) Str::of($this->getName())
+        return $this->label ? $this->evaluate($this->label) : (string) Str::of($this->getName())
             ->before('.')
             ->kebab()
             ->replace(['-', '_'], ' ')


### PR DESCRIPTION
Just some further enhancements to allow `evaluate` to be used with `Filament\Support\Actions\Concerns\HasColor` and `Filament\Support\Actions\Concerns\HasLabel`