### PR TITLE
Add page default actions

### DIFF
--- a/packages/admin/docs/03-pages/02-actions.md
+++ b/packages/admin/docs/03-pages/02-actions.md
@@ -195,3 +195,32 @@ Action::make('save')
     ->action(fn () => $this->save())
     ->keyBindings(['command+s', 'ctrl+s'])
 ```
+
+## Default actions
+
+You may add default actions to every page by calling the `Page::defaultActions()` method inside the `FilamentServing` event. 
+
+```php
+use Filament\Pages\Page;
+
+Page::defaultActions([
+    Action::make('back')
+        ->url(fn (): string => Url::previous())
+]);
+```
+
+Paired with the `visible()` and `hidden()` methods, this makes for a very powerful tool:
+
+```php
+use Livewire\Component;
+use Filament\Pages\Page;
+use Filament\Resources\Pages\ListRecords;
+
+Page::defaultActions([
+    Action::make('back')
+        ->url(fn (): string => Url::previous())
+        ->hidden(fn(Component $livewire) => $livewire instanceof ListRecords || Url::previous() === Url::current())
+]);
+```
+
+If you want to reliably get the previous URL in a Livewire application such as Filament, you can use the [ralphjsmit/livewire-urls](https://github.com/ralphjsmit/livewire-urls) package.

--- a/packages/admin/src/Pages/Concerns/HasActions.php
+++ b/packages/admin/src/Pages/Concerns/HasActions.php
@@ -23,6 +23,8 @@ trait HasActions
 
     protected ?array $cachedActions = null;
 
+    protected static array $defaultActions = [];
+
     public function callMountedAction(?string $arguments = null)
     {
         $action = $this->getMountedAction();
@@ -226,6 +228,16 @@ trait HasActions
 
     protected function getActions(): array
     {
-        return [];
+        return static::getDefaultActions();
+    }
+
+    public static function defaultActions(array $actions = []): void
+    {
+        static::$defaultActions = $actions;
+    }
+
+    public static function getDefaultActions(): array
+    {
+        return static::$defaultActions;
     }
 }

--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -144,7 +144,7 @@ class Page extends Component implements Forms\Contracts\HasForms, RendersFormCom
 
     protected function getActions(): array
     {
-        return [];
+        return static::getDefaultActions();
     }
 
     protected function getFooter(): ?View

--- a/packages/admin/src/Resources/Pages/CreateRecord.php
+++ b/packages/admin/src/Resources/Pages/CreateRecord.php
@@ -112,6 +112,11 @@ class CreateRecord extends Page implements HasFormActions
         );
     }
 
+    protected function getActions(): array
+    {
+        return static::getDefaultActions();
+    }
+
     protected function getCreateFormAction(): Action
     {
         return Action::make('create')

--- a/packages/admin/src/Resources/Pages/EditRecord.php
+++ b/packages/admin/src/Resources/Pages/EditRecord.php
@@ -152,8 +152,8 @@ class EditRecord extends Page implements HasFormActions
 
         return array_merge(
             static::getDefaultActions(),
-            ( ( $resource::hasPage('view') && $resource::canView($this->getRecord()) ) ? [$this->getViewAction()] : [] ),
-            ( $resource::canDelete($this->getRecord()) ? [$this->getDeleteAction()] : [] ),
+            (($resource::hasPage('view') && $resource::canView($this->getRecord())) ? [$this->getViewAction()] : []),
+            ($resource::canDelete($this->getRecord()) ? [$this->getDeleteAction()] : []),
         );
     }
 

--- a/packages/admin/src/Resources/Pages/EditRecord.php
+++ b/packages/admin/src/Resources/Pages/EditRecord.php
@@ -151,8 +151,9 @@ class EditRecord extends Page implements HasFormActions
         $resource = static::getResource();
 
         return array_merge(
-            (($resource::hasPage('view') && $resource::canView($this->getRecord())) ? [$this->getViewAction()] : []),
-            ($resource::canDelete($this->getRecord()) ? [$this->getDeleteAction()] : []),
+            static::getDefaultActions(),
+            ( ( $resource::hasPage('view') && $resource::canView($this->getRecord()) ) ? [$this->getViewAction()] : [] ),
+            ( $resource::canDelete($this->getRecord()) ? [$this->getDeleteAction()] : [] ),
         );
     }
 

--- a/packages/admin/src/Resources/Pages/ListRecords.php
+++ b/packages/admin/src/Resources/Pages/ListRecords.php
@@ -158,10 +158,10 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
     protected function getActions(): array
     {
         if (! $this->hasCreateAction()) {
-            return [];
+            return static::getDefaultActions();
         }
 
-        return [$this->getCreateAction()];
+        return array_merge(static::getDefaultActions(), [$this->getCreateAction()]);
     }
 
     /**

--- a/packages/admin/src/Resources/Pages/ViewRecord.php
+++ b/packages/admin/src/Resources/Pages/ViewRecord.php
@@ -59,14 +59,14 @@ class ViewRecord extends Page
         $resource = static::getResource();
 
         if (! $resource::hasPage('edit')) {
-            return [];
+            return static::getDefaultActions();
         }
 
         if (! $resource::canEdit($this->getRecord())) {
-            return [];
+            return static::getDefaultActions();
         }
 
-        return [$this->getEditAction()];
+        return array_merge(static::getDefaultActions(), [$this->getEditAction()]);
     }
 
     protected function configureAction(Action $action): void

--- a/tests/src/Admin/Pages/PageTest.php
+++ b/tests/src/Admin/Pages/PageTest.php
@@ -3,7 +3,6 @@
 use Filament\Pages\Actions\Action;
 use Filament\Tests\Admin\Fixtures\Pages\Settings;
 use Filament\Tests\Admin\Pages\TestCase;
-use Livewire\Livewire;
 
 use function Livewire\invade;
 
@@ -20,7 +19,7 @@ it('can generate a slug based on the page name', function () {
 
 it('can have default page actions', function () {
     Settings::defaultActions($actions = [
-        Action::make('test')
+        Action::make('test'),
     ]);
 
     expect(Settings::getDefaultActions())

--- a/tests/src/Admin/Pages/PageTest.php
+++ b/tests/src/Admin/Pages/PageTest.php
@@ -1,7 +1,11 @@
 <?php
 
+use Filament\Pages\Actions\Action;
 use Filament\Tests\Admin\Fixtures\Pages\Settings;
 use Filament\Tests\Admin\Pages\TestCase;
+use Livewire\Livewire;
+
+use function Livewire\invade;
 
 uses(TestCase::class);
 
@@ -12,4 +16,16 @@ it('can render page', function () {
 it('can generate a slug based on the page name', function () {
     expect(Settings::getSlug())
         ->toBe('settings');
+});
+
+it('can have default page actions', function () {
+    Settings::defaultActions($actions = [
+        Action::make('test')
+    ]);
+
+    expect(Settings::getDefaultActions())
+        ->toBe($actions);
+
+    expect(invade(app(Settings::class))->getActions())
+        ->toBe($actions);
 });


### PR DESCRIPTION
This PR allows to add a default set of page actions to every page. I used it to add a back-button to every page in the application (some clients...😆).

```php
Page::defaultActions([
    Action::make('back')
        ->url(fn (): string => Url::previous())
        ->hidden(fn(Component $livewire) => $livewire instanceof ListRecords || Url::previous() === Url::current())
]);
```

PS: the sentence about the Livewire URLs package is totally optional, but I at least wanted to mention it in the PR for people who try to use the normal URL facade. Feel free to remove.