### PR TITLE
Pass old state to form field callback

### DIFF
--- a/packages/forms/src/Components/Component.php
+++ b/packages/forms/src/Components/Component.php
@@ -38,6 +38,7 @@ class Component extends ViewComponent
             'get' => $this->getGetCallback(),
             'livewire' => $this->getLivewire(),
             'model' => $this->getModel(),
+            'old' => $this->getOld(),
             'record' => $this->getRecord(),
             'set' => $this->getSetCallback(),
             'state' => $this->shouldEvaluateWithState() ? $this->getState() : null,

--- a/packages/forms/src/Components/Component.php
+++ b/packages/forms/src/Components/Component.php
@@ -38,7 +38,6 @@ class Component extends ViewComponent
             'get' => $this->getGetCallback(),
             'livewire' => $this->getLivewire(),
             'model' => $this->getModel(),
-            'old' => $this->getOldState(),
             'record' => $this->getRecord(),
             'set' => $this->getSetCallback(),
             'state' => $this->shouldEvaluateWithState() ? $this->getState() : null,

--- a/packages/forms/src/Components/Component.php
+++ b/packages/forms/src/Components/Component.php
@@ -38,7 +38,7 @@ class Component extends ViewComponent
             'get' => $this->getGetCallback(),
             'livewire' => $this->getLivewire(),
             'model' => $this->getModel(),
-            'old' => $this->getOld(),
+            'old' => $this->getOldState(),
             'record' => $this->getRecord(),
             'set' => $this->getSetCallback(),
             'state' => $this->shouldEvaluateWithState() ? $this->getState() : null,

--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -187,7 +187,7 @@ trait HasState
         return $state;
     }
 
-    public function getOld()
+    public function getOldState()
     {
         $state = request('serverMemo.data.' . $this->getStatePath());
 

--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -5,6 +5,7 @@ namespace Filament\Forms\Components\Concerns;
 use Closure;
 use Filament\Forms\Components\Component;
 use Illuminate\Support\Str;
+use Livewire\Livewire;
 
 trait HasState
 {

--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -186,6 +186,17 @@ trait HasState
         return $state;
     }
 
+    public function getOld()
+    {
+        $state = request('serverMemo.data.' . $this->getStatePath());
+
+        if (blank($state) || ! Livewire::isLivewireRequest()) {
+            return null;
+        }
+
+        return $state;
+    }
+
     public function getStatePath(bool $isAbsolute = true): string
     {
         $pathComponents = [];

--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -189,9 +189,13 @@ trait HasState
 
     public function getOldState()
     {
+        if (! Livewire::isLivewireRequest()) {
+            return null;
+        }
+
         $state = request('serverMemo.data.' . $this->getStatePath());
 
-        if (blank($state) || ! Livewire::isLivewireRequest()) {
+        if (blank($state)) {
             return null;
         }
 

--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -60,7 +60,9 @@ trait HasState
     public function callAfterStateUpdated(): static
     {
         if ($callback = $this->afterStateUpdated) {
-            $this->evaluate($callback);
+            $this->evaluate($callback, [
+                'old' => $this->getOldState(),
+            ]);
         }
 
         return $this;


### PR DESCRIPTION
This PR provide a way to get the old state from field callback
usage:
```php
->afterStateUpdated(function ($old) {
    // do something that require old state
})
```