### PR TITLE
Refactor PageActions

### DIFF
--- a/packages/admin/src/Pages/Actions/DeleteAction.php
+++ b/packages/admin/src/Pages/Actions/DeleteAction.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Filament\Pages\Actions;
+
+use Filament\Support\Actions\Concerns\CanNotify;
+use Filament\Support\Actions\Concerns\CanRedirect;
+use Filament\Support\Actions\Concerns\HasBeforeAfterCallbacks;
+use Illuminate\Database\Eloquent\Model;
+
+use function Livewire\invade;
+
+class DeleteAction extends Action
+{
+    use CanNotify;
+    use CanRedirect;
+    use HasBeforeAfterCallbacks;
+
+    protected function setUp(): void
+    {
+        $this->label(__('filament::resources/pages/edit-record.actions.delete.label'));
+
+        $this->requiresConfirmation();
+
+        $this->modalHeading(
+            fn () => __('filament::resources/pages/edit-record.actions.delete.modal.heading', ['label' => invade($this->getLivewire())->getRecordTitle() ?? $this->getLivewire()::getResource()::getLabel()])
+        );
+
+        $this->modalSubheading(__('filament::resources/pages/edit-record.actions.delete.modal.subheading'));
+
+        $this->modalButton(__('filament::resources/pages/edit-record.actions.delete.modal.buttons.delete.label'));
+
+        $this->action(fn () => $this->execute());
+
+        $this->keyBindings(['mod+d']);
+
+        $this->color('danger');
+
+        // Compatibility with V2
+
+        $this->notificationMessage(fn () => $this->getLivewire()->getDeletedNotificationMessage());
+
+        $this->redirectUrl(fn () => $this->getLivewire()->getDeleteRedirectUrl());
+    }
+
+    public function getRecord(): ?Model
+    {
+        return $this->getLivewire()->record;
+    }
+
+    public function execute()
+    {
+        $page = $this->getLivewire();
+
+        $reflector = new \ReflectionMethod($page, 'delete');
+        if ($reflector->getDeclaringClass()->getName() !== get_class($page)) {
+            // Compatiblity for V2
+            return $page->delete();
+        }
+
+        // New implementation
+
+        $record = $this->getRecord();
+
+        abort_unless($page::getResource()::canDelete($record), 403);
+
+        $this->evaluate($this->beforeCallback, ['record' => $record]);
+
+        $record->delete();
+
+        $this->evaluate($this->afterCallback, ['record' => $record]);
+
+        $this->notify();
+
+        $this->redirect();
+    }
+}

--- a/packages/admin/src/Pages/Actions/DeleteAction.php
+++ b/packages/admin/src/Pages/Actions/DeleteAction.php
@@ -3,6 +3,7 @@
 namespace Filament\Pages\Actions;
 
 use Filament\Resources\Pages\EditRecord;
+use Filament\Resources\Pages\ViewRecord;
 use Filament\Support\Actions\Concerns\CanNotify;
 use Filament\Support\Actions\Concerns\CanRedirect;
 use Filament\Support\Actions\Concerns\HasBeforeAfterCallbacks;
@@ -22,9 +23,13 @@ class DeleteAction extends Action
 
         $this->requiresConfirmation();
 
-        $this->modalHeading(
-            fn () => __('filament::resources/pages/edit-record.actions.delete.modal.heading', ['label' => invade($this->getLivewire())->getRecordTitle() ?? $this->getLivewire()::getResource()::getLabel()])
-        );
+        $this->modalHeading(function () {
+            $page = invade($this->getLivewire());
+
+            return __('filament::resources/pages/edit-record.actions.delete.modal.heading', [
+                'label' => $page->getRecordTitle() ?? $page::getResource()::getLabel()
+            ]);
+        });
 
         $this->modalSubheading(__('filament::resources/pages/edit-record.actions.delete.modal.subheading'));
 
@@ -49,18 +54,24 @@ class DeleteAction extends Action
 
     public function getRecord(): ?Model
     {
-        return $this->getLivewire()->record;
+        /** @var ViewRecord | EditRecord $page */
+        $page = $this->getLivewire();
+
+        return $page->record;
     }
 
     public function execute()
     {
+        /** @var ViewRecord | EditRecord $page */
         $page = $this->getLivewire();
+
+        // Compatiblity for V2
 
         $reflector = new \ReflectionMethod($page, 'delete');
 
         if ($reflector->getDeclaringClass()->getName() !== EditRecord::class) {
-            // Compatiblity for V2
-            return $page->delete();
+            $page->delete();
+            return;
         }
 
         // New implementation

--- a/packages/admin/src/Pages/Actions/DeleteAction.php
+++ b/packages/admin/src/Pages/Actions/DeleteAction.php
@@ -27,7 +27,7 @@ class DeleteAction extends Action
             $page = invade($this->getLivewire());
 
             return __('filament::resources/pages/edit-record.actions.delete.modal.heading', [
-                'label' => $page->getRecordTitle() ?? $page::getResource()::getLabel()
+                'label' => $page->getRecordTitle() ?? $page::getResource()::getLabel(),
             ]);
         });
 
@@ -71,6 +71,7 @@ class DeleteAction extends Action
 
         if ($reflector->getDeclaringClass()->getName() !== EditRecord::class) {
             $page->delete();
+
             return;
         }
 

--- a/packages/admin/src/Pages/Actions/DeleteAction.php
+++ b/packages/admin/src/Pages/Actions/DeleteAction.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Pages\Actions;
 
+use Filament\Resources\Pages\EditRecord;
 use Filament\Support\Actions\Concerns\CanNotify;
 use Filament\Support\Actions\Concerns\CanRedirect;
 use Filament\Support\Actions\Concerns\HasBeforeAfterCallbacks;
@@ -37,13 +38,13 @@ class DeleteAction extends Action
 
         // Compatibility with V2
 
-        $this->notificationMessage(fn () => $this->getLivewire()->getDeletedNotificationMessage());
+        $this->notificationMessage(fn () => invade($this->getLivewire())->getDeletedNotificationMessage());
 
-        $this->redirectUrl(fn () => $this->getLivewire()->getDeleteRedirectUrl());
+        $this->redirectUrl(fn () => invade($this->getLivewire())->getDeleteRedirectUrl());
 
-        $this->callBefore(fn () => $this->getLivewire()->callHook('beforeDelete'));
+        $this->callBefore(fn () => invade($this->getLivewire())->callHook('beforeDelete'));
 
-        $this->callAfter(fn () => $this->getLivewire()->callHook('afterDelete'));
+        $this->callAfter(fn () => invade($this->getLivewire())->callHook('afterDelete'));
     }
 
     public function getRecord(): ?Model
@@ -56,7 +57,8 @@ class DeleteAction extends Action
         $page = $this->getLivewire();
 
         $reflector = new \ReflectionMethod($page, 'delete');
-        if ($reflector->getDeclaringClass()->getName() !== get_class($page)) {
+
+        if ($reflector->getDeclaringClass()->getName() !== EditRecord::class) {
             // Compatiblity for V2
             return $page->delete();
         }

--- a/packages/admin/src/Pages/Actions/DeleteAction.php
+++ b/packages/admin/src/Pages/Actions/DeleteAction.php
@@ -40,6 +40,10 @@ class DeleteAction extends Action
         $this->notificationMessage(fn () => $this->getLivewire()->getDeletedNotificationMessage());
 
         $this->redirectUrl(fn () => $this->getLivewire()->getDeleteRedirectUrl());
+
+        $this->callBefore(fn () => $this->getLivewire()->callHook('beforeDelete'));
+
+        $this->callAfter(fn () => $this->getLivewire()->callHook('afterDelete'));
     }
 
     public function getRecord(): ?Model

--- a/packages/admin/src/Resources/Pages/EditRecord.php
+++ b/packages/admin/src/Resources/Pages/EditRecord.php
@@ -171,7 +171,7 @@ class EditRecord extends Page implements HasFormActions
      */
     protected function getDeleteAction(): Action
     {
-        return DeleteAction::make('delete')->livewire($this);
+        return DeleteAction::make('delete');
     }
 
     protected function getTitle(): string

--- a/packages/admin/src/Resources/Pages/EditRecord.php
+++ b/packages/admin/src/Resources/Pages/EditRecord.php
@@ -4,6 +4,7 @@ namespace Filament\Resources\Pages;
 
 use Filament\Forms\ComponentContainer;
 use Filament\Pages\Actions\Action;
+use Filament\Pages\Actions\DeleteAction;
 use Filament\Pages\Contracts\HasFormActions;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
@@ -116,6 +117,9 @@ class EditRecord extends Page implements HasFormActions
         ]);
     }
 
+    /**
+     * @deprecated
+     */
     public function delete(): void
     {
         abort_unless(static::getResource()::canDelete($this->record), 403);
@@ -136,6 +140,9 @@ class EditRecord extends Page implements HasFormActions
         $this->redirect($this->getDeleteRedirectUrl());
     }
 
+    /**
+     * @deprecated
+     */
     protected function getDeletedNotificationMessage(): ?string
     {
         return __('filament::resources/pages/edit-record.actions.delete.messages.deleted');
@@ -159,17 +166,12 @@ class EditRecord extends Page implements HasFormActions
             ->color('secondary');
     }
 
+    /**
+     * @deprecated
+     */
     protected function getDeleteAction(): Action
     {
-        return Action::make('delete')
-            ->label(__('filament::resources/pages/edit-record.actions.delete.label'))
-            ->requiresConfirmation()
-            ->modalHeading(__('filament::resources/pages/edit-record.actions.delete.modal.heading', ['label' => $this->getRecordTitle() ?? static::getResource()::getLabel()]))
-            ->modalSubheading(__('filament::resources/pages/edit-record.actions.delete.modal.subheading'))
-            ->modalButton(__('filament::resources/pages/edit-record.actions.delete.modal.buttons.delete.label'))
-            ->action('delete')
-            ->keyBindings(['mod+d'])
-            ->color('danger');
+        return DeleteAction::make('delete')->livewire($this);
     }
 
     protected function getTitle(): string
@@ -234,6 +236,9 @@ class EditRecord extends Page implements HasFormActions
         return null;
     }
 
+    /**
+     * @deprecated
+     */
     protected function getDeleteRedirectUrl(): ?string
     {
         return static::getResource()::getUrl('index');

--- a/packages/support/src/Actions/Concerns/CanNotify.php
+++ b/packages/support/src/Actions/Concerns/CanNotify.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Filament\Support\Actions\Concerns;
+
+use Closure;
+use Filament\Facades\Filament;
+
+trait CanNotify
+{
+    protected Closure | string | null $notificationMessage = null;
+
+    public function notify(): void
+    {
+        if (filled($message = $this->getNotificationMessage())) {
+            Filament::notify('success', $message);
+        }
+    }
+
+    protected function getNotificationMessage(): string
+    {
+        return $this->evaluate($this->notificationMessage);
+    }
+
+    public function notificationMessage(Closure | string $message): static
+    {
+        $this->notificationMessage = $message;
+
+        return $this;
+    }
+}

--- a/packages/support/src/Actions/Concerns/CanRedirect.php
+++ b/packages/support/src/Actions/Concerns/CanRedirect.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Filament\Support\Actions\Concerns;
+
+use Closure;
+
+trait CanRedirect
+{
+    protected Closure | string | null $redirectUrl = null;
+
+    public function redirect()
+    {
+        if (filled($redirect = $this->getRedirectUrl())) {
+            $this->getLivewire()->redirect($redirect);
+        }
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->evaluate($this->redirectUrl);
+    }
+
+    public function redirectUrl(Closure | string $redirectUrl): static
+    {
+        $this->redirectUrl = $redirectUrl;
+
+        return $this;
+    }
+}

--- a/packages/support/src/Actions/Concerns/HasBeforeAfterCallbacks.php
+++ b/packages/support/src/Actions/Concerns/HasBeforeAfterCallbacks.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Filament\Support\Actions\Concerns;
+
+use Closure;
+
+trait HasBeforeAfterCallbacks
+{
+    protected ?Closure $beforeCallback = null;
+
+    protected ?Closure $afterCallback = null;
+
+    public function callBefore(Closure $callback): static
+    {
+        $this->beforeCallback = $callback;
+
+        return $this;
+    }
+
+    public function callAfter(Closure $callback): static
+    {
+        $this->afterCallback = $callback;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
As discussed with Dan on Discord this is a first POC how we could refactor the page actions into separate classes while keeping them compatible with V2. 

This could clean up Page classes a lot and also make Actions easier to modify globally by using Laravel's container, e.g.:

```php
$this->app->bind(
    \Filament\Pages\Actions\DeleteAction::class,
    \App\Filament\Actions\DeleteAction::class,
);
```

Page actions could then be defined and modified like this:

```php

protected function getActions(): array
{
    return [
        DeleteAction::make('delete')->color('primary'),
        EditAction::make('edit')->color('danger'),
    ];
}
```