### PR TITLE
Allow mutate view record data before fill form

### DIFF
--- a/packages/admin/src/Resources/Pages/ViewRecord.php
+++ b/packages/admin/src/Resources/Pages/ViewRecord.php
@@ -49,9 +49,18 @@ class ViewRecord extends Page
     {
         $this->callHook('beforeFill');
 
-        $this->form->fill($this->getRecord()->toArray());
+        $data = $this->getRecord()->toArray();
+
+        $data = $this->mutateFormDataBeforeFill($data);
+
+        $this->form->fill($data);
 
         $this->callHook('afterFill');
+    }
+
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        return $data;
     }
 
     protected function getActions(): array


### PR DESCRIPTION
Apparently, the method to [customize the data before filling the form in view record](https://filamentphp.com/docs/2.x/admin/resources/viewing-records#customizing-data-before-filling-the-form) is not implemented yet. 

This pull request will fix that.
