### PR TITLE
Add support for overriding the maximum content width on a page

### DIFF
--- a/packages/admin/docs/03-pages/01-getting-started.md
+++ b/packages/admin/docs/03-pages/01-getting-started.md
@@ -48,12 +48,6 @@ protected static ?string $navigationLabel = 'Custom Navigation Label';
 protected static ?string $slug = 'custom-url-slug';
 ```
 
-You may override the [maximum content width](https://filamentphp.com/docs/2.x/admin/appearance#changing-the-maximum-content-width) of a page using the `$maxContentWidth` property:
-
-```php
-protected static ?string $maxContentWidth = 'full';
-```
-
 You may also specify a custom header and footer view for any page. You may return them from the `getHeader()` and `getFooter()` methods:
 
 ```php

--- a/packages/admin/docs/03-pages/01-getting-started.md
+++ b/packages/admin/docs/03-pages/01-getting-started.md
@@ -48,6 +48,12 @@ protected static ?string $navigationLabel = 'Custom Navigation Label';
 protected static ?string $slug = 'custom-url-slug';
 ```
 
+You may override the [maximum content width](https://filamentphp.com/docs/2.x/admin/appearance#changing-the-maximum-content-width) of a page using the `$maxContentWidth` property:
+
+```php
+protected static ?string $maxContentWidth = 'full';
+```
+
 You may also specify a custom header and footer view for any page. You may return them from the `getHeader()` and `getFooter()` methods:
 
 ```php

--- a/packages/admin/docs/07-appearance.md
+++ b/packages/admin/docs/07-appearance.md
@@ -164,7 +164,7 @@ The default is `7xl`.
 You may override the maximum content width for a specific page in the admin panel by using the `$maxContentWidth` property:
 
 ```php
-protected static ?string $maxContentWidth = 'full';
+protected ?string $maxContentWidth = 'full';
 ```
 
 ## Including frontend assets

--- a/packages/admin/docs/07-appearance.md
+++ b/packages/admin/docs/07-appearance.md
@@ -161,6 +161,12 @@ In `config/filament.php`, set the `layouts.max_content_width` to any value betwe
 
 The default is `7xl`.
 
+You may override the maximum content width for a specific page in the admin panel by using the `$maxContentWidth` property:
+
+```php
+protected static ?string $maxContentWidth = 'full';
+```
+
 ## Including frontend assets
 
 You may register your own scripts and styles using the `registerScripts()` and `registerStyles()` methods in a service provider's `boot()` method:

--- a/packages/admin/resources/views/components/layouts/app.blade.php
+++ b/packages/admin/resources/views/components/layouts/app.blade.php
@@ -33,7 +33,7 @@
             ])>
                 <div @class([
                     'flex items-center w-full px-2 mx-auto sm:px-4 md:px-6 lg:px-8',
-                    match ($maxContentWidth ?: config('filament.layout.max_content_width')) {
+                    match ($maxContentWidth ?? config('filament.layout.max_content_width')) {
                         'xl' => 'max-w-xl',
                         '2xl' => 'max-w-2xl',
                         '3xl' => 'max-w-3xl',

--- a/packages/admin/resources/views/components/layouts/app.blade.php
+++ b/packages/admin/resources/views/components/layouts/app.blade.php
@@ -1,3 +1,7 @@
+@props([
+    'maxContentWidth' => null,
+])
+
 <x-filament::layouts.base :title="$title">
     <div class="flex min-h-screen overflow-x-hidden w-full filament-app-layout">
         <div
@@ -29,7 +33,7 @@
             ])>
                 <div @class([
                     'flex items-center w-full px-2 mx-auto sm:px-4 md:px-6 lg:px-8',
-                    match (config('filament.layout.max_content_width')) {
+                    match ($maxContentWidth ?: config('filament.layout.max_content_width')) {
                         'xl' => 'max-w-xl',
                         '2xl' => 'max-w-2xl',
                         '3xl' => 'max-w-3xl',
@@ -64,7 +68,7 @@
 
             <div @class([
                 'flex-1 w-full px-4 mx-auto md:px-6 lg:px-8 filament-main-content',
-                match (config('filament.layout.max_content_width')) {
+                match ($maxContentWidth ?: config('filament.layout.max_content_width')) {
                     'xl' => 'max-w-xl',
                     '2xl' => 'max-w-2xl',
                     '3xl' => 'max-w-3xl',

--- a/packages/admin/resources/views/components/layouts/app.blade.php
+++ b/packages/admin/resources/views/components/layouts/app.blade.php
@@ -68,7 +68,7 @@
 
             <div @class([
                 'flex-1 w-full px-4 mx-auto md:px-6 lg:px-8 filament-main-content',
-                match ($maxContentWidth ?: config('filament.layout.max_content_width')) {
+                match ($maxContentWidth ?? config('filament.layout.max_content_width')) {
                     'xl' => 'max-w-xl',
                     '2xl' => 'max-w-2xl',
                     '3xl' => 'max-w-3xl',

--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -181,7 +181,7 @@ class Page extends Component implements Forms\Contracts\HasForms
 
     protected function getMaxContentWidth(): ?string
     {
-        return $this->$maxContentWidth;
+        return $this->maxContentWidth;
     }
 
     protected function getLayoutData(): array

--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -37,6 +37,8 @@ class Page extends Component implements Forms\Contracts\HasForms
 
     protected static string | array $middlewares = [];
 
+    protected static ?string $maxContentWidth = null;
+
     public static function registerNavigationItems(): void
     {
         if (! static::shouldRegisterNavigation()) {
@@ -177,11 +179,17 @@ class Page extends Component implements Forms\Contracts\HasForms
             ->title();
     }
 
+    protected function getMaxContentWidth(): ?string
+    {
+        return static::$maxContentWidth;
+    }
+
     protected function getLayoutData(): array
     {
         return [
             'breadcrumbs' => $this->getBreadcrumbs(),
             'title' => $this->getTitle(),
+            'maxContentWidth' => $this->getMaxContentWidth(),
         ];
     }
 

--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -37,7 +37,7 @@ class Page extends Component implements Forms\Contracts\HasForms
 
     protected static string | array $middlewares = [];
 
-    protected static ?string $maxContentWidth = null;
+    protected ?string $maxContentWidth = null;
 
     public static function registerNavigationItems(): void
     {

--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -181,7 +181,7 @@ class Page extends Component implements Forms\Contracts\HasForms
 
     protected function getMaxContentWidth(): ?string
     {
-        return static::$maxContentWidth;
+        return $this->$maxContentWidth;
     }
 
     protected function getLayoutData(): array


### PR DESCRIPTION
This PR adds support for overriding the maximum content width on an individual page:

```php
protected static ?string $maxContentWidth = 'full';
```

Useful for example to limit the width of certain small "create"-pages, whilst keeping index pages full width.