### PR TITLE
German translations

### DIFF
--- a/packages/admin/resources/lang/de/global-search.php
+++ b/packages/admin/resources/lang/de/global-search.php
@@ -1,6 +1,12 @@
 <?php
 
 return [
-    'field' => ['label' => 'Globale Suche', 'placeholder' => 'Suchen'],
+
+    'field' => [
+        'label' => 'Globale Suche',
+        'placeholder' => 'Suchen'
+    ],
+
     'no_results_message' => 'Keine Ergebnisse gefunden.',
+
 ];

--- a/packages/admin/resources/lang/de/global-search.php
+++ b/packages/admin/resources/lang/de/global-search.php
@@ -4,7 +4,7 @@ return [
 
     'field' => [
         'label' => 'Globale Suche',
-        'placeholder' => 'Suchen'
+        'placeholder' => 'Suchen',
     ],
 
     'no_results_message' => 'Keine Ergebnisse gefunden.',

--- a/packages/admin/resources/lang/de/global-search.php
+++ b/packages/admin/resources/lang/de/global-search.php
@@ -1,12 +1,6 @@
 <?php
 
 return [
-
-    'field' => [
-        'label' => 'Globale Suche',
-        'placeholder' => 'Suchen',
-    ],
-
+    'field' => ['label' => 'Globale Suche', 'placeholder' => 'Suchen'],
     'no_results_message' => 'Keine Ergebnisse gefunden.',
-
 ];

--- a/packages/admin/resources/lang/de/layout.php
+++ b/packages/admin/resources/lang/de/layout.php
@@ -2,9 +2,20 @@
 
 return [
     'buttons' => [
-        'dark_mode' => ['label' => 'Dark Mode einschalten'],
-        'light_mode' => ['label' => 'Light Mode einschalten'],
-        'logout' => ['label' => 'Abmelden'],
+
+        'dark_mode' => [
+            'label' => 'Dark Mode einschalten'
+        ],
+
+        'light_mode' => [
+            'label' => 'Light Mode einschalten'
+        ],
+
+        'logout' => [
+            'label' => 'Abmelden'
+        ],
+
     ],
+
     'direction' => 'ltr',
 ];

--- a/packages/admin/resources/lang/de/layout.php
+++ b/packages/admin/resources/lang/de/layout.php
@@ -4,15 +4,15 @@ return [
     'buttons' => [
 
         'dark_mode' => [
-            'label' => 'Dark Mode einschalten'
+            'label' => 'Dark Mode einschalten',
         ],
 
         'light_mode' => [
-            'label' => 'Light Mode einschalten'
+            'label' => 'Light Mode einschalten',
         ],
 
         'logout' => [
-            'label' => 'Abmelden'
+            'label' => 'Abmelden',
         ],
 
     ],

--- a/packages/admin/resources/lang/de/layout.php
+++ b/packages/admin/resources/lang/de/layout.php
@@ -1,13 +1,10 @@
 <?php
 
 return [
-
-    'direction' => 'ltr',
-
     'buttons' => [
-        'logout' => [
-            'label' => 'Abmelden',
-        ],
+        'dark_mode' => ['label' => 'Dark Mode einschalten'],
+        'light_mode' => ['label' => 'Light Mode einschalten'],
+        'logout' => ['label' => 'Abmelden'],
     ],
-
+    'direction' => 'ltr',
 ];

--- a/packages/admin/resources/lang/de/login.php
+++ b/packages/admin/resources/lang/de/login.php
@@ -4,23 +4,23 @@ return [
     'buttons' => [
 
         'submit' => [
-            'label' => 'Anmelden'
-        ]
+            'label' => 'Anmelden',
+        ],
 
     ],
 
     'fields' => [
 
         'email' => [
-            'label' => 'E-Mail-Adresse'
+            'label' => 'E-Mail-Adresse',
         ],
 
         'password' => [
-            'label' => 'Passwort'
+            'label' => 'Passwort',
         ],
 
         'remember' => [
-            'label' => 'Angemeldet bleiben'
+            'label' => 'Angemeldet bleiben',
         ],
 
     ],

--- a/packages/admin/resources/lang/de/login.php
+++ b/packages/admin/resources/lang/de/login.php
@@ -1,16 +1,37 @@
 <?php
 
 return [
-    'buttons' => ['submit' => ['label' => 'Anmelden']],
-    'fields' => [
-        'email' => ['label' => 'E-Mail-Adresse'],
-        'password' => ['label' => 'Passwort'],
-        'remember' => ['label' => 'Angemeldet bleiben'],
+    'buttons' => [
+
+        'submit' => [
+            'label' => 'Anmelden'
+        ]
+
     ],
+
+    'fields' => [
+
+        'email' => [
+            'label' => 'E-Mail-Adresse'
+        ],
+
+        'password' => [
+            'label' => 'Passwort'
+        ],
+
+        'remember' => [
+            'label' => 'Angemeldet bleiben'
+        ],
+
+    ],
+
     'heading' => 'Melden Sie sich an.',
+
     'messages' => [
         'failed' => 'Diese Kombination aus Zugangsdaten wurde nicht in unserer Datenbank gefunden.',
         'throttled' => 'Zu viele Loginversuche. Versuchen Sie es bitte in :seconds Sekunden nochmal.',
     ],
+
     'title' => 'Anmelden',
+
 ];

--- a/packages/admin/resources/lang/de/login.php
+++ b/packages/admin/resources/lang/de/login.php
@@ -1,38 +1,16 @@
 <?php
 
 return [
-
-    'title' => 'Anmelden',
-
-    'heading' => 'Melden Sie sich an.',
-
-    'buttons' => [
-
-        'submit' => [
-            'label' => 'Anmelden',
-        ],
-
-    ],
-
+    'buttons' => ['submit' => ['label' => 'Anmelden']],
     'fields' => [
-
-        'email' => [
-            'label' => 'E-Mail-Adresse',
-        ],
-
-        'password' => [
-            'label' => 'Passwort',
-        ],
-
-        'remember' => [
-            'label' => 'Angemeldet bleiben',
-        ],
-
+        'email' => ['label' => 'E-Mail-Adresse'],
+        'password' => ['label' => 'Passwort'],
+        'remember' => ['label' => 'Angemeldet bleiben'],
     ],
-
+    'heading' => 'Melden Sie sich an.',
     'messages' => [
         'failed' => 'Diese Kombination aus Zugangsdaten wurde nicht in unserer Datenbank gefunden.',
         'throttled' => 'Zu viele Loginversuche. Versuchen Sie es bitte in :seconds Sekunden nochmal.',
     ],
-
+    'title' => 'Anmelden',
 ];

--- a/packages/forms/resources/lang/de/components.php
+++ b/packages/forms/resources/lang/de/components.php
@@ -2,26 +2,76 @@
 
 return [
     'builder' => [
+
         'buttons' => [
-            'collapse_all' => ['label' => 'Alle einklappen'],
-            'collapse_item' => ['label' => 'Einklappen'],
-            'create_item' => ['label' => 'Zu :label hinzufügen'],
-            'delete_item' => ['label' => 'Löschen'],
-            'expand_all' => ['label' => 'Alle ausklappen'],
-            'expand_item' => ['label' => 'Ausklappen'],
-            'move_item_down' => ['label' => 'Runter verschieben'],
-            'move_item_up' => ['label' => 'Hoch verschieben'],
+
+            'collapse_all' => [
+                'label' => 'Alle einklappen'
+            ],
+
+            'collapse_item' => [
+                'label' => 'Einklappen'
+            ],
+
+            'create_item' => [
+                'label' => 'Zu :label hinzufügen'
+            ],
+
+            'delete_item' => [
+                'label' => 'Löschen'
+            ],
+
+            'expand_all' => [
+                'label' => 'Alle ausklappen'
+            ],
+
+            'expand_item' => [
+                'label' => 'Ausklappen'
+            ],
+
+            'move_item_down' => [
+                'label' => 'Runter verschieben'
+            ],
+
+            'move_item_up' => [
+                'label' => 'Hoch verschieben'
+            ],
+
         ],
+
         'collapsed' => 'Inhalt eingeklappt',
     ],
+
     'key_value' => [
+
         'buttons' => [
-            'add' => ['label' => 'Zeile hinzufügen'],
-            'delete' => ['label' => 'Zeile löschen'],
+
+            'add' => [
+                'label' => 'Zeile hinzufügen'
+            ],
+
+            'delete' => [
+                'label' => 'Zeile löschen'
+            ],
+
         ],
-        'fields' => ['key' => ['label' => 'Schlüssel'], 'value' => ['label' => 'Wert']],
+
+        'fields' => [
+
+            'key' => [
+                'label' => 'Schlüssel'
+            ],
+
+            'value' => [
+                'label' => 'Wert'
+            ]
+
+        ],
+
     ],
+
     'markdown_editor' => [
+
         'toolbar_buttons' => [
             'attach_files' => 'Dateien hinzufügen',
             'bold' => 'Fett',
@@ -34,28 +84,67 @@ return [
             'preview' => 'Vorschau',
             'strike' => 'Durchgestrichen',
         ],
+
     ],
+
     'repeater' => [
+
         'buttons' => [
-            'collapse_all' => ['label' => 'Alle einklappen'],
-            'collapse_item' => ['label' => 'Einklappen'],
-            'create_item' => ['label' => 'Zu :label hinzufügen'],
-            'delete_item' => ['label' => 'Löschen'],
-            'expand_all' => ['label' => 'Alle ausklappen'],
-            'expand_item' => ['label' => 'Ausklappen'],
-            'move_item_down' => ['label' => 'Runter verschieben'],
-            'move_item_up' => ['label' => 'Hoch verschieben'],
+
+            'collapse_all' => [
+                'label' => 'Alle einklappen'
+            ],
+
+            'collapse_item' => [
+                'label' => 'Einklappen'
+            ],
+
+            'create_item' => [
+                'label' => 'Zu :label hinzufügen'
+            ],
+
+            'delete_item' => [
+                'label' => 'Löschen'
+            ],
+
+            'expand_all' => [
+                'label' => 'Alle ausklappen'
+            ],
+
+            'expand_item' => [
+                'label' => 'Ausklappen'
+            ],
+
+            'move_item_down' => [
+                'label' => 'Runter verschieben'
+            ],
+
+            'move_item_up' => [
+                'label' => 'Hoch verschieben'
+            ],
+
         ],
+
         'collapsed' => 'Inhalt eingeklappt',
     ],
+
     'rich_editor' => [
+
         'dialogs' => [
+
             'link' => [
-                'buttons' => ['link' => 'Verlinken', 'unlink' => 'Verlinkung aufheben'],
+
+                'buttons' => [
+                    'link' => 'Verlinken',
+                    'unlink' => 'Verlinkung aufheben'
+                ],
+
                 'label' => 'URL',
+
                 'placeholder' => 'URL eingeben',
             ],
         ],
+
         'toolbar_buttons' => [
             'attach_files' => 'Dateien anhängen',
             'blockquote' => 'Zitat',
@@ -73,21 +162,59 @@ return [
             'undo' => 'Rückgängig',
         ],
     ],
+
     'select' => [
+
         'actions' => [
+
             'create_option' => [
-                'modal' => ['actions' => ['create' => ['label' => 'Erstellen']], 'heading' => 'Erstellen'],
+
+                'modal' => [
+
+                    'actions' => [
+
+                        'create' => [
+                            'label' => 'Erstellen'
+                        ]
+
+                    ],
+
+                    'heading' => 'Erstellen'
+                ],
+
             ],
         ],
-        'boolean' => ['false' => 'Nein', 'true' => 'Ja'],
+
+        'boolean' => [
+            'false' => 'Nein',
+            'true' => 'Ja'
+        ],
+
         'loading_message' => 'Lädt...',
         'no_search_results_message' => 'Keine Optionen passen zu Ihrer Suche.',
         'placeholder' => 'Wählen Sie eine Option',
         'search_prompt' => 'Beginnen Sie mit der Eingabe, um zu suchen...',
         'searching_message' => 'Sucht...',
     ],
-    'tags_input' => ['placeholder' => 'Neues Etikett'],
-    'wizard' => [
-        'buttons' => ['next_step' => ['label' => 'Weiter'], 'previous_step' => ['label' => 'Zurück']],
+
+    'tags_input' => [
+        'placeholder' => 'Neues Etikett'
     ],
+
+    'wizard' => [
+
+        'buttons' => [
+
+            'next_step' => [
+                'label' => 'Weiter'
+            ],
+
+            'previous_step' => [
+                'label' => 'Zurück'
+            ]
+
+        ],
+
+    ],
+
 ];

--- a/packages/forms/resources/lang/de/components.php
+++ b/packages/forms/resources/lang/de/components.php
@@ -6,35 +6,35 @@ return [
         'buttons' => [
 
             'collapse_all' => [
-                'label' => 'Alle einklappen'
+                'label' => 'Alle einklappen',
             ],
 
             'collapse_item' => [
-                'label' => 'Einklappen'
+                'label' => 'Einklappen',
             ],
 
             'create_item' => [
-                'label' => 'Zu :label hinzufügen'
+                'label' => 'Zu :label hinzufügen',
             ],
 
             'delete_item' => [
-                'label' => 'Löschen'
+                'label' => 'Löschen',
             ],
 
             'expand_all' => [
-                'label' => 'Alle ausklappen'
+                'label' => 'Alle ausklappen',
             ],
 
             'expand_item' => [
-                'label' => 'Ausklappen'
+                'label' => 'Ausklappen',
             ],
 
             'move_item_down' => [
-                'label' => 'Runter verschieben'
+                'label' => 'Runter verschieben',
             ],
 
             'move_item_up' => [
-                'label' => 'Hoch verschieben'
+                'label' => 'Hoch verschieben',
             ],
 
         ],
@@ -47,11 +47,11 @@ return [
         'buttons' => [
 
             'add' => [
-                'label' => 'Zeile hinzufügen'
+                'label' => 'Zeile hinzufügen',
             ],
 
             'delete' => [
-                'label' => 'Zeile löschen'
+                'label' => 'Zeile löschen',
             ],
 
         ],
@@ -59,12 +59,12 @@ return [
         'fields' => [
 
             'key' => [
-                'label' => 'Schlüssel'
+                'label' => 'Schlüssel',
             ],
 
             'value' => [
-                'label' => 'Wert'
-            ]
+                'label' => 'Wert',
+            ],
 
         ],
 
@@ -92,35 +92,35 @@ return [
         'buttons' => [
 
             'collapse_all' => [
-                'label' => 'Alle einklappen'
+                'label' => 'Alle einklappen',
             ],
 
             'collapse_item' => [
-                'label' => 'Einklappen'
+                'label' => 'Einklappen',
             ],
 
             'create_item' => [
-                'label' => 'Zu :label hinzufügen'
+                'label' => 'Zu :label hinzufügen',
             ],
 
             'delete_item' => [
-                'label' => 'Löschen'
+                'label' => 'Löschen',
             ],
 
             'expand_all' => [
-                'label' => 'Alle ausklappen'
+                'label' => 'Alle ausklappen',
             ],
 
             'expand_item' => [
-                'label' => 'Ausklappen'
+                'label' => 'Ausklappen',
             ],
 
             'move_item_down' => [
-                'label' => 'Runter verschieben'
+                'label' => 'Runter verschieben',
             ],
 
             'move_item_up' => [
-                'label' => 'Hoch verschieben'
+                'label' => 'Hoch verschieben',
             ],
 
         ],
@@ -136,7 +136,7 @@ return [
 
                 'buttons' => [
                     'link' => 'Verlinken',
-                    'unlink' => 'Verlinkung aufheben'
+                    'unlink' => 'Verlinkung aufheben',
                 ],
 
                 'label' => 'URL',
@@ -174,12 +174,12 @@ return [
                     'actions' => [
 
                         'create' => [
-                            'label' => 'Erstellen'
-                        ]
+                            'label' => 'Erstellen',
+                        ],
 
                     ],
 
-                    'heading' => 'Erstellen'
+                    'heading' => 'Erstellen',
                 ],
 
             ],
@@ -187,7 +187,7 @@ return [
 
         'boolean' => [
             'false' => 'Nein',
-            'true' => 'Ja'
+            'true' => 'Ja',
         ],
 
         'loading_message' => 'Lädt...',
@@ -198,7 +198,7 @@ return [
     ],
 
     'tags_input' => [
-        'placeholder' => 'Neues Etikett'
+        'placeholder' => 'Neues Etikett',
     ],
 
     'wizard' => [
@@ -206,12 +206,12 @@ return [
         'buttons' => [
 
             'next_step' => [
-                'label' => 'Weiter'
+                'label' => 'Weiter',
             ],
 
             'previous_step' => [
-                'label' => 'Zurück'
-            ]
+                'label' => 'Zurück',
+            ],
 
         ],
 

--- a/packages/forms/resources/lang/de/components.php
+++ b/packages/forms/resources/lang/de/components.php
@@ -1,26 +1,61 @@
 <?php
 
 return [
-
-    'rich_editor' => [
-
-        'dialogs' => [
-
-            'link' => [
-
-                'buttons' => [
-                    'link' => 'Verlinken',
-                    'unlink' => 'Verlinkung aufheben',
-                ],
-
-                'label' => 'URL',
-
-                'placeholder' => 'URL eingeben',
-
-            ],
-
+    'builder' => [
+        'buttons' => [
+            'collapse_all' => ['label' => 'Alle einklappen'],
+            'collapse_item' => ['label' => 'Einklappen'],
+            'create_item' => ['label' => 'Zu :label hinzufügen'],
+            'delete_item' => ['label' => 'Löschen'],
+            'expand_all' => ['label' => 'Alle ausklappen'],
+            'expand_item' => ['label' => 'Ausklappen'],
+            'move_item_down' => ['label' => 'Runter verschieben'],
+            'move_item_up' => ['label' => 'Hoch verschieben'],
         ],
-
+        'collapsed' => 'Inhalt eingeklappt',
+    ],
+    'key_value' => [
+        'buttons' => [
+            'add' => ['label' => 'Zeile hinzufügen'],
+            'delete' => ['label' => 'Zeile löschen'],
+        ],
+        'fields' => ['key' => ['label' => 'Schlüssel'], 'value' => ['label' => 'Wert']],
+    ],
+    'markdown_editor' => [
+        'toolbar_buttons' => [
+            'attach_files' => 'Dateien hinzufügen',
+            'bold' => 'Fett',
+            'bullet_list' => 'Liste',
+            'code_block' => 'Code Block',
+            'edit' => 'Bearbeiten',
+            'italic' => 'Kursiv',
+            'link' => 'Link',
+            'ordered_list' => 'Nummerierte Liste',
+            'preview' => 'Vorschau',
+            'strike' => 'Durchgestrichen',
+        ],
+    ],
+    'repeater' => [
+        'buttons' => [
+            'collapse_all' => ['label' => 'Alle einklappen'],
+            'collapse_item' => ['label' => 'Einklappen'],
+            'create_item' => ['label' => 'Zu :label hinzufügen'],
+            'delete_item' => ['label' => 'Löschen'],
+            'expand_all' => ['label' => 'Alle ausklappen'],
+            'expand_item' => ['label' => 'Ausklappen'],
+            'move_item_down' => ['label' => 'Runter verschieben'],
+            'move_item_up' => ['label' => 'Hoch verschieben'],
+        ],
+        'collapsed' => 'Inhalt eingeklappt',
+    ],
+    'rich_editor' => [
+        'dialogs' => [
+            'link' => [
+                'buttons' => ['link' => 'Verlinken', 'unlink' => 'Verlinkung aufheben'],
+                'label' => 'URL',
+                'placeholder' => 'URL eingeben',
+            ],
+        ],
         'toolbar_buttons' => [
             'attach_files' => 'Dateien anhängen',
             'blockquote' => 'Zitat',
@@ -37,17 +72,22 @@ return [
             'strike' => 'Durchgestrichen',
             'undo' => 'Rückgängig',
         ],
-
     ],
-
     'select' => [
+        'actions' => [
+            'create_option' => [
+                'modal' => ['actions' => ['create' => ['label' => 'Erstellen']], 'heading' => 'Erstellen'],
+            ],
+        ],
+        'boolean' => ['false' => 'Nein', 'true' => 'Ja'],
+        'loading_message' => 'Lädt...',
         'no_search_results_message' => 'Keine Optionen passen zu Ihrer Suche.',
         'placeholder' => 'Wählen Sie eine Option',
         'search_prompt' => 'Beginnen Sie mit der Eingabe, um zu suchen...',
+        'searching_message' => 'Sucht...',
     ],
-
-    'tags_input' => [
-        'placeholder' => 'Neues Etikett',
+    'tags_input' => ['placeholder' => 'Neues Etikett'],
+    'wizard' => [
+        'buttons' => ['next_step' => ['label' => 'Weiter'], 'previous_step' => ['label' => 'Zurück']],
     ],
-
 ];

--- a/packages/forms/resources/lang/it/components.php
+++ b/packages/forms/resources/lang/it/components.php
@@ -202,7 +202,7 @@ return [
     ],
 
     'tags_input' => [
-         'placeholder' => 'Nuovo tag',
+        'placeholder' => 'Nuovo tag',
     ],
 
     'wizard' => [

--- a/packages/support/resources/lang/de/actions/attach.php
+++ b/packages/support/resources/lang/de/actions/attach.php
@@ -1,41 +1,16 @@
 <?php
 
 return [
-
     'single' => [
-
         'label' => 'Verknüpfen',
-
+        'messages' => ['attached' => 'Verknüpft'],
         'modal' => [
-
-            'heading' => ':label verknüpfen',
-
-            'fields' => [
-
-                'record_ids' => [
-                    'label' => 'Einträge',
-                ],
-
-            ],
-
             'actions' => [
-
-                'attach' => [
-                    'label' => 'Verknüpfen',
-                ],
-
-                'attach_another' => [
-                    'label' => 'Verknüpfen & weiterer Eintrag',
-                ],
-
+                'attach' => ['label' => 'Verknüpfen'],
+                'attach_another' => ['label' => 'Verknüpfen & weiterer Eintrag'],
             ],
-
+            'fields' => ['record_ids' => ['label' => 'Einträge']],
+            'heading' => ':label verknüpfen',
         ],
-
-        'messages' => [
-            'attached' => 'Verknüpft',
-        ],
-
     ],
-
 ];

--- a/packages/support/resources/lang/de/actions/attach.php
+++ b/packages/support/resources/lang/de/actions/attach.php
@@ -1,16 +1,40 @@
 <?php
 
 return [
+
     'single' => [
+
         'label' => 'Verknüpfen',
-        'messages' => ['attached' => 'Verknüpft'],
+
+        'messages' => [
+            'attached' => 'Verknüpft'
+        ],
+
         'modal' => [
+
             'actions' => [
-                'attach' => ['label' => 'Verknüpfen'],
-                'attach_another' => ['label' => 'Verknüpfen & weiterer Eintrag'],
+
+                'attach' => [
+                    'label' => 'Verknüpfen'
+                ],
+
+                'attach_another' => [
+                    'label' => 'Verknüpfen & weiterer Eintrag'
+                ],
+
             ],
-            'fields' => ['record_ids' => ['label' => 'Einträge']],
+
+            'fields' => [
+
+                'record_ids' => [
+                    'label' => 'Einträge'
+                ]
+
+            ],
+
             'heading' => ':label verknüpfen',
         ],
+
     ],
+
 ];

--- a/packages/support/resources/lang/de/actions/attach.php
+++ b/packages/support/resources/lang/de/actions/attach.php
@@ -7,7 +7,7 @@ return [
         'label' => 'Verknüpfen',
 
         'messages' => [
-            'attached' => 'Verknüpft'
+            'attached' => 'Verknüpft',
         ],
 
         'modal' => [
@@ -15,11 +15,11 @@ return [
             'actions' => [
 
                 'attach' => [
-                    'label' => 'Verknüpfen'
+                    'label' => 'Verknüpfen',
                 ],
 
                 'attach_another' => [
-                    'label' => 'Verknüpfen & weiterer Eintrag'
+                    'label' => 'Verknüpfen & weiterer Eintrag',
                 ],
 
             ],
@@ -27,8 +27,8 @@ return [
             'fields' => [
 
                 'record_ids' => [
-                    'label' => 'Einträge'
-                ]
+                    'label' => 'Einträge',
+                ],
 
             ],
 

--- a/packages/support/resources/lang/de/actions/create.php
+++ b/packages/support/resources/lang/de/actions/create.php
@@ -1,33 +1,15 @@
 <?php
 
 return [
-
     'single' => [
-
         'label' => 'Erstellen',
-
+        'messages' => ['created' => 'Erstellt'],
         'modal' => [
-
-            'heading' => ':label erstellen',
-
             'actions' => [
-
-                'create' => [
-                    'label' => 'Erstellen',
-                ],
-
-                'create_another' => [
-                    'label' => 'Erstellen & weiterer Eintrag',
-                ],
-
+                'create' => ['label' => 'Erstellen'],
+                'create_another' => ['label' => 'Erstellen & weiterer Eintrag'],
             ],
-
+            'heading' => ':label erstellen',
         ],
-
-        'messages' => [
-            'created' => 'Erstellt',
-        ],
-
     ],
-
 ];

--- a/packages/support/resources/lang/de/actions/create.php
+++ b/packages/support/resources/lang/de/actions/create.php
@@ -7,7 +7,7 @@ return [
         'label' => 'Erstellen',
 
         'messages' => [
-            'created' => 'Erstellt'
+            'created' => 'Erstellt',
         ],
 
         'modal' => [
@@ -15,11 +15,11 @@ return [
             'actions' => [
 
                 'create' => [
-                    'label' => 'Erstellen'
+                    'label' => 'Erstellen',
                 ],
 
                 'create_another' => [
-                    'label' => 'Erstellen & weiterer Eintrag'
+                    'label' => 'Erstellen & weiterer Eintrag',
                 ],
 
             ],

--- a/packages/support/resources/lang/de/actions/create.php
+++ b/packages/support/resources/lang/de/actions/create.php
@@ -1,15 +1,32 @@
 <?php
 
 return [
+
     'single' => [
+
         'label' => 'Erstellen',
-        'messages' => ['created' => 'Erstellt'],
+
+        'messages' => [
+            'created' => 'Erstellt'
+        ],
+
         'modal' => [
+
             'actions' => [
-                'create' => ['label' => 'Erstellen'],
-                'create_another' => ['label' => 'Erstellen & weiterer Eintrag'],
+
+                'create' => [
+                    'label' => 'Erstellen'
+                ],
+
+                'create_another' => [
+                    'label' => 'Erstellen & weiterer Eintrag'
+                ],
+
             ],
+
             'heading' => ':label erstellen',
         ],
+
     ],
+
 ];

--- a/packages/support/resources/lang/de/actions/delete.php
+++ b/packages/support/resources/lang/de/actions/delete.php
@@ -1,17 +1,51 @@
 <?php
 
 return [
+
     'multiple' => [
+
         'label' => 'Ausgewählte löschen',
-        'messages' => ['deleted' => 'Gelöscht'],
+
+        'messages' => [
+            'deleted' => 'Gelöscht'
+        ],
+
         'modal' => [
-            'actions' => ['delete' => ['label' => 'Ausgewählte löschen']],
+
+            'actions' => [
+
+                'delete' => [
+                    'label' => 'Ausgewählte löschen'
+                ]
+
+            ],
+
             'heading' => 'Ausgewählte :label löschen',
         ],
+
     ],
+
     'single' => [
+
         'label' => 'Löschen',
-        'messages' => ['deleted' => 'Gelöscht'],
-        'modal' => ['actions' => ['delete' => ['label' => 'Löschen']], 'heading' => ':label löschen'],
+
+        'messages' => [
+            'deleted' => 'Gelöscht'
+        ],
+
+        'modal' => [
+
+            'actions' => [
+
+                'delete' => [
+                    'label' => 'Löschen'
+                ]
+
+            ],
+
+            'heading' => ':label löschen'
+        ],
+
     ],
+
 ];

--- a/packages/support/resources/lang/de/actions/delete.php
+++ b/packages/support/resources/lang/de/actions/delete.php
@@ -7,7 +7,7 @@ return [
         'label' => 'Ausgewählte löschen',
 
         'messages' => [
-            'deleted' => 'Gelöscht'
+            'deleted' => 'Gelöscht',
         ],
 
         'modal' => [
@@ -15,8 +15,8 @@ return [
             'actions' => [
 
                 'delete' => [
-                    'label' => 'Ausgewählte löschen'
-                ]
+                    'label' => 'Ausgewählte löschen',
+                ],
 
             ],
 
@@ -30,7 +30,7 @@ return [
         'label' => 'Löschen',
 
         'messages' => [
-            'deleted' => 'Gelöscht'
+            'deleted' => 'Gelöscht',
         ],
 
         'modal' => [
@@ -38,12 +38,12 @@ return [
             'actions' => [
 
                 'delete' => [
-                    'label' => 'Löschen'
-                ]
+                    'label' => 'Löschen',
+                ],
 
             ],
 
-            'heading' => ':label löschen'
+            'heading' => ':label löschen',
         ],
 
     ],

--- a/packages/support/resources/lang/de/actions/delete.php
+++ b/packages/support/resources/lang/de/actions/delete.php
@@ -1,53 +1,17 @@
 <?php
 
 return [
-
-    'single' => [
-
-        'label' => 'Löschen',
-
-        'modal' => [
-
-            'heading' => ':label löschen',
-
-            'actions' => [
-
-                'delete' => [
-                    'label' => 'Löschen',
-                ],
-
-            ],
-
-        ],
-
-        'messages' => [
-            'deleted' => 'Gelöscht',
-        ],
-
-    ],
-
     'multiple' => [
-
         'label' => 'Ausgewählte löschen',
-
+        'messages' => ['deleted' => 'Gelöscht'],
         'modal' => [
-
+            'actions' => ['delete' => ['label' => 'Ausgewählte löschen']],
             'heading' => 'Ausgewählte :label löschen',
-
-            'actions' => [
-
-                'delete' => [
-                    'label' => 'Ausgewählte löschen',
-                ],
-
-            ],
-
         ],
-
-        'messages' => [
-            'deleted' => 'Gelöscht',
-        ],
-
     ],
-
+    'single' => [
+        'label' => 'Löschen',
+        'messages' => ['deleted' => 'Gelöscht'],
+        'modal' => ['actions' => ['delete' => ['label' => 'Löschen']], 'heading' => ':label löschen'],
+    ],
 ];

--- a/packages/support/resources/lang/de/actions/detach.php
+++ b/packages/support/resources/lang/de/actions/detach.php
@@ -1,53 +1,17 @@
 <?php
 
 return [
-
-    'single' => [
-
-        'label' => 'Trennen',
-
-        'modal' => [
-
-            'heading' => ':label trennen',
-
-            'actions' => [
-
-                'detach' => [
-                    'label' => 'Trennen',
-                ],
-
-            ],
-
-        ],
-
-        'messages' => [
-            'detached' => 'Getrennt',
-        ],
-
-    ],
-
     'multiple' => [
-
         'label' => 'Ausgewählte trennen',
-
+        'messages' => ['detached' => 'Getrennt'],
         'modal' => [
-
+            'actions' => ['detach' => ['label' => 'Ausgewählte trennen']],
             'heading' => 'Ausgewählte :label trennen',
-
-            'actions' => [
-
-                'detach' => [
-                    'label' => 'Ausgewählte trennen',
-                ],
-
-            ],
-
         ],
-
-        'messages' => [
-            'detached' => 'Getrennt',
-        ],
-
     ],
-
+    'single' => [
+        'label' => 'Trennen',
+        'messages' => ['detached' => 'Getrennt'],
+        'modal' => ['actions' => ['detach' => ['label' => 'Trennen']], 'heading' => ':label trennen'],
+    ],
 ];

--- a/packages/support/resources/lang/de/actions/detach.php
+++ b/packages/support/resources/lang/de/actions/detach.php
@@ -7,7 +7,7 @@ return [
         'label' => 'Ausgewählte trennen',
 
         'messages' => [
-            'detached' => 'Getrennt'
+            'detached' => 'Getrennt',
         ],
 
         'modal' => [
@@ -15,8 +15,8 @@ return [
             'actions' => [
 
                 'detach' => [
-                    'label' => 'Ausgewählte trennen'
-                ]
+                    'label' => 'Ausgewählte trennen',
+                ],
 
             ],
 
@@ -31,7 +31,7 @@ return [
         'label' => 'Trennen',
 
         'messages' => [
-            'detached' => 'Getrennt'
+            'detached' => 'Getrennt',
         ],
 
         'modal' => [
@@ -39,12 +39,12 @@ return [
             'actions' => [
 
                 'detach' => [
-                    'label' => 'Trennen'
-                ]
+                    'label' => 'Trennen',
+                ],
 
             ],
 
-            'heading' => ':label trennen'
+            'heading' => ':label trennen',
         ],
     ],
 

--- a/packages/support/resources/lang/de/actions/detach.php
+++ b/packages/support/resources/lang/de/actions/detach.php
@@ -1,17 +1,51 @@
 <?php
 
 return [
+
     'multiple' => [
+
         'label' => 'Ausgewählte trennen',
-        'messages' => ['detached' => 'Getrennt'],
+
+        'messages' => [
+            'detached' => 'Getrennt'
+        ],
+
         'modal' => [
-            'actions' => ['detach' => ['label' => 'Ausgewählte trennen']],
+
+            'actions' => [
+
+                'detach' => [
+                    'label' => 'Ausgewählte trennen'
+                ]
+
+            ],
+
             'heading' => 'Ausgewählte :label trennen',
+
+        ],
+
+    ],
+
+    'single' => [
+
+        'label' => 'Trennen',
+
+        'messages' => [
+            'detached' => 'Getrennt'
+        ],
+
+        'modal' => [
+
+            'actions' => [
+
+                'detach' => [
+                    'label' => 'Trennen'
+                ]
+
+            ],
+
+            'heading' => ':label trennen'
         ],
     ],
-    'single' => [
-        'label' => 'Trennen',
-        'messages' => ['detached' => 'Getrennt'],
-        'modal' => ['actions' => ['detach' => ['label' => 'Trennen']], 'heading' => ':label trennen'],
-    ],
+
 ];

--- a/packages/support/resources/lang/de/actions/edit.php
+++ b/packages/support/resources/lang/de/actions/edit.php
@@ -1,29 +1,12 @@
 <?php
 
 return [
-
     'single' => [
-
         'label' => 'Bearbeiten',
-
+        'messages' => ['saved' => 'Gespeichert'],
         'modal' => [
-
+            'actions' => ['save' => ['label' => 'Speichern']],
             'heading' => ':label bearbeiten',
-
-            'actions' => [
-
-                'save' => [
-                    'label' => 'Speichern',
-                ],
-
-            ],
-
         ],
-
-        'messages' => [
-            'saved' => 'Gespeichert',
-        ],
-
     ],
-
 ];

--- a/packages/support/resources/lang/de/actions/edit.php
+++ b/packages/support/resources/lang/de/actions/edit.php
@@ -7,7 +7,7 @@ return [
         'label' => 'Bearbeiten',
 
         'messages' => [
-            'saved' => 'Gespeichert'
+            'saved' => 'Gespeichert',
         ],
 
         'modal' => [
@@ -15,8 +15,8 @@ return [
             'actions' => [
 
                 'save' => [
-                    'label' => 'Speichern'
-                ]
+                    'label' => 'Speichern',
+                ],
 
             ],
 

--- a/packages/support/resources/lang/de/actions/edit.php
+++ b/packages/support/resources/lang/de/actions/edit.php
@@ -1,12 +1,28 @@
 <?php
 
 return [
+
     'single' => [
+
         'label' => 'Bearbeiten',
-        'messages' => ['saved' => 'Gespeichert'],
+
+        'messages' => [
+            'saved' => 'Gespeichert'
+        ],
+
         'modal' => [
-            'actions' => ['save' => ['label' => 'Speichern']],
+
+            'actions' => [
+
+                'save' => [
+                    'label' => 'Speichern'
+                ]
+
+            ],
+
             'heading' => ':label bearbeiten',
         ],
+
     ],
+
 ];

--- a/packages/support/resources/lang/de/actions/modal.php
+++ b/packages/support/resources/lang/de/actions/modal.php
@@ -5,15 +5,15 @@ return [
     'actions' => [
 
         'cancel' => [
-            'label' => 'Abbrechen'
+            'label' => 'Abbrechen',
         ],
 
         'confirm' => [
-            'label' => 'Bestätigen'
+            'label' => 'Bestätigen',
         ],
 
         'submit' => [
-            'label' => 'Absenden'
+            'label' => 'Absenden',
         ],
 
     ],

--- a/packages/support/resources/lang/de/actions/modal.php
+++ b/packages/support/resources/lang/de/actions/modal.php
@@ -1,23 +1,10 @@
 <?php
 
 return [
-
-    'confirmation' => 'Sind Sie sicher, dass Sie dies tun möchten?',
-
     'actions' => [
-
-        'cancel' => [
-            'label' => 'Abbrechen',
-        ],
-
-        'confirm' => [
-            'label' => 'Bestätigen',
-        ],
-
-        'submit' => [
-            'label' => 'Absenden',
-        ],
-
+        'cancel' => ['label' => 'Abbrechen'],
+        'confirm' => ['label' => 'Bestätigen'],
+        'submit' => ['label' => 'Absenden'],
     ],
-
+    'confirmation' => 'Sind Sie sicher, dass Sie dies tun möchten?',
 ];

--- a/packages/support/resources/lang/de/actions/modal.php
+++ b/packages/support/resources/lang/de/actions/modal.php
@@ -1,10 +1,23 @@
 <?php
 
 return [
+
     'actions' => [
-        'cancel' => ['label' => 'Abbrechen'],
-        'confirm' => ['label' => 'Bestätigen'],
-        'submit' => ['label' => 'Absenden'],
+
+        'cancel' => [
+            'label' => 'Abbrechen'
+        ],
+
+        'confirm' => [
+            'label' => 'Bestätigen'
+        ],
+
+        'submit' => [
+            'label' => 'Absenden'
+        ],
+
     ],
+
     'confirmation' => 'Sind Sie sicher, dass Sie dies tun möchten?',
+
 ];

--- a/packages/tables/resources/lang/de/table.php
+++ b/packages/tables/resources/lang/de/table.php
@@ -1,46 +1,138 @@
 <?php
 
 return [
+
     "bulk_actions" => [
-        "force_delete" => ["label" => "Endgültig löschen", "messages" => ["deleted" => "Gelöscht"]],
-        "restore" => ["label" => "Wiederherstellen", "messages" => ["restored" => "Wiederhergestellt"]],
-    ],
-    "buttons" => [
-        "filter" => ["label" => "Filtern"],
-        "open_actions" => ["label" => "Aktionen öffnen"],
-        "toggle_columns" => ["label" => "Spalten auswählen"],
-    ],
-    "empty" => ["heading" => "Keine Datensätze gefunden"],
-    "fields" => ["search_query" => ["label" => "Suche", "placeholder" => "Suche"]],
-    "filters" => [
-        "buttons" => [
-            "close" => ["label" => "Schließen"],
-            "reset" => ["label" => "Filter zurücksetzen"],
+
+        "force_delete" => [
+
+            "label" => "Endgültig löschen",
+
+            "messages" => [
+                "deleted" => "Gelöscht"
+            ]
+
         ],
-        "multi_select" => ["placeholder" => "Alle"],
-        "select" => ["placeholder" => "Alle"],
+
+        "restore" => [
+
+            "label" => "Wiederherstellen",
+
+            "messages" => [
+                "restored" => "Wiederhergestellt"
+            ]
+
+        ],
+
+    ],
+
+    "buttons" => [
+
+        "filter" => [
+            "label" => "Filtern"
+        ],
+
+        "open_actions" => [
+            "label" => "Aktionen öffnen"
+        ],
+
+        "toggle_columns" => [
+            "label" => "Spalten auswählen"
+        ],
+
+    ],
+
+    "empty" => [
+        "heading" => "Keine Datensätze gefunden"
+    ],
+
+    "fields" => [
+
+        "search_query" => [
+            "label" => "Suche",
+            "placeholder" => "Suche"
+        ]
+
+    ],
+
+    "filters" => [
+
+        "buttons" => [
+
+            "close" => [
+                "label" => "Schließen"
+            ],
+
+            "reset" => [
+                "label" => "Filter zurücksetzen"
+            ],
+
+        ],
+
+        "multi_select" => [
+            "placeholder" => "Alle"
+        ],
+
+        "select" => [
+            "placeholder" => "Alle"
+        ],
+
         "trashed" => [
             "label" => "Gelöschte Einträge",
             "only_trashed" => "Nur gelöschte Einträge",
             "with_trashed" => "Mit gelöschten Einträgen",
             "without_trashed" => "Ohne gelöschte Einträge",
         ],
+
     ],
+
     "pagination" => [
+
         "buttons" => [
-            "go_to_page" => ["label" => "Weiter zur Seite :page"],
-            "next" => ["label" => "Nächste"],
-            "previous" => ["label" => "Vorherige"],
+
+            "go_to_page" => [
+                "label" => "Weiter zur Seite :page"
+            ],
+
+            "next" => [
+                "label" => "Nächste"
+            ],
+
+            "previous" => [
+                "label" => "Vorherige"
+            ],
+
         ],
-        "fields" => ["records_per_page" => ["label" => "pro Seite"]],
+
+        "fields" => [
+
+            "records_per_page" => [
+                "label" => "pro Seite"
+            ]
+
+        ],
+
         "label" => "Seitennavigation",
+
         "overview" => ":first bis :last von :total Ergebnissen",
+
     ],
+
     "selection_indicator" => [
+
         "buttons" => [
-            "deselect_all" => ["label" => "Auswahl aufheben"],
-            "select_all" => ["label" => "Alle :count Datensätze auswählen"],
+
+            "deselect_all" => [
+                "label" => "Auswahl aufheben"
+            ],
+
+            "select_all" => [
+                "label" => "Alle :count Datensätze auswählen"
+            ],
+
         ],
+
         "selected_count" => "1 Datensatz ausgewählt ausgewählt.|:count Datensätze ausgewählt.",
     ],
+
 ];

--- a/packages/tables/resources/lang/de/table.php
+++ b/packages/tables/resources/lang/de/table.php
@@ -1,20 +1,21 @@
 <?php
+
 return [
     "bulk_actions" => [
         "force_delete" => ["label" => "Endgültig löschen", "messages" => ["deleted" => "Gelöscht"]],
-        "restore" => ["label" => "Wiederherstellen", "messages" => ["restored" => "Wiederhergestellt"]]
+        "restore" => ["label" => "Wiederherstellen", "messages" => ["restored" => "Wiederhergestellt"]],
     ],
     "buttons" => [
         "filter" => ["label" => "Filtern"],
         "open_actions" => ["label" => "Aktionen öffnen"],
-        "toggle_columns" => ["label" => "Spalten auswählen"]
+        "toggle_columns" => ["label" => "Spalten auswählen"],
     ],
     "empty" => ["heading" => "Keine Datensätze gefunden"],
     "fields" => ["search_query" => ["label" => "Suche", "placeholder" => "Suche"]],
     "filters" => [
         "buttons" => [
             "close" => ["label" => "Schließen"],
-            "reset" => ["label" => "Filter zurücksetzen"]
+            "reset" => ["label" => "Filter zurücksetzen"],
         ],
         "multi_select" => ["placeholder" => "Alle"],
         "select" => ["placeholder" => "Alle"],
@@ -22,24 +23,24 @@ return [
             "label" => "Gelöschte Einträge",
             "only_trashed" => "Nur gelöschte Einträge",
             "with_trashed" => "Mit gelöschten Einträgen",
-            "without_trashed" => "Ohne gelöschte Einträge"
-        ]
+            "without_trashed" => "Ohne gelöschte Einträge",
+        ],
     ],
     "pagination" => [
         "buttons" => [
             "go_to_page" => ["label" => "Weiter zur Seite :page"],
             "next" => ["label" => "Nächste"],
-            "previous" => ["label" => "Vorherige"]
+            "previous" => ["label" => "Vorherige"],
         ],
         "fields" => ["records_per_page" => ["label" => "pro Seite"]],
         "label" => "Seitennavigation",
-        "overview" => ":first bis :last von :total Ergebnissen"
+        "overview" => ":first bis :last von :total Ergebnissen",
     ],
     "selection_indicator" => [
         "buttons" => [
             "deselect_all" => ["label" => "Auswahl aufheben"],
-            "select_all" => ["label" => "Alle :count Datensätze auswählen"]
+            "select_all" => ["label" => "Alle :count Datensätze auswählen"],
         ],
-        "selected_count" => "1 Datensatz ausgewählt ausgewählt.|:count Datensätze ausgewählt."
-    ]
+        "selected_count" => "1 Datensatz ausgewählt ausgewählt.|:count Datensätze ausgewählt.",
+    ],
 ];

--- a/packages/tables/resources/lang/de/table.php
+++ b/packages/tables/resources/lang/de/table.php
@@ -9,8 +9,8 @@ return [
             "label" => "Endgültig löschen",
 
             "messages" => [
-                "deleted" => "Gelöscht"
-            ]
+                "deleted" => "Gelöscht",
+            ],
 
         ],
 
@@ -19,8 +19,8 @@ return [
             "label" => "Wiederherstellen",
 
             "messages" => [
-                "restored" => "Wiederhergestellt"
-            ]
+                "restored" => "Wiederhergestellt",
+            ],
 
         ],
 
@@ -29,29 +29,29 @@ return [
     "buttons" => [
 
         "filter" => [
-            "label" => "Filtern"
+            "label" => "Filtern",
         ],
 
         "open_actions" => [
-            "label" => "Aktionen öffnen"
+            "label" => "Aktionen öffnen",
         ],
 
         "toggle_columns" => [
-            "label" => "Spalten auswählen"
+            "label" => "Spalten auswählen",
         ],
 
     ],
 
     "empty" => [
-        "heading" => "Keine Datensätze gefunden"
+        "heading" => "Keine Datensätze gefunden",
     ],
 
     "fields" => [
 
         "search_query" => [
             "label" => "Suche",
-            "placeholder" => "Suche"
-        ]
+            "placeholder" => "Suche",
+        ],
 
     ],
 
@@ -60,21 +60,21 @@ return [
         "buttons" => [
 
             "close" => [
-                "label" => "Schließen"
+                "label" => "Schließen",
             ],
 
             "reset" => [
-                "label" => "Filter zurücksetzen"
+                "label" => "Filter zurücksetzen",
             ],
 
         ],
 
         "multi_select" => [
-            "placeholder" => "Alle"
+            "placeholder" => "Alle",
         ],
 
         "select" => [
-            "placeholder" => "Alle"
+            "placeholder" => "Alle",
         ],
 
         "trashed" => [
@@ -91,15 +91,15 @@ return [
         "buttons" => [
 
             "go_to_page" => [
-                "label" => "Weiter zur Seite :page"
+                "label" => "Weiter zur Seite :page",
             ],
 
             "next" => [
-                "label" => "Nächste"
+                "label" => "Nächste",
             ],
 
             "previous" => [
-                "label" => "Vorherige"
+                "label" => "Vorherige",
             ],
 
         ],
@@ -107,8 +107,8 @@ return [
         "fields" => [
 
             "records_per_page" => [
-                "label" => "pro Seite"
-            ]
+                "label" => "pro Seite",
+            ],
 
         ],
 
@@ -123,11 +123,11 @@ return [
         "buttons" => [
 
             "deselect_all" => [
-                "label" => "Auswahl aufheben"
+                "label" => "Auswahl aufheben",
             ],
 
             "select_all" => [
-                "label" => "Alle :count Datensätze auswählen"
+                "label" => "Alle :count Datensätze auswählen",
             ],
 
         ],

--- a/packages/tables/resources/lang/de/table.php
+++ b/packages/tables/resources/lang/de/table.php
@@ -1,100 +1,45 @@
 <?php
-
 return [
-
-    'fields' => [
-
-        'search_query' => [
-            'label' => 'Suche',
-            'placeholder' => 'Suche',
-        ],
-
+    "bulk_actions" => [
+        "force_delete" => ["label" => "Endgültig löschen", "messages" => ["deleted" => "Gelöscht"]],
+        "restore" => ["label" => "Wiederherstellen", "messages" => ["restored" => "Wiederhergestellt"]]
     ],
-
-    'pagination' => [
-
-        'label' => 'Seitennavigation',
-
-        'overview' => ':first bis :last von :total Ergebnissen',
-
-        'fields' => [
-
-            'records_per_page' => [
-                'label' => 'pro Seite',
-            ],
-
-        ],
-
-        'buttons' => [
-
-            'go_to_page' => [
-                'label' => 'Weiter zur Seite :page',
-            ],
-
-            'next' => [
-                'label' => 'Nächste',
-            ],
-
-            'previous' => [
-                'label' => 'Vorherige',
-            ],
-
-        ],
-
+    "buttons" => [
+        "filter" => ["label" => "Filtern"],
+        "open_actions" => ["label" => "Aktionen öffnen"],
+        "toggle_columns" => ["label" => "Spalten auswählen"]
     ],
-
-    'buttons' => [
-
-        'filter' => [
-            'label' => 'Filtern',
+    "empty" => ["heading" => "Keine Datensätze gefunden"],
+    "fields" => ["search_query" => ["label" => "Suche", "placeholder" => "Suche"]],
+    "filters" => [
+        "buttons" => [
+            "close" => ["label" => "Schließen"],
+            "reset" => ["label" => "Filter zurücksetzen"]
         ],
-
-        'open_actions' => [
-            'label' => 'Aktionen öffnen',
-        ],
-
+        "multi_select" => ["placeholder" => "Alle"],
+        "select" => ["placeholder" => "Alle"],
+        "trashed" => [
+            "label" => "Gelöschte Einträge",
+            "only_trashed" => "Nur gelöschte Einträge",
+            "with_trashed" => "Mit gelöschten Einträgen",
+            "without_trashed" => "Ohne gelöschte Einträge"
+        ]
     ],
-
-    'empty' => [
-        'heading' => 'Keine Datensätze gefunden',
+    "pagination" => [
+        "buttons" => [
+            "go_to_page" => ["label" => "Weiter zur Seite :page"],
+            "next" => ["label" => "Nächste"],
+            "previous" => ["label" => "Vorherige"]
+        ],
+        "fields" => ["records_per_page" => ["label" => "pro Seite"]],
+        "label" => "Seitennavigation",
+        "overview" => ":first bis :last von :total Ergebnissen"
     ],
-
-    'filters' => [
-
-        'buttons' => [
-
-            'reset' => [
-                'label' => 'Filter zurücksetzen',
-            ],
-
+    "selection_indicator" => [
+        "buttons" => [
+            "deselect_all" => ["label" => "Auswahl aufheben"],
+            "select_all" => ["label" => "Alle :count Datensätze auswählen"]
         ],
-
-        'multi_select' => [
-            'placeholder' => 'Alle',
-        ],
-
-        'select' => [
-            'placeholder' => 'Alle',
-        ],
-
-    ],
-
-    'selection_indicator' => [
-
-        'selected_count' => '1 Datensatz ausgewählt ausgewählt.|:count Datensätze ausgewählt.',
-
-        'buttons' => [
-
-            'select_all' => [
-                'label' => 'Alle :count Datensätze auswählen',
-            ],
-
-            'deselect_all' => [
-                'label' => 'Auswahl aufheben',
-            ],
-
-        ],
-
-    ],
-
+        "selected_count" => "1 Datensatz ausgewählt ausgewählt.|:count Datensätze ausgewählt."
+    ]
 ];


### PR DESCRIPTION
Just tried [babel edit](https://www.codeandweb.com/babeledit) for translating the missing German strings. Unfortunately, that overwrote the formatting 🙈

I guess we should find a free tool for translations to have a common formatting and easier translation.