### PR TITLE
Add prefix and suffix icons to text-input field

### DIFF
--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -22,6 +22,10 @@
             {{ $prefixAction }}
         @endif
 
+        @if ($icon = $getPrefixIcon())
+            <x-dynamic-component :component="$icon" class="w-5 h-5" />
+        @endif
+
         @if ($label = $getPrefixLabel())
             <span @class($affixLabelClasses)>
                 {{ $label }}
@@ -94,6 +98,10 @@
             <span @class($affixLabelClasses)>
                 {{ $label }}
             </span>
+        @endif
+
+        @if ($icon = $getSuffixIcon())
+            <x-dynamic-component :component="$icon" class="w-5 h-5" />
         @endif
 
         @if (($suffixAction = $getSuffixAction()) && (! $suffixAction->isHidden()))

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -22,6 +22,10 @@
             {{ $prefixAction }}
         @endif
 
+        @if ($icon = $getPrefixIcon())
+            <x-dynamic-component :component="$icon" class="w-5 h-5" />
+        @endif
+
         @if ($label = $getPrefixLabel())
             <span @class($affixLabelClasses)>
                 {{ $label }}
@@ -106,6 +110,10 @@
             <span @class($affixLabelClasses)>
                 {{ $label }}
             </span>
+        @endif
+
+        @if ($icon = $getSuffixIcon())
+            <x-dynamic-component :component="$icon" class="w-5 h-5" />
         @endif
 
         @if (($suffixAction = $getSuffixAction()) && (! $suffixAction->isHidden()))

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -30,6 +30,10 @@
             </span>
         @endif
 
+        @if($icon = $getPrefixIcon())
+            <x-dynamic-component :component="$icon" class="w-6 h-6" />
+        @endif
+
         <div class="flex-1">
             <input
                 @unless ($hasMask())
@@ -75,6 +79,10 @@
             <span @class($affixLabelClasses)>
                 {{ $label }}
             </span>
+        @endif
+
+        @if($icon = $getSuffixIcon())
+            <x-dynamic-component :component="$icon" class="w-6 h-6" />
         @endif
 
         @if (($suffixAction = $getSuffixAction()) && (! $suffixAction->isHidden()))

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -19,19 +19,19 @@
     :required="$isRequired()"
     :state-path="$getStatePath()"
 >
-    <div {{ $attributes->merge($getExtraAttributes())->class(['flex items-center space-x-1 rtl:space-x-reverse group filament-forms-text-input-component']) }}>
+    <div {{ $attributes->merge($getExtraAttributes())->class(['flex items-center space-x-2 rtl:space-x-reverse group filament-forms-text-input-component']) }}>
         @if (($prefixAction = $getPrefixAction()) && (! $prefixAction->isHidden()))
             {{ $prefixAction }}
+        @endif
+
+        @if ($icon = $getPrefixIcon())
+            <x-dynamic-component :component="$icon" class="w-5 h-5" />
         @endif
 
         @if ($label = $getPrefixLabel())
             <span @class($affixLabelClasses)>
                 {{ $label }}
             </span>
-        @endif
-
-        @if($icon = $getPrefixIcon())
-            <x-dynamic-component :component="$icon" class="w-6 h-6" />
         @endif
 
         <div class="flex-1">
@@ -81,8 +81,8 @@
             </span>
         @endif
 
-        @if($icon = $getSuffixIcon())
-            <x-dynamic-component :component="$icon" class="w-6 h-6" />
+        @if ($icon = $getSuffixIcon())
+            <x-dynamic-component :component="$icon" class="w-5 h-5" />
         @endif
 
         @if (($suffixAction = $getSuffixAction()) && (! $suffixAction->isHidden()))

--- a/packages/forms/src/Components/Concerns/HasAffixes.php
+++ b/packages/forms/src/Components/Concerns/HasAffixes.php
@@ -15,6 +15,10 @@ trait HasAffixes
 
     protected string | Closure | null $prefixLabel = null;
 
+    protected string | Closure | null $prefixIcon = null;
+
+    protected string | Closure | null $suffixIcon = null;
+
     public function prefix(string | Closure | null $label): static
     {
         $this->prefixLabel = $label;
@@ -48,6 +52,20 @@ trait HasAffixes
         return $this;
     }
 
+    public function prefixIcon(string | Closure | null $iconName): static
+    {
+        $this->prefixIcon = $iconName;
+
+        return $this;
+    }
+
+    public function suffixIcon(string | Closure | null $iconName): static
+    {
+        $this->suffixIcon = $iconName;
+
+        return $this;
+    }
+
     public function getPrefixAction(): ?Action
     {
         return $this->evaluate($this->prefixAction);
@@ -71,5 +89,15 @@ trait HasAffixes
     public function getSuffixLabel()
     {
         return $this->evaluate($this->suffixLabel);
+    }
+
+    public function getPrefixIcon()
+    {
+        return $this->evaluate($this->prefixIcon);
+    }
+
+    public function getSuffixIcon()
+    {
+        return $this->evaluate($this->suffixIcon);
     }
 }


### PR DESCRIPTION
Ability to add prefix or suffix icons to text-inputs.
You must pass a valid Blade dynamic component "name"

Example:
```php
Forms\Components\TextInput::make('featured_video')
->url()
->prefixIcon('heroicon-o-external-link')
```

<img width="608" alt="image" src="https://user-images.githubusercontent.com/21239634/171040699-f86a238d-e6a8-4556-a443-ab28130447fe.png">


```php
Forms\Components\TextInput::make('featured_video')
->url()
->suffixIcon('heroicon-o-external-link')
```

<img width="608" alt="image" src="https://user-images.githubusercontent.com/21239634/171040769-99baae8c-d993-449e-b950-eb3215dd2075.png">
