### PR TITLE
Fix Spatie translatable plugin getRecordTitle() error

### DIFF
--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/Concerns/HasActiveFormLocaleSwitcher.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/Concerns/HasActiveFormLocaleSwitcher.php
@@ -26,7 +26,7 @@ trait HasActiveFormLocaleSwitcher
         $this->activeFormLocale = $this->activeLocale;
     }
 
-    protected function getRecordTitle(): ?string
+    public function getRecordTitle(): string
     {
         if ($this->activeFormLocale) {
             $this->record->setLocale($this->activeFormLocale);


### PR DESCRIPTION
Declaration of Filament\Resources\Pages\EditRecord\Concerns\Translatable::getRecordTitle(): **?string** must be compatible with Filament\Resources\Pages\EditRecord::getRecordTitle(): **string**


  Access level to Filament\Resources\Pages\EditRecord\Concerns\Translatable::getRecordTitle() **must be public** (as in class Filament\Resources\Pages\EditRecord)

