### PR TITLE
Use `getRecordTitle()` for relation manager

### DIFF
--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanAssociateRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanAssociateRecords.php
@@ -95,7 +95,7 @@ trait CanAssociateRecords
                     $isFirst = false;
                 }
 
-                $relatedKey = $relationship->getLocalKeyName();
+                $localKeyName = $relationship->getLocalKeyName();
 
                 return $relationshipQuery
                     ->whereDoesntHave($livewire->getInverseRelationshipName(), function (Builder $query) use ($livewire): void {
@@ -103,7 +103,7 @@ trait CanAssociateRecords
                     })
                     ->get()
                     ->mapWithKeys(static fn (Model $record) => [
-                        $record->{$relatedKey} => static::getRecordTitle($record),
+                        $record->{$localKeyName} => static::getRecordTitle($record),
                     ])
                     ->toArray();
             })

--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanAssociateRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanAssociateRecords.php
@@ -8,6 +8,7 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -97,7 +98,10 @@ trait CanAssociateRecords
                     ->whereDoesntHave($livewire->getInverseRelationshipName(), function (Builder $query) use ($livewire): void {
                         $query->where($livewire->ownerRecord->getQualifiedKeyName(), $livewire->ownerRecord->getKey());
                     })
-                    ->pluck($displayColumnName, $relationship->getRelated()->getKeyName())
+                    ->get()
+                    ->mapWithKeys(static fn (Model $record) => [
+                        $record->{$relationship->getRelated()->getKeyName()} => static::getRecordTitle($record),
+                    ])
                     ->toArray();
             })
             ->getOptionLabelUsing(static fn (RelationManager $livewire, $value): ?string => static::getRecordTitle($livewire->getRelationship()->getRelated()->query()->find($value)))

--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanAssociateRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanAssociateRecords.php
@@ -100,7 +100,7 @@ trait CanAssociateRecords
                     })
                     ->get()
                     ->mapWithKeys(static fn (Model $record) => [
-                        $record->{$relationship->getRelated()->getKeyName()} => static::getRecordTitle($record),
+                        $record->{$relationship->getLocalKeyName()} => static::getRecordTitle($record),
                     ])
                     ->toArray();
             })

--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanAssociateRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanAssociateRecords.php
@@ -62,6 +62,7 @@ trait CanAssociateRecords
             ->label(__('filament::resources/relation-managers/associate.action.modal.fields.record_id.label'))
             ->searchable()
             ->getSearchResultsUsing(static function (Select $component, RelationManager $livewire, string $searchQuery): array {
+                /** @var HasMany $relationship */
                 $relationship = $livewire->getRelationship();
 
                 $displayColumnName = static::getRecordTitleAttribute();
@@ -94,13 +95,15 @@ trait CanAssociateRecords
                     $isFirst = false;
                 }
 
+                $relatedKey = $relationship->getLocalKeyName();
+
                 return $relationshipQuery
                     ->whereDoesntHave($livewire->getInverseRelationshipName(), function (Builder $query) use ($livewire): void {
                         $query->where($livewire->ownerRecord->getQualifiedKeyName(), $livewire->ownerRecord->getKey());
                     })
                     ->get()
                     ->mapWithKeys(static fn (Model $record) => [
-                        $record->{$relationship->getLocalKeyName()} => static::getRecordTitle($record),
+                        $record->{$relatedKey} => static::getRecordTitle($record),
                     ])
                     ->toArray();
             })

--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanAssociateRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanAssociateRecords.php
@@ -102,9 +102,7 @@ trait CanAssociateRecords
                         $query->where($livewire->ownerRecord->getQualifiedKeyName(), $livewire->ownerRecord->getKey());
                     })
                     ->get()
-                    ->mapWithKeys(static fn (Model $record) => [
-                        $record->{$localKeyName} => static::getRecordTitle($record),
-                    ])
+                    ->mapWithKeys(static fn (Model $record): array => [$record->{$localKeyName} => static::getRecordTitle($record)])
                     ->toArray();
             })
             ->getOptionLabelUsing(static fn (RelationManager $livewire, $value): ?string => static::getRecordTitle($livewire->getRelationship()->getRelated()->query()->find($value)))

--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanAttachRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanAttachRecords.php
@@ -108,6 +108,7 @@ trait CanAttachRecords
                     return [];
                 }
 
+                /** @var BelongsToMany $relationship */
                 $relationship = $livewire->getRelationship();
 
                 $displayColumnName = static::getRecordTitleAttribute();

--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanAttachRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanAttachRecords.php
@@ -90,16 +90,14 @@ trait CanAttachRecords
                     $isFirst = false;
                 }
 
-                $relatedKey = $relationship->getRelatedKeyName();
+                $relatedKeyName = $relationship->getRelatedKeyName();
 
                 return $relationshipQuery
                     ->whereDoesntHave($livewire->getInverseRelationshipName(), function (Builder $query) use ($livewire): void {
                         $query->where($livewire->ownerRecord->getQualifiedKeyName(), $livewire->ownerRecord->getKey());
                     })
                     ->get()
-                    ->mapWithKeys(static fn (Model $record) => [
-                        $record->{$relatedKey} => static::getRecordTitle($record),
-                    ])
+                    ->mapWithKeys(static fn (Model $record): array => [$record->{$relatedKeyName} => static::getRecordTitle($record)])
                     ->toArray();
             })
             ->getOptionLabelUsing(static fn (RelationManager $livewire, $value): ?string => static::getRecordTitle($livewire->getRelationship()->getRelated()->query()->find($value)))
@@ -113,7 +111,7 @@ trait CanAttachRecords
 
                 $displayColumnName = static::getRecordTitleAttribute();
 
-                $relatedKey = $relationship->getRelatedKeyName();
+                $relatedKeyName = $relationship->getRelatedKeyName();
 
                 return $relationship
                     ->getRelated()
@@ -123,9 +121,7 @@ trait CanAttachRecords
                         $query->where($livewire->ownerRecord->getQualifiedKeyName(), $livewire->ownerRecord->getKey());
                     })
                     ->get()
-                    ->mapWithKeys(static fn (Model $record) => [
-                        $record->{$relatedKey} => static::getRecordTitle($record),
-                    ])
+                    ->mapWithKeys(static fn (Model $record): array => [$record->{$relatedKeyName} => static::getRecordTitle($record)])
                     ->toArray();
             })
             ->disableLabel();

--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanAttachRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanAttachRecords.php
@@ -8,6 +8,7 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Arr;
 
@@ -92,7 +93,10 @@ trait CanAttachRecords
                     ->whereDoesntHave($livewire->getInverseRelationshipName(), function (Builder $query) use ($livewire): void {
                         $query->where($livewire->ownerRecord->getQualifiedKeyName(), $livewire->ownerRecord->getKey());
                     })
-                    ->pluck($displayColumnName, $relationship->getRelated()->getKeyName())
+                    ->get()
+                    ->mapWithKeys(static fn (Model $record) => [
+                        $record->{$relationship->getRelated()->getKeyName()} => static::getRecordTitle($record),
+                    ])
                     ->toArray();
             })
             ->getOptionLabelUsing(static fn (RelationManager $livewire, $value): ?string => static::getRecordTitle($livewire->getRelationship()->getRelated()->query()->find($value)))
@@ -112,7 +116,10 @@ trait CanAttachRecords
                     ->whereDoesntHave($livewire->getInverseRelationshipName(), function (Builder $query) use ($livewire): void {
                         $query->where($livewire->ownerRecord->getQualifiedKeyName(), $livewire->ownerRecord->getKey());
                     })
-                    ->pluck($displayColumnName, $relationship->getRelated()->getKeyName())
+                    ->get()
+                    ->mapWithKeys(static fn (Model $record) => [
+                        $record->{$relationship->getRelated()->getKeyName()} => static::getRecordTitle($record),
+                    ])
                     ->toArray();
             })
             ->disableLabel();

--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanAttachRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanAttachRecords.php
@@ -95,7 +95,7 @@ trait CanAttachRecords
                     })
                     ->get()
                     ->mapWithKeys(static fn (Model $record) => [
-                        $record->{$relationship->getRelated()->getKeyName()} => static::getRecordTitle($record),
+                        $record->{$relationship->getRelatedKeyName()} => static::getRecordTitle($record),
                     ])
                     ->toArray();
             })
@@ -118,7 +118,7 @@ trait CanAttachRecords
                     })
                     ->get()
                     ->mapWithKeys(static fn (Model $record) => [
-                        $record->{$relationship->getRelated()->getKeyName()} => static::getRecordTitle($record),
+                        $record->{$relationship->getRelatedKeyName()} => static::getRecordTitle($record),
                     ])
                     ->toArray();
             })

--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanAttachRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanAttachRecords.php
@@ -57,6 +57,7 @@ trait CanAttachRecords
             ->label(__('filament::resources/relation-managers/attach.action.modal.fields.record_id.label'))
             ->searchable()
             ->getSearchResultsUsing(static function (Select $component, RelationManager $livewire, string $searchQuery): array {
+                /** @var BelongsToMany $relationship */
                 $relationship = $livewire->getRelationship();
 
                 $displayColumnName = static::getRecordTitleAttribute();
@@ -89,13 +90,15 @@ trait CanAttachRecords
                     $isFirst = false;
                 }
 
+                $relatedKey = $relationship->getRelatedKeyName();
+
                 return $relationshipQuery
                     ->whereDoesntHave($livewire->getInverseRelationshipName(), function (Builder $query) use ($livewire): void {
                         $query->where($livewire->ownerRecord->getQualifiedKeyName(), $livewire->ownerRecord->getKey());
                     })
                     ->get()
                     ->mapWithKeys(static fn (Model $record) => [
-                        $record->{$relationship->getRelatedKeyName()} => static::getRecordTitle($record),
+                        $record->{$relatedKey} => static::getRecordTitle($record),
                     ])
                     ->toArray();
             })
@@ -109,6 +112,8 @@ trait CanAttachRecords
 
                 $displayColumnName = static::getRecordTitleAttribute();
 
+                $relatedKey = $relationship->getRelatedKeyName();
+
                 return $relationship
                     ->getRelated()
                     ->query()
@@ -118,7 +123,7 @@ trait CanAttachRecords
                     })
                     ->get()
                     ->mapWithKeys(static fn (Model $record) => [
-                        $record->{$relationship->getRelatedKeyName()} => static::getRecordTitle($record),
+                        $record->{$relatedKey} => static::getRecordTitle($record),
                     ])
                     ->toArray();
             })


### PR DESCRIPTION
@danharrin We already use `getRecordTitle()` for  the option labels, but not for the search results. I'd like to introduce the functionality to customize the label based on the record as in `Select` or `BelongsToSelect`.

As `getRecordTitle()` is already used and has a fallback there is no way to check whether it was defined, so we need to apply it to every query instead of the bit more performant `->pluck()`.

What do you think?