### PR TITLE
Change `data` parameter to `state`

### DIFF
--- a/packages/tables/src/Filters/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Filters/Concerns/InteractsWithTableQuery.php
@@ -25,6 +25,7 @@ trait InteractsWithTableQuery
 
         $callback = $this->modifyQueryUsing;
         $this->evaluate($callback, [
+            'data' => $data,
             'query' => $query,
             'state' => $data,
         ]);

--- a/packages/tables/src/Filters/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Filters/Concerns/InteractsWithTableQuery.php
@@ -26,7 +26,7 @@ trait InteractsWithTableQuery
         $callback = $this->modifyQueryUsing;
         $this->evaluate($callback, [
             'query' => $query,
-            'data' => $data,
+            'state' => $data,
         ]);
 
         return $query;


### PR DESCRIPTION
This can help when using the `->query()` function

Example : 

```php
Tables\Filters\MultiSelectFilter::make('field')
          ->options(Model::all()->pluck('name', 'id'))
          ->query(function (Builder $query, array $state) { // <-- HERE using the $state parameter
                      // ... Some code here
                      return $query;
           }),
```