### PR TITLE
Fix: RichEditor spacing when no buttons

### DIFF
--- a/packages/forms/resources/views/component-container.blade.php
+++ b/packages/forms/resources/views/component-container.blade.php
@@ -1,6 +1,6 @@
 <div @class([
     'grid gap-6 filament-forms-component-container',
-    'grid-cols-1' => $getColumns('default') === 1,
+    'grid-cols-1' => (! $getColumns('default')) || $getColumns('default') === 1,
     'grid-cols-2' => $getColumns('default') === 2,
     'grid-cols-3' => $getColumns('default') === 3,
     'grid-cols-4' => $getColumns('default') === 4,

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -11,7 +11,7 @@
 >
     <div @class([
         'grid gap-1 filament-forms-checkbox-list-component',
-        'grid-cols-1' => $getColumns('default') === 1,
+        'grid-cols-1' => (! $getColumns('default')) || $getColumns('default') === 1,
         'grid-cols-2' => $getColumns('default') === 2,
         'grid-cols-3' => $getColumns('default') === 3,
         'grid-cols-4' => $getColumns('default') === 4,

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -16,7 +16,7 @@
                 'filament-forms-radio-component',
                 'flex flex-wrap gap-3' => $isInline(),
                 'grid gap-2' => ! $isInline(),
-                'grid-cols-1' => $getColumns('default') === 1,
+                'grid-cols-1' => (! $getColumns('default')) || $getColumns('default') === 1,
                 'grid-cols-2' => $getColumns('default') === 2,
                 'grid-cols-3' => $getColumns('default') === 3,
                 'grid-cols-4' => $getColumns('default') === 4,

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -42,7 +42,7 @@
             <trix-toolbar id="trix-toolbar-{{ $getId() }}">
                 <div class="flex justify-between space-x-4 rtl:space-x-reverse overflow-x-auto items-stretch overflow-y-hidden">
                     <div @class([
-                        'flex justify-between space-x-4 rtl:space-x-reverse overflow-x-auto items-stretch overflow-y-hidden',
+                        'flex items-stretch space-x-4 rtl:space-x-reverse focus:outline-none',
                         'hidden' => count($getToolbarButtons()) == 0,
                     ])>
                         @if ($hasToolbarButton(['bold', 'italic', 'strike', 'link']))

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -38,13 +38,11 @@
     >
         @unless ($isDisabled())
             <input id="trix-value-{{ $getId() }}" type="hidden" />
-
+            
+            @if (count($getToolbarButtons()))
             <trix-toolbar id="trix-toolbar-{{ $getId() }}">
                 <div class="flex justify-between space-x-4 rtl:space-x-reverse overflow-x-auto items-stretch overflow-y-hidden">
-                    <div @class([
-                        'flex items-stretch space-x-4 rtl:space-x-reverse focus:outline-none',
-                        'hidden' => count($getToolbarButtons()) == 0,
-                    ])>
+                    <div class="flex items-stretch space-x-4 rtl:space-x-reverse focus:outline-none">
                         @if ($hasToolbarButton(['bold', 'italic', 'strike', 'link']))
                             <div data-trix-button-group="text-tools" class="flex items-stretch space-x-1 rtl:space-x-reverse">
                                 @if ($hasToolbarButton('bold'))
@@ -282,6 +280,7 @@
                     </div>
                 </div>
             </trix-toolbar>
+            @endif
 
             <trix-editor
                 wire:ignore

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -38,9 +38,13 @@
     >
         @unless ($isDisabled())
             <input id="trix-value-{{ $getId() }}" type="hidden" />
-            
-            @if (count($getToolbarButtons()))
-            <trix-toolbar id="trix-toolbar-{{ $getId() }}">
+
+            <trix-toolbar
+                id="trix-toolbar-{{ $getId() }}"
+                @class([
+                    'hidden' => ! count($getToolbarButtons()),
+                ])
+            >
                 <div class="flex justify-between space-x-4 rtl:space-x-reverse overflow-x-auto items-stretch overflow-y-hidden">
                     <div class="flex items-stretch space-x-4 rtl:space-x-reverse focus:outline-none">
                         @if ($hasToolbarButton(['bold', 'italic', 'strike', 'link']))
@@ -280,7 +284,6 @@
                     </div>
                 </div>
             </trix-toolbar>
-            @endif
 
             <trix-editor
                 wire:ignore

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -41,7 +41,7 @@
 
             <trix-toolbar id="trix-toolbar-{{ $getId() }}">
                 <div class="flex justify-between space-x-4 rtl:space-x-reverse overflow-x-auto items-stretch overflow-y-hidden">
-                    <div class="flex items-stretch space-x-4 rtl:space-x-reverse focus:outline-none">
+                    <div class="{{ count($getToolbarButtons()) > 0 ? 'flex' : 'flex' }} justify-between space-x-4 rtl:space-x-reverse overflow-x-auto items-stretch overflow-y-hidden">
                         @if ($hasToolbarButton(['bold', 'italic', 'strike', 'link']))
                             <div data-trix-button-group="text-tools" class="flex items-stretch space-x-1 rtl:space-x-reverse">
                                 @if ($hasToolbarButton('bold'))

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -41,7 +41,10 @@
 
             <trix-toolbar id="trix-toolbar-{{ $getId() }}">
                 <div class="flex justify-between space-x-4 rtl:space-x-reverse overflow-x-auto items-stretch overflow-y-hidden">
-                    <div class="{{ count($getToolbarButtons()) > 0 ? 'flex' : 'hidden' }} justify-between space-x-4 rtl:space-x-reverse overflow-x-auto items-stretch overflow-y-hidden">
+                    <div @class([
+                        'flex justify-between space-x-4 rtl:space-x-reverse overflow-x-auto items-stretch overflow-y-hidden',
+                        'hidden' => count($getToolbarButtons()) == 0,
+                    ])>
                         @if ($hasToolbarButton(['bold', 'italic', 'strike', 'link']))
                             <div data-trix-button-group="text-tools" class="flex items-stretch space-x-1 rtl:space-x-reverse">
                                 @if ($hasToolbarButton('bold'))

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -41,7 +41,7 @@
 
             <trix-toolbar id="trix-toolbar-{{ $getId() }}">
                 <div class="flex justify-between space-x-4 rtl:space-x-reverse overflow-x-auto items-stretch overflow-y-hidden">
-                    <div class="{{ count($getToolbarButtons()) > 0 ? 'flex' : 'flex' }} justify-between space-x-4 rtl:space-x-reverse overflow-x-auto items-stretch overflow-y-hidden">
+                    <div class="{{ count($getToolbarButtons()) > 0 ? 'flex' : 'hidden' }} justify-between space-x-4 rtl:space-x-reverse overflow-x-auto items-stretch overflow-y-hidden">
                         @if ($hasToolbarButton(['bold', 'italic', 'strike', 'link']))
                             <div data-trix-button-group="text-tools" class="flex items-stretch space-x-1 rtl:space-x-reverse">
                                 @if ($hasToolbarButton('bold'))


### PR DESCRIPTION
When there are no buttons the toolbar `->disableAllToolbarButtons()` - the bar still shows, causing an extra line.
#### Before

![image](https://user-images.githubusercontent.com/3776888/170033188-7ab35862-16fb-4972-b8a3-95625b3ff005.png)

#### After

![image](https://user-images.githubusercontent.com/3776888/170033418-4e412dd0-1d71-44fb-aa70-0c903047dd7d.png)

This conditionally hides the bar is no buttons.

Please let me know if you prefer a different syntax for the conditional class.