### PR TITLE
refactor(generate): Allow partial model namespaces during resource generation

### DIFF
--- a/packages/admin/src/Commands/Concerns/CanGenerateResources.php
+++ b/packages/admin/src/Commands/Concerns/CanGenerateResources.php
@@ -181,7 +181,7 @@ trait CanGenerateResources
 
     protected function getModelTable(string $model): ?Table
     {
-        if (! class_exists($model)) {
+        if (! class_exists($model) && (($model = 'App\\Models\\' . $model) && ! class_exists($model))) {
             return null;
         }
 

--- a/packages/admin/src/Commands/Concerns/CanGenerateResources.php
+++ b/packages/admin/src/Commands/Concerns/CanGenerateResources.php
@@ -181,7 +181,7 @@ trait CanGenerateResources
 
     protected function getModelTable(string $model): ?Table
     {
-        if (! class_exists($model) && (($model = 'App\\Models\\' . $model) && ! class_exists($model))) {
+        if ((! class_exists($model)) && (! class_exists($model = "App\\Models\\{$model}"))) {
             return null;
         }
 


### PR DESCRIPTION
Ahoy

I added a double check for default model paths `App/Models` in case, only a partial model namespace is given during resource generation with `--generate` option when looking for the models table.

If only a partial sub-folder is given, that resides under `App/Models` for example `Test/TestModel`, the resource is correctly generated, but the forms and table contents by `-generate` is not captured, because the path is split to a model namespace, which leads to it not being passed into the generation, hence the class cannot be found, as it would be `App/Models/Test/TestModel` while looking for `Test/TestModel`.

This can be circumvented when passing a full namespace path such as `App/Models/Test/TestModel` to the resource generation command, but it leads to the effect of having an `App` and `Models` sub-folder being created under `Filament/Resources`.

This is a follow-up in consequence to https://github.com/filamentphp/filament/pull/2029. I do not know if this is the preferred behaviour now, but would double-down here and hear what you suggest. Happy to adapt.

Looking forward to your feedback.


Thanks