### PR TITLE
Do not process schema when hidden

### DIFF
--- a/packages/forms/src/Components/Concerns/HasChildComponents.php
+++ b/packages/forms/src/Components/Concerns/HasChildComponents.php
@@ -25,7 +25,7 @@ trait HasChildComponents
 
     public function getChildComponents(): array
     {
-        return $this->evaluate($this->childComponents);
+        return $this->isHidden() ? [] : $this->evaluate($this->childComponents);
     }
 
     public function getChildComponentContainer(): ComponentContainer


### PR DESCRIPTION
Small change to submit an empty array as the schema for anything that has `childComponents` when it is `hidden`. I noticed that if the `schema` was generated dynamically with a callback, this would run even if the component was hidden. For my use case, I wanted to display a `Section` with dynamically created components when editing but not when creating as the generation was dependent on a property that could not be calculated at the time of creation.