### PR TITLE
Remove keybindings from DeleteAction

### DIFF
--- a/packages/admin/src/Pages/Actions/DeleteAction.php
+++ b/packages/admin/src/Pages/Actions/DeleteAction.php
@@ -32,8 +32,6 @@ class DeleteAction extends Action
 
         $this->requiresConfirmation();
 
-        $this->keyBindings(['mod+d']);
-
         $this->hidden(static function (Model $record): bool {
             if (! method_exists($record, 'trashed')) {
                 return false;


### PR DESCRIPTION
The keybinding on DeleteAction (which is the only PageAction with a keybinding) is causing issues as `+` is not a valid char for attribute names (https://github.com/filamentphp/filament/issues/2834).

Removing this until there is a solution for `x-mousetrap`