### PR TITLE
Revert getQualifiedKeyName on records and pivots

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -148,8 +148,8 @@ trait CanBeValidated
                 ->when(
                     $ignorable,
                     fn (Unique $rule) => $rule->ignore(
-                        $ignorable->getOriginal($ignorable->getQualifiedKeyName()),
-                        $ignorable->getQualifiedKeyName(),
+                        $ignorable->getOriginal($ignorable->getKeyName()),
+                        $ignorable->getKeyName(),
                     ),
                 );
 

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -149,7 +149,7 @@ trait CanBeValidated
                     $ignorable,
                     fn (Unique $rule) => $rule->ignore(
                         $ignorable->getOriginal($ignorable->getKeyName()),
-                        $ignorable->getKeyName(),
+                        $ignorable->getQualifiedKeyName(),
                     ),
                 );
 

--- a/packages/tables/src/Concerns/CanSelectRecords.php
+++ b/packages/tables/src/Concerns/CanSelectRecords.php
@@ -45,7 +45,7 @@ trait CanSelectRecords
         $relationship = $this->getRelationship();
 
         $pivotClass = $relationship->getPivotClass();
-        $pivotKeyName = app($pivotClass)->getQualifiedKeyName();
+        $pivotKeyName = app($pivotClass)->getKeyName();
 
         return $this->selectPivotDataInQuery(
             $relationship->wherePivotIn($pivotKeyName, $this->selectedTableRecords),

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Tables\Concerns;
 
-use function Filament\Support\get_model_label;
 use Filament\Tables\Contracts\HasRelationshipTable;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Builder;
@@ -10,6 +9,8 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Str;
+
+use function Filament\Support\get_model_label;
 
 trait HasRecords
 {
@@ -91,7 +92,7 @@ trait HasRecords
         $relationship = $this->getRelationship();
 
         $pivotClass = $relationship->getPivotClass();
-        $pivotKeyName = app($pivotClass)->getQualifiedKeyName();
+        $pivotKeyName = app($pivotClass)->getKeyName();
 
         return $record->getAttributeValue($pivotKeyName);
     }

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -2,15 +2,15 @@
 
 namespace Filament\Tables\Concerns;
 
+use function Filament\Support\get_model_label;
 use Filament\Tables\Contracts\HasRelationshipTable;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Support\Str;
 
-use function Filament\Support\get_model_label;
+use Illuminate\Support\Str;
 
 trait HasRecords
 {


### PR DESCRIPTION
Seems like we were over optimistic and the search and replace broke more stuff than it worked on (https://github.com/laravel-filament/filament/pull/2842)
Basically, we shouldn't use `getQualifiedKeyName()` when plucking models or on pivot data.

