### PR TITLE
Check if state has changed in file upload watcher

### DIFF
--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -62,6 +62,8 @@ export default (Alpine) => {
             shouldUpdateState: true,
 
             state,
+            
+            lastState: null,
 
             uploadedFileUrlIndex: {},
 
@@ -139,6 +141,13 @@ export default (Alpine) => {
                     if (Object.values(this.state).filter((file) => file.startsWith('livewire-file:')).length) {
                         return
                     }
+                    
+                    // Don't do anything if the state hasn't changed
+                    if (JSON.stringify(this.state) === this.lastState) {
+                        return
+                    }
+                    
+                    this.lastState = JSON.stringify(this.state)
 
                     this.pond.files = await this.getFiles()
                 })


### PR DESCRIPTION
When using Laravel Vapor with Octane the watcher can get into a loop, this fix prevents it.