### PR TITLE
Fix: fixes json_decode passing null deprecation in Actions

### DIFF
--- a/packages/admin/src/Pages/Concerns/HasActions.php
+++ b/packages/admin/src/Pages/Concerns/HasActions.php
@@ -27,7 +27,7 @@ trait HasActions
     {
         $action = $this->getMountedAction();
 
-        if (!$action) {
+        if (! $action) {
             return;
         }
 
@@ -74,7 +74,7 @@ trait HasActions
 
         $action = $this->getMountedAction();
 
-        if (!$action) {
+        if (! $action) {
             return;
         }
 
@@ -100,7 +100,7 @@ trait HasActions
             $action->callAfterFormFilled();
         }
 
-        if (!$action->shouldOpenModal()) {
+        if (! $action->shouldOpenModal()) {
             return $this->callMountedAction();
         }
 
@@ -150,7 +150,7 @@ trait HasActions
 
     public function getMountedAction(): ?Action
     {
-        if (!$this->mountedAction) {
+        if (! $this->mountedAction) {
             return null;
         }
 
@@ -160,7 +160,7 @@ trait HasActions
             return $action;
         }
 
-        if (!$this instanceof Contracts\HasFormActions) {
+        if (! $this instanceof Contracts\HasFormActions) {
             return null;
         }
 
@@ -178,11 +178,11 @@ trait HasActions
     {
         $action = $this->getMountedAction();
 
-        if (!$action) {
+        if (! $action) {
             return null;
         }
 
-        if ((!$this->isCachingForms) && $this->hasCachedForm('mountedActionForm')) {
+        if ((! $this->isCachingForms) && $this->hasCachedForm('mountedActionForm')) {
             return $this->getCachedForm('mountedActionForm');
         }
 
@@ -208,13 +208,13 @@ trait HasActions
         }
 
         foreach ($actions as $action) {
-            if (!$action instanceof ActionGroup) {
+            if (! $action instanceof ActionGroup) {
                 continue;
             }
 
             $groupedAction = $action->getActions()[$name] ?? null;
 
-            if (!$groupedAction) {
+            if (! $groupedAction) {
                 continue;
             }
 

--- a/packages/admin/src/Pages/Concerns/HasActions.php
+++ b/packages/admin/src/Pages/Concerns/HasActions.php
@@ -27,7 +27,7 @@ trait HasActions
     {
         $action = $this->getMountedAction();
 
-        if (! $action) {
+        if (!$action) {
             return;
         }
 
@@ -49,7 +49,7 @@ trait HasActions
 
         try {
             $result = $action->call([
-                'arguments' => json_decode($arguments, associative: true) ?? [],
+                'arguments' => $arguments ? json_decode($arguments, associative: true) : [],
                 'form' => $form,
             ]);
         } catch (Hold $exception) {
@@ -74,7 +74,7 @@ trait HasActions
 
         $action = $this->getMountedAction();
 
-        if (! $action) {
+        if (!$action) {
             return;
         }
 
@@ -100,7 +100,7 @@ trait HasActions
             $action->callAfterFormFilled();
         }
 
-        if (! $action->shouldOpenModal()) {
+        if (!$action->shouldOpenModal()) {
             return $this->callMountedAction();
         }
 
@@ -150,7 +150,7 @@ trait HasActions
 
     public function getMountedAction(): ?Action
     {
-        if (! $this->mountedAction) {
+        if (!$this->mountedAction) {
             return null;
         }
 
@@ -160,7 +160,7 @@ trait HasActions
             return $action;
         }
 
-        if (! $this instanceof Contracts\HasFormActions) {
+        if (!$this instanceof Contracts\HasFormActions) {
             return null;
         }
 
@@ -178,11 +178,11 @@ trait HasActions
     {
         $action = $this->getMountedAction();
 
-        if (! $action) {
+        if (!$action) {
             return null;
         }
 
-        if ((! $this->isCachingForms) && $this->hasCachedForm('mountedActionForm')) {
+        if ((!$this->isCachingForms) && $this->hasCachedForm('mountedActionForm')) {
             return $this->getCachedForm('mountedActionForm');
         }
 
@@ -208,13 +208,13 @@ trait HasActions
         }
 
         foreach ($actions as $action) {
-            if (! $action instanceof ActionGroup) {
+            if (!$action instanceof ActionGroup) {
                 continue;
             }
 
             $groupedAction = $action->getActions()[$name] ?? null;
 
-            if (! $groupedAction) {
+            if (!$groupedAction) {
                 continue;
             }
 

--- a/packages/forms/src/Concerns/HasFormComponentActions.php
+++ b/packages/forms/src/Concerns/HasFormComponentActions.php
@@ -27,11 +27,11 @@ trait HasFormComponentActions
     {
         $action = $this->getMountedFormComponentAction();
 
-        if (!$action) {
+        if (! $action) {
             return null;
         }
 
-        if ((!$this->isCachingForms) && $this->hasCachedForm('mountedFormComponentActionForm')) {
+        if ((! $this->isCachingForms) && $this->hasCachedForm('mountedFormComponentActionForm')) {
             return $this->getCachedForm('mountedFormComponentActionForm');
         }
 
@@ -45,7 +45,7 @@ trait HasFormComponentActions
     {
         $action = $this->getMountedFormComponentAction();
 
-        if (!$action) {
+        if (! $action) {
             return;
         }
 
@@ -88,7 +88,7 @@ trait HasFormComponentActions
 
     public function getMountedFormComponentAction(): ?Action
     {
-        if (!$this->mountedFormComponentAction) {
+        if (! $this->mountedFormComponentAction) {
             return null;
         }
 
@@ -102,7 +102,7 @@ trait HasFormComponentActions
 
         $action = $this->getMountedFormComponentAction();
 
-        if (!$action) {
+        if (! $action) {
             return;
         }
 
@@ -128,7 +128,7 @@ trait HasFormComponentActions
             $action->callAfterFormFilled();
         }
 
-        if (!$action->shouldOpenModal()) {
+        if (! $action->shouldOpenModal()) {
             return $this->callMountedFormComponentAction();
         }
 
@@ -141,14 +141,14 @@ trait HasFormComponentActions
 
     public function getMountedFormComponentActionComponent(): ?Component
     {
-        if (!$this->hasMountedFormComponentAction()) {
+        if (! $this->hasMountedFormComponentAction()) {
             return null;
         }
 
         foreach ($this->getCachedForms() as $form) {
             $component = $form->getComponent($this->mountedFormComponentActionComponent);
 
-            if (!$component) {
+            if (! $component) {
                 continue;
             }
 

--- a/packages/forms/src/Concerns/HasFormComponentActions.php
+++ b/packages/forms/src/Concerns/HasFormComponentActions.php
@@ -27,11 +27,11 @@ trait HasFormComponentActions
     {
         $action = $this->getMountedFormComponentAction();
 
-        if (! $action) {
+        if (!$action) {
             return null;
         }
 
-        if ((! $this->isCachingForms) && $this->hasCachedForm('mountedFormComponentActionForm')) {
+        if ((!$this->isCachingForms) && $this->hasCachedForm('mountedFormComponentActionForm')) {
             return $this->getCachedForm('mountedFormComponentActionForm');
         }
 
@@ -45,7 +45,7 @@ trait HasFormComponentActions
     {
         $action = $this->getMountedFormComponentAction();
 
-        if (! $action) {
+        if (!$action) {
             return;
         }
 
@@ -67,7 +67,7 @@ trait HasFormComponentActions
 
         try {
             $result = $action->call([
-                'arguments' => json_decode($arguments, associative: true) ?? [],
+                'arguments' => $arguments ? json_decode($arguments, associative: true) : [],
                 'form' => $form,
             ]);
         } catch (Hold $exception) {
@@ -88,7 +88,7 @@ trait HasFormComponentActions
 
     public function getMountedFormComponentAction(): ?Action
     {
-        if (! $this->mountedFormComponentAction) {
+        if (!$this->mountedFormComponentAction) {
             return null;
         }
 
@@ -102,7 +102,7 @@ trait HasFormComponentActions
 
         $action = $this->getMountedFormComponentAction();
 
-        if (! $action) {
+        if (!$action) {
             return;
         }
 
@@ -128,7 +128,7 @@ trait HasFormComponentActions
             $action->callAfterFormFilled();
         }
 
-        if (! $action->shouldOpenModal()) {
+        if (!$action->shouldOpenModal()) {
             return $this->callMountedFormComponentAction();
         }
 
@@ -141,14 +141,14 @@ trait HasFormComponentActions
 
     public function getMountedFormComponentActionComponent(): ?Component
     {
-        if (! $this->hasMountedFormComponentAction()) {
+        if (!$this->hasMountedFormComponentAction()) {
             return null;
         }
 
         foreach ($this->getCachedForms() as $form) {
             $component = $form->getComponent($this->mountedFormComponentActionComponent);
 
-            if (! $component) {
+            if (!$component) {
                 continue;
             }
 

--- a/packages/forms/src/Concerns/HasFormComponentActions.php
+++ b/packages/forms/src/Concerns/HasFormComponentActions.php
@@ -27,11 +27,11 @@ trait HasFormComponentActions
     {
         $action = $this->getMountedFormComponentAction();
 
-        if (!$action) {
+        if (! $action) {
             return null;
         }
 
-        if ((!$this->isCachingForms) && $this->hasCachedForm('mountedFormComponentActionForm')) {
+        if ((! $this->isCachingForms) && $this->hasCachedForm('mountedFormComponentActionForm')) {
             return $this->getCachedForm('mountedFormComponentActionForm');
         }
 
@@ -45,7 +45,7 @@ trait HasFormComponentActions
     {
         $action = $this->getMountedFormComponentAction();
 
-        if (!$action) {
+        if (! $action) {
             return;
         }
 
@@ -88,7 +88,7 @@ trait HasFormComponentActions
 
     public function getMountedFormComponentAction(): ?Action
     {
-        if (!$this->mountedFormComponentAction) {
+        if (! $this->mountedFormComponentAction) {
             return null;
         }
 
@@ -102,7 +102,7 @@ trait HasFormComponentActions
 
         $action = $this->getMountedFormComponentAction();
 
-        if (!$action) {
+        if (! $action) {
             return;
         }
 
@@ -128,7 +128,7 @@ trait HasFormComponentActions
             $action->callAfterFormFilled();
         }
 
-        if (!$action->shouldOpenModal()) {
+        if (! $action->shouldOpenModal()) {
             return $this->callMountedFormComponentAction();
         }
 
@@ -141,7 +141,7 @@ trait HasFormComponentActions
 
     public function getMountedFormComponentActionComponent(): ?Component
     {
-        if (!$this->hasMountedFormComponentAction()) {
+        if (! $this->hasMountedFormComponentAction()) {
             return null;
         }
 

--- a/packages/forms/src/Concerns/HasFormComponentActions.php
+++ b/packages/forms/src/Concerns/HasFormComponentActions.php
@@ -27,11 +27,11 @@ trait HasFormComponentActions
     {
         $action = $this->getMountedFormComponentAction();
 
-        if (! $action) {
+        if (!$action) {
             return null;
         }
 
-        if ((! $this->isCachingForms) && $this->hasCachedForm('mountedFormComponentActionForm')) {
+        if ((!$this->isCachingForms) && $this->hasCachedForm('mountedFormComponentActionForm')) {
             return $this->getCachedForm('mountedFormComponentActionForm');
         }
 
@@ -45,7 +45,7 @@ trait HasFormComponentActions
     {
         $action = $this->getMountedFormComponentAction();
 
-        if (! $action) {
+        if (!$action) {
             return;
         }
 
@@ -88,7 +88,7 @@ trait HasFormComponentActions
 
     public function getMountedFormComponentAction(): ?Action
     {
-        if (! $this->mountedFormComponentAction) {
+        if (!$this->mountedFormComponentAction) {
             return null;
         }
 
@@ -102,7 +102,7 @@ trait HasFormComponentActions
 
         $action = $this->getMountedFormComponentAction();
 
-        if (! $action) {
+        if (!$action) {
             return;
         }
 
@@ -128,7 +128,7 @@ trait HasFormComponentActions
             $action->callAfterFormFilled();
         }
 
-        if (! $action->shouldOpenModal()) {
+        if (!$action->shouldOpenModal()) {
             return $this->callMountedFormComponentAction();
         }
 
@@ -141,7 +141,7 @@ trait HasFormComponentActions
 
     public function getMountedFormComponentActionComponent(): ?Component
     {
-        if (! $this->hasMountedFormComponentAction()) {
+        if (!$this->hasMountedFormComponentAction()) {
             return null;
         }
 

--- a/packages/tables/src/Concerns/HasActions.php
+++ b/packages/tables/src/Concerns/HasActions.php
@@ -57,7 +57,7 @@ trait HasActions
     {
         $action = $this->getMountedTableAction();
 
-        if (! $action) {
+        if (!$action) {
             return;
         }
 
@@ -79,7 +79,7 @@ trait HasActions
 
         try {
             $result = $action->call([
-                'arguments' => json_decode($arguments, associative: true) ?? [],
+                'arguments' => $arguments ? json_decode($arguments, associative: true) : [],
                 'form' => $form,
             ]);
         } catch (Hold $exception) {
@@ -111,7 +111,7 @@ trait HasActions
 
         $action = $this->getMountedTableAction();
 
-        if (! $action) {
+        if (!$action) {
             return;
         }
 
@@ -138,7 +138,7 @@ trait HasActions
             $action->callAfterFormFilled();
         }
 
-        if (! $action->shouldOpenModal()) {
+        if (!$action->shouldOpenModal()) {
             return $this->callMountedTableAction();
         }
 
@@ -156,7 +156,7 @@ trait HasActions
 
     public function getMountedTableAction(): ?Action
     {
-        if (! $this->mountedTableAction) {
+        if (!$this->mountedTableAction) {
             return null;
         }
 
@@ -167,11 +167,11 @@ trait HasActions
     {
         $action = $this->getMountedTableAction();
 
-        if (! $action) {
+        if (!$action) {
             return null;
         }
 
-        if ((! $this->isCachingForms) && $this->hasCachedForm('mountedTableActionForm')) {
+        if ((!$this->isCachingForms) && $this->hasCachedForm('mountedTableActionForm')) {
             return $this->getCachedForm('mountedTableActionForm');
         }
 
@@ -210,13 +210,13 @@ trait HasActions
         }
 
         foreach ($actions as $action) {
-            if (! $action instanceof ActionGroup) {
+            if (!$action instanceof ActionGroup) {
                 continue;
             }
 
             $groupedAction = $action->getActions()[$name] ?? null;
 
-            if (! $groupedAction) {
+            if (!$groupedAction) {
                 continue;
             }
 

--- a/packages/tables/src/Concerns/HasActions.php
+++ b/packages/tables/src/Concerns/HasActions.php
@@ -57,7 +57,7 @@ trait HasActions
     {
         $action = $this->getMountedTableAction();
 
-        if (!$action) {
+        if (! $action) {
             return;
         }
 
@@ -111,7 +111,7 @@ trait HasActions
 
         $action = $this->getMountedTableAction();
 
-        if (!$action) {
+        if (! $action) {
             return;
         }
 
@@ -138,7 +138,7 @@ trait HasActions
             $action->callAfterFormFilled();
         }
 
-        if (!$action->shouldOpenModal()) {
+        if (! $action->shouldOpenModal()) {
             return $this->callMountedTableAction();
         }
 
@@ -156,7 +156,7 @@ trait HasActions
 
     public function getMountedTableAction(): ?Action
     {
-        if (!$this->mountedTableAction) {
+        if (! $this->mountedTableAction) {
             return null;
         }
 
@@ -167,11 +167,11 @@ trait HasActions
     {
         $action = $this->getMountedTableAction();
 
-        if (!$action) {
+        if (! $action) {
             return null;
         }
 
-        if ((!$this->isCachingForms) && $this->hasCachedForm('mountedTableActionForm')) {
+        if ((! $this->isCachingForms) && $this->hasCachedForm('mountedTableActionForm')) {
             return $this->getCachedForm('mountedTableActionForm');
         }
 
@@ -210,13 +210,13 @@ trait HasActions
         }
 
         foreach ($actions as $action) {
-            if (!$action instanceof ActionGroup) {
+            if (! $action instanceof ActionGroup) {
                 continue;
             }
 
             $groupedAction = $action->getActions()[$name] ?? null;
 
-            if (!$groupedAction) {
+            if (! $groupedAction) {
                 continue;
             }
 

--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -42,7 +42,7 @@ trait HasBulkActions
     {
         $action = $this->getMountedTableBulkAction();
 
-        if (! $action) {
+        if (!$action) {
             return;
         }
 
@@ -64,7 +64,7 @@ trait HasBulkActions
 
         try {
             $result = $action->call([
-                'arguments' => json_decode($arguments, associative: true) ?? [],
+                'arguments' => $arguments ? json_decode($arguments, associative: true) : [],
                 'form' => $form,
             ]);
         } catch (Hold $exception) {
@@ -91,7 +91,7 @@ trait HasBulkActions
 
         $action = $this->getMountedTableBulkAction();
 
-        if (! $action) {
+        if (!$action) {
             return;
         }
 
@@ -118,7 +118,7 @@ trait HasBulkActions
             $action->callAfterFormFilled();
         }
 
-        if (! $action->shouldOpenModal()) {
+        if (!$action->shouldOpenModal()) {
             return $this->callMountedTableBulkAction();
         }
 
@@ -132,13 +132,13 @@ trait HasBulkActions
     public function getCachedTableBulkActions(): array
     {
         return collect($this->cachedTableBulkActions)
-            ->filter(fn (BulkAction $action): bool => ! $action->isHidden())
+            ->filter(fn (BulkAction $action): bool => !$action->isHidden())
             ->toArray();
     }
 
     public function getMountedTableBulkAction(): ?BulkAction
     {
-        if (! $this->mountedTableBulkAction) {
+        if (!$this->mountedTableBulkAction) {
             return null;
         }
 
@@ -149,11 +149,11 @@ trait HasBulkActions
     {
         $action = $this->getMountedTableBulkAction();
 
-        if (! $action) {
+        if (!$action) {
             return null;
         }
 
-        if ((! $this->isCachingForms) && $this->hasCachedForm('mountedTableBulkActionForm')) {
+        if ((!$this->isCachingForms) && $this->hasCachedForm('mountedTableBulkActionForm')) {
             return $this->getCachedForm('mountedTableBulkActionForm');
         }
 

--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -42,7 +42,7 @@ trait HasBulkActions
     {
         $action = $this->getMountedTableBulkAction();
 
-        if (!$action) {
+        if (! $action) {
             return;
         }
 
@@ -91,7 +91,7 @@ trait HasBulkActions
 
         $action = $this->getMountedTableBulkAction();
 
-        if (!$action) {
+        if (! $action) {
             return;
         }
 
@@ -118,7 +118,7 @@ trait HasBulkActions
             $action->callAfterFormFilled();
         }
 
-        if (!$action->shouldOpenModal()) {
+        if (! $action->shouldOpenModal()) {
             return $this->callMountedTableBulkAction();
         }
 
@@ -138,7 +138,7 @@ trait HasBulkActions
 
     public function getMountedTableBulkAction(): ?BulkAction
     {
-        if (!$this->mountedTableBulkAction) {
+        if (! $this->mountedTableBulkAction) {
             return null;
         }
 
@@ -149,11 +149,11 @@ trait HasBulkActions
     {
         $action = $this->getMountedTableBulkAction();
 
-        if (!$action) {
+        if (! $action) {
             return null;
         }
 
-        if ((!$this->isCachingForms) && $this->hasCachedForm('mountedTableBulkActionForm')) {
+        if ((! $this->isCachingForms) && $this->hasCachedForm('mountedTableBulkActionForm')) {
             return $this->getCachedForm('mountedTableBulkActionForm');
         }
 

--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -132,7 +132,7 @@ trait HasBulkActions
     public function getCachedTableBulkActions(): array
     {
         return collect($this->cachedTableBulkActions)
-            ->filter(fn (BulkAction $action): bool => !$action->isHidden())
+            ->filter(fn (BulkAction $action): bool => ! $action->isHidden())
             ->toArray();
     }
 


### PR DESCRIPTION
Fixes Issue #2967 

Example log errors that this PR fixes:

laravel.WARNING: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in /vendor/filament/tables/src/Concerns/HasActions.php on line 82 

laravel.WARNING: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in /vendor/filament/filament/src/Pages/Concerns/HasActions.php on line 52