### PR TITLE
Make excluded field list more specific

### DIFF
--- a/packages/admin/src/Commands/Concerns/CanGenerateResources.php
+++ b/packages/admin/src/Commands/Concerns/CanGenerateResources.php
@@ -27,7 +27,9 @@ trait CanGenerateResources
             }
 
             if (Str::of($column->getName())->endsWith([
-                '_at',
+                'created_at',
+                'updated_at',
+                'deleted_at',
                 '_token',
             ])) {
                 continue;

--- a/packages/admin/src/Commands/Concerns/CanGenerateResources.php
+++ b/packages/admin/src/Commands/Concerns/CanGenerateResources.php
@@ -26,11 +26,11 @@ trait CanGenerateResources
                 continue;
             }
 
-            if (Str::of($column->getName())->endsWith([
+            if (Str::of($column->getName())->is([
                 'created_at',
-                'updated_at',
                 'deleted_at',
-                '_token',
+                'updated_at',
+                '*_token',
             ])) {
                 continue;
             }


### PR DESCRIPTION
Make the list of fields excluded from table column generation more specific so that custom field names such as "starts_at" or "ends_at" are generated if they exist in the schema but Laravel system fields still remain hidden.