### PR TITLE
Feature: Disable URL on table column

### DIFF
--- a/packages/tables/docs/03-columns.md
+++ b/packages/tables/docs/03-columns.md
@@ -153,15 +153,6 @@ TextColumn::make('title')
     ->openUrlInNewTab()
 ```
 
-Alternatively, you can also disable URL entirely:
-
-```php
-use Filament\Tables\Columns\TextColumn;
-
-TextColumn::make('title')
-    ->disableUrl()
-```
-
 ### Setting a default value
 
 To set a default value for fields with a `null` state, you may use the `default()` method:

--- a/packages/tables/docs/03-columns.md
+++ b/packages/tables/docs/03-columns.md
@@ -159,7 +159,7 @@ Alternatively, you can also disable URL entirely:
 use Filament\Tables\Columns\TextColumn;
 
 TextColumn::make('title')
-    ->disableUrl()
+    ->disableClick()
 ```
 
 ### Setting a default value

--- a/packages/tables/docs/03-columns.md
+++ b/packages/tables/docs/03-columns.md
@@ -153,6 +153,15 @@ TextColumn::make('title')
     ->openUrlInNewTab()
 ```
 
+Alternatively, you can also disable URL entirely:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('title')
+    ->disableUrl()
+```
+
 ### Setting a default value
 
 To set a default value for fields with a `null` state, you may use the `default()` method:
@@ -351,11 +360,11 @@ TextColumn::make('description')
     ->limit(50)
     ->tooltip(function (TextColumn $column): ?string {
         $state = $column->getState();
-    
+
         if (strlen($state) <= $column->getLimit()) {
             return null;
         }
-        
+
         // Only render the tooltip if the column contents exceeds the length limit.
         return $state;
     })

--- a/packages/tables/resources/views/components/cell.blade.php
+++ b/packages/tables/resources/views/components/cell.blade.php
@@ -26,7 +26,7 @@
         x-tooltip.raw="{{ $tooltip }}"
     @endif
 >
-    @if ($action || ((is_null($url)) && $recordAction))
+    @if ($action || ($recordAction && $url === null))
         <button
             wire:click="{{ $action ? "callTableColumnAction('{$name}', " : "{$recordAction}(" }}'{{ $this->getTableRecordKey($record) }}')"
             wire:target="{{ $action ? "callTableColumnAction('{$name}', " : "{$recordAction}(" }}'{{ $this->getTableRecordKey($record) }}')"
@@ -37,7 +37,7 @@
         >
             {{ $slot }}
         </button>
-    @elseif ($url || (is_null($url) && $recordUrl))
+    @elseif ($url || ($recordUrl && $url === null))
         <a
             href="{{ $url ?: $recordUrl }}"
             {{ $shouldOpenUrlInNewTab ? 'target="_blank"' : null }}

--- a/packages/tables/resources/views/components/cell.blade.php
+++ b/packages/tables/resources/views/components/cell.blade.php
@@ -1,6 +1,7 @@
 @props([
     'action' => null,
     'alignment' => null,
+    'isClickDisabled' => false,
     'name',
     'record',
     'recordAction' => null,
@@ -26,7 +27,9 @@
         x-tooltip.raw="{{ $tooltip }}"
     @endif
 >
-    @if ($action || ((is_null($url)) && $recordAction))
+    @if ($isClickDisabled)
+        {{ $slot }}
+    @elseif ($action || ((! $url) && $recordAction))
         <button
             wire:click="{{ $action ? "callTableColumnAction('{$name}', " : "{$recordAction}(" }}'{{ $this->getTableRecordKey($record) }}')"
             wire:target="{{ $action ? "callTableColumnAction('{$name}', " : "{$recordAction}(" }}'{{ $this->getTableRecordKey($record) }}')"
@@ -37,7 +40,7 @@
         >
             {{ $slot }}
         </button>
-    @elseif ($url || (is_null($url) && $recordUrl))
+    @elseif ($url || $recordUrl)
         <a
             href="{{ $url ?: $recordUrl }}"
             {{ $shouldOpenUrlInNewTab ? 'target="_blank"' : null }}

--- a/packages/tables/resources/views/components/cell.blade.php
+++ b/packages/tables/resources/views/components/cell.blade.php
@@ -26,7 +26,7 @@
         x-tooltip.raw="{{ $tooltip }}"
     @endif
 >
-    @if ($action || ((! $url) && $recordAction))
+    @if ($action || ((is_null($url)) && $recordAction))
         <button
             wire:click="{{ $action ? "callTableColumnAction('{$name}', " : "{$recordAction}(" }}'{{ $this->getTableRecordKey($record) }}')"
             wire:target="{{ $action ? "callTableColumnAction('{$name}', " : "{$recordAction}(" }}'{{ $this->getTableRecordKey($record) }}')"
@@ -37,7 +37,7 @@
         >
             {{ $slot }}
         </button>
-    @elseif ($url || $recordUrl)
+    @elseif ($url || (is_null($url) && $recordUrl))
         <a
             href="{{ $url ?: $recordUrl }}"
             {{ $shouldOpenUrlInNewTab ? 'target="_blank"' : null }}

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -399,6 +399,7 @@
                                         :record-url="$recordUrl"
                                         :should-open-url-in-new-tab="$column->shouldOpenUrlInNewTab()"
                                         :url="$column->getUrl()"
+                                        :is-click-disabled="$column->isClickDisabled()"
                                         :class="$getHiddenClasses($column)"
                                         wire:loading.remove.delay
                                         wire:target="{{ implode(',', \Filament\Tables\Table::LOADING_TARGETS) }}"

--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -10,6 +10,7 @@ class Column extends ViewComponent
 {
     use Concerns\BelongsToTable;
     use Concerns\CanAggregateRelatedModels;
+    use Concerns\CanBeDisabled;
     use Concerns\CanBeHidden;
     use Concerns\CanBeSearchable;
     use Concerns\CanBeSortable;

--- a/packages/tables/src/Columns/Concerns/CanBeDisabled.php
+++ b/packages/tables/src/Columns/Concerns/CanBeDisabled.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Filament\Tables\Columns\Concerns;
+
+use Closure;
+
+trait CanBeDisabled
+{
+    protected bool | Closure $isClickDisabled = false;
+
+    public function disableClick(bool | Closure $condition = true): static
+    {
+        $this->isClickDisabled = $condition;
+
+        return $this;
+    }
+
+    public function isClickDisabled(): bool
+    {
+        return $this->evaluate($this->isClickDisabled);
+    }
+}

--- a/packages/tables/src/Columns/Concerns/CanOpenUrl.php
+++ b/packages/tables/src/Columns/Concerns/CanOpenUrl.php
@@ -8,7 +8,7 @@ trait CanOpenUrl
 {
     protected bool | Closure $shouldOpenUrlInNewTab = false;
 
-    protected string | Closure | false | null $url = null;
+    protected string | Closure | null $url = null;
 
     public function openUrlInNewTab(bool | Closure $condition = true): static
     {
@@ -17,17 +17,10 @@ trait CanOpenUrl
         return $this;
     }
 
-    public function url(string | Closure | false | null $url, bool | Closure $shouldOpenInNewTab = false): static
+    public function url(string | Closure | null $url, bool | Closure $shouldOpenInNewTab = false): static
     {
         $this->openUrlInNewTab($shouldOpenInNewTab);
         $this->url = $url;
-
-        return $this;
-    }
-
-    public function disableUrl(): static
-    {
-        $this->url = false;
 
         return $this;
     }

--- a/packages/tables/src/Columns/Concerns/CanOpenUrl.php
+++ b/packages/tables/src/Columns/Concerns/CanOpenUrl.php
@@ -8,7 +8,7 @@ trait CanOpenUrl
 {
     protected bool | Closure $shouldOpenUrlInNewTab = false;
 
-    protected string | Closure | null $url = null;
+    protected string | Closure | false | null $url = null;
 
     public function openUrlInNewTab(bool | Closure $condition = true): static
     {

--- a/packages/tables/src/Columns/Concerns/CanOpenUrl.php
+++ b/packages/tables/src/Columns/Concerns/CanOpenUrl.php
@@ -17,10 +17,17 @@ trait CanOpenUrl
         return $this;
     }
 
-    public function url(string | Closure | null $url, bool | Closure $shouldOpenInNewTab = false): static
+    public function url(string | Closure | false | null $url, bool | Closure $shouldOpenInNewTab = false): static
     {
         $this->openUrlInNewTab($shouldOpenInNewTab);
         $this->url = $url;
+
+        return $this;
+    }
+
+    public function disableUrl(): static
+    {
+        $this->url = false;
 
         return $this;
     }


### PR DESCRIPTION
This is reopen of this: https://github.com/laravel-filament/filament/pull/2742 as I messed up with commits and couldn`t put it in order. Now things are cleaned up.

Sometimes it could be usefull if column doesn`t link to anything, eg: if you want to copy it or attach own action:

```php
TextColumn::make('is_paid')
    ->disableUrl()
    ->extraAttributes(function (Invoice $record) {
        return [
            'wire:click' => 'mountTableAction("settle", ' . $record->getKey() . ')',
            'class' => 'cursor-pointer',
        ];
    })
```

This change allows to do it 2 ways by: `url(false)` or `disableUrl()`. However only the second method is documented as I think it is more transparent.