### PR TITLE
fix date null

### DIFF
--- a/packages/forms/resources/js/components/date-time-picker.js
+++ b/packages/forms/resources/js/components/date-time-picker.js
@@ -217,15 +217,12 @@ export default (Alpine) => {
                         return
                     }
 
-                    let date = this.getSelectedDate() ?? dayjs().tz(timezone)
-                        .hour(0)
-                        .minute(0)
-                        .second(0)
+                    let date = this.getSelectedDate()
 
-                    if (this.getMaxDate() !== null && date.isAfter(this.getMaxDate())) {
+                    if (this.getMaxDate() !== null && date?.isAfter(this.getMaxDate())) {
                         date = null
                     }
-                    if (this.getMinDate() !== null && date.isBefore(this.getMinDate())) {
+                    if (this.getMinDate() !== null && date?.isBefore(this.getMinDate())) {
                         date = null
                     }
 

--- a/packages/forms/resources/js/components/date-time-picker.js
+++ b/packages/forms/resources/js/components/date-time-picker.js
@@ -217,7 +217,10 @@ export default (Alpine) => {
                         return
                     }
 
-                    let date = this.getSelectedDate()
+                    let date = this.getSelectedDate() ?? dayjs().tz(timezone)
+                        .hour(0)
+                        .minute(0)
+                        .second(0)
 
                     if (this.getMaxDate() !== null && date.isAfter(this.getMaxDate())) {
                         date = null


### PR DESCRIPTION
console error 
`module.esm.js:12010 
        
       Uncaught TypeError: Cannot read properties of null (reading 'isBefore')
    at module.esm.js:12010:51
    at module.esm.js:2153:9
` 

to replicate
```php
Forms\Components\DatePicker::make('start_date')
                    ->label('Start date')
                    ->minDate(Carbon::now()->addDay())
                    ->afterStateUpdated(fn ($set) => $set('end_date', null))
                    ->reactive()
                    ->required(),
                Forms\Components\DatePicker::make('end_date')
                    ->label('End date')
                    ->minDate(fn ($get) => filled($get('start_date')) ? $get('start_date') : Carbon::now()->addDay())
                    ->reactive()
                    ->required(),
```

set end date first then set start date on screen