### PR TITLE
Adds support for `extraImgAttributes()` on ImageColumn

### DIFF
--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -11,12 +11,12 @@
             ></div>
         @else
             <img
-                {!! $attributes->merge($getExtraImgAttributes()) !!}
                 src="{{ $path }}"
                 style="
                     {!! ($height = $getHeight()) !== null ? "height: {$height};" : null !!}
                     {!! ($width = $getWidth()) !== null ? "width: {$width};" : null !!}
                 "
+                {{ $getExtraImgAttributeBag() }}
             >
         @endif
     @endif

--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -11,6 +11,7 @@
             ></div>
         @else
             <img
+                {!! $attributes->merge($getExtraImgAttributes()) !!}
                 src="{{ $path }}"
                 style="
                     {!! ($height = $getHeight()) !== null ? "height: {$height};" : null !!}

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -20,6 +20,8 @@ class ImageColumn extends Column
 
     protected int | string | Closure | null $width = null;
 
+    protected array | Closure $extraImgAttributes = [];
+
     protected function setUp(): void
     {
         $this->disk(config('tables.default_filesystem_disk'));
@@ -137,5 +139,17 @@ class ImageColumn extends Column
     public function isRounded(): bool
     {
         return $this->evaluate($this->isRounded);
+    }
+
+    public function extraImgAttributes(array | Closure $attributes): static
+    {
+        $this->extraImgAttributes = $attributes;
+
+        return $this;
+    }
+
+    public function getExtraImgAttributes(): array
+    {
+        return $this->evaluate($this->extraImgAttributes);
     }
 }

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\View\ComponentAttributeBag;
 use Throwable;
 
 class ImageColumn extends Column
@@ -151,5 +152,10 @@ class ImageColumn extends Column
     public function getExtraImgAttributes(): array
     {
         return $this->evaluate($this->extraImgAttributes);
+    }
+
+    public function getExtraImgAttributeBag(): ComponentAttributeBag
+    {
+        return new ComponentAttributeBag($this->getExtraImgAttributes());
     }
 }


### PR DESCRIPTION
Allows us to add attributes to the `img` tag on an `ImageColumn`, so we can do stuff like:
```php
        return $table
            ->columns([
                ImageColumn::make('logo')
                    ->extraAttributes(['class' => 'flex items-center h-16 w-32'])
                    ->extraImgAttributes(['class' => 'object-contain w-full h-full']),
            ]);
```

Getting logos to contain within the bounds of predefined area:

![image](https://user-images.githubusercontent.com/3776888/169280440-1dbb86ca-337a-4265-b528-e3f101ab0459.png)
