### PR TITLE
feat: add the possibility to configure namespace for make page command

### DIFF
--- a/packages/admin/src/Commands/Concerns/CanTransposeStringPath.php
+++ b/packages/admin/src/Commands/Concerns/CanTransposeStringPath.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Filament\Commands\Concerns;
+
+use Illuminate\Support\Str;
+
+trait CanTransposeStringPath
+{
+    protected function changeForwardSlashToBackSlashes(string $value): string
+    {
+        return (string)Str::of($value)
+            ->trim('/')
+            ->trim('\\')
+            ->trim(' ')
+            ->replace('/', '\\')
+            ->append('\\');
+    }
+}

--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -156,11 +156,11 @@ class FilamentServiceProvider extends PackageServiceProvider
 
         Filament::registerPages(config('filament.pages.register', []));
 
-        if (! $filesystem->exists(config('filament.pages.path'))) {
+        if (! $filesystem->exists(app_path(config('filament.pages.path')))) {
             return;
         }
 
-        Filament::registerPages(collect($filesystem->allFiles(config('filament.pages.path')))
+        Filament::registerPages(collect($filesystem->allFiles(app_path(config('filament.pages.path'))))
             ->map(function (SplFileInfo $file): string {
                 return (string) Str::of(config('filament.pages.namespace'))
                     ->append('\\', $file->getRelativePathname())
@@ -176,7 +176,7 @@ class FilamentServiceProvider extends PackageServiceProvider
 
         Filament::registerResources(config('filament.resources.register', []));
 
-        if (! $filesystem->exists(config('filament.resources.path'))) {
+        if (! $filesystem->exists(app_path(config('filament.resources.path')))) {
             return;
         }
 


### PR DESCRIPTION
BREAKING CHANGE: Change configuration file :
  pages->path becomes string instead app_path()
  resources->path becomes string instead app_path()
  possibility to use a ```$JOKER$``` for resources->path and namespace
  e.g :
```php
  resources' => [
          'namespace' => 'App\\Filament\\$RESOURCE$\\Resources',
          'path' => 'Filament/Resources/$RESOURCE$/Pages',
          'register' => [],
      ],
```
resolve #2494 