### PR TITLE
Set anchor in sidebar to width full

### DIFF
--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -20,7 +20,7 @@
     ])>
         <a
             href="{{ config('filament.home_url') }}"
-            class="w-full"
+            class="block w-full"
             @if (config('filament.layout.sidebar.is_collapsible_on_desktop'))
                 x-show="$store.sidebar.isOpen"
                 x-transition:enter="lg:transition delay-100"

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -20,6 +20,7 @@
     ])>
         <a
             href="{{ config('filament.home_url') }}"
+            class="w-full"
             @if (config('filament.layout.sidebar.is_collapsible_on_desktop'))
                 x-show="$store.sidebar.isOpen"
                 x-transition:enter="lg:transition delay-100"


### PR DESCRIPTION
This allows us to center elements inside the sidebar with `flex justify-center` for example.