### PR TITLE
Added 500ms debounce to key value field inputs

### DIFF
--- a/packages/forms/resources/views/components/key-value.blade.php
+++ b/packages/forms/resources/views/components/key-value.blade.php
@@ -69,7 +69,7 @@
                                 <input
                                     type="text"
                                     x-model="row.key"
-                                    x-on:input="updateState"
+                                    x-on:input.debounce.500ms="updateState"
                                     {!! ($placeholder = $getKeyPlaceholder()) ? "placeholder=\"{$placeholder}\"" : '' !!}
                                     @if ((! $canEditKeys()) || $isDisabled())
                                         disabled
@@ -82,7 +82,7 @@
                                 <input
                                     type="text"
                                     x-model="row.value"
-                                    x-on:input="updateState"
+                                    x-on:input.debounce.500ms="updateState"
                                     {!! ($placeholder = $getValuePlaceholder()) ? "placeholder=\"{$placeholder}\"" : '' !!}
                                     @if ((! $canEditValues()) || $isDisabled())
                                         disabled


### PR DESCRIPTION
@danharrin As we discussed in the discord channel key value field is now pretty hard to type when used with ->reactive(). Until we can debounce $entangle statement this should do the trick.