### PR TITLE
fix: MarkdownEditor preview

### DIFF
--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -240,8 +240,8 @@
                 'dark:bg-gray-700 dark:border-gray-600' => config('forms.dark_mode'),
             ]) x-show="tab === 'preview'" x-cloak style="min-height: 150px;">
                 <div @class([
-                    'prose block w-full max-w-none rounded-lg border border-gray-300 bg-white p-3 shadow-sm',
-                    'dark:prose-invert dark:border-gray-600 dark:bg-gray-700' => config('forms.dark_mode'),
+                    'prose block w-full max-w-none rounded-lg bg-white p-3',
+                    'dark:prose-invert dark:bg-gray-700' => config('forms.dark_mode'),
                 ]) x-html="preview"></div>
             </div>
         </div>


### PR DESCRIPTION
Improve markdown editor preview ui
just remove `border border-gray-300  dark:border-gray-600 shadow-sm`