### PR TITLE
Add id column

### DIFF
--- a/packages/tables/src/Columns/IdColumn.php
+++ b/packages/tables/src/Columns/IdColumn.php
@@ -20,8 +20,6 @@ class IdColumn extends TextColumn
             $this->label('ID');
         }
 
-        $this->searchable();
-
         $this->sortable();
 
         $this->url(function (Model $record): ?string {

--- a/packages/tables/src/Columns/IdColumn.php
+++ b/packages/tables/src/Columns/IdColumn.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Filament\Tables\Columns;
+
+use Filament\Facades\Filament;
+use Illuminate\Database\Eloquent\Model;
+
+class IdColumn extends TextColumn
+{
+    public static function make(string $name = 'id'): static
+    {
+        return parent::make($name);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->getName() === 'id') {
+            $this->label('ID');
+        }
+
+        $this->searchable();
+
+        $this->sortable();
+
+        $this->url(function (Model $record): ?string {
+            $resource = Filament::getModelResource($record);
+
+            if ($resource === null) {
+                return null;
+            }
+
+            if ($resource::hasPage('view') && $resource::canView($record)) {
+                return $resource::getUrl('view', ['record' => $record]);
+            }
+
+            if ($resource::hasPage('edit') && $resource::canEdit($record)) {
+                return $resource::getUrl('edit', ['record' => $record]);
+            }
+
+            return null;
+        });
+    }
+}


### PR DESCRIPTION
Often I need a column for the id of a model. Essentially it's just a text column, but with a few defaults:

- `id` as name
- `ID` as label
- Searchable; not too sure about this one, but personally I always want to be able to find models by their id
- Sortable
- Link to the resource view or edit page when available

I've talked to @dododedodonl, another Filament user, about this field and he was about to PR something similar. We've both been using a field like this for some time and would love to see it in the Filament core. So let me know what you think!