### PR TITLE
Make Card Width configurable

### DIFF
--- a/packages/admin/resources/views/components/layouts/card.blade.php
+++ b/packages/admin/resources/views/components/layouts/card.blade.php
@@ -1,6 +1,6 @@
 @props([
     'title' => null,
-    'width' => 'md'
+    'width' => 'md',
 ])
 
 <x-filament::layouts.base :title="$title">

--- a/packages/admin/resources/views/components/layouts/card.blade.php
+++ b/packages/admin/resources/views/components/layouts/card.blade.php
@@ -11,18 +11,18 @@
         <div @class([
             'w-screen px-6 -mt-16 space-y-8 md:mt-0 md:px-2',
             match($width) {
-                    'xs' => 'max-w-xs',
-                    'sm' => 'max-w-sm',
-                    'md' => 'max-w-md',
-                    'lg' => 'max-w-lg',
-                    'xl' => 'max-w-xl',
-                    '2xl' => 'max-w-2xl',
-                    '3xl' => 'max-w-3xl',
-                    '4xl' => 'max-w-4xl',
-                    '5xl' => 'max-w-5xl',
-                    '6xl' => 'max-w-6xl',
-                    '7xl' => 'max-w-7xl',
-                }
+                'xs' => 'max-w-xs',
+                'sm' => 'max-w-sm',
+                'md' => 'max-w-md',
+                'lg' => 'max-w-lg',
+                'xl' => 'max-w-xl',
+                '2xl' => 'max-w-2xl',
+                '3xl' => 'max-w-3xl',
+                '4xl' => 'max-w-4xl',
+                '5xl' => 'max-w-5xl',
+                '6xl' => 'max-w-6xl',
+                '7xl' => 'max-w-7xl',
+            }
         ])>
             <div @class([
                 'p-8 space-y-4 bg-white/50 backdrop-blur-xl border border-gray-200 shadow-2xl rounded-2xl relative',

--- a/packages/admin/resources/views/components/layouts/card.blade.php
+++ b/packages/admin/resources/views/components/layouts/card.blade.php
@@ -22,6 +22,7 @@
                 '5xl' => 'max-w-5xl',
                 '6xl' => 'max-w-6xl',
                 '7xl' => 'max-w-7xl',
+                default => $width,
             }
         ])>
             <div @class([

--- a/packages/admin/resources/views/components/layouts/card.blade.php
+++ b/packages/admin/resources/views/components/layouts/card.blade.php
@@ -23,7 +23,7 @@
                 '6xl' => 'max-w-6xl',
                 '7xl' => 'max-w-7xl',
                 default => $width,
-            }
+            },
         ])>
             <div @class([
                 'p-8 space-y-4 bg-white/50 backdrop-blur-xl border border-gray-200 shadow-2xl rounded-2xl relative',

--- a/packages/admin/resources/views/components/layouts/card.blade.php
+++ b/packages/admin/resources/views/components/layouts/card.blade.php
@@ -1,5 +1,6 @@
 @props([
     'title' => null,
+    'width' => 'md'
 ])
 
 <x-filament::layouts.base :title="$title">
@@ -7,7 +8,22 @@
         'flex items-center justify-center min-h-screen filament-login-page bg-gray-100 text-gray-900',
         'dark:bg-gray-900 dark:text-white' => config('filament.dark_mode'),
     ])>
-        <div class="w-screen max-w-md px-6 -mt-16 space-y-8 md:mt-0 md:px-2">
+        <div @class([
+            'w-screen px-6 -mt-16 space-y-8 md:mt-0 md:px-2',
+            match($width) {
+                    'xs' => 'max-w-xs',
+                    'sm' => 'max-w-sm',
+                    'md' => 'max-w-md',
+                    'lg' => 'max-w-lg',
+                    'xl' => 'max-w-xl',
+                    '2xl' => 'max-w-2xl',
+                    '3xl' => 'max-w-3xl',
+                    '4xl' => 'max-w-4xl',
+                    '5xl' => 'max-w-5xl',
+                    '6xl' => 'max-w-6xl',
+                    '7xl' => 'max-w-7xl',
+                }
+        ])>
             <div @class([
                 'p-8 space-y-4 bg-white/50 backdrop-blur-xl border border-gray-200 shadow-2xl rounded-2xl relative',
                 'dark:bg-gray-900/50 dark:border-gray-700' => config('filament.dark_mode'),


### PR DESCRIPTION
This PR adds a simple prop to the `components/layouts/card.blade.php` template to specify the width of the card (the template used for the login card).

This is useful for plugin authors who want to display a wider form or wizard in those components. For example, in the onboarding plugin I'm working, I allow people to add wizards or forms into that card. Making the width dynamic would be very handy. 

Thanks!