### PR TITLE
Fix: require recordId in Attach and Associate actions

### DIFF
--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanAssociateRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanAssociateRecords.php
@@ -89,6 +89,7 @@ trait CanAssociateRecords
     {
         return Select::make('recordId')
             ->label(__('filament-support::actions/associate.single.modal.fields.record_id.label'))
+            ->required()
             ->searchable()
             ->getSearchResultsUsing(static function (Select $component, RelationManager $livewire, string $search): array {
                 /** @var HasMany $relationship */

--- a/packages/admin/src/Resources/RelationManagers/Concerns/CanAttachRecords.php
+++ b/packages/admin/src/Resources/RelationManagers/Concerns/CanAttachRecords.php
@@ -72,6 +72,7 @@ trait CanAttachRecords
     {
         return Select::make('recordId')
             ->label(__('filament-support::actions/attach.single.modal.fields.record_id.label'))
+            ->required()
             ->searchable()
             ->getSearchResultsUsing(static function (Select $component, BelongsToManyRelationManager $livewire, string $search): array {
                 /** @var BelongsToMany $relationship */

--- a/packages/tables/src/Actions/AssociateAction.php
+++ b/packages/tables/src/Actions/AssociateAction.php
@@ -190,6 +190,7 @@ class AssociateAction extends Action
 
         $select = Select::make('recordId')
             ->label(__('filament-support::actions/associate.single.modal.fields.record_id.label'))
+            ->required()
             ->searchable()
             ->getSearchResultsUsing(static fn (Select $component, string $search): array => $getOptions(search: $search, searchColumns: $component->getSearchColumns()))
             ->getOptionLabelUsing(fn ($value): string => $this->getRecordTitle($this->getRelationship()->getRelated()->query()->find($value)))

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -195,6 +195,7 @@ class AttachAction extends Action
 
         $select = Select::make('recordId')
             ->label(__('filament-support::actions/attach.single.modal.fields.record_id.label'))
+            ->required()
             ->searchable()
             ->getSearchResultsUsing(static fn (Select $component, string $search): array => $getOptions(search: $search, searchColumns: $component->getSearchColumns()))
             ->getOptionLabelUsing(fn ($value): string => $this->getRecordTitle($this->getRelationship()->getRelated()->query()->find($value)))


### PR DESCRIPTION
Closes #2864.

Attach and Associate actions don't require `recordId` form select, which results in undesired behavior, when submitting the form - success notification is displayed, but no change is being made.

I also noticed `recordId` in two deprecated methods and placed it there too.