### PR TITLE
feat: floating action groups

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -12,3 +12,15 @@ esbuild.build({
     mainFields: ['module', 'main'],
     watch: shouldWatch,
 }).catch(() => process.exit(1))
+
+esbuild.build({
+    define: {
+        'process.env.NODE_ENV': shouldWatch ? `'production'` : `'development'`,
+    },
+    entryPoints: ['packages/support/resources/js/index.js'],
+    outfile: 'packages/tables/dist/module.esm.js',
+    bundle: true,
+    platform: 'neutral',
+    mainFields: ['module', 'main'],
+    watch: shouldWatch,
+}).catch(() => process.exit(1))

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "@alpinejs/persist": "^3.8.1",
         "@babel/runtime": "^7.15.3",
         "@danharrin/alpine-mousetrap": "^0.1.0",
+        "@floating-ui/dom": "^0.5.3",
         "@github/file-attachment-element": "^2.0.1",
         "@github/markdown-toolbar-element": "^1.5.1",
         "@ryangjchandler/alpine-tooltip": "^1.2.0",

--- a/packages/admin/resources/js/app.js
+++ b/packages/admin/resources/js/app.js
@@ -5,6 +5,7 @@ import Chart from 'chart.js/auto'
 
 import Collapse from '@alpinejs/collapse'
 import FormsAlpinePlugin from '../../../forms/dist/module.esm'
+import TablesAlpinePlugin from '../../../tables/dist/module.esm'
 import Focus from '@alpinejs/focus'
 import Mousetrap from '@danharrin/alpine-mousetrap'
 import Persist from '@alpinejs/persist'
@@ -12,6 +13,7 @@ import Tooltip from '@ryangjchandler/alpine-tooltip'
 
 Alpine.plugin(Collapse)
 Alpine.plugin(FormsAlpinePlugin)
+Alpine.plugin(TablesAlpinePlugin)
 Alpine.plugin(Focus)
 Alpine.plugin(Mousetrap)
 Alpine.plugin(Persist)

--- a/packages/support/resources/js/components/action-group.js
+++ b/packages/support/resources/js/components/action-group.js
@@ -1,0 +1,55 @@
+import {computePosition, flip, shift, autoUpdate} from '@floating-ui/dom'
+
+export default (Alpine) => {
+    Alpine.data('actionGroupTableComponent', ({
+        mountTableActionUsing
+    }) => {
+        return {
+            isOpen: false,
+
+            mountTableActionUsing,
+
+            cancelAutoUpdate: function () {},
+
+            init: function () {
+                //
+            },
+
+            update: function () {
+                const trigger = this.$refs.trigger
+                const dropdown = this.$refs.dropdown
+
+                this.cancelAutoUpdate = autoUpdate(trigger, dropdown, () => {
+                    computePosition( trigger, dropdown, {
+                        placement: 'bottom-end',
+                        middleware: [
+                            flip(),
+                            shift({ padding: 5 })
+                        ],
+                    }).then(({x, y}) => {
+                        Object.assign(dropdown.style, {
+                            left: `${x}px`,
+                            top: `${y}px`,
+                        })
+                    })
+                })
+            },
+
+            toggleDropdown: function () {
+                this.isOpen = ! this.isOpen
+
+                if( this.isOpen ){
+                    this.update()
+                } else {
+                    this.cancelAutoUpdate()
+                }
+            },
+
+            wireClickAction: function (actionName, tableRecordKey) {
+                if(! actionName) return
+
+                this.mountTableActionUsing(actionName, tableRecordKey)
+            }
+        }
+    })
+}

--- a/packages/support/resources/js/index.js
+++ b/packages/support/resources/js/index.js
@@ -1,0 +1,9 @@
+import ActionGroupTableComponentAlpinePlugin from './components/action-group'
+
+export default (Alpine) => {
+    Alpine.plugin(ActionGroupTableComponentAlpinePlugin)
+}
+
+export {
+    ActionGroupTableComponentAlpinePlugin,
+}

--- a/packages/support/resources/views/components/actions/group.blade.php
+++ b/packages/support/resources/views/components/actions/group.blade.php
@@ -7,9 +7,17 @@
     'tooltip' => null,
 ])
 
-<div x-data="{ isOpen: false }" {{ $attributes->class(['relative']) }}>
+<div
+    x-data="actionGroupTableComponent({
+        mountTableActionUsing: async (...args) => {
+            return await $wire.mountTableAction(...args)
+        }
+    })"
+    {{ $attributes->class(['relative']) }}
+>
     <x-filament-support::icon-button
-        x-on:click="isOpen = ! isOpen"
+        x-ref="trigger"
+        x-on:click="toggleDropdown"
         :color="$color"
         :dark-mode="$darkMode"
         :icon="$icon"
@@ -21,25 +29,28 @@
         </x-slot>
     </x-filament-support::icon-button>
 
-    <div
-        x-show="isOpen"
-        x-on:click.away="isOpen = false"
-        x-transition
-        x-cloak
-        @class([
-            'absolute right-0 rtl:left-0 rtl:right-auto z-20 mt-4 shadow-xl ring-1 ring-gray-900/10 overflow-hidden rounded-xl w-52 filament-action-group-dropdown',
-            'dark:ring-white/20' => $darkMode,
-        ])
-    >
-        <ul @class([
-            'py-1 space-y-1 bg-white shadow rounded-xl',
-            'dark:bg-gray-700 dark:divide-gray-600' => $darkMode,
-        ])>
-            @foreach ($actions as $action)
-                @if (! $action->isHidden())
-                    {{ $action }}
-                @endif
-            @endforeach
-        </ul>
-    </div>
+    <template x-teleport="body">
+        <div
+            x-ref="dropdown"
+            x-show="isOpen"
+            x-on:click.away="isOpen = false"
+            x-transition
+            x-cloak
+            @class([
+                'absolute right-0 rtl:left-0 rtl:right-auto z-20 mt-4 shadow-xl ring-1 ring-gray-900/10 overflow-hidden rounded-xl w-52 filament-action-group-dropdown',
+                'dark:ring-white/20' => $darkMode,
+            ])
+        >
+            <ul @class([
+                'py-1 space-y-1 bg-white shadow rounded-xl',
+                'dark:bg-gray-700 dark:divide-gray-600' => $darkMode,
+            ])>
+                @foreach ($actions as $action)
+                    @if (! $action->isHidden())
+                        {{ $action }}
+                    @endif
+                @endforeach
+            </ul>
+        </div>
+    </template>
 </div>

--- a/packages/tables/resources/views/components/actions/action.blade.php
+++ b/packages/tables/resources/views/components/actions/action.blade.php
@@ -8,9 +8,9 @@
     if ((! $action->getAction()) || $action->getUrl()) {
         $wireClickAction = null;
     } elseif ($record = $action->getRecord()) {
-        $wireClickAction = "mountTableAction('{$action->getName()}', '{$this->getTableRecordKey($record)}')";
+        $wireClickAction = "wireClickAction('{$action->getName()}', '{$this->getTableRecordKey($record)}')";
     } else {
-        $wireClickAction = "mountTableAction('{$action->getName()}')";
+        $wireClickAction = "wireClickAction('{$action->getName()}')";
     }
 @endphp
 
@@ -19,7 +19,6 @@
     :dark-mode="config('tables.dark_mode')"
     :attributes="\Filament\Support\prepare_inherited_attributes($attributes)->merge($action->getExtraAttributes())"
     :tag="$action->getUrl() ? 'a' : 'button'"
-    :wire:click="$action->isEnabled() ? $wireClickAction : null"
     :href="$action->isEnabled() ? $action->getUrl() : null"
     :target="$action->shouldOpenUrlInNewTab() ? '_blank' : null"
     :disabled="$action->isDisabled()"
@@ -27,6 +26,7 @@
     :tooltip="$action->getTooltip()"
     :icon="$icon ?? $action->getIcon()"
     :size="$action->getSize() ?? 'sm'"
+    x-on:click="{!! $action->isEnabled() ? $wireClickAction : null !!}"
 >
     {{ $slot }}
 </x-dynamic-component>


### PR DESCRIPTION
This PR fixes the action group behavior inside the table. As now, the table has a overflow-x to allow horizontal scroll, but then the action group modal "clips" inside de table container.

### Before this PR:
<img width="502" alt="image" src="https://user-images.githubusercontent.com/14329460/174938568-23aa9e0f-2621-4d36-9e2e-881ec8a1aca0.png">

### After this PR:
<img width="569" alt="image" src="https://user-images.githubusercontent.com/14329460/174938623-10c469f4-9f3d-49b9-a56d-d385d1bef175.png">


As discussed on [discord](https://discord.com/channels/883083792112300104/883085291722788964/988356164985159710) Dan suggested Floating UI as an alternative to the Popper.js lib, so this PR uses Floating UI to position the dropdown near its trigger button, and Alpine's [x-teleport](https://alpinejs.dev/directives/teleport) to teleport the dropdown outside the table to prevent the overflow clipping.


@danharrin please see my comments down below.

Alpine.js docs states that it wont work with Livewire (because of the teleport to outside the Livewire component). But i've found a way around by making the Alpine.js do the call to Livewire using $wire.