### PR TITLE
Add temporary url support for SpatieMediaLibraryImageColumn

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/docs/03-table-columns.md
+++ b/packages/spatie-laravel-media-library-plugin/docs/03-table-columns.md
@@ -29,13 +29,3 @@ SpatieMediaLibraryImageColumn::make('avatar')->conversion('thumb'),
 ```
 
 The media library image column supports all the customization options of the [original image column](/docs/tables/columns#image-column).
-
-### Temporary URLS
-
-To use temporary urls, you may set the `visibility()` to private:
-
-```php
-use Filament\Tables\Columns\SpatieMediaLibraryImageColumn;
-
-SpatieMediaLibraryImageColumn::make('avatar')->visibility('private'),
-```

--- a/packages/spatie-laravel-media-library-plugin/docs/03-table-columns.md
+++ b/packages/spatie-laravel-media-library-plugin/docs/03-table-columns.md
@@ -29,3 +29,13 @@ SpatieMediaLibraryImageColumn::make('avatar')->conversion('thumb'),
 ```
 
 The media library image column supports all the customization options of the [original image column](/docs/tables/columns#image-column).
+
+### Temporary URLS
+
+To use temporary urls, you may set the `visibility()` to private:
+
+```php
+use Filament\Tables\Columns\SpatieMediaLibraryImageColumn;
+
+SpatieMediaLibraryImageColumn::make('avatar')->visibility('private'),
+```

--- a/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -3,12 +3,15 @@
 namespace Filament\Tables\Columns;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Filesystem\FilesystemAdapter;
 
 class SpatieMediaLibraryImageColumn extends ImageColumn
 {
     protected ?string $collection = null;
 
     protected string $conversion = '';
+
+    protected string | Closure $visibility = 'public';
 
     public function collection(string $collection): static
     {
@@ -24,6 +27,13 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
         return $this;
     }
 
+    public function visibility(string | Closure | null $visibility): static
+    {
+        $this->visibility = $visibility;
+
+        return $this;
+    }
+
     public function getCollection(): ?string
     {
         return $this->collection ?? 'default';
@@ -32,6 +42,11 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
     public function getConversion(): string
     {
         return $this->conversion ?? '';
+    }
+
+    public function getVisibility(): string
+    {
+        return $this->evaluate($this->visibility);
     }
 
     public function getImagePath(): ?string
@@ -46,6 +61,10 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
 
         if (! method_exists($record, 'getFirstMediaUrl')) {
             return $state;
+        }
+
+        if ($this->getVisibility() === 'private') {
+            return $record->getFirstTemporaryUrl(now()->addMinutes(5), $this->getCollection(), $this->getConversion());
         }
 
         return $record->getFirstMediaUrl($this->getCollection(), $this->getConversion());

--- a/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -3,7 +3,6 @@
 namespace Filament\Tables\Columns;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Filesystem\FilesystemAdapter;
 
 class SpatieMediaLibraryImageColumn extends ImageColumn
 {

--- a/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -3,14 +3,13 @@
 namespace Filament\Tables\Columns;
 
 use Illuminate\Database\Eloquent\Builder;
+use Throwable;
 
 class SpatieMediaLibraryImageColumn extends ImageColumn
 {
     protected ?string $collection = null;
 
     protected string $conversion = '';
-
-    protected string | Closure $visibility = 'public';
 
     public function collection(string $collection): static
     {
@@ -26,13 +25,6 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
         return $this;
     }
 
-    public function visibility(string | Closure | null $visibility): static
-    {
-        $this->visibility = $visibility;
-
-        return $this;
-    }
-
     public function getCollection(): ?string
     {
         return $this->collection ?? 'default';
@@ -41,11 +33,6 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
     public function getConversion(): string
     {
         return $this->conversion ?? '';
-    }
-
-    public function getVisibility(): string
-    {
-        return $this->evaluate($this->visibility);
     }
 
     public function getImagePath(): ?string
@@ -58,12 +45,20 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
 
         $record = $this->getRecord();
 
-        if (! method_exists($record, 'getFirstMediaUrl')) {
-            return $state;
+        if ($this->getVisibility() === 'private' && method_exists($record, 'getFirstTemporaryUrl')) {
+            try {
+                return $record->getFirstTemporaryUrl(
+                    now()->addMinutes(5),
+                    $this->getCollection(),
+                    $this->getConversion(),
+                );
+            } catch (Throwable $exception) {
+                // This driver does not support creating temporary URLs.
+            }
         }
 
-        if ($this->getVisibility() === 'private') {
-            return $record->getFirstTemporaryUrl(now()->addMinutes(5), $this->getCollection(), $this->getConversion());
+        if (! method_exists($record, 'getFirstMediaUrl')) {
+            return $state;
         }
 
         return $record->getFirstMediaUrl($this->getCollection(), $this->getConversion());

--- a/packages/tables/docs/03-columns.md
+++ b/packages/tables/docs/03-columns.md
@@ -437,6 +437,16 @@ use Filament\Tables\Columns\ImageColumn;
 ImageColumn::make('header_image')->disk('s3')
 ```
 
+### Private images
+
+Filament can generate temporary URLs to render private images, you may set the `visibility()` to `private`:
+
+```php
+use Filament\Tables\Columns\ImageColumn;
+
+ImageColumn::make('header_image')->visibility('private')
+```
+
 ## Icon column
 
 Icon columns render a Blade icon component representing their contents:

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -19,6 +19,8 @@ class ImageColumn extends Column
 
     protected bool | Closure $isRounded = false;
 
+    protected string | Closure $visibility = 'public';
+
     protected int | string | Closure | null $width = null;
 
     protected array | Closure $extraImgAttributes = [];
@@ -53,6 +55,13 @@ class ImageColumn extends Column
     {
         $this->width($size);
         $this->height($size);
+
+        return $this;
+    }
+
+    public function visibility(string | Closure $visibility): static
+    {
+        $this->visibility = $visibility;
 
         return $this;
     }
@@ -108,7 +117,7 @@ class ImageColumn extends Column
             return null;
         }
 
-        if ($storage->getVisibility($state) === 'private') {
+        if ($this->getVisibility() === 'private' || $storage->getVisibility($state) === 'private') {
             try {
                 return $storage->temporaryUrl(
                     $state,
@@ -120,6 +129,11 @@ class ImageColumn extends Column
         }
 
         return $storage->url($state);
+    }
+
+    public function getVisibility(): string
+    {
+        return $this->evaluate($this->visibility);
     }
 
     public function getWidth(): ?string


### PR DESCRIPTION
This PR adds support for showing private images using a temporary url with the SpatieMediaLibraryImageColumn. 