### PR TITLE
fix: allow collapse by default on repeater

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -57,7 +57,7 @@
                         x-data="{
                             isCreateButtonDropdownOpen: false,
                             isCreateButtonVisible: false,
-                            isCollapsed: false,
+                            isCollapsed: @js($isCollapsed()),
                         }"
                         x-on:builder-collapse.window="$event.detail === '{{ $getStatePath() }}' && (isCollapsed = true)"
                         x-on:builder-expand.window="$event.detail === '{{ $getStatePath() }}' && (isCollapsed = false)"

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -50,7 +50,7 @@
             >
                 @foreach ($containers as $uuid => $item)
                     <li
-                        x-data="{ isCollapsed: false }"
+                        x-data="{ isCollapsed: {{ $isCollapsed() }} }"
                         x-on:repeater-collapse.window="$event.detail === '{{ $getStatePath() }}' && (isCollapsed = true)"
                         x-on:repeater-expand.window="$event.detail === '{{ $getStatePath() }}' && (isCollapsed = false)"
                         wire:key="{{ $item->getStatePath() }}"

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -50,7 +50,7 @@
             >
                 @foreach ($containers as $uuid => $item)
                     <li
-                        x-data="{ isCollapsed: {{ $isCollapsed() }} }"
+                        x-data="{ isCollapsed: @js($isCollapsed()) }"
                         x-on:repeater-collapse.window="$event.detail === '{{ $getStatePath() }}' && (isCollapsed = true)"
                         x-on:repeater-expand.window="$event.detail === '{{ $getStatePath() }}' && (isCollapsed = false)"
                         wire:key="{{ $item->getStatePath() }}"

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Str;
 
 class Builder extends Field
 {
+    use Concerns\CanBeCollapsed;
     use Concerns\CanLimitItemsLength;
 
     protected string $view = 'forms::components.builder';
@@ -82,6 +83,8 @@ class Builder extends Field
                     $component->getChildComponentContainers()[$newUuid]->fill();
 
                     $component->hydrateDefaultItemState($newUuid);
+
+                    $component->collapsed(false);
                 },
             ],
             'builder::deleteItem' => [

--- a/packages/forms/src/Components/Concerns/CanBeCollapsed.php
+++ b/packages/forms/src/Components/Concerns/CanBeCollapsed.php
@@ -8,15 +8,15 @@ trait CanBeCollapsed
 {
     protected bool | Closure $isCollapsed = false;
 
-    public function collapse(bool | Closure $condition = true): static
+    public function collapsed(bool | Closure $condition = true): static
     {
         $this->isCollapsed = $condition;
 
         return $this;
     }
 
-    public function isCollapsed(): string
+    public function isCollapsed(): bool
     {
-        return (bool) $this->evaluate($this->isCollapsed) ? 'true' : 'false';
+        return (bool) $this->evaluate($this->isCollapsed);
     }
 }

--- a/packages/forms/src/Components/Concerns/CanBeCollapsed.php
+++ b/packages/forms/src/Components/Concerns/CanBeCollapsed.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Filament\Forms\Components\Concerns;
+
+use Closure;
+
+trait CanBeCollapsed
+{
+    protected bool | Closure $isCollapsed = false;
+
+    public function collapse(bool | Closure $condition = true): static
+    {
+        $this->isCollapsed = $condition;
+
+        return $this;
+    }
+
+    public function isCollapsed(): string
+    {
+        return (bool) $this->evaluate($this->isCollapsed) ? 'true' : 'false';
+    }
+}

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -54,7 +54,8 @@ class Repeater extends Field
                     $component->getChildComponentContainers()[$newUuid]->fill();
 
                     $component->hydrateDefaultItemState($newUuid);
-                    $component->collapse(false);
+
+                    $component->collapsed(false);
                 },
             ],
             'repeater::deleteItem' => [

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -54,6 +54,7 @@ class Repeater extends Field
                     $component->getChildComponentContainers()[$newUuid]->fill();
 
                     $component->hydrateDefaultItemState($newUuid);
+                    $component->collapse(false);
                 },
             ],
             'repeater::deleteItem' => [

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Str;
 class Repeater extends Field
 {
     use Concerns\CanLimitItemsLength;
+    use Concerns\CanBeCollapsed;
 
     protected string $view = 'forms::components.repeater';
 

--- a/packages/forms/src/Components/Section.php
+++ b/packages/forms/src/Components/Section.php
@@ -9,12 +9,11 @@ use Illuminate\Support\Str;
 
 class Section extends Component implements Contracts\CanConcealComponents, Contracts\CanEntangleWithSingularRelationships
 {
+    use Concerns\CanBeCollapsed;
     use Concerns\EntanglesStateWithSingularRelationship;
     use HasExtraAlpineAttributes;
 
     protected string $view = 'forms::components.section';
-
-    protected bool | Closure $isCollapsed = false;
 
     protected bool | Closure $isCollapsible = false;
 
@@ -94,11 +93,6 @@ class Section extends Component implements Contracts\CanConcealComponents, Contr
         }
 
         return $id;
-    }
-
-    public function isCollapsed(): bool
-    {
-        return (bool) $this->evaluate($this->isCollapsed);
     }
 
     public function isCollapsible(): bool


### PR DESCRIPTION
This PR allows you to set `->collapse()` on a repeater field to automatically collapse all repeaters on page load.