### PR TITLE
fix: tables also use a user timezone setting same as forms

### DIFF
--- a/packages/forms/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
+++ b/packages/forms/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
@@ -23,7 +23,7 @@ trait EntanglesStateWithSingularRelationship
         $this->statePath($relationshipName);
 
         $this->loadStateFromRelationshipsUsing(static function (Component $component) {
-            /** @var Component|CanEntangleWithSingularRelationships $component */
+            /** @var Component | CanEntangleWithSingularRelationships $component */
 
             $component->clearCachedExistingRecord();
 
@@ -31,7 +31,7 @@ trait EntanglesStateWithSingularRelationship
         });
 
         $this->saveRelationshipsUsing(static function (Component $component, HasForms $livewire): void {
-            /** @var Component|CanEntangleWithSingularRelationships $component */
+            /** @var Component | CanEntangleWithSingularRelationships $component */
 
             $state = $component->getChildComponentContainer()->getState(shouldCallHooksBefore: false);
 

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -5,6 +5,7 @@ namespace Filament\Tables\Columns\Concerns;
 use Akaunting\Money;
 use Closure;
 use Filament\Tables\Columns\Column;
+use Filament\Tables\Columns\TextColumn;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\HtmlString;
@@ -26,9 +27,17 @@ trait CanFormatState
     {
         $format ??= config('tables.date_format');
 
-        $timezone ??= $this->getTimezone();
+        $this->formatStateUsing(static function (Column $column, $state) use ($format, $timezone): ?string {
+            /** @var TextColumn $column */
 
-        $this->formatStateUsing(static fn ($state): ?string => $state ? Carbon::parse($state)->setTimezone($timezone)->translatedFormat($format) : null);
+            if (blank($state)) {
+                return null;
+            }
+
+            return Carbon::parse($state)
+                ->setTimezone($timezone ?? $column->getTimezone())
+                ->translatedFormat($format);
+        });
 
         return $this;
     }
@@ -44,7 +53,17 @@ trait CanFormatState
 
     public function since(?string $timezone = null): static
     {
-        $this->formatStateUsing(static fn ($state): ?string => $state ? Carbon::parse($state)->setTimezone($timezone)->diffForHumans() : null);
+        $this->formatStateUsing(static function (Column $column, $state) use ($timezone): ?string {
+            /** @var TextColumn $column */
+
+            if (blank($state)) {
+                return null;
+            }
+
+            return Carbon::parse($state)
+                ->setTimezone($timezone ?? $column->getTimezone())
+                ->diffForHumans();
+        });
 
         return $this;
     }

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -20,11 +20,13 @@ trait CanFormatState
 
     protected string | Closure | null $suffix = null;
 
+    protected string | Closure | null $timezone = null;
+
     public function date(?string $format = null, ?string $timezone = null): static
     {
         $format ??= config('tables.date_format');
 
-        $timezone ??= config('app.timezone');
+        $timezone ??= $this->getTimezone();
 
         $this->formatStateUsing(static fn ($state): ?string => $state ? Carbon::parse($state)->setTimezone($timezone)->translatedFormat($format) : null);
 
@@ -145,5 +147,17 @@ trait CanFormatState
         $this->date($format, $timezone);
 
         return $this;
+    }
+
+    public function timezone(string | Closure | null $timezone): static
+    {
+        $this->timezone = $timezone;
+
+        return $this;
+    }
+
+    public function getTimezone(): string
+    {
+        return $this->evaluate($this->timezone) ?? config('app.timezone');
     }
 }


### PR DESCRIPTION
@danharrin -- Thanks for the form - your solution was more elegant :-)
I feel we should be able to do the same with table date columns so replicated it to the hasFormatters trait so that can be set in a service provider aswell.