### PR TITLE
fix/2896 Fix saving pivot values in CreateAction

### DIFF
--- a/packages/tables/src/Actions/CreateAction.php
+++ b/packages/tables/src/Actions/CreateAction.php
@@ -55,9 +55,11 @@ class CreateAction extends Action
 
                 if ($relationship instanceof BelongsToMany) {
                     $pivotColumns = $relationship->getPivotColumns();
-                    $data = Arr::except($data, $pivotColumns);
-                    $pivotData = Arr::only($data, $pivotColumns);
-                    return $relationship->create($data, $pivotData);
+                    
+                    return $relationship->create(
+                        Arr::except($data, $pivotColumns),
+                        Arr::only($data, $pivotColumns),
+                    );
                 }
                 
                 return $relationship->create($data);

--- a/packages/tables/src/Actions/CreateAction.php
+++ b/packages/tables/src/Actions/CreateAction.php
@@ -58,15 +58,12 @@ class CreateAction extends Action
                     $data = Arr::except($data, $pivotColumns);
                 }
 
-                $record = $relationship->create($data);
-
+                $pivotData = [];
                 if ($relationship instanceof BelongsToMany) {
                     $pivotData = Arr::only($data, $pivotColumns);
-
-                    if (count($pivotColumns)) {
-                        $record->{$relationship->getPivotAccessor()}->update($pivotData);
-                    }
                 }
+
+                $record = $relationship->create($data, $pivotData);
 
                 return $record;
             });

--- a/packages/tables/src/Actions/CreateAction.php
+++ b/packages/tables/src/Actions/CreateAction.php
@@ -61,7 +61,7 @@ class CreateAction extends Action
                 $pivotData = [];
                 if ($relationship instanceof BelongsToMany) {
                     $pivotData = Arr::only($data, $pivotColumns);
-                    $record = $relationship->create($data, $pivotData);
+                    return $relationship->create($data, $pivotData);
                 }
                 else {
                     $record = $relationship->create($data);

--- a/packages/tables/src/Actions/CreateAction.php
+++ b/packages/tables/src/Actions/CreateAction.php
@@ -61,9 +61,11 @@ class CreateAction extends Action
                 $pivotData = [];
                 if ($relationship instanceof BelongsToMany) {
                     $pivotData = Arr::only($data, $pivotColumns);
+                    $record = $relationship->create($data, $pivotData);
                 }
-
-                $record = $relationship->create($data, $pivotData);
+                else {
+                    $record = $relationship->create($data);
+                }
 
                 return $record;
             });

--- a/packages/tables/src/Actions/CreateAction.php
+++ b/packages/tables/src/Actions/CreateAction.php
@@ -56,18 +56,11 @@ class CreateAction extends Action
                 if ($relationship instanceof BelongsToMany) {
                     $pivotColumns = $relationship->getPivotColumns();
                     $data = Arr::except($data, $pivotColumns);
-                }
-
-                $pivotData = [];
-                if ($relationship instanceof BelongsToMany) {
                     $pivotData = Arr::only($data, $pivotColumns);
                     return $relationship->create($data, $pivotData);
                 }
-                else {
-                    $record = $relationship->create($data);
-                }
-
-                return $record;
+                
+                return $relationship->create($data);
             });
 
             $this->record($record);


### PR DESCRIPTION
This uses the create function to directly save the pivot values on the relations. See issue 2896 & https://github.com/filamentphp/filament/issues/2896#issuecomment-1176066942