### PR TITLE
fix: syntax error on table search query

### DIFF
--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -84,7 +84,7 @@ trait InteractsWithTableQuery
                     $activeLocale = $this->getLivewire()->getActiveTableLocale() ?: app()->getLocale();
 
                     return $query->{"{$whereClause}Raw"}(
-                        "lower(json_extract({$searchColumnName}, \"$.{$this->getLivewire()->activeLocale}\")) {$searchOperator} ?",
+                        "lower(json_extract({$searchColumnName}, \"$.{$activeLocale}\")) {$searchOperator} ?",
                         "%{$search}%",
                     );
                 },

--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -84,7 +84,7 @@ trait InteractsWithTableQuery
                     $activeLocale = $this->getLivewire()->getActiveTableLocale() ?: app()->getLocale();
 
                     return $query->{"{$whereClause}Raw"}(
-                        "lower({$searchColumnName}->\"$.{$activeLocale}\") {$searchOperator} ?",
+                        "lower(json_extract({$searchColumnName}, \"$.{$this->getLivewire()->activeLocale}\")) {$searchOperator} ?",
                         "%{$search}%",
                     );
                 },


### PR DESCRIPTION
Mariadb doesn't support ``->`` operator on queries. I'm changed ``->`` operator to ``json_extract`` function.

I'm tested Mariadb 10.x and MySQL 5.x versions and working correctly