### PR TITLE
Fixes typo in FA translations.

### DIFF
--- a/packages/forms/resources/lang/fa/components.php
+++ b/packages/forms/resources/lang/fa/components.php
@@ -202,7 +202,7 @@ return [
             'false' => 'خیر',
         ],
 
-        'loading_message' => 'درحال بارگزاری...',
+        'loading_message' => 'درحال بارگذاری...',
 
         'no_search_results_message' => 'هیچ گزینه ای با جستجوی شما مطابقت ندارد',
 


### PR DESCRIPTION
It's a common typo in FA. Although it might be hard to see the difference, you can check its correctness with [google translate](https://translate.google.com/?sl=en&tl=fa&text=loading&op=translate).