### PR TITLE
Only dispatch notifications via LW on Livewire requests

### DIFF
--- a/packages/admin/src/NotificationManager.php
+++ b/packages/admin/src/NotificationManager.php
@@ -2,8 +2,8 @@
 
 namespace Filament;
 
-use Filament\Pages\Page;
 use Livewire\Component;
+use Livewire\Livewire;
 use Livewire\Response;
 
 class NotificationManager
@@ -23,7 +23,7 @@ class NotificationManager
 
     public function handleLivewireResponses(Component $component, Response $response): Response
     {
-        if (! $component instanceof Page) {
+        if (! Livewire::isLivewireRequest()) {
             return $response;
         }
 

--- a/tests/src/Admin/NotificationManager/NotificationManagerTest.php
+++ b/tests/src/Admin/NotificationManager/NotificationManagerTest.php
@@ -4,11 +4,16 @@ use Filament\Tests\Admin\Fixtures\Pages\Settings;
 use Filament\Tests\Admin\NotificationManager\TestCase;
 use Illuminate\Support\Facades\Session;
 use Livewire\Livewire;
+use Livewire\LivewireManager;
 
 uses(TestCase::class);
 
 it('can immediately dispatch notify event to browser', function () {
-    Livewire::test(Settings::class)
+    $component = Livewire::test(Settings::class);
+
+    LivewireManager::$isLivewireRequestTestingOverride = true;
+
+    $component
         ->call('notificationManager')
         ->assertDispatchedBrowserEvent('notify');
 


### PR DESCRIPTION
The issue with the notifications was, that every component would call the `dehydrate` hook on render and therefore trigger `NotificationManager::handleLivewireResponses()`. But we only want this to happen on LiveWire requests, as otherwise a rendering component will clear the notifications while it cannot dispatch browser events.