### PR TITLE
Allow Dependency injection in $table->query()

### DIFF
--- a/packages/tables/src/Filters/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Filters/Concerns/InteractsWithTableQuery.php
@@ -24,7 +24,10 @@ trait InteractsWithTableQuery
         }
 
         $callback = $this->modifyQueryUsing;
-        $callback($query, $data);
+        $this->evaluate($callback, [
+			'query' => $query,
+			'data'  => $data,
+		]);
 
         return $query;
     }


### PR DESCRIPTION
this allows the use of dependency injection in table's query method

```php
public static function table(Table $table): Table
{
    return $table->columns([/*...*/])->query(fn ($query, $data, Component $livewire) => $query)
}
```

my use-case:
I have a ListRecords with a modal action to configure a `frame_quote_price` and `vat`
I can show the final price with a TextColumn
```php
TextColumn::make('sell_price_with_frame')->prefix('€')->formatStateUsing(function (Product $record, Component $livewire) {
	return round(($record->sell_price_eur + $livewire->frame_quote_price) * (1 + ($livewire->vat / 100)), 2);
}),
```
but I also  want to be able to filter for max price considering `frame_quote_price` and `vat`
now it's not possible to access `$livewire` from the `->query` method's callback