### PR TITLE
Fix redundant focus event on modals

### DIFF
--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -46,16 +46,15 @@
         x-cloak
         class="fixed inset-0 z-40 flex items-center min-h-screen p-4 overflow-y-auto transition"
     >
-        <button
+        <div
             @if (filled($id))
                 x-on:click="$dispatch('{{ $closeEventName }}', { id: '{{ $id }}' })"
             @else
                 x-on:click="isOpen = false"
             @endif
-            type="button"
             aria-hidden="true"
-            class="fixed inset-0 w-full h-full bg-black/50 focus:outline-none filament-modal-close-overlay"
-        ></button>
+            class="fixed inset-0 w-full h-full bg-black/50 cursor-pointer filament-modal-close-overlay"
+        ></div>
 
         <div
             x-show="isOpen"

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -59,7 +59,7 @@
 
         <div
             x-show="isOpen"
-            x-trap="isOpen"
+            x-trap.inert.noscroll="isOpen"
             @if (filled($id))
                 x-on:keydown.window.escape="$dispatch('{{ $closeEventName }}', { id: '{{ $id }}' })"
             @else


### PR DESCRIPTION
I noticed when I try to close a modal by clicking outside it triggers a focus event on modal elements which isn't desired IMO. I looked into it and figured this happens because of the alpine x-trap plugin and the presence of a button tag to close the overlay.

this PR fixes it, also I've added [innert](https://alpinejs.dev/plugins/focus#inert) and [noscroll](https://alpinejs.dev/plugins/focus#noscroll) modifiers to x-trap 

I tested the issue by registering event listeners in the console and clicking outside the modal window:
`document.getElementById('mountedTableActionData.THE_NAME').addEventListener('focus', ()=> console.log('focused'));
document.getElementById('mountedTableActionData.THE_NAME').addEventListener('click', ()=> console.log('clicked'));
`