### PR TITLE
Fixing idea #3053

### DIFF
--- a/packages/forms/docs/04-layout.md
+++ b/packages/forms/docs/04-layout.md
@@ -273,6 +273,7 @@ Tabs::make('Heading')
                 // ...
             ]),
         Tabs\Tab::make('Label 3')
+            ->icon('heroicon-o-eye') // Optional icon
             ->schema([
                 // ...
             ]),

--- a/packages/forms/resources/views/components/tabs.blade.php
+++ b/packages/forms/resources/views/components/tabs.blade.php
@@ -57,6 +57,10 @@
                 class="shrink-0 p-3 text-sm font-medium"
                 x-bind:class="{ 'bg-white @if (config('forms.dark_mode')) dark:bg-gray-800 @endif': tab === '{{ $tab->getId() }}' }"
             >
+                @if ($tab->hasIcon())
+                    <x-dynamic-component :component="$tab->getIcon()" class="h-5 w-5 mr-1 text-gray-500 @if (config('forms.dark_mode')) dark:text-gray-400 @endif inline"/>
+                @endif
+
                 {{ $tab->getLabel() }}
             </button>
         @endforeach

--- a/packages/forms/resources/views/components/tabs.blade.php
+++ b/packages/forms/resources/views/components/tabs.blade.php
@@ -54,11 +54,17 @@
                 x-on:click="tab = '{{ $tab->getId() }}'"
                 role="tab"
                 x-bind:tabindex="tab === '{{ $tab->getId() }}' ? 0 : -1"
-                class="shrink-0 p-3 text-sm font-medium"
+                class="flex items-center gap-2 shrink-0 p-3 text-sm font-medium"
                 x-bind:class="{ 'bg-white @if (config('forms.dark_mode')) dark:bg-gray-800 @endif': tab === '{{ $tab->getId() }}' }"
             >
-                @if ($tab->hasIcon())
-                    <x-dynamic-component :component="$tab->getIcon()" class="h-5 w-5 mr-1 text-gray-500 @if (config('forms.dark_mode')) dark:text-gray-400 @endif inline"/>
+                @if ($icon = $tab->getIcon())
+                    <x-dynamic-component
+                        :component="$icon"
+                        :class="\Illuminate\Support\Arr::toCssClasses([
+                            'h-4 w-4 text-gray-500',
+                            'dark:text-gray-400' => config('forms.dark_mode'),
+                        ])"
+                    />
                 @endif
 
                 {{ $tab->getLabel() }}

--- a/packages/forms/src/Components/Tabs/Tab.php
+++ b/packages/forms/src/Components/Tabs/Tab.php
@@ -44,12 +44,9 @@ class Tab extends Component implements CanConcealComponents
         return $this->columns ?? $this->getContainer()->getColumnsConfig();
     }
 
-    public function getIcon(): ?string {
+    public function getIcon(): ?string
+    {
         return $this->evaluate($this->icon);
-    }
-
-    public function hasIcon(): bool {
-        return (bool) $this->getIcon();
     }
 
     public function canConcealComponents(): bool

--- a/packages/forms/src/Components/Tabs/Tab.php
+++ b/packages/forms/src/Components/Tabs/Tab.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Forms\Components\Tabs;
 
+use Closure;
 use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Contracts\CanConcealComponents;
 use Illuminate\Support\Str;
@@ -9,6 +10,8 @@ use Illuminate\Support\Str;
 class Tab extends Component implements CanConcealComponents
 {
     protected string $view = 'forms::components.tabs.tab';
+
+    protected string | Closure | null $icon = null;
 
     final public function __construct(string $label)
     {
@@ -24,6 +27,13 @@ class Tab extends Component implements CanConcealComponents
         return $static;
     }
 
+    public function icon(string | Closure | null $icon): static
+    {
+        $this->icon = $icon;
+
+        return $this;
+    }
+
     public function getId(): string
     {
         return $this->getContainer()->getParentComponent()->getId() . '-' . parent::getId() . '-tab';
@@ -32,6 +42,14 @@ class Tab extends Component implements CanConcealComponents
     public function getColumnsConfig(): array
     {
         return $this->columns ?? $this->getContainer()->getColumnsConfig();
+    }
+
+    public function getIcon(): ?string {
+        return $this->evaluate($this->icon);
+    }
+
+    public function hasIcon(): bool {
+        return (bool) $this->getIcon();
     }
 
     public function canConcealComponents(): bool


### PR DESCRIPTION
Fixing idea #3053 

Adds the possibility to create a tab with an icon.

Usage:

```php
Tab::make('Devices')
    ->icon('heroicon-o-desktop-computer')
    ->schema([]);
```