### PR TITLE
Feature/make repeater and builder collapsible

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -1410,6 +1410,32 @@ Repeater::make('members')
     ->maxItems(10)
 ```
 
+### Collapsible
+
+The repeater may be `collapsible()` to optionally hide content in long forms:
+
+```php
+use Filament\Forms\Components\Repeater;
+
+Repeater::make('qualifications')
+    ->schema([
+        // ...
+    ])
+    ->collapsible()
+```
+
+You may collapse all items by default:
+
+```php
+use Filament\Forms\Components\Repeater;
+
+Repeater::make('qualifications')
+    ->schema([
+        // ...
+    ])
+    ->collapsed()
+```
+
 ### Populating automatically from a `HasMany` relationship
 
 You may employ the `relationship()` method of the `HasManyRepeater` to configure a relationship to automatically retrieve and save repeater items:
@@ -1457,19 +1483,6 @@ HasManyRepeater::make('qualifications')
         // ...
     ])
     ->orderable('order_column')
-```
-
-### Collapsible
-Repeater (and `Builder`) may be `collapsible()` to optionally hide content in long forms:
-
-```php
-use Filament\Forms\Components\Section;
-
-Repeater::make('Heading')
-    ->schema([
-        // ...
-    ])
-    ->collapsible()
 ```
 
 ### Populating automatically from a `MorphMany` relationship
@@ -1592,6 +1605,32 @@ Builder::make('content')
     ])
     ->minItems(1)
     ->maxItems(10)
+```
+
+### Collapsible
+
+The builder may be `collapsible()` to optionally hide content in long forms:
+
+```php
+use Filament\Forms\Components\Builder;
+
+Builder::make('content')
+    ->blocks([
+        // ...
+    ])
+    ->collapsible()
+```
+
+You may collapse all items by default:
+
+```php
+use Filament\Forms\Components\Builder;
+
+Builder::make('content')
+    ->blocks([
+        // ...
+    ])
+    ->collapsed()
 ```
 
 ## Tags input

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -1459,6 +1459,19 @@ HasManyRepeater::make('qualifications')
     ->orderable('order_column')
 ```
 
+### Collapsible
+Repeater (and `Builder`) may be `collapsible()` to optionally hide content in long forms:
+
+```php
+use Filament\Forms\Components\Section;
+
+Repeater::make('Heading')
+    ->schema([
+        // ...
+    ])
+    ->collapsible()
+```
+
 ### Populating automatically from a `MorphMany` relationship
 
 You may employ the `relationship()` method of the `MorphManyRepeater` to configure a relationship to automatically retrieve and save repeater items:

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -17,7 +17,7 @@
         $isItemMovementDisabled = $isItemMovementDisabled();
     @endphp
 
-    @if (count($containers) > 1)
+    @if (count($containers) > 1 && $isCollapsible())
         <div class="space-x-2 rtl:space-x-reverse" x-data="{}">
             <x-forms::link
                 x-on:click="$dispatch('builder-collapse', '{{ $getStatePath() }}')"
@@ -131,28 +131,30 @@
                                     </li>
                                 @endunless
 
-                                <li>
-                                    <button
-                                        x-on:click="isCollapsed = !isCollapsed"
-                                        type="button"
-                                        @class([
-                                            'flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-300',
-                                            'dark:text-gray-400 dark:hover:text-gray-500' => config('forms.dark_mode'),
-                                        ])
-                                    >
-                                        <x-heroicon-s-minus-sm class="w-4 h-4" x-show="! isCollapsed"/>
+                                @if($isCollapsible())
+                                    <li>
+                                        <button
+                                            x-on:click="isCollapsed = !isCollapsed"
+                                            type="button"
+                                            @class([
+                                                'flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-300',
+                                                'dark:text-gray-400 dark:hover:text-gray-500' => config('forms.dark_mode'),
+                                            ])
+                                        >
+                                            <x-heroicon-s-minus-sm class="w-4 h-4" x-show="! isCollapsed"/>
 
-                                        <span class="sr-only" x-show="! isCollapsed">
-                                            {{ __('forms::components.builder.buttons.collapse_item.label') }}
-                                        </span>
+                                            <span class="sr-only" x-show="! isCollapsed">
+                                                {{ __('forms::components.builder.buttons.collapse_item.label') }}
+                                            </span>
 
-                                        <x-heroicon-s-plus-sm class="w-4 h-4" x-show="isCollapsed" x-cloak/>
+                                            <x-heroicon-s-plus-sm class="w-4 h-4" x-show="isCollapsed" x-cloak/>
 
-                                        <span class="sr-only" x-show="isCollapsed" x-cloak>
-                                            {{ __('forms::components.builder.buttons.expand_item.label') }}
-                                        </span>
-                                    </button>
-                                </li>
+                                            <span class="sr-only" x-show="isCollapsed" x-cloak>
+                                                {{ __('forms::components.builder.buttons.expand_item.label') }}
+                                            </span>
+                                        </button>
+                                    </li>
+                                @endif
                             </ul>
                         </header>
 

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -12,12 +12,13 @@
     @php
         $containers = $getChildComponentContainers();
 
+        $isCollapsible = $isCollapsible();
         $isItemCreationDisabled = $isItemCreationDisabled();
         $isItemDeletionDisabled = $isItemDeletionDisabled();
         $isItemMovementDisabled = $isItemMovementDisabled();
     @endphp
 
-    @if (count($containers) > 1 && $isCollapsible())
+    @if ((count($containers) > 1) && $isCollapsible)
         <div class="space-x-2 rtl:space-x-reverse" x-data="{}">
             <x-forms::link
                 x-on:click="$dispatch('builder-collapse', '{{ $getStatePath() }}')"
@@ -72,91 +73,93 @@
                             'dark:bg-gray-800 dark:border-gray-600' => config('forms.dark_mode'),
                         ])
                     >
-                        <header @class([
-                            'flex items-center h-10 overflow-hidden border-b bg-gray-50 rounded-t-xl',
-                            'dark:bg-gray-800 dark:border-gray-700' => config('forms.dark_mode'),
-                        ])>
-                            @unless ($isItemMovementDisabled)
-                                <button
-                                    wire:sortable.handle
-                                    wire:keydown.prevent.arrow-up="dispatchFormEvent('builder::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
-                                    wire:keydown.prevent.arrow-down="dispatchFormEvent('builder::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
-                                    type="button"
-                                    @class([
-                                        'flex items-center justify-center flex-none w-10 h-10 text-gray-400 border-r transition hover:text-gray-300',
-                                        'dark:text-gray-400 dark:border-gray-700 dark:hover:text-gray-500' => config('forms.dark_mode'),
-                                    ])
-                                >
-                                    <span class="sr-only">
-                                        {{ __('forms::components.builder.buttons.move_item_down.label') }}
-                                    </span>
-
-                                    <x-heroicon-s-switch-vertical class="w-4 h-4"/>
-                                </button>
-                            @endunless
-
-                            @if ($hasBlockLabels)
-                                <p @class([
-                                    'flex-none px-4 text-xs font-medium text-gray-600 truncate',
-                                    'dark:text-gray-400' => config('forms.dark_mode'),
-                                ])>
-                                    {{ $item->getParentComponent()->getLabel() }}
-
-                                    <small class="font-mono">{{ $loop->iteration }}</small>
-                                </p>
-                            @endif
-
-                            <div class="flex-1"></div>
-
-                            <ul @class([
-                                'flex divide-x',
-                                'dark:divide-gray-700' => config('forms.dark_mode'),
+                        @if ((! $isItemMovementDisabled) || $hasBlockLabels || (! $isItemDeletionDisabled) || $isCollapsible)
+                            <header @class([
+                                'flex items-center h-10 overflow-hidden border-b bg-gray-50 rounded-t-xl',
+                                'dark:bg-gray-800 dark:border-gray-700' => config('forms.dark_mode'),
                             ])>
-                                @unless ($isItemDeletionDisabled)
-                                    <li>
-                                        <button
-                                            wire:click="dispatchFormEvent('builder::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
-                                            type="button"
-                                            @class([
-                                                'flex items-center justify-center flex-none w-10 h-10 text-danger-600 transition hover:text-danger-500',
-                                                'dark:text-danger-500 dark:hover:text-danger-400' => config('forms.dark_mode'),
-                                            ])
-                                        >
-                                            <span class="sr-only">
-                                                {{ __('forms::components.builder.buttons.delete_item.label') }}
-                                            </span>
+                                @unless ($isItemMovementDisabled)
+                                    <button
+                                        wire:sortable.handle
+                                        wire:keydown.prevent.arrow-up="dispatchFormEvent('builder::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                        wire:keydown.prevent.arrow-down="dispatchFormEvent('builder::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                        type="button"
+                                        @class([
+                                            'flex items-center justify-center flex-none w-10 h-10 text-gray-400 border-r transition hover:text-gray-300',
+                                            'dark:text-gray-400 dark:border-gray-700 dark:hover:text-gray-500' => config('forms.dark_mode'),
+                                        ])
+                                    >
+                                        <span class="sr-only">
+                                            {{ __('forms::components.builder.buttons.move_item_down.label') }}
+                                        </span>
 
-                                            <x-heroicon-s-trash class="w-4 h-4"/>
-                                        </button>
-                                    </li>
+                                        <x-heroicon-s-switch-vertical class="w-4 h-4"/>
+                                    </button>
                                 @endunless
 
-                                @if($isCollapsible())
-                                    <li>
-                                        <button
-                                            x-on:click="isCollapsed = !isCollapsed"
-                                            type="button"
-                                            @class([
-                                                'flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-300',
-                                                'dark:text-gray-400 dark:hover:text-gray-500' => config('forms.dark_mode'),
-                                            ])
-                                        >
-                                            <x-heroicon-s-minus-sm class="w-4 h-4" x-show="! isCollapsed"/>
+                                @if ($hasBlockLabels)
+                                    <p @class([
+                                        'flex-none px-4 text-xs font-medium text-gray-600 truncate',
+                                        'dark:text-gray-400' => config('forms.dark_mode'),
+                                    ])>
+                                        {{ $item->getParentComponent()->getLabel() }}
 
-                                            <span class="sr-only" x-show="! isCollapsed">
-                                                {{ __('forms::components.builder.buttons.collapse_item.label') }}
-                                            </span>
-
-                                            <x-heroicon-s-plus-sm class="w-4 h-4" x-show="isCollapsed" x-cloak/>
-
-                                            <span class="sr-only" x-show="isCollapsed" x-cloak>
-                                                {{ __('forms::components.builder.buttons.expand_item.label') }}
-                                            </span>
-                                        </button>
-                                    </li>
+                                        <small class="font-mono">{{ $loop->iteration }}</small>
+                                    </p>
                                 @endif
-                            </ul>
-                        </header>
+
+                                <div class="flex-1"></div>
+
+                                <ul @class([
+                                    'flex divide-x',
+                                    'dark:divide-gray-700' => config('forms.dark_mode'),
+                                ])>
+                                    @unless ($isItemDeletionDisabled)
+                                        <li>
+                                            <button
+                                                wire:click="dispatchFormEvent('builder::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                type="button"
+                                                @class([
+                                                    'flex items-center justify-center flex-none w-10 h-10 text-danger-600 transition hover:text-danger-500',
+                                                    'dark:text-danger-500 dark:hover:text-danger-400' => config('forms.dark_mode'),
+                                                ])
+                                            >
+                                                <span class="sr-only">
+                                                    {{ __('forms::components.builder.buttons.delete_item.label') }}
+                                                </span>
+
+                                                <x-heroicon-s-trash class="w-4 h-4"/>
+                                            </button>
+                                        </li>
+                                    @endunless
+
+                                    @if ($isCollapsible)
+                                        <li>
+                                            <button
+                                                x-on:click="isCollapsed = !isCollapsed"
+                                                type="button"
+                                                @class([
+                                                    'flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-300',
+                                                    'dark:text-gray-400 dark:hover:text-gray-500' => config('forms.dark_mode'),
+                                                ])
+                                            >
+                                                <x-heroicon-s-minus-sm class="w-4 h-4" x-show="! isCollapsed"/>
+
+                                                <span class="sr-only" x-show="! isCollapsed">
+                                                    {{ __('forms::components.builder.buttons.collapse_item.label') }}
+                                                </span>
+
+                                                <x-heroicon-s-plus-sm class="w-4 h-4" x-show="isCollapsed" x-cloak/>
+
+                                                <span class="sr-only" x-show="isCollapsed" x-cloak>
+                                                    {{ __('forms::components.builder.buttons.expand_item.label') }}
+                                                </span>
+                                            </button>
+                                        </li>
+                                    @endif
+                                </ul>
+                            </header>
+                        @endif
 
                         <div class="p-6" x-show="! isCollapsed">
                             {{ $item }}

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -12,12 +12,13 @@
     @php
         $containers = $getChildComponentContainers();
 
+        $isCollapsible = $isCollapsible();
         $isItemCreationDisabled = $isItemCreationDisabled();
         $isItemDeletionDisabled = $isItemDeletionDisabled();
         $isItemMovementDisabled = $isItemMovementDisabled();
     @endphp
 
-    @if (count($containers) > 1 && $isCollapsible())
+    @if ((count($containers) > 1) && $isCollapsible)
         <div class="space-x-2 rtl:space-x-reverse" x-data="{}">
             <x-forms::link
                 x-on:click="$dispatch('repeater-collapse', '{{ $getStatePath() }}')"
@@ -60,80 +61,82 @@
                             'dark:bg-gray-800 dark:border-gray-600' => config('forms.dark_mode'),
                         ])
                     >
-                        <header @class([
-                            'flex items-center h-10 overflow-hidden border-b bg-gray-50 rounded-t-xl',
-                            'dark:bg-gray-800 dark:border-gray-700' => config('forms.dark_mode'),
-                        ])>
-                            @unless ($isItemMovementDisabled)
-                                <button
-                                    wire:sortable.handle
-                                    wire:keydown.prevent.arrow-up="dispatchFormEvent('repeater::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
-                                    wire:keydown.prevent.arrow-down="dispatchFormEvent('repeater::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
-                                    type="button"
-                                    @class([
-                                        'flex items-center justify-center flex-none w-10 h-10 text-gray-400 border-r transition hover:text-gray-300',
-                                        'dark:text-gray-400 dark:border-gray-700 dark:hover:text-gray-500' => config('forms.dark_mode'),
-                                    ])
-                                >
-                                    <span class="sr-only">
-                                        {{ __('forms::components.repeater.buttons.move_item_down.label') }}
-                                    </span>
-
-                                    <x-heroicon-s-switch-vertical class="w-4 h-4"/>
-                                </button>
-                            @endunless
-
-                            <div class="flex-1"></div>
-
-                            <ul @class([
-                                'flex divide-x',
-                                'dark:divide-gray-700' => config('forms.dark_mode'),
+                        @if ((! $isItemMovementDisabled) || (! $isItemDeletionDisabled) || $isCollapsible)
+                            <header @class([
+                                'flex items-center h-10 overflow-hidden border-b bg-gray-50 rounded-t-xl',
+                                'dark:bg-gray-800 dark:border-gray-700' => config('forms.dark_mode'),
                             ])>
-                                @unless ($isItemDeletionDisabled)
-                                    <li>
-                                        <button
-                                            wire:click="dispatchFormEvent('repeater::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
-                                            type="button"
-                                            @class([
-                                                'flex items-center justify-center flex-none w-10 h-10 text-danger-600 transition hover:text-danger-500',
-                                                'dark:text-danger-500 dark:hover:text-danger-400' => config('forms.dark_mode'),
-                                            ])
-                                        >
-                                            <span class="sr-only">
-                                                {{ __('forms::components.repeater.buttons.delete_item.label') }}
-                                            </span>
+                                @unless ($isItemMovementDisabled)
+                                    <button
+                                        wire:sortable.handle
+                                        wire:keydown.prevent.arrow-up="dispatchFormEvent('repeater::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                        wire:keydown.prevent.arrow-down="dispatchFormEvent('repeater::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                        type="button"
+                                        @class([
+                                            'flex items-center justify-center flex-none w-10 h-10 text-gray-400 border-r transition hover:text-gray-300',
+                                            'dark:text-gray-400 dark:border-gray-700 dark:hover:text-gray-500' => config('forms.dark_mode'),
+                                        ])
+                                    >
+                                        <span class="sr-only">
+                                            {{ __('forms::components.repeater.buttons.move_item_down.label') }}
+                                        </span>
 
-                                            <x-heroicon-s-trash class="w-4 h-4"/>
-                                        </button>
-                                    </li>
+                                        <x-heroicon-s-switch-vertical class="w-4 h-4"/>
+                                    </button>
                                 @endunless
 
-                                @if($isCollapsible())
-                                    <li>
-                                        <button
-                                            x-on:click="isCollapsed = !isCollapsed"
-                                            type="button"
-                                            @class([
-                                                'flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-300',
-                                                'dark:text-gray-400 dark:hover:text-gray-500' => config('forms.dark_mode'),
-                                            ])
-                                        >
-                                            <x-heroicon-s-minus-sm class="w-4 h-4" x-show="! isCollapsed"/>
+                                <div class="flex-1"></div>
 
-                                            <span class="sr-only" x-show="! isCollapsed">
-                                                {{ __('forms::components.repeater.buttons.collapse_item.label') }}
-                                            </span>
+                                <ul @class([
+                                    'flex divide-x',
+                                    'dark:divide-gray-700' => config('forms.dark_mode'),
+                                ])>
+                                    @unless ($isItemDeletionDisabled)
+                                        <li>
+                                            <button
+                                                wire:click="dispatchFormEvent('repeater::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                type="button"
+                                                @class([
+                                                    'flex items-center justify-center flex-none w-10 h-10 text-danger-600 transition hover:text-danger-500',
+                                                    'dark:text-danger-500 dark:hover:text-danger-400' => config('forms.dark_mode'),
+                                                ])
+                                            >
+                                                <span class="sr-only">
+                                                    {{ __('forms::components.repeater.buttons.delete_item.label') }}
+                                                </span>
 
-                                            <x-heroicon-s-plus-sm class="w-4 h-4" x-show="isCollapsed" x-cloak/>
+                                                <x-heroicon-s-trash class="w-4 h-4"/>
+                                            </button>
+                                        </li>
+                                    @endunless
 
-                                            <span class="sr-only" x-show="isCollapsed" x-cloak>
-                                                {{ __('forms::components.repeater.buttons.expand_item.label') }}
-                                            </span>
-                                        </button>
-                                    </li>
-                                @endif
-                            </ul>
-                        </header>
+                                    @if ($isCollapsible)
+                                        <li>
+                                            <button
+                                                x-on:click="isCollapsed = !isCollapsed"
+                                                type="button"
+                                                @class([
+                                                    'flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-300',
+                                                    'dark:text-gray-400 dark:hover:text-gray-500' => config('forms.dark_mode'),
+                                                ])
+                                            >
+                                                <x-heroicon-s-minus-sm class="w-4 h-4" x-show="! isCollapsed"/>
+
+                                                <span class="sr-only" x-show="! isCollapsed">
+                                                    {{ __('forms::components.repeater.buttons.collapse_item.label') }}
+                                                </span>
+
+                                                <x-heroicon-s-plus-sm class="w-4 h-4" x-show="isCollapsed" x-cloak/>
+
+                                                <span class="sr-only" x-show="isCollapsed" x-cloak>
+                                                    {{ __('forms::components.repeater.buttons.expand_item.label') }}
+                                                </span>
+                                            </button>
+                                        </li>
+                                    @endif
+                                </ul>
+                            </header>
+                        @endif
 
                         <div class="p-6" x-show="! isCollapsed">
                             {{ $item }}

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -17,7 +17,7 @@
         $isItemMovementDisabled = $isItemMovementDisabled();
     @endphp
 
-    @if (count($containers) > 1)
+    @if (count($containers) > 1 && $isCollapsible())
         <div class="space-x-2 rtl:space-x-reverse" x-data="{}">
             <x-forms::link
                 x-on:click="$dispatch('repeater-collapse', '{{ $getStatePath() }}')"
@@ -108,28 +108,30 @@
                                     </li>
                                 @endunless
 
-                                <li>
-                                    <button
-                                        x-on:click="isCollapsed = !isCollapsed"
-                                        type="button"
-                                        @class([
-                                            'flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-300',
-                                            'dark:text-gray-400 dark:hover:text-gray-500' => config('forms.dark_mode'),
-                                        ])
-                                    >
-                                        <x-heroicon-s-minus-sm class="w-4 h-4" x-show="! isCollapsed"/>
+                                @if($isCollapsible())
+                                    <li>
+                                        <button
+                                            x-on:click="isCollapsed = !isCollapsed"
+                                            type="button"
+                                            @class([
+                                                'flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-300',
+                                                'dark:text-gray-400 dark:hover:text-gray-500' => config('forms.dark_mode'),
+                                            ])
+                                        >
+                                            <x-heroicon-s-minus-sm class="w-4 h-4" x-show="! isCollapsed"/>
 
-                                        <span class="sr-only" x-show="! isCollapsed">
-                                            {{ __('forms::components.repeater.buttons.collapse_item.label') }}
-                                        </span>
+                                            <span class="sr-only" x-show="! isCollapsed">
+                                                {{ __('forms::components.repeater.buttons.collapse_item.label') }}
+                                            </span>
 
-                                        <x-heroicon-s-plus-sm class="w-4 h-4" x-show="isCollapsed" x-cloak/>
+                                            <x-heroicon-s-plus-sm class="w-4 h-4" x-show="isCollapsed" x-cloak/>
 
-                                        <span class="sr-only" x-show="isCollapsed" x-cloak>
-                                            {{ __('forms::components.repeater.buttons.expand_item.label') }}
-                                        </span>
-                                    </button>
-                                </li>
+                                            <span class="sr-only" x-show="isCollapsed" x-cloak>
+                                                {{ __('forms::components.repeater.buttons.expand_item.label') }}
+                                            </span>
+                                        </button>
+                                    </li>
+                                @endif
                             </ul>
                         </header>
 

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -84,7 +84,7 @@ class Builder extends Field
 
                     $component->hydrateDefaultItemState($newUuid);
 
-                    $component->collapsed(false);
+                    $component->collapsed(false, shouldMakeComponentCollapsible: false);
                 },
             ],
             'builder::deleteItem' => [

--- a/packages/forms/src/Components/Concerns/CanBeCollapsed.php
+++ b/packages/forms/src/Components/Concerns/CanBeCollapsed.php
@@ -8,11 +8,15 @@ trait CanBeCollapsed
 {
     protected bool | Closure $isCollapsed = false;
 
-    protected bool | Closure $isCollapsible = false;
+    protected bool | Closure | null $isCollapsible = null;
 
-    public function collapsed(bool | Closure $condition = true): static
+    public function collapsed(bool | Closure $condition = true, bool $shouldMakeComponentCollapsible = true): static
     {
         $this->isCollapsed = $condition;
+
+        if ($shouldMakeComponentCollapsible && $this->isCollapsible === null) {
+            $this->collapsible();
+        }
 
         return $this;
     }
@@ -22,7 +26,7 @@ trait CanBeCollapsed
         return (bool) $this->evaluate($this->isCollapsed);
     }
 
-    public function collapsible(bool | Closure $condition = true): static
+    public function collapsible(bool | Closure | null $condition = true): static
     {
         $this->isCollapsible = $condition;
 
@@ -31,6 +35,6 @@ trait CanBeCollapsed
 
     public function isCollapsible(): bool
     {
-        return (bool) $this->evaluate($this->isCollapsible);
+        return (bool) ($this->evaluate($this->isCollapsible) ?? false);
     }
 }

--- a/packages/forms/src/Components/Concerns/CanBeCollapsed.php
+++ b/packages/forms/src/Components/Concerns/CanBeCollapsed.php
@@ -8,6 +8,8 @@ trait CanBeCollapsed
 {
     protected bool | Closure $isCollapsed = false;
 
+    protected bool | Closure $isCollapsible = false;
+
     public function collapsed(bool | Closure $condition = true): static
     {
         $this->isCollapsed = $condition;
@@ -18,5 +20,17 @@ trait CanBeCollapsed
     public function isCollapsed(): bool
     {
         return (bool) $this->evaluate($this->isCollapsed);
+    }
+
+    public function collapsible(bool | Closure $condition = true): static
+    {
+        $this->isCollapsible = $condition;
+
+        return $this;
+    }
+
+    public function isCollapsible(): bool
+    {
+        return (bool) $this->evaluate($this->isCollapsible);
     }
 }

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -10,8 +10,8 @@ use Illuminate\Support\Str;
 
 class Repeater extends Field
 {
-    use Concerns\CanLimitItemsLength;
     use Concerns\CanBeCollapsed;
+    use Concerns\CanLimitItemsLength;
 
     protected string $view = 'forms::components.repeater';
 
@@ -55,7 +55,7 @@ class Repeater extends Field
 
                     $component->hydrateDefaultItemState($newUuid);
 
-                    $component->collapsed(false);
+                    $component->collapsed(false, shouldMakeComponentCollapsible: false);
                 },
             ],
             'repeater::deleteItem' => [

--- a/packages/forms/src/Components/Section.php
+++ b/packages/forms/src/Components/Section.php
@@ -39,14 +39,6 @@ class Section extends Component implements Contracts\CanConcealComponents, Contr
         $this->columnSpan('full');
     }
 
-    public function collapsed(bool | Closure $condition = true): static
-    {
-        $this->isCollapsed = $condition;
-        $this->collapsible(true);
-
-        return $this;
-    }
-
     public function description(string | Htmlable | Closure | null $description = null): static
     {
         $this->description = $description;

--- a/packages/forms/src/Components/Section.php
+++ b/packages/forms/src/Components/Section.php
@@ -15,8 +15,6 @@ class Section extends Component implements Contracts\CanConcealComponents, Contr
 
     protected string $view = 'forms::components.section';
 
-    protected bool | Closure $isCollapsible = false;
-
     protected string | Htmlable | Closure | null $description = null;
 
     protected string | Closure $heading;
@@ -45,13 +43,6 @@ class Section extends Component implements Contracts\CanConcealComponents, Contr
     {
         $this->isCollapsed = $condition;
         $this->collapsible(true);
-
-        return $this;
-    }
-
-    public function collapsible(bool | Closure $condition = true): static
-    {
-        $this->isCollapsible = $condition;
 
         return $this;
     }
@@ -93,11 +84,6 @@ class Section extends Component implements Contracts\CanConcealComponents, Contr
         }
 
         return $id;
-    }
-
-    public function isCollapsible(): bool
-    {
-        return (bool) $this->evaluate($this->isCollapsible);
     }
 
     public function canConcealComponents(): bool


### PR DESCRIPTION
As discussed in discord...

I moved the `isCollapsible` logic from `Section` into the `CanBeCollapsed` trait and added the necessary `if`'s to the views of `Repeater` and `Builder`. 

For the docs, I also added (copy+paste from section) the documentation for `Repeater`. Not sure, if I should also add it to the 'Builder` block as well.