### PR TITLE
close modal in response to dynamic event fired when modal backdrop clicked or escape key is pressed

### DIFF
--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -47,8 +47,8 @@
         class="fixed inset-0 z-40 flex items-center min-h-screen p-4 overflow-y-auto transition"
     >
         <button
-            @if ($id)
-                x-on:click="$dispatch('{{ $closeEventName }}', {id: '{{ $id }}' })"
+            @if (filled($id))
+                x-on:click="$dispatch('{{ $closeEventName }}', { id: '{{ $id }}' })"
             @else
                 x-on:click="isOpen = false"
             @endif
@@ -60,8 +60,8 @@
         <div
             x-show="isOpen"
             x-trap="isOpen"
-            @if ($id)
-                x-on:keydown.window.escape="$dispatch('{{ $closeEventName }}', {id: '{{ $id }}' })"
+            @if (filled($id))
+                x-on:keydown.window.escape="$dispatch('{{ $closeEventName }}', { id: '{{ $id }}' })"
             @else
                 x-on:keydown.window.escape="isOpen = false"
             @endif

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -47,7 +47,11 @@
         class="fixed inset-0 z-40 flex items-center min-h-screen p-4 overflow-y-auto transition"
     >
         <button
-            x-on:click="isOpen = false"
+            @if ($id)
+                x-on:click="$dispatch('{{ $closeEventName }}', {id: '{{ $id }}' })"
+            @else
+                x-on:click="isOpen = false"
+            @endif
             type="button"
             aria-hidden="true"
             class="fixed inset-0 w-full h-full bg-black/50 focus:outline-none filament-modal-close-overlay"
@@ -56,7 +60,11 @@
         <div
             x-show="isOpen"
             x-trap="isOpen"
-            x-on:keydown.window.escape="isOpen = false"
+            @if ($id)
+                x-on:keydown.window.escape="$dispatch('{{ $closeEventName }}', {id: '{{ $id }}' })"
+            @else
+                x-on:keydown.window.escape="isOpen = false"
+            @endif
             x-transition:enter="ease duration-300"
             x-transition:enter-start="translate-y-8"
             x-transition:enter-end="translate-y-0"


### PR DESCRIPTION
Currently trying to create a plugin for filament that makes use of modals;

I specifically needed to hook into the **`close-modal`** event to run some code when the modal is closed, this work fine when the modal is closed by clicking the button that dispatches the event responsible for closing the modal, but fails when the modal is closed by clicking the backdrop or pressing the escape key. 

I know this is a very niche use case but I would love to use the modal provided by Filament.

I've implemented a working fix for this and I would be glad if it is considered or improved.

Thank you and thanks for the awesome package.