### PR TITLE
chore: deprecated `MultiSelect`

### DIFF
--- a/packages/forms/src/Components/MultiSelect.php
+++ b/packages/forms/src/Components/MultiSelect.php
@@ -2,6 +2,10 @@
 
 namespace Filament\Forms\Components;
 
+/**
+ * @deprecated Use `\Filament\Forms\Components\Select` and `->multiple()` instead.
+ * @see Select
+ */
 class MultiSelect extends Select
 {
     public function isMultiple(): bool


### PR DESCRIPTION
`MultiSelect` can now be replaced with `Select::multiple()` so we should mark as deprecated before v3.x.