### PR TITLE
Sidebar Item active class

### DIFF
--- a/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
@@ -6,7 +6,7 @@
     'url',
 ])
 
-<li class="filament-sidebar-item">
+<li @class(['filament-sidebar-item', 'filament-sidebar-item-active' => $active])>
     <a
         href="{{ $url }}"
         {!! $shouldOpenUrlInNewTab ? 'target="_blank"' : '' !!}


### PR DESCRIPTION
Adds a `filament-sidebar-item-active` class to the active sidebar item. Can be used for styling the active item using CSS