### PR TITLE
change calendar width for persian languade

### DIFF
--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -93,7 +93,7 @@
                 @class([
                     'absolute z-10 my-1 bg-white border border-gray-300 rounded-lg shadow-md',
                     'dark:bg-gray-700 dark:border-gray-600' => config('forms.dark_mode'),
-                    'p-4 w-64' => $hasDate(),
+                    'p-4 min-w-64 w-fit' => $hasDate(),
                 ])
             >
                 <div class="space-y-3">


### PR DESCRIPTION
in persian language (maybe it occur in other language's too based on their locale and the size of the days label) we have a overlap on label's of the days and make it unreadable :
![before](https://user-images.githubusercontent.com/15873972/171949290-353fe38a-5d87-4229-b91d-6d232746667a.png)

for fixing this i made a simple change to the width of the calendar it will set the min of the width to 64 and will fit the width according to the content this is the result after this change for persian language:
![after](https://user-images.githubusercontent.com/15873972/171949573-eb3877f3-95eb-4633-9116-fc541e0c0bbf.png)
it's may be a little bit ugly but atleast it's readabble 
