### PR TITLE
Feature: add `extraAttributes` to StatsOverView Widget Card

### DIFF
--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -10,10 +10,11 @@
     'label' => null,
     'tag' => 'div',
     'value' => null,
+    'extraAttributes' => [],
 ])
 
 <{!! $tag !!}
-    {{ $attributes->class([
+    {{ $attributes->merge($extraAttributes)->class([
         'relative p-6 rounded-2xl bg-white shadow filament-stats-card',
         'dark:bg-gray-800' => config('filament.dark_mode'),
     ]) }}

--- a/packages/admin/resources/views/widgets/stats-overview-widget/card.blade.php
+++ b/packages/admin/resources/views/widgets/stats-overview-widget/card.blade.php
@@ -15,5 +15,6 @@
     :target="$shouldOpenUrlInNewTab() ? '_blank' : null"
     :label="$getLabel()"
     :value="$getValue()"
+    :extra-attributes="$getExtraAttributes()"
     class="filament-stats-overview-widget-card"
 />

--- a/packages/admin/src/Widgets/StatsOverviewWidget/Card.php
+++ b/packages/admin/src/Widgets/StatsOverviewWidget/Card.php
@@ -23,6 +23,8 @@ class Card extends Component implements Htmlable
 
     protected ?string $descriptionColor = null;
 
+    protected array $extraAttributes = [];
+
     protected bool $shouldOpenUrlInNewTab = false;
 
     protected ?string $url = null;
@@ -82,6 +84,13 @@ class Card extends Component implements Htmlable
     public function descriptionIcon(?string $icon): static
     {
         $this->descriptionIcon = $icon;
+
+        return $this;
+    }
+
+    public function extraAttributes(array $attributes): static
+    {
+        $this->extraAttributes = $attributes;
 
         return $this;
     }
@@ -162,6 +171,11 @@ class Card extends Component implements Htmlable
     public function getDescriptionIcon(): ?string
     {
         return $this->descriptionIcon;
+    }
+
+    public function getExtraAttributes(): array
+    {
+        return $this->extraAttributes;
     }
 
     public function getUrl(): ?string


### PR DESCRIPTION
Sample use case fire custom livewire events
```php
Card::make(Str::headline($status), $total)
                ->extraAttributes([
                    'class' => 'cursor-pointer',
                    'wire:click' => '$emitUp("filterStatus", "' . $status . '")',
                ]);
```