### PR TITLE
fix: avoiding repeated queries on table

### DIFF
--- a/packages/tables/src/Concerns/CanSelectRecords.php
+++ b/packages/tables/src/Concerns/CanSelectRecords.php
@@ -3,6 +3,7 @@
 namespace Filament\Tables\Concerns;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 trait CanSelectRecords
 {
@@ -22,7 +23,7 @@ trait CanSelectRecords
 
     public function getAllTableRecordsCount(): int
     {
-        if ($this->isTablePaginationEnabled()) {
+        if ($this->records instanceof LengthAwarePaginator) {
             return $this->records->total();
         }
 

--- a/packages/tables/src/Concerns/CanSelectRecords.php
+++ b/packages/tables/src/Concerns/CanSelectRecords.php
@@ -22,6 +22,10 @@ trait CanSelectRecords
 
     public function getAllTableRecordsCount(): int
     {
+        if ($this->isTablePaginationEnabled()) {
+            return $this->records->total();
+        }
+
         return $this->getFilteredTableQuery()->count();
     }
 


### PR DESCRIPTION
When the table is loaded it query the count of items on table 3 times the same query:

![Captura de tela de 2022-05-24 16-11-03](https://user-images.githubusercontent.com/49805116/170114071-e53a264d-0f8d-4f44-8b5d-d9cb8ffb8f20.png)

I made the CanSelectRecords verify if the pagination is enable to get the total count of items from the LengthAwarePaginator. With change:

![Captura de tela de 2022-05-24 16-13-52](https://user-images.githubusercontent.com/49805116/170114372-cf88a3e7-c939-46f5-8ed5-37676e92e3b1.png)


