### PR TITLE
Revert fully qualified key names for pivot

### DIFF
--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -2,8 +2,6 @@
 
 namespace Filament\Tables\Concerns;
 
-use function Filament\locale_has_pluralization;
-use function Filament\Support\get_model_label;
 use Filament\Tables\Contracts\HasRelationshipTable;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Builder;
@@ -11,6 +9,9 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Str;
+
+use function Filament\locale_has_pluralization;
+use function Filament\Support\get_model_label;
 
 trait HasRecords
 {
@@ -66,7 +67,7 @@ trait HasRecords
         $relationship = $this->getRelationship();
 
         $pivotClass = $relationship->getPivotClass();
-        $pivotKeyName = app($pivotClass)->getQualifiedKeyName();
+        $pivotKeyName = app($pivotClass)->getKeyName();
 
         $query = $this->allowsDuplicates() ?
             $relationship->wherePivot($pivotKeyName, $key) :

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -2,16 +2,16 @@
 
 namespace Filament\Tables\Concerns;
 
+use function Filament\locale_has_pluralization;
+use function Filament\Support\get_model_label;
 use Filament\Tables\Contracts\HasRelationshipTable;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Str;
-
-use function Filament\locale_has_pluralization;
-use function Filament\Support\get_model_label;
 
 trait HasRecords
 {


### PR DESCRIPTION
I thought I reverted all of these changes with https://github.com/filamentphp/filament/pull/2857, but apparently I missed one occurence.