### PR TITLE
Use qualified key name for BelongsToMany relationship

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -148,8 +148,8 @@ trait CanBeValidated
                 ->when(
                     $ignorable,
                     fn (Unique $rule) => $rule->ignore(
-                        $ignorable->getOriginal($ignorable->getKeyName()),
-                        $ignorable->getKeyName(),
+                        $ignorable->getOriginal($ignorable->getQualifiedKeyName()),
+                        $ignorable->getQualifiedKeyName(),
                     ),
                 );
 

--- a/packages/tables/src/Concerns/CanSelectRecords.php
+++ b/packages/tables/src/Concerns/CanSelectRecords.php
@@ -35,7 +35,7 @@ trait CanSelectRecords
     public function getSelectedTableRecords(): Collection
     {
         if (! ($this instanceof HasRelationshipTable && $this->getRelationship() instanceof BelongsToMany && $this->allowsDuplicates())) {
-            $query = $this->getTableQuery()->whereIn(app($this->getTableModel())->getKeyName(), $this->selectedTableRecords);
+            $query = $this->getTableQuery()->whereIn(app($this->getTableModel())->getQualifiedKeyName(), $this->selectedTableRecords);
             $this->applySortingToTableQuery($query);
 
             return $query->get();

--- a/packages/tables/src/Concerns/CanSelectRecords.php
+++ b/packages/tables/src/Concerns/CanSelectRecords.php
@@ -20,7 +20,7 @@ trait CanSelectRecords
     {
         $query = $this->getFilteredTableQuery();
 
-        return $query->pluck($query->getModel()->getKeyName())->toArray();
+        return $query->pluck($query->getModel()->getQualifiedKeyName())->toArray();
     }
 
     public function getAllTableRecordsCount(): int
@@ -45,7 +45,7 @@ trait CanSelectRecords
         $relationship = $this->getRelationship();
 
         $pivotClass = $relationship->getPivotClass();
-        $pivotKeyName = app($pivotClass)->getKeyName();
+        $pivotKeyName = app($pivotClass)->getQualifiedKeyName();
 
         return $this->selectPivotDataInQuery(
             $relationship->wherePivotIn($pivotKeyName, $this->selectedTableRecords),

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -65,7 +65,7 @@ trait HasRecords
         $relationship = $this->getRelationship();
 
         $pivotClass = $relationship->getPivotClass();
-        $pivotKeyName = app($pivotClass)->getKeyName();
+        $pivotKeyName = app($pivotClass)->getQualifiedKeyName();
 
         $query = $this->allowsDuplicates() ?
             $relationship->wherePivot($pivotKeyName, $key) :
@@ -91,7 +91,7 @@ trait HasRecords
         $relationship = $this->getRelationship();
 
         $pivotClass = $relationship->getPivotClass();
-        $pivotKeyName = app($pivotClass)->getKeyName();
+        $pivotKeyName = app($pivotClass)->getQualifiedKeyName();
 
         return $record->getAttributeValue($pivotKeyName);
     }


### PR DESCRIPTION
I have an "ambiguous id" error (https://flareapp.io/share/DPygnXg5#F70) with BelongsToMany relationship that I cannot replicate inside the demo. But using the fully qualified key name instead of the key name fixes the issue. I only changed this on line but I guess we could use `getQualifiedKeyName()` instead of `getKeyName()` everywhere?
