### PR TITLE
fix: pass an array to the Spatie TagInput state like taginput

### DIFF
--- a/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
+++ b/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
@@ -23,7 +23,7 @@ class SpatieTagsInput extends TagsInput
             $type = $component->getType();
             $tags = $record->tagsWithType($type);
 
-            $component->state($tags->pluck('name'));
+            $component->state($tags->pluck('name')->toArray());
         });
 
         $this->saveRelationshipsUsing(static function (SpatieTagsInput $component, ?Model $record, array $state) {


### PR DESCRIPTION
Hello Filament team.

This fix makes the Spatie Tag plugin render like the normal tag input by passing an array like the normal `TagInput` does.

It seems that when passing a collection it isn't converting to an array. This was confirmed by going to the blade component and rendering the states length `<code x-html="state.length"></code>` this had 0 as the value when there were tags and with the old code. But adding the toArray to force that being passed down it actually gave a length and showed tags.

So this basically adds the one method call. I haven't noticed any adverse affects from doing this.

Reece