### PR TITLE
Feature: limit on Tables\TagsColumn

### DIFF
--- a/packages/tables/resources/lang/en/table.php
+++ b/packages/tables/resources/lang/en/table.php
@@ -10,7 +10,7 @@ return [
         ],
 
         'tags' => [
-            'more_results' => 'and %d more',
+            'more_results' => 'and :count more',
         ],
 
     ],

--- a/packages/tables/resources/lang/en/table.php
+++ b/packages/tables/resources/lang/en/table.php
@@ -2,15 +2,19 @@
 
 return [
 
+    'columns' => [
+
+        'tags' => [
+            'more' => 'and :count more',
+        ],
+
+    ],
+
     'fields' => [
 
         'search_query' => [
             'label' => 'Search',
             'placeholder' => 'Search',
-        ],
-
-        'tags' => [
-            'more_results' => 'and :count more',
         ],
 
     ],

--- a/packages/tables/resources/lang/en/table.php
+++ b/packages/tables/resources/lang/en/table.php
@@ -9,6 +9,10 @@ return [
             'placeholder' => 'Search',
         ],
 
+        'tags' => [
+            'more_results' => 'and %d more',
+        ],
+
     ],
 
     'pagination' => [

--- a/packages/tables/resources/lang/it/table.php
+++ b/packages/tables/resources/lang/it/table.php
@@ -10,7 +10,7 @@ return [
         ],
 
         'tags' => [
-            'more_results' => 'e altri %d',
+            'more_results' => 'e altri :count',
         ],
 
     ],

--- a/packages/tables/resources/lang/it/table.php
+++ b/packages/tables/resources/lang/it/table.php
@@ -9,6 +9,10 @@ return [
             'placeholder' => 'Cerca',
         ],
 
+        'tags' => [
+            'more_results' => 'e altri %d',
+        ],
+
     ],
 
     'pagination' => [

--- a/packages/tables/resources/lang/it/table.php
+++ b/packages/tables/resources/lang/it/table.php
@@ -2,15 +2,19 @@
 
 return [
 
+    'columns' => [
+
+        'tags' => [
+            'more' => 'e altri :count',
+        ],
+
+    ],
+
     'fields' => [
 
         'search_query' => [
             'label' => 'Cerca',
             'placeholder' => 'Cerca',
-        ],
-
-        'tags' => [
-            'more_results' => 'e altri :count',
         ],
 
     ],

--- a/packages/tables/resources/views/columns/tags-column.blade.php
+++ b/packages/tables/resources/views/columns/tags-column.blade.php
@@ -20,7 +20,9 @@
         </span>
     @endforeach
 
-    @if ($getMoreLabel())
-        <span class="text-xs ml-1">{{ $getMoreLabel() }}</span>
+    @if ($hasActiveLimit())
+        <span class="text-xs ml-1">
+            {{ trans_choice('tables::table.columns.tags.more', count($getTags()) - $getLimit()) }}
+        </span>
     @endif
 </div>

--- a/packages/tables/resources/views/columns/tags-column.blade.php
+++ b/packages/tables/resources/views/columns/tags-column.blade.php
@@ -3,7 +3,7 @@
 @endphp
 
 <div {{ $attributes->merge($getExtraAttributes())->class([
-    'px-4 py-3 flex flex-wrap gap-1 filament-tables-tags-column',
+    'px-4 py-3 flex flex-wrap items-center gap-1 filament-tables-tags-column',
     match ($getAlignment()) {
         'left' => 'justify-start',
         'center' => 'justify-center',
@@ -11,7 +11,7 @@
         default => null,
     },
 ]) }}>
-    @foreach ($getTags() as $tag)
+    @foreach (array_slice($getTags(), 0, $getLimit()) as $tag)
         <span @class([
             'inline-flex items-center justify-center min-h-6 px-2 py-0.5 text-sm font-medium tracking-tight rounded-xl text-primary-700 bg-primary-500/10 whitespace-normal',
             'dark:text-primary-500' => config('tables.dark_mode'),
@@ -19,4 +19,8 @@
             {{ $tag }}
         </span>
     @endforeach
+
+    @if ($getMoreLabel())
+        <span class="text-xs ml-1">{{ $getMoreLabel() }}</span>
+    @endif
 </div>

--- a/packages/tables/src/Columns/TagsColumn.php
+++ b/packages/tables/src/Columns/TagsColumn.php
@@ -10,6 +10,8 @@ class TagsColumn extends Column
 
     protected string | Closure | null $separator = null;
 
+    protected ?int $limit = null;
+
     public function getTags(): array
     {
         $tags = $this->getState();
@@ -38,8 +40,42 @@ class TagsColumn extends Column
         return $this;
     }
 
+    public function limit(int $limit): static
+    {
+        $this->limit = $limit;
+
+        return $this;
+    }
+
     public function getSeparator(): ?string
     {
         return $this->evaluate($this->separator);
+    }
+
+    public function getLimit(): ?int
+    {
+        return $this->limit;
+    }
+
+    public function hasMoreTags(): bool
+    {
+        return $this->limit && count($this->getTags()) > $this->limit;
+    }
+
+    public function getMoreTags(): array
+    {
+        return array_slice($this->getTags(), $this->limit);
+    }
+
+    public function getMoreLabel(): ?string
+    {
+        if (! $this->hasMoreTags()) {
+            return null;
+        }
+
+        return sprintf(
+            __('tables::table.fields.tags.more_results'),
+            count($this->getTags()) - $this->limit
+        );
     }
 }

--- a/packages/tables/src/Columns/TagsColumn.php
+++ b/packages/tables/src/Columns/TagsColumn.php
@@ -73,9 +73,8 @@ class TagsColumn extends Column
             return null;
         }
 
-        return sprintf(
-            __('tables::table.fields.tags.more_results'),
-            count($this->getTags()) - $this->limit
-        );
+        return __('tables::table.fields.tags.more_results', [
+            'count' => count($this->getTags()) - $this->limit,
+        ]);
     }
 }

--- a/packages/tables/src/Columns/TagsColumn.php
+++ b/packages/tables/src/Columns/TagsColumn.php
@@ -10,7 +10,7 @@ class TagsColumn extends Column
 
     protected string | Closure | null $separator = null;
 
-    protected ?int $limit = null;
+    protected int | Closure | null $limit = null;
 
     public function getTags(): array
     {
@@ -40,7 +40,7 @@ class TagsColumn extends Column
         return $this;
     }
 
-    public function limit(int $limit): static
+    public function limit (int | Closure | null $limit = 3): static
     {
         $this->limit = $limit;
 
@@ -54,27 +54,18 @@ class TagsColumn extends Column
 
     public function getLimit(): ?int
     {
-        return $this->limit;
+        return $this->evaluate($this->limit);
     }
 
-    public function hasMoreTags(): bool
+    public function hasActiveLimit(): bool
     {
-        return $this->limit && count($this->getTags()) > $this->limit;
+        $limit = $this->getLimit();
+
+        return $limit && count($this->getTags()) > $limit;
     }
 
-    public function getRemainingTags(): array
+    public function getMoreTags(): array
     {
-        return array_slice($this->getTags(), $this->limit);
-    }
-
-    public function getMoreLabel(): ?string
-    {
-        if (! $this->hasMoreTags()) {
-            return null;
-        }
-
-        return __('tables::table.fields.tags.more_results', [
-            'count' => count($this->getTags()) - $this->limit,
-        ]);
+        return array_slice($this->getTags(), $this->getLimit());
     }
 }

--- a/packages/tables/src/Columns/TagsColumn.php
+++ b/packages/tables/src/Columns/TagsColumn.php
@@ -62,7 +62,7 @@ class TagsColumn extends Column
         return $this->limit && count($this->getTags()) > $this->limit;
     }
 
-    public function getMoreTags(): array
+    public function getRemainingTags(): array
     {
         return array_slice($this->getTags(), $this->limit);
     }


### PR DESCRIPTION
This PR adds the feature to limit the tags displayed on `Tables\TagsColumn` through the new `limit()` method.
Additional methods `hasMoreTags()` and `getMoreTags()` have been added as helper for the final user, e.g. to build a more complex UI.

**Example**

```php
Tables\Columns\TagsColumn::make('tags')
    ->limit(2)
    // Display a tooltip with the remaining tags
    ->tooltip(function (Tables\Columns\TagsColumn $column): ?string {
        if ($column->hasMoreTags()) {
            return Arr::join($column->getRemainingTags(), ', ');
        }
    
        return null;
    }),
```

**Output**
![image](https://user-images.githubusercontent.com/6277291/174683462-ac3cf601-34f2-4938-aa75-881b7755d7e3.png)

![image](https://user-images.githubusercontent.com/6277291/174683622-70fc821e-f9cd-44cf-bcda-a839f606a194.png)

## Questions

1. Is it ok the path of the new translation?
2. Should I add the new translation (in english) to all the other lang files?
3. `getRemainingTags()` or `getMoreTags()`? 🤔 

### Testing

I tried to add tests, but I had a few errors. For example, I had to mock the ` getTags()` method because otherwise it was complaining about accessing `$table` before initialization. I noticed that this was solved on `Forms` with `Livewire::mock()`, but implementing `HasTables` on that class was a pain.

Furthermore I got an error about the database setup and I can't get how to setup the `testing` driver correctly 😅 If you can give me a hint about this I can give it a shot!