### PR TITLE
Allows refreshing chart in widget after data changes

### DIFF
--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -29,6 +29,7 @@
             @if ($icon)
                 <x-dynamic-component :component="$icon" class="w-4 h-4" />
             @endif
+
             <span>{{ $label }}</span>
         </div>
 
@@ -58,65 +59,62 @@
 
     @if ($chart)
         <div
-            x-title="card-chart"
+            x-title="filament-stats-card-chart"
             x-data="{
+                chart: null,
+
                 labels: {{ json_encode(array_keys($chart)) }},
                 values: {{ json_encode(array_values($chart)) }},
 
-                init() {
-                    chart = Chart.getChart(this.$refs.canvas)
-
-                    chart ? this.update(chart) : this.create()
+                init: function () {
+                    this.chart ? this.updateChart() : this.initChart()
                 },
 
-                create: function() {
-                    new Chart(
-                        this.$refs.canvas,
-                        {
-                            type: 'line',
-                            data: {
-                                labels: this.labels,
-                                datasets: [{
-                                    data: this.values,
-                                    backgroundColor: getComputedStyle($refs.backgroundColorElement).color,
-                                    borderColor: getComputedStyle($refs.borderColorElement).color,
-                                    borderWidth: 2,
-                                    fill: 'start',
-                                    tension: 0.5,
-                                }],
-                            },
-                            options: {
-                                elements: {
-                                    point: {
-                                        radius: 0,
-                                    },
-                                },
-                                maintainAspectRatio: false,
-                                plugins: {
-                                    legend: {
-                                        display: false,
-                                    },
-                                },
-                                scales: {
-                                    x:  {
-                                        display: false,
-                                    },
-                                    y:  {
-                                        display: false,
-                                    },
-                                },
-                                tooltips: {
-                                    enabled: false,
+                initChart: function () {
+                    return this.chart = new Chart(this.$refs.canvas, {
+                        type: 'line',
+                        data: {
+                            labels: this.labels,
+                            datasets: [{
+                                data: this.values,
+                                backgroundColor: getComputedStyle($refs.backgroundColorElement).color,
+                                borderColor: getComputedStyle($refs.borderColorElement).color,
+                                borderWidth: 2,
+                                fill: 'start',
+                                tension: 0.5,
+                            }],
+                        },
+                        options: {
+                            elements: {
+                                point: {
+                                    radius: 0,
                                 },
                             },
-                        }
-                    )
+                            maintainAspectRatio: false,
+                            plugins: {
+                                legend: {
+                                    display: false,
+                                },
+                            },
+                            scales: {
+                                x:  {
+                                    display: false,
+                                },
+                                y:  {
+                                    display: false,
+                                },
+                            },
+                            tooltips: {
+                                enabled: false,
+                            },
+                        },
+                    })
                 },
 
-                update: function(chart) {
-                    chart.data.labels = this.labels
-                    chart.data.datasets[0].data = this.values
-                    chart.update()
+                updateChart: function () {
+                    this.chart.data.labels = this.labels
+                    this.chart.data.datasets[0].data = this.values
+                    this.chart.update()
                 },
             }"
             class="absolute bottom-0 inset-x-0 rounded-b-2xl overflow-hidden"

--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -66,7 +66,7 @@
                 init() {
                     chart = Chart.getChart(this.$refs.canvas);
 
-                    chart ? this.update(chart) : this.create();
+                    chart ? this.update(chart) : this.create()
                 },
 
                 create: function() {

--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -69,7 +69,7 @@
                     chart ? this.update(chart) : this.create();
                 },
 
-                create() {
+                create: function() {
                     new Chart(
                         this.$refs.canvas,
                         {

--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -64,7 +64,7 @@
                 values: {{ json_encode(array_values($chart)) }},
 
                 init() {
-                    chart = Chart.getChart(this.$refs.canvas);
+                    chart = Chart.getChart(this.$refs.canvas)
 
                     chart ? this.update(chart) : this.create()
                 },

--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -113,7 +113,7 @@
                     )
                 },
 
-                update(chart) {
+                update: function(chart) {
                     chart.data.labels = this.labels
                     chart.data.datasets[0].data = this.values
                     chart.update()

--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -57,56 +57,73 @@
     </div>
 
     @if ($chart)
-        <div class="absolute bottom-0 inset-x-0 rounded-b-2xl overflow-hidden">
-            <canvas
-                x-data="{
-                    chart: null,
+        <div
+            x-title="card-chart"
+            x-data="{
+                labels: {{ json_encode(array_keys($chart)) }},
+                values: {{ json_encode(array_values($chart)) }},
 
-                    init: function () {
-                        chart = new Chart(
-                            $el,
-                            {
-                                type: 'line',
-                                data: {
-                                    labels: {{ json_encode(array_keys($chart)) }},
-                                    datasets: [{
-                                        data: {{ json_encode(array_values($chart)) }},
-                                        backgroundColor: getComputedStyle($refs.backgroundColorElement).color,
-                                        borderColor: getComputedStyle($refs.borderColorElement).color,
-                                        borderWidth: 2,
-                                        fill: 'start',
-                                        tension: 0.5,
-                                    }],
-                                },
-                                options: {
-                                    elements: {
-                                        point: {
-                                            radius: 0,
-                                        },
-                                    },
-                                    maintainAspectRatio: false,
-                                    plugins: {
-                                        legend: {
-                                            display: false,
-                                        },
-                                    },
-                                    scales: {
-                                        x:  {
-                                            display: false,
-                                        },
-                                        y:  {
-                                            display: false,
-                                        },
-                                    },
-                                    tooltips: {
-                                        enabled: false,
+                init() {
+                    chart = Chart.getChart(this.$refs.canvas);
+
+                    chart ? this.update(chart) : this.create();
+                },
+
+                create() {
+                    new Chart(
+                        this.$refs.canvas,
+                        {
+                            type: 'line',
+                            data: {
+                                labels: this.labels,
+                                datasets: [{
+                                    data: this.values,
+                                    backgroundColor: getComputedStyle($refs.backgroundColorElement).color,
+                                    borderColor: getComputedStyle($refs.borderColorElement).color,
+                                    borderWidth: 2,
+                                    fill: 'start',
+                                    tension: 0.5,
+                                }],
+                            },
+                            options: {
+                                elements: {
+                                    point: {
+                                        radius: 0,
                                     },
                                 },
-                            }
-                        )
-                    },
-                }"
+                                maintainAspectRatio: false,
+                                plugins: {
+                                    legend: {
+                                        display: false,
+                                    },
+                                },
+                                scales: {
+                                    x:  {
+                                        display: false,
+                                    },
+                                    y:  {
+                                        display: false,
+                                    },
+                                },
+                                tooltips: {
+                                    enabled: false,
+                                },
+                            },
+                        }
+                    )
+                },
+
+                update(chart) {
+                    chart.data.labels = this.labels
+                    chart.data.datasets[0].data = this.values
+                    chart.update()
+                },
+            }"
+            class="absolute bottom-0 inset-x-0 rounded-b-2xl overflow-hidden"
+        >
+            <canvas
                 wire:ignore
+                x-ref="canvas"
                 class="h-6"
             >
                 <span


### PR DESCRIPTION
So far, the chart in the header or footer widget (BaseWidget) was initialized on page load and changing data did not refreshed it.

This change makes it possible. Solves: #2161 and #2552

Be merciful, this is my first PR ever =).