### PR TITLE
fix error with BulkActions

### DIFF
--- a/packages/tables/src/Actions/BulkAction.php
+++ b/packages/tables/src/Actions/BulkAction.php
@@ -60,7 +60,7 @@ class BulkAction extends BaseAction
         return array_merge(parent::getDefaultEvaluationParameters(), [
             'records' => $this->resolveEvaluationParameter(
                 'records',
-                fn (): Collection => $this->getRecords(),
+                fn (): ?Collection => $this->getRecords(),
             ),
         ]);
     }


### PR DESCRIPTION
fix for error #2791
```
 Filament\Tables\Actions\BulkAction::Filament\Tables\Actions\{closure}(): Return value must be of type Illuminate\Database\Eloquent\Collection, null returned
```

returning value from https://github.com/laravel-filament/filament/blob/a79660175a204d1188ccca59446f5fc8ce21a11a/packages/tables/src/Actions/Concerns/InteractsWithRecords.php#L64 can be null