### PR TITLE
fix(admin): remove duplicate display properties and use flex

### DIFF
--- a/packages/admin/resources/views/components/layouts/app.blade.php
+++ b/packages/admin/resources/views/components/layouts/app.blade.php
@@ -18,7 +18,7 @@
         @if (config('filament.layout.sidebar.is_collapsible_on_desktop'))
             <div
                 x-data="{}"
-                class="transition-all w-screen space-y-6 flex-1 flex-col filament-main lg:pl-80 rtl:lg:pl-0 rtl:lg:pr-80"
+                class="hidden transition-all w-screen space-y-6 flex-1 flex-col filament-main lg:pl-80 rtl:lg:pl-0 rtl:lg:pr-80"
                 x-bind:class.="{
                     '!flex': true, // Prevent flash, x-cloak not working with charts
                     'lg:pl-[5.4rem] rtl:lg:pr-[5.4rem]': ! $store.sidebar.isOpen

--- a/packages/admin/resources/views/components/layouts/app.blade.php
+++ b/packages/admin/resources/views/components/layouts/app.blade.php
@@ -18,9 +18,9 @@
         @if (config('filament.layout.sidebar.is_collapsible_on_desktop'))
             <div
                 x-data="{}"
-                class="hidden transition-all w-screen space-y-6 flex-1 flex flex-col filament-main lg:pl-80 rtl:lg:pl-0 rtl:lg:pr-80"
+                class="transition-all w-screen space-y-6 flex-1 flex-col filament-main lg:pl-80 rtl:lg:pl-0 rtl:lg:pr-80"
                 x-bind:class.="{
-                    '!block': true, // Prevent flash, x-cloak not working with charts
+                    '!flex': true, // Prevent flash, x-cloak not working with charts
                     'lg:pl-[5.4rem] rtl:lg:pr-[5.4rem]': ! $store.sidebar.isOpen
                 }"
             >


### PR DESCRIPTION
This PR fixes an issue on the `app.blade.php` layout.
Two different CSS display properties were applied with `hidden` and `flex`. This was ambiguous.

Also, the custom `x-cloak` behaviour was implemented using `!block` instead of `!flex`.
Using `!flex` here allows to make custom pages's root element full height using `h-full`.