### PR TITLE
[2.X] Add Limit to property

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -14,7 +14,7 @@ trait CanFormatState
 {
     protected ?Closure $formatStateUsing = null;
 
-    private ?int $limit = null;
+    protected ?int $limit = null;
 
     protected string | Closure | null $prefix = null;
 
@@ -124,6 +124,11 @@ trait CanFormatState
         }
 
         return $state;
+    }
+    
+    public function getLimit(): ?int
+    {
+        return $this->limit;
     }
 
     public function time(?string $format = null, ?string $timezone = null): static

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -18,6 +18,8 @@ trait CanFormatState
 
     protected string | Closure | null $suffix = null;
 
+    protected ?int $limit = null;
+
     public function date(?string $format = null, ?string $timezone = null): static
     {
         $format ??= config('tables.date_format');
@@ -47,6 +49,8 @@ trait CanFormatState
 
     public function limit(int $length = 100, string $end = '...'): static
     {
+        $this->limit = $length;
+        
         $this->formatStateUsing(static function ($state) use ($length, $end): ?string {
             if (blank($state)) {
                 return null;

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -14,11 +14,11 @@ trait CanFormatState
 {
     protected ?Closure $formatStateUsing = null;
 
+    private ?int $limit = null;
+
     protected string | Closure | null $prefix = null;
 
     protected string | Closure | null $suffix = null;
-
-    protected ?int $limit = null;
 
     public function date(?string $format = null, ?string $timezone = null): static
     {
@@ -50,7 +50,7 @@ trait CanFormatState
     public function limit(int $length = 100, string $end = '...'): static
     {
         $this->limit = $length;
-        
+
         $this->formatStateUsing(static function ($state) use ($length, $end): ?string {
             if (blank($state)) {
                 return null;


### PR DESCRIPTION
I have been using `limit` in my `TextColumn` but I can't reuse it on my other methods such as `tooltip`

I have been trying to show the tooltip only if the limit exceeds

Before

```
TextColumn::make('instance_name')
->limit(20)
->tooltip(fn ($record): string => strlen($record->instance_name) >=20 ? $record->instance_name : "")
->searchable()
->sortable()
->default('N/A'),
```

After

```
TextColumn::make('instance_name')
->limit(20)
->tooltip(fn ($column,$record): string => strlen($record->instance_name) >= $column->limit ? $record->instance_name : "")
->searchable()
->sortable()
->default('N/A'),
```