### PR TITLE
Update getRules() to stay compatible with future v. of Livewire

### DIFF
--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -300,15 +300,7 @@ trait InteractsWithForms
 
     protected function getRules(): array
     {
-        $rules = [];
-
-        if (method_exists($this, 'rules')) {
-            $rules = $this->rules();
-        }
-
-        if (property_exists($this, 'rules')) {
-            $rules = $this->rules;
-        }
+        $rules = \Livewire\Component::getRules();
 
         foreach ($this->getCachedForms() as $form) {
             $rules = array_merge($rules, $form->getValidationRules());

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -300,7 +300,7 @@ trait InteractsWithForms
 
     protected function getRules(): array
     {
-        $rules = \Livewire\Component::getRules();
+        $rules = parent::getRules();
 
         foreach ($this->getCachedForms() as $form) {
             $rules = array_merge($rules, $form->getValidationRules());


### PR DESCRIPTION
There's been som chatter about changing `Livewire\Component::getRules()` to support this'n'that...

Thought best to change the current `InteractsWithForms::getRules()` to pull in the original Livewire method instead of manually replicating it. To stay compatible with however it changes.

I chose not to use `parent::getRules()` as there may be multiple parents, thus causing potential errors.