### PR TITLE
Store filters in query string by default

### DIFF
--- a/packages/admin/src/Resources/Pages/ListRecords.php
+++ b/packages/admin/src/Resources/Pages/ListRecords.php
@@ -22,6 +22,7 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
     protected static string $view = 'filament::resources.pages.list-records';
 
     protected $queryString = [
+        'tableFilters',
         'tableSortColumn',
         'tableSortDirection',
         'tableSearchQuery' => ['except' => ''],


### PR DESCRIPTION
Currently, `ListRecords` table filters are not being stored in the query string by default, while sort and search are. As a user I'd expect all or none of them to be restored on a page reload, but not just some of them.

This has been discussed on Discord and @danharrin stated its a design choice as he's not 100% sure that all filters can be serialized to the query string yet.

We agreed it's probably better UX to store the filters in the query string by default. So I checked the filters for serialization issues and couldn't find any.