### PR TITLE
Fix: Disable tap highlight on WebKit browsers

### DIFF
--- a/packages/admin/resources/css/app.css
+++ b/packages/admin/resources/css/app.css
@@ -9,6 +9,10 @@
 
 /* @override: @tailwindcss/forms */
 @layer base {
+    html {
+        -webkit-tap-highlight-color: transparent;
+    }
+
     [dir='rtl'] select {
         background-position: left 0.5rem center !important;
         padding-left: 2.5rem;

--- a/packages/admin/resources/css/app.css
+++ b/packages/admin/resources/css/app.css
@@ -7,20 +7,19 @@
 @tailwind components;
 @tailwind utilities;
 
-/* @override: @tailwindcss/forms */
 @layer base {
     html {
         -webkit-tap-highlight-color: transparent;
+    }
+
+    :root.dark {
+        color-scheme: dark;
     }
 
     [dir='rtl'] select {
         background-position: left 0.5rem center !important;
         padding-left: 2.5rem;
         padding-right: 0.75rem;
-    }
-
-    :root.dark {
-        color-scheme: dark;
     }
 }
 


### PR DESCRIPTION
Closes #2846. Issue applies to Chromium-based browsers and probably Safari, since it's a WebKit prefix.

I only placed the code in admin package's base layer. **Forms** and **Tables** users probably should control this behavior themselves.