### PR TITLE
feat: Option to disable outputting the default DM Sans font

### DIFF
--- a/packages/admin/config/filament.php
+++ b/packages/admin/config/filament.php
@@ -259,7 +259,7 @@ return [
     |
     */
 
-    'output_default_font' => env('FILAMENT_DEFAULT_FONT', false),
+    'output_default_font' => env('FILAMENT_DEFAULT_FONT', true),
 
     /*
     |--------------------------------------------------------------------------

--- a/packages/admin/config/filament.php
+++ b/packages/admin/config/filament.php
@@ -251,6 +251,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Output Default Font
+    |--------------------------------------------------------------------------
+    |
+    | Output the default `DM Sans` font to the front-end assets. You may disable
+    | this and load your own fonts.
+    |
+    */
+
+    'output_default_font' => env('FILAMENT_DEFAULT_FONT', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Middleware
     |--------------------------------------------------------------------------
     |

--- a/packages/admin/config/filament.php
+++ b/packages/admin/config/filament.php
@@ -251,17 +251,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Google Font
+    | Google Fonts
     |--------------------------------------------------------------------------
     |
-    | This is the URL for the font Filament will use. You may use any font on
-    | Google, or set to `NULL` to disable the default font. You should also
-    | override the `sans` font-family in your `tailwind.config.js` for
-    | your custom theme.
+    | This is the URL for Google Fonts that should be loaded. You may use any
+    | font, or set to `null` to prevent any Google Fonts from loading.
+    |
+    | When using a custom font, you should also set the font family in your
+    | custom theme's `tailwind.config.js` file.
     |
     */
 
-    'google_font' => env('FILAMENT_GOOGLE_FONT', 'https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap'),
+    'google_fonts' => 'https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap',
 
     /*
     |--------------------------------------------------------------------------

--- a/packages/admin/config/filament.php
+++ b/packages/admin/config/filament.php
@@ -251,15 +251,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Output Default Font
+    | Google Font
     |--------------------------------------------------------------------------
     |
-    | Output the default `DM Sans` font to the front-end assets. You may disable
-    | this and load your own fonts.
+    | This is the URL for the font Filament will use. You may use any font on
+    | Google, or set to `NULL` to disable the default font. You should also
+    | override the `sans` font-family in your `tailwind.config.js` for
+    | your custom theme.
     |
     */
 
-    'output_default_font' => env('FILAMENT_DEFAULT_FONT', true),
+    'google_font' => env('FILAMENT_GOOGLE_FONT', 'https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap'),
 
     /*
     |--------------------------------------------------------------------------

--- a/packages/admin/docs/07-appearance.md
+++ b/packages/admin/docs/07-appearance.md
@@ -133,6 +133,18 @@ Filament::serving(function () {
 });
 ```
 
+### Loading Google Fonts
+
+If you specify a custom font family in your `tailwind.config.js`, you may wish to import it via Google Fonts.
+
+You must [publish the configuration](installation#publishing-the-configuration) in order to access this feature.
+
+Set the `google_fonts` config option to a new Google Fonts URL to load:
+
+```php
+'google_fonts' => 'https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap',
+```
+
 ## Changing the maximum content width
 
 Filament exposes a configuration option that allows you to change the maximum content width of all pages.

--- a/packages/admin/resources/views/components/layouts/base.blade.php
+++ b/packages/admin/resources/views/components/layouts/base.blade.php
@@ -33,10 +33,10 @@
 
         @livewireStyles
 
-        @if(config('filament.output_default_font'))
+        @if($font = config('filament.google_font'))
             <link rel="preconnect" href="https://fonts.googleapis.com">
             <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-            <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap" rel="stylesheet" />
+            <link href="{{$font}}" rel="stylesheet" />
         @endif
 
         @foreach (\Filament\Facades\Filament::getStyles() as $name => $path)

--- a/packages/admin/resources/views/components/layouts/base.blade.php
+++ b/packages/admin/resources/views/components/layouts/base.blade.php
@@ -33,10 +33,10 @@
 
         @livewireStyles
 
-        @if($font = config('filament.google_font'))
+        @if (filled($fontsUrl = config('filament.google_fonts')))
             <link rel="preconnect" href="https://fonts.googleapis.com">
             <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-            <link href="{{$font}}" rel="stylesheet" />
+            <link href="{{ $fontsUrl }}" rel="stylesheet" />
         @endif
 
         @foreach (\Filament\Facades\Filament::getStyles() as $name => $path)

--- a/packages/admin/resources/views/components/layouts/base.blade.php
+++ b/packages/admin/resources/views/components/layouts/base.blade.php
@@ -33,9 +33,11 @@
 
         @livewireStyles
 
-        <link rel="preconnect" href="https://fonts.googleapis.com">
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap" rel="stylesheet" />
+        @if(config('filament.output_default_font'))
+            <link rel="preconnect" href="https://fonts.googleapis.com">
+            <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+            <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap" rel="stylesheet" />
+        @endif
 
         @foreach (\Filament\Facades\Filament::getStyles() as $name => $path)
             @if (Str::of($path)->startsWith(['http://', 'https://']))


### PR DESCRIPTION
Having the ability to optionally disable outputting the default DM Sans as the front-end assets, helps developers to optimise their panels when they're loading their own fonts. Otherwise, they'll be forced to load multiple fonts, even if they're using a custom theme (thus custom styles, and fonts).

This is especially important for dashboards that are publicly accessible for all users, rather than just administrators.

Notes:
- Config option is set to true by default to not change the current behaviour
- When setting to the config option to false, it will also remove the preconnect links for Google Fonts, but these can be added back in by the developer (if they wish to still use Google Fonts).