### PR TITLE
doc: correct hidden() to visible() method

### DIFF
--- a/packages/tables/docs/05-actions.md
+++ b/packages/tables/docs/05-actions.md
@@ -224,7 +224,7 @@ BulkAction::make('delete')
 
 ## Authorization
 
-You may conditionally hide actions and bulk actions for certain users using the `hidden()` method, passing a closure:
+You may conditionally show or hide actions and bulk actions for certain users using either the `visible()` or `hidden()` methods, passing a closure:
 
 ```php
 use App\Models\Post;
@@ -232,7 +232,7 @@ use Filament\Tables\Actions\Action;
 
 Action::make('edit')
     ->url(fn (Post $record): string => route('posts.edit', $record))
-    ->hidden(fn (Post $record): bool => auth()->user()->can('update', $record))
+    ->visible(fn (Post $record): bool => auth()->user()->can('update', $record))
 ```
 
 This is useful for authorization of certain actions to only users who have permission.


### PR DESCRIPTION
- the `hidden()` method was incorrect:

```php
// was:
->hidden(fn (Post $record): bool => auth()->user()->can('update', $record))
// should be:
->hidden(fn (Post $record): bool => ! auth()->user()->can('update', $record))
```

- I think the `visible()` method is easier to read, in this example.

```php
// now:
->visible(fn (Post $record): bool => auth()->user()->can('update', $record))
```