### PR TITLE
refactor(generate): Allow partial model namespaces during resource generation

### DIFF
--- a/packages/admin/src/Commands/Concerns/CanGenerateResources.php
+++ b/packages/admin/src/Commands/Concerns/CanGenerateResources.php
@@ -183,7 +183,7 @@ trait CanGenerateResources
 
     protected function getModelTable(string $model): ?Table
     {
-        if (! class_exists($model)) {
+        if ((! class_exists($model)) && (! class_exists($model = "App\\Models\\{$model}"))) {
             return null;
         }
 


### PR DESCRIPTION
Ahoy

Duplicate of https://github.com/filamentphp/filament/pull/2920 but now into the correct branch ^^# My bad!


Sorry and Thanks