### PR TITLE
Add `enableOpen` to FileUpload field

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -1170,7 +1170,7 @@ FileUpload::make('attachments')
     ->enableReordering()
 ```
 
-You can add a button to open the file in a new tab to each uploaded file with the `enableOpen()` method:
+You can add a button to open each file in a new tab with the `enableOpen()` method:
 
 ```php
 use Filament\Forms\Components\FileUpload;
@@ -1180,7 +1180,7 @@ FileUpload::make('attachments')
     ->enableOpen()
 ```
 
-If you wish to add a download button to each uploaded file instead, you can use the `enableDownload()` method:
+If you wish to add a download button to each file instead, you can use the `enableDownload()` method:
 
 ```php
 use Filament\Forms\Components\FileUpload;

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -1170,7 +1170,17 @@ FileUpload::make('attachments')
     ->enableReordering()
 ```
 
-If you wish to add a download button to each uploaded file, you can use the `enableDownload()` method:
+You can add a button to open the file in a new tab to each uploaded file with the `enableOpen()` method:
+
+```php
+use Filament\Forms\Components\FileUpload;
+
+FileUpload::make('attachments')
+    ->multipe()
+    ->enableOpen()
+```
+
+If you wish to add a download button to each uploaded file instead, you can use the `enableDownload()` method:
 
 ```php
 use Filament\Forms\Components\FileUpload;

--- a/packages/forms/resources/css/components/file-upload.css
+++ b/packages/forms/resources/css/components/file-upload.css
@@ -65,7 +65,7 @@
     mask-size: 100%;
 }
 
-.filepond--external-icon {
+.filepond--open-icon {
     @apply inline-block align-bottom bg-white w-4 h-4 mr-1 pointer-events-auto hover:bg-white/70;
     -webkit-mask-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGNsYXNzPSJoLTYgdy02IiBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjIiPgogIDxwYXRoIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgZD0iTTEwIDZINmEyIDIgMCAwMC0yIDJ2MTBhMiAyIDAgMDAyIDJoMTBhMiAyIDAgMDAyLTJ2LTRNMTQgNGg2bTAgMHY2bTAtNkwxMCAxNCIgLz4KPC9zdmc+Cg==);
     mask-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGNsYXNzPSJoLTYgdy02IiBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjIiPgogIDxwYXRoIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgZD0iTTEwIDZINmEyIDIgMCAwMC0yIDJ2MTBhMiAyIDAgMDAyIDJoMTBhMiAyIDAgMDAyLTJ2LTRNMTQgNGg2bTAgMHY2bTAtNkwxMCAxNCIgLz4KPC9zdmc+Cg==);

--- a/packages/forms/resources/css/components/file-upload.css
+++ b/packages/forms/resources/css/components/file-upload.css
@@ -64,3 +64,13 @@
     -webkit-mask-size: 100%;
     mask-size: 100%;
 }
+
+.filepond--external-icon {
+    @apply inline-block align-bottom bg-white w-4 h-4 mr-1 pointer-events-auto hover:bg-white/70;
+    -webkit-mask-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGNsYXNzPSJoLTYgdy02IiBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjIiPgogIDxwYXRoIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgZD0iTTEwIDZINmEyIDIgMCAwMC0yIDJ2MTBhMiAyIDAgMDAyIDJoMTBhMiAyIDAgMDAyLTJ2LTRNMTQgNGg2bTAgMHY2bTAtNkwxMCAxNCIgLz4KPC9zdmc+Cg==);
+    mask-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGNsYXNzPSJoLTYgdy02IiBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjIiPgogIDxwYXRoIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgZD0iTTEwIDZINmEyIDIgMCAwMC0yIDJ2MTBhMiAyIDAgMDAyIDJoMTBhMiAyIDAgMDAyLTJ2LTRNMTQgNGg2bTAgMHY2bTAtNkwxMCAxNCIgLz4KPC9zdmc+Cg==);
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: 100%;
+    mask-size: 100%;
+}

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -28,6 +28,8 @@ export default (Alpine) => {
     Alpine.data('fileUploadFormComponent', ({
         acceptedFileTypes,
         canDownload,
+        canOpen,
+        shouldOpenInNewTab,
         canPreview,
         canReorder,
         deleteUploadedFileUsing,
@@ -62,7 +64,7 @@ export default (Alpine) => {
             shouldUpdateState: true,
 
             state,
-            
+
             lastState: null,
 
             uploadedFileUrlIndex: {},
@@ -141,12 +143,12 @@ export default (Alpine) => {
                     if (Object.values(this.state).filter((file) => file.startsWith('livewire-file:')).length) {
                         return
                     }
-                    
+
                     // Don't do anything if the state hasn't changed
                     if (JSON.stringify(this.state) === this.lastState) {
                         return
                     }
-                    
+
                     this.lastState = JSON.stringify(this.state)
 
                     this.pond.files = await this.getFiles()
@@ -161,7 +163,7 @@ export default (Alpine) => {
                 })
 
                 this.pond.on('initfile', async (fileItem) => {
-                    if (! canDownload) {
+                    if (! (canOpen || canDownload)) {
                         return
                     }
 
@@ -169,7 +171,7 @@ export default (Alpine) => {
                         return
                     }
 
-                    this.insertDownloadLink(fileItem)
+                    this.insertLinkToFile(fileItem)
                 })
 
                 this.pond.on('processfilestart', async () => {
@@ -241,12 +243,12 @@ export default (Alpine) => {
                 return shouldAppendFiles ? files : files.reverse()
             },
 
-            insertDownloadLink: function (file) {
+            insertLinkToFile: function (file) {
                 if (file.origin !== FilePond.FileOrigin.LOCAL) {
                     return
                 }
 
-                const url = this.getDownloadUrl(file)
+                const url = this.getFileUrl(file)
 
                 if (! url) {
                     return
@@ -257,7 +259,7 @@ export default (Alpine) => {
                     .prepend(url)
             },
 
-            getDownloadUrl: function (file) {
+            getFileUrl: function (file) {
                 let fileSource = file.source
 
                 if (! fileSource) {
@@ -265,9 +267,17 @@ export default (Alpine) => {
                 }
 
                 const anchor = document.createElement('a')
-                anchor.className = 'filepond--download-icon'
+                anchor.className = canDownload ? 'filepond--download-icon' : 'filepond--external-icon'
                 anchor.href = fileSource
-                anchor.download = file.file.name
+
+                if (shouldOpenInNewTab) {
+                    anchor.target = '_blank'
+                }
+
+                if (canDownload) {
+                    anchor.download = file.file.name
+                }
+
                 return anchor
             }
         }

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -163,7 +163,7 @@ export default (Alpine) => {
                 })
 
                 this.pond.on('initfile', async (fileItem) => {
-                    if (! (canOpen || canDownload)) {
+                    if (! canDownload) {
                         return
                     }
 
@@ -171,7 +171,20 @@ export default (Alpine) => {
                         return
                     }
 
-                    this.insertLinkToFile(fileItem)
+                    this.insertDownloadLink(fileItem)
+                })
+
+
+                this.pond.on('initfile', async (fileItem) => {
+                    if (! canOpen) {
+                        return
+                    }
+
+                    if (isAvatar) {
+                        return
+                    }
+
+                    this.insertOpenLink(fileItem)
                 })
 
                 this.pond.on('processfilestart', async () => {
@@ -243,23 +256,40 @@ export default (Alpine) => {
                 return shouldAppendFiles ? files : files.reverse()
             },
 
-            insertLinkToFile: function (file) {
+            insertDownloadLink: function (file) {
                 if (file.origin !== FilePond.FileOrigin.LOCAL) {
                     return
                 }
 
-                const url = this.getFileUrl(file)
+                const anchor = this.getDownloadLink(file)
 
-                if (! url) {
+                if (! anchor) {
                     return
                 }
 
                 document.getElementById(`filepond--item-${file.id}`)
                     .querySelector('.filepond--file-info-main')
-                    .prepend(url)
+                    .prepend(anchor)
             },
 
-            getFileUrl: function (file) {
+
+            insertOpenLink: function (file) {
+                if (file.origin !== FilePond.FileOrigin.LOCAL) {
+                    return
+                }
+
+                const anchor = this.getOpenLink(file)
+
+                if (! anchor) {
+                    return
+                }
+
+                document.getElementById(`filepond--item-${file.id}`)
+                    .querySelector('.filepond--file-info-main')
+                    .prepend(anchor)
+            },
+
+            getDownloadLink: function (file) {
                 let fileSource = file.source
 
                 if (! fileSource) {
@@ -267,15 +297,26 @@ export default (Alpine) => {
                 }
 
                 const anchor = document.createElement('a')
-                anchor.className = canDownload ? 'filepond--download-icon' : 'filepond--external-icon'
+                anchor.className = 'filepond--download-icon'
+                anchor.href = fileSource
+                anchor.download = file.file.name
+
+                return anchor
+            },
+
+            getOpenLink: function (file) {
+                let fileSource = file.source
+
+                if (! fileSource) {
+                    return
+                }
+
+                const anchor = document.createElement('a')
+                anchor.className = 'filepond--external-icon'
                 anchor.href = fileSource
 
                 if (shouldOpenInNewTab) {
                     anchor.target = '_blank'
-                }
-
-                if (canDownload) {
-                    anchor.download = file.file.name
                 }
 
                 return anchor

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -174,7 +174,6 @@ export default (Alpine) => {
                     this.insertDownloadLink(fileItem)
                 })
 
-
                 this.pond.on('initfile', async (fileItem) => {
                     if (! canOpen) {
                         return

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -29,7 +29,6 @@ export default (Alpine) => {
         acceptedFileTypes,
         canDownload,
         canOpen,
-        shouldOpenInNewTab,
         canPreview,
         canReorder,
         deleteUploadedFileUsing,
@@ -311,12 +310,9 @@ export default (Alpine) => {
                 }
 
                 const anchor = document.createElement('a')
-                anchor.className = 'filepond--external-icon'
+                anchor.className = 'filepond--open-icon'
                 anchor.href = fileSource
-
-                if (shouldOpenInNewTab) {
-                    anchor.target = '_blank'
-                }
+                anchor.target = '_blank'
 
                 return anchor
             }

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -45,7 +45,6 @@
             acceptedFileTypes: {{ json_encode($getAcceptedFileTypes()) }},
             canDownload: {{ $canDownload() ? 'true' : 'false' }},
             canOpen: {{ $canOpen() ? 'true' : 'false' }},
-            shouldOpenInNewTab: {{ $shouldOpenInNewTab() ? 'true' : 'false' }},
             canPreview: {{ $canPreview() ? 'true' : 'false' }},
             canReorder: {{ $canReorder() ? 'true' : 'false' }},
             deleteUploadedFileUsing: async (fileKey) => {

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -44,6 +44,8 @@
         x-data="fileUploadFormComponent({
             acceptedFileTypes: {{ json_encode($getAcceptedFileTypes()) }},
             canDownload: {{ $canDownload() ? 'true' : 'false' }},
+            canOpen: {{ $canOpen() ? 'true' : 'false' }},
+            shouldOpenInNewTab: {{ $shouldOpenInNewTab() ? 'true' : 'false' }},
             canPreview: {{ $canPreview() ? 'true' : 'false' }},
             canReorder: {{ $canReorder() ? 'true' : 'false' }},
             deleteUploadedFileUsing: async (fileKey) => {

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -19,6 +19,10 @@ class BaseFileUpload extends Field
 
     protected bool | Closure $canDownload = false;
 
+    protected bool | Closure $canOpen = false;
+
+    protected bool | Closure $shouldOpenInNewTab = true;
+
     protected bool | Closure $canPreview = true;
 
     protected bool | Closure $canReorder = false;
@@ -180,6 +184,14 @@ class BaseFileUpload extends Field
         return $this;
     }
 
+    public function enableOpen(bool | Closure $condition = true, bool | Closure $newTab = true): static
+    {
+        $this->canOpen = $condition;
+        $this->shouldOpenInNewTab = $newTab;
+
+        return $this;
+    }
+
     public function enableReordering(bool | Closure $condition = true): static
     {
         $this->canReorder = $condition;
@@ -286,6 +298,16 @@ class BaseFileUpload extends Field
     public function canDownload(): bool
     {
         return $this->evaluate($this->canDownload);
+    }
+
+    public function canOpen(): bool
+    {
+        return $this->evaluate($this->canOpen);
+    }
+
+    public function shouldOpenInNewTab(): bool
+    {
+        return $this->evaluate($this->shouldOpenInNewTab);
     }
 
     public function canPreview(): bool

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -21,8 +21,6 @@ class BaseFileUpload extends Field
 
     protected bool | Closure $canOpen = false;
 
-    protected bool | Closure $shouldOpenInNewTab = true;
-
     protected bool | Closure $canPreview = true;
 
     protected bool | Closure $canReorder = false;
@@ -184,10 +182,9 @@ class BaseFileUpload extends Field
         return $this;
     }
 
-    public function enableOpen(bool | Closure $condition = true, bool | Closure $newTab = true): static
+    public function enableOpen(bool | Closure $condition = true): static
     {
         $this->canOpen = $condition;
-        $this->shouldOpenInNewTab = $newTab;
 
         return $this;
     }
@@ -303,11 +300,6 @@ class BaseFileUpload extends Field
     public function canOpen(): bool
     {
         return $this->evaluate($this->canOpen);
-    }
-
-    public function shouldOpenInNewTab(): bool
-    {
-        return $this->evaluate($this->shouldOpenInNewTab);
     }
 
     public function canPreview(): bool


### PR DESCRIPTION
Add a new feature `enableOpen()`, which adds an `external-link` icon to the files and opens them in a new tab (or same tab if you wish)

![Bildschirmfoto 2022-06-30 um 12 50 59](https://user-images.githubusercontent.com/22632550/176659738-c3d9161e-d23f-4843-901c-785edd28515d.png)
