### PR TITLE
chore: use `$this` instead of `static` calls to instance methods

### DIFF
--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanDeleteRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanDeleteRecords.php
@@ -63,7 +63,7 @@ trait CanDeleteRecords
             ->action(fn () => $this->delete())
             ->color('danger')
             ->icon('heroicon-s-trash')
-            ->hidden(fn (Model $record): bool => ! static::canDelete($record));
+            ->hidden(fn (Model $record): bool => ! $this->canDelete($record));
     }
 
     protected function getDeleteBulkAction(): Tables\Actions\BulkAction

--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanDetachRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanDetachRecords.php
@@ -84,7 +84,7 @@ trait CanDetachRecords
             ->action(fn () => $this->detach())
             ->color('danger')
             ->icon('heroicon-s-x')
-            ->hidden(fn (Model $record): bool => ! static::canDetach($record));
+            ->hidden(fn (Model $record): bool => ! $this->canDetach($record));
     }
 
     protected function getDetachBulkAction(): Tables\Actions\BulkAction

--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanDissociateRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanDissociateRecords.php
@@ -90,7 +90,7 @@ trait CanDissociateRecords
             ->action(fn () => $this->dissociate())
             ->color('danger')
             ->icon('heroicon-s-x')
-            ->hidden(fn (Model $record): bool => ! static::canDissociate($record));
+            ->hidden(fn (Model $record): bool => ! $this->canDissociate($record));
     }
 
     protected function getDissociateBulkAction(): Tables\Actions\BulkAction

--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanEditRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanEditRecords.php
@@ -88,6 +88,6 @@ trait CanEditRecords
             ->modalHeading(__('filament::resources/relation-managers/edit.action.modal.heading', ['label' => static::getRecordLabel()]))
             ->action(fn () => $this->save())
             ->icon('heroicon-s-pencil')
-            ->hidden(fn (Model $record): bool => ! static::canEdit($record));
+            ->hidden(fn (Model $record): bool => ! $this->canEdit($record));
     }
 }


### PR DESCRIPTION
In this PR I've refactored to use `$this->` instead of `static::` for readability and to get rid of IDE warning

`static::` is identical to `$this->`, when used inside the class scope.
Since php allows it [phpstan also allows it](https://github.com/phpstan/phpstan/issues/7245).