### PR TITLE
Do not adjust global search button font size on large screens

### DIFF
--- a/packages/admin/resources/views/components/global-search/input.blade.php
+++ b/packages/admin/resources/views/components/global-search/input.blade.php
@@ -20,7 +20,7 @@
             type="search"
             autocomplete="off"
             @class([
-                'block w-full h-10 pl-10 lg:text-lg bg-gray-400/10 placeholder-gray-500 border-transparent transition duration-75 rounded-lg focus:bg-white focus:placeholder-gray-400 focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600',
+                'block w-full h-10 pl-10 bg-gray-400/10 placeholder-gray-500 border-transparent transition duration-75 rounded-lg focus:bg-white focus:placeholder-gray-400 focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600',
                 'dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400' => config('filament.dark_mode'),
             ])
         >


### PR DESCRIPTION
In my opinion - from an aesthetic point of view - we should not make the global search button text larger on lg:screens.

Old:
<img width="1680" alt="Screenshot-2022-07-06 at 14 05 46@2x-old" src="https://user-images.githubusercontent.com/789541/177546301-80e0b8f0-6a5a-4169-a31f-be0db791a797.png">

New:
<img width="1680" alt="Screenshot-2022-07-06 at 14 05 58@2x-new" src="https://user-images.githubusercontent.com/789541/177546337-4c7ada58-114c-4bd6-8c92-7aec361a434d.png">
