### PR TITLE
fix: add modal trigger slot to captureSlots

### DIFF
--- a/packages/admin/resources/views/components/modal/index.blade.php
+++ b/packages/admin/resources/views/components/modal/index.blade.php
@@ -5,6 +5,7 @@
     'header',
     'heading',
     'subheading',
+    'trigger',
 ])
 
 <x-filament-support::modal

--- a/packages/forms/resources/views/components/modal/index.blade.php
+++ b/packages/forms/resources/views/components/modal/index.blade.php
@@ -5,6 +5,7 @@
     'header',
     'heading',
     'subheading',
+    'trigger',
 ])
 
 <x-filament-support::modal

--- a/packages/support/resources/lang/fa/actions/create.php
+++ b/packages/support/resources/lang/fa/actions/create.php
@@ -4,7 +4,7 @@ return [
 
     'single' => [
 
-        'label' => 'ساختن',
+        'label' => 'ساختن :label',
 
         'modal' => [
 

--- a/packages/support/resources/lang/fa/actions/dissociate.php
+++ b/packages/support/resources/lang/fa/actions/dissociate.php
@@ -32,7 +32,7 @@ return [
 
         'modal' => [
 
-            'heading' => 'جداکردن انتخاب شده :label',
+            'heading' => 'جداکردن :label انتخاب شده',
 
             'actions' => [
 

--- a/packages/support/resources/lang/fa/actions/force-delete.php
+++ b/packages/support/resources/lang/fa/actions/force-delete.php
@@ -32,7 +32,7 @@ return [
 
         'modal' => [
 
-            'heading' => 'حذف دائمی انتخاب شده :label',
+            'heading' => 'حذف دائمی :label انتخاب شده',
 
             'actions' => [
 

--- a/packages/support/resources/lang/fa/actions/restore.php
+++ b/packages/support/resources/lang/fa/actions/restore.php
@@ -32,7 +32,7 @@ return [
 
         'modal' => [
 
-            'heading' => 'بازگردانی انتخاب شده :label',
+            'heading' => 'بازگردانی :label انتخاب شده',
 
             'actions' => [
 
@@ -45,7 +45,7 @@ return [
         ],
 
         'messages' => [
-            'restored' => 'رکورد ها بازگردانی شدند',
+            'restored' => 'رکوردها بازگردانی شدند',
         ],
 
     ],

--- a/packages/tables/resources/views/components/modal/index.blade.php
+++ b/packages/tables/resources/views/components/modal/index.blade.php
@@ -5,6 +5,7 @@
     'header',
     'heading',
     'subheading',
+    'trigger',
 ])
 
 <x-filament-support::modal


### PR DESCRIPTION
Add `trigger` to captureSlots of each modal index in admin, forms and tables packages

this fix capture the trigger slot of main modal from support to all packages modal 