### PR TITLE
Use placeholder for ImageColumn when empty

### DIFF
--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -1,23 +1,26 @@
 <div {{ $attributes->merge($getExtraAttributes())->class(['px-4 py-3 filament-tables-image-column']) }}>
-    @if ($path = $getImagePath())
-        @if ($isRounded())
-            <div
-                class="rounded-full bg-center bg-cover"
-                style="
-                    background-image: url('{{ addslashes($path) }}');
-                    height: {{ $getHeight() ?? '40px' }};
-                    width: {{ $getWidth() ?? '40px' }};
-                "
-            ></div>
-        @else
+    @php
+        $height = $getHeight();
+        $width = $getWidth() ?? ($isRounded() ? $height : null);
+    @endphp
+
+    <div
+        style="
+            {!! $height !== null ? "height: {$height};" : null !!}
+            {!! $width !== null ? "width: {$width};" : null !!}
+        "
+        @class(['rounded-full overflow-hidden' => $isRounded()])
+    >
+        @if ($path = $getImagePath())
             <img
                 src="{{ $path }}"
                 style="
-                    {!! ($height = $getHeight()) !== null ? "height: {$height};" : null !!}
-                    {!! ($width = $getWidth()) !== null ? "width: {$width};" : null !!}
+                    {!! $height !== null ? "height: {$height};" : null !!}
+                    {!! $width !== null ? "width: {$width};" : null !!}
                 "
+                @class(['object-cover object-center' => $isRounded])
                 {{ $getExtraImgAttributeBag() }}
             >
-        @endif
-    @endif
+       @endif
+    </div>
 </div>

--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -18,7 +18,7 @@
                     {!! $height !== null ? "height: {$height};" : null !!}
                     {!! $width !== null ? "width: {$width};" : null !!}
                 "
-                @class(['object-cover object-center' => $isRounded])
+                @class(['object-cover object-center' => $isRounded()])
                 {{ $getExtraImgAttributeBag() }}
             >
        @endif


### PR DESCRIPTION
RFC: https://github.com/laravel-filament/filament/discussions/2344

1. Added a placeholder div so the row height doesn't collapse when an image is missing.
1. Simplified the HTML structure by using `object-fit object-center` instead of a background image.
1. Fixed a bug where e.g. `->width(120)` on non-rounded images would collapse the width on tables where content requires full width, as `img` have `max-width: 100%`
