### PR TITLE
removed inert modifier from x-trap for modals

### DIFF
--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -58,7 +58,7 @@
 
         <div
             x-show="isOpen"
-            x-trap.inert.noscroll="isOpen"
+            x-trap.noscroll="isOpen"
             @if (filled($id))
                 x-on:keydown.window.escape="$dispatch('{{ $closeEventName }}', { id: '{{ $id }}' })"
             @else


### PR DESCRIPTION
As @danharrin requested in the [discord channel](https://discord.com/channels/883083792112300104/883085291722788964/989947646938599434) I removed the inert modifier due to performance issues.