### PR TITLE
Prevent markdown editor form submission

### DIFF
--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -147,6 +147,7 @@
                         <div class="flex items-center space-x-4 rtl:space-x-reverse">
                             @if ($hasToolbarButton('edit'))
                                 <button
+                                    type="button"
                                     x-on:click.prevent="tab = 'edit'"
                                     x-bind:class="{ 'text-gray-400 @if (config('forms.dark_mode')) dark:text-gray-400 @endif': tab !== 'edit' }"
                                     class="text-sm hover:underline"
@@ -157,6 +158,7 @@
 
                             @if ($hasToolbarButton('preview'))
                                 <button
+                                    type="button"
                                     x-on:click.prevent="tab = 'preview'"
                                     x-bind:class="{ 'text-gray-400 @if (config('forms.dark_mode')) dark:text-gray-400 @endif': tab !== 'preview' }"
                                     @class([


### PR DESCRIPTION
This PR adds `type="button"` to both the “edit” and “preview” buttons of the markdown editor to prevent form submission.

A button without a type gets considered as a submit button. Therefore, clicking on one of them submits the form — which is not the intended behavior at this point.

Fixes #2605