### PR TITLE
refactor: replace `Str::title` with `Str::headline`

### DIFF
--- a/packages/admin/src/Resources/Pages/Concerns/InteractsWithRecord.php
+++ b/packages/admin/src/Resources/Pages/Concerns/InteractsWithRecord.php
@@ -31,7 +31,7 @@ trait InteractsWithRecord
         $resource = static::getResource();
 
         if (! $resource::hasRecordTitle()) {
-            return Str::title($resource::getModelLabel());
+            return Str::headline($resource::getModelLabel());
         }
 
         return $resource::getRecordTitle($this->getRecord());

--- a/packages/admin/src/Resources/Pages/ListRecords.php
+++ b/packages/admin/src/Resources/Pages/ListRecords.php
@@ -152,7 +152,7 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
 
     protected function getTitle(): string
     {
-        return static::$title ?? Str::title(static::getResource()::getPluralModelLabel());
+        return static::$title ?? Str::headline(static::getResource()::getPluralModelLabel());
     }
 
     protected function getActions(): array

--- a/packages/admin/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/admin/src/Resources/RelationManagers/RelationManager.php
@@ -278,7 +278,7 @@ class RelationManager extends Component implements Tables\Contracts\HasRelations
 
     public static function getTitle(): string
     {
-        return static::$title ?? Str::title(static::getPluralModelLabel());
+        return static::$title ?? Str::headline(static::getPluralModelLabel());
     }
 
     public static function getTitleForRecord(Model $ownerRecord): string

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -175,7 +175,7 @@ class Resource
 
     public static function getBreadcrumb(): string
     {
-        return static::$breadcrumb ?? Str::title(static::getPluralModelLabel());
+        return static::$breadcrumb ?? Str::headline(static::getPluralModelLabel());
     }
 
     public static function getEloquentQuery(): Builder
@@ -427,7 +427,7 @@ class Resource
 
     protected static function getNavigationLabel(): string
     {
-        return static::$navigationLabel ?? Str::title(static::getPluralModelLabel());
+        return static::$navigationLabel ?? Str::headline(static::getPluralModelLabel());
     }
 
     protected static function getNavigationBadge(): ?string


### PR DESCRIPTION
This PR replaces occurrences of `Str::title` with `Str::headline` so `snake_cased` names are properly converted to `Title Case`.

![image](https://user-images.githubusercontent.com/16060559/174821944-5e971493-0bea-469f-b159-281e0c5fa1e7.png)