### PR TITLE
Extract design of login-page to a reusable Card layout

### DIFF
--- a/packages/admin/resources/views/components/layouts/card.blade.php
+++ b/packages/admin/resources/views/components/layouts/card.blade.php
@@ -1,0 +1,31 @@
+@props([
+    'title' => null,
+])
+
+<x-filament::layouts.base :title="$title">
+    <div @class([
+    'flex items-center justify-center min-h-screen filament-login-page bg-gray-100 text-gray-900',
+    'dark:bg-gray-900 dark:text-white' => config('filament.dark_mode'),
+])>
+        <div class="w-screen max-w-md px-6 -mt-16 space-y-8 md:mt-0 md:px-2">
+            <div @class([
+            'p-8 space-y-4 bg-white/50 backdrop-blur-xl border border-gray-200 shadow-2xl rounded-2xl relative',
+            'dark:bg-gray-900/50 dark:border-gray-700' => config('filament.dark_mode'),
+        ])>
+                <div class="flex justify-center w-full">
+                    <x-filament::brand />
+                </div>
+
+                @if($title)
+                    <h2 class="text-2xl font-bold tracking-tight text-center">
+                        {{ $title }}
+                    </h2>
+                @endif
+
+                <div {{ $attributes }}>
+                    {{ $slot }}
+                </div>
+            </div>
+        </div>
+    </div>
+</x-filament::layouts.base>

--- a/packages/admin/resources/views/components/layouts/card.blade.php
+++ b/packages/admin/resources/views/components/layouts/card.blade.php
@@ -4,19 +4,19 @@
 
 <x-filament::layouts.base :title="$title">
     <div @class([
-    'flex items-center justify-center min-h-screen filament-login-page bg-gray-100 text-gray-900',
-    'dark:bg-gray-900 dark:text-white' => config('filament.dark_mode'),
-])>
+        'flex items-center justify-center min-h-screen filament-login-page bg-gray-100 text-gray-900',
+        'dark:bg-gray-900 dark:text-white' => config('filament.dark_mode'),
+    ])>
         <div class="w-screen max-w-md px-6 -mt-16 space-y-8 md:mt-0 md:px-2">
             <div @class([
-            'p-8 space-y-4 bg-white/50 backdrop-blur-xl border border-gray-200 shadow-2xl rounded-2xl relative',
-            'dark:bg-gray-900/50 dark:border-gray-700' => config('filament.dark_mode'),
-        ])>
+                'p-8 space-y-4 bg-white/50 backdrop-blur-xl border border-gray-200 shadow-2xl rounded-2xl relative',
+                'dark:bg-gray-900/50 dark:border-gray-700' => config('filament.dark_mode'),
+            ])>
                 <div class="flex justify-center w-full">
                     <x-filament::brand />
                 </div>
 
-                @if($title)
+                @if (filled($title))
                     <h2 class="text-2xl font-bold tracking-tight text-center">
                         {{ $title }}
                     </h2>

--- a/packages/admin/resources/views/login.blade.php
+++ b/packages/admin/resources/views/login.blade.php
@@ -1,25 +1,7 @@
-<div @class([
-    'flex items-center justify-center min-h-screen filament-login-page bg-gray-100 text-gray-900',
-    'dark:bg-gray-900 dark:text-white' => config('filament.dark_mode'),
-])>
-    <div class="w-screen max-w-md px-6 -mt-16 space-y-8 md:mt-0 md:px-2">
-        <form wire:submit.prevent="authenticate" @class([
-            'p-8 space-y-8 bg-white/50 backdrop-blur-xl border border-gray-200 shadow-2xl rounded-2xl relative',
-            'dark:bg-gray-900/50 dark:border-gray-700' => config('filament.dark_mode'),
-        ])>
-            <div class="flex justify-center w-full">
-                <x-filament::brand />
-            </div>
+<form wire:submit.prevent="authenticate" class="space-y-8">
+    {{ $this->form }}
 
-            <h2 class="text-2xl font-bold tracking-tight text-center">
-                {{ __('filament::login.heading') }}
-            </h2>
-
-            {{ $this->form }}
-
-            <x-filament::button type="submit" form="authenticate" class="w-full">
-                {{ __('filament::login.buttons.submit.label') }}
-            </x-filament::button>
-        </form>
-    </div>
-</div>
+    <x-filament::button type="submit" form="authenticate" class="w-full">
+        {{ __('filament::login.buttons.submit.label') }}
+    </x-filament::button>
+</form>

--- a/packages/admin/src/Http/Livewire/Auth/Login.php
+++ b/packages/admin/src/Http/Livewire/Auth/Login.php
@@ -82,7 +82,7 @@ class Login extends Component implements HasForms
     public function render(): View
     {
         return view('filament::login')
-            ->layout('filament::components.layouts.base', [
+            ->layout('filament::components.layouts.card', [
                 'title' => __('filament::login.title'),
             ]);
     }


### PR DESCRIPTION
This PR extracts the design of the frontend "card-component" to a separate Blade-component, so that packages can use this design as well, without having to copy it over (e.g. in Filament Breezy @jeffgreco13 ).

For example, you can now create components with the following markup:

```blade
<x-filament::layouts.card :title="__('user.pages.billing.title')" class="">
    <p class="text-sm text-center text-gray-600">
        {{ __('user.pages.billing.description') }}
    </p>
    
    <x-filament::button tag="a" :href="route('filament.pages.billing')" class="mt-8 w-full">
        {{ __('user.pages.billing.button') }}
    </x-filament::button>
    
    <form method="POST" action="{{ route('filament.auth.logout') }}" class="mt-3 -mb-4">
        @csrf
        <button type="submit" class="w-full text-sm text-gray-400 text-center">{{ __('filament::layout.buttons.logout.label') }}</button>
    </form>
</x-filament::layouts.card>
```

<img width="1170" alt="Schermafbeelding 2022-05-26 om 21 12 26" src="https://user-images.githubusercontent.com/59207045/170564306-9f8abb2f-3eda-4184-8459-486625d3fa46.png">

This didn't have influence on the design of the login page.




