### PR TITLE
Fix section component flicker

### DIFF
--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -57,6 +57,7 @@
         @if ($isCollapsible())
             x-bind:class="{ 'invisible h-0 !m-0 overflow-y-hidden': isCollapsed }"
             x-bind:aria-expanded="(! isCollapsed).toString()"
+            @if ($isCollapsed()) x-cloak @endif
         @endif
     >
         <div class="p-6">

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -46,7 +46,7 @@
                 }" type="button"
                 @class([
                     'flex items-center justify-center w-10 h-10 transform rounded-full text-primary-500 hover:bg-gray-500/5 focus:bg-primary-500/10 focus:outline-none',
-                    '-rotate-180' => !$isCollapsed(),
+                    '-rotate-180' => ! $isCollapsed(),
                 ])
             >
                 <svg class="h-7 w-7" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -44,7 +44,11 @@
                 x-bind:class="{
                     '-rotate-180': !isCollapsed,
                 }" type="button"
-                class="flex items-center justify-center w-10 h-10 transform rounded-full text-primary-500 hover:bg-gray-500/5 focus:bg-primary-500/10 focus:outline-none">
+                @class([
+                    'flex items-center justify-center w-10 h-10 transform rounded-full text-primary-500 hover:bg-gray-500/5 focus:bg-primary-500/10 focus:outline-none',
+                    '-rotate-180' => !$isCollapsed(),
+                ])
+            >
                 <svg class="h-7 w-7" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
                     stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />


### PR DESCRIPTION
Before Alpine.js loads, a programmatically collapsed section component briefly shows its contents. I've added an `x-cloak` attribute via Blade to prevent this from happening.

Before:
![section-flicker](https://user-images.githubusercontent.com/3736774/172965988-ffdc4acc-8680-4dcd-8c9c-31b93f42feb0.gif)

Additionally, for the same reason, the disclosure indicator for a collapsed section is briefly rotated 180º. I've included the correct class via Blade, which on subsequent changes is handled by Alpine.

Before:
![disclosure-indicator-flicker](https://user-images.githubusercontent.com/3736774/172966011-152d7fb1-dc77-436d-b99b-aa4e93aada07.gif)

(Apologies the GIFs are so short – each loop is a page refresh)