### PR TITLE
Make collapsible Section header clickable + scrollIntoView onClick

### DIFF
--- a/packages/admin/resources/views/components/notification-manager.blade.php
+++ b/packages/admin/resources/views/components/notification-manager.blade.php
@@ -4,10 +4,21 @@
         add: function (event) {
             this.notifications = this.notifications.concat(event.detail)
         },
+        addError: function (notificationObject) {
+            this.notifications = this.notifications.concat(notificationObject)
+        },
         remove: function (notification) {
             this.notifications = this.notifications.filter(i => i.id !== notification.id)
         },
     }"
+    x-init="
+        $watch('$store.errors.all', () => {
+            notifications = [];
+            setTimeout(() =>
+                $store.errors.all.forEach((message, index) => addError({id: index, status: 'danger', message: message })),
+            100)
+        })
+    "
     x-on:notify.window="add($event)"
     @class([
         'flex fixed inset-0 z-50 p-3 pointer-events-none filament-notifications',

--- a/packages/admin/resources/views/components/notification-manager.blade.php
+++ b/packages/admin/resources/views/components/notification-manager.blade.php
@@ -4,21 +4,10 @@
         add: function (event) {
             this.notifications = this.notifications.concat(event.detail)
         },
-        addError: function (notificationObject) {
-            this.notifications = this.notifications.concat(notificationObject)
-        },
         remove: function (notification) {
             this.notifications = this.notifications.filter(i => i.id !== notification.id)
         },
     }"
-    x-init="
-        $watch('$store.errors.all', () => {
-            notifications = [];
-            setTimeout(() =>
-                $store.errors.all.forEach((message, index) => addError({id: index, status: 'danger', message: message })),
-            100)
-        })
-    "
     x-on:notify.window="add($event)"
     @class([
         'flex fixed inset-0 z-50 p-3 pointer-events-none filament-notifications',

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -27,13 +27,19 @@
             x-bind:class="{ 'rounded-b-xl': isCollapsed }"
         @endif
     >
-        <div class="flex-1 filament-forms-section-header">
-            <h3 class="text-xl font-bold tracking-tight">
+        <div
+            @class([
+                'flex-1 filament-forms-section-header',
+                'cursor-pointer' => $isCollapsible(),
+            ])
+            @if ($isCollapsible()) x-on:click="isCollapsed = ! isCollapsed" @endif
+        >
+            <h3 class="text-xl font-bold tracking-tight pointer-events-none">
                 {{ $getHeading() }}
             </h3>
 
             @if ($description = $getDescription())
-                <p class="text-gray-500">
+                <p class="text-gray-500 pointer-events-none">
                     {{ $description }}
                 </p>
             @endif

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -21,7 +21,7 @@
             x-bind:class="{ 'rounded-b-xl': isCollapsed }"
             x-on:click="
                 isCollapsed = ! isCollapsed
-                setTimeout(() => $el.scrollIntoView({behavior: 'smooth', block: 'start', inline: 'start'}), 150)
+                if(!isCollapsed) setTimeout(() => $el.scrollIntoView({behavior: 'smooth', block: 'start', inline: 'start'}), 150)
             "
         @endif
     >

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -30,7 +30,7 @@
                 if (! isCollapsed) {
                     setTimeout(
                         () => $el.scrollIntoView({behavior: 'smooth', block: 'start', inline: 'start'}),
-                        150,
+                        100,
                     )
                 }
             "

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -4,6 +4,13 @@
         x-on:open-form-section.window="if ($event.detail.id == $el.id) isCollapsed = false"
         x-on:collapse-form-section.window="if ($event.detail.id == $el.id) isCollapsed = true"
         x-on:toggle-form-section.window="if ($event.detail.id == $el.id) isCollapsed = ! isCollapsed"
+        x-on:expand-concealing-component.window="
+            if ($event.detail.id === $el.id) {
+                isCollapsed = false
+                $el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                setTimeout(() => $el.scrollIntoView({behavior: 'smooth', block: 'start', inline: 'start'}), 150)
+            }
+        "
     @endif
     id="{{ $getId() }}"
     {{ $attributes->merge($getExtraAttributes())->class([
@@ -48,7 +55,7 @@
         </div>
 
         @if ($isCollapsible())
-            <button x-on:click="isCollapsed = ! isCollapsed"
+            <button x-on:click.stop="isCollapsed = ! isCollapsed"
                 x-bind:class="{
                     '-rotate-180': !isCollapsed,
                 }" type="button"

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -27,12 +27,15 @@
             x-bind:class="{ 'rounded-b-xl': isCollapsed }"
             x-on:click="
                 isCollapsed = ! isCollapsed
-                if (! isCollapsed) {
-                    setTimeout(
-                        () => $el.scrollIntoView({behavior: 'smooth', block: 'start', inline: 'start'}),
-                        100,
-                    )
+                
+                if (isCollapsed) {
+                    return
                 }
+                
+                setTimeout(
+                    () => $el.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'start' }),
+                    100,
+                )
             "
         @endif
     >

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -21,7 +21,12 @@
             x-bind:class="{ 'rounded-b-xl': isCollapsed }"
             x-on:click="
                 isCollapsed = ! isCollapsed
-                if(!isCollapsed) setTimeout(() => $el.scrollIntoView({behavior: 'smooth', block: 'start', inline: 'start'}), 150)
+                if (! isCollapsed) {
+                    setTimeout(
+                        () => $el.scrollIntoView({behavior: 'smooth', block: 'start', inline: 'start'}),
+                        150,
+                    )
+                }
             "
         @endif
     >

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -4,12 +4,6 @@
         x-on:open-form-section.window="if ($event.detail.id == $el.id) isCollapsed = false"
         x-on:collapse-form-section.window="if ($event.detail.id == $el.id) isCollapsed = true"
         x-on:toggle-form-section.window="if ($event.detail.id == $el.id) isCollapsed = ! isCollapsed"
-        x-on:expand-concealing-component.window="
-            if ($event.detail.id === $el.id) {
-                isCollapsed = false
-                $el.scrollIntoView({ behavior: 'smooth', block: 'start' })
-            }
-        "
     @endif
     id="{{ $getId() }}"
     {{ $attributes->merge($getExtraAttributes())->class([
@@ -25,6 +19,10 @@
         ])
         @if ($isCollapsible())
             x-bind:class="{ 'rounded-b-xl': isCollapsed }"
+            x-on:click="
+                isCollapsed = ! isCollapsed
+                setTimeout(() => $el.scrollIntoView({behavior: 'smooth', block: 'start', inline: 'start'}), 150)
+            "
         @endif
     >
         <div
@@ -32,7 +30,6 @@
                 'flex-1 filament-forms-section-header',
                 'cursor-pointer' => $isCollapsible(),
             ])
-            @if ($isCollapsible()) x-on:click="isCollapsed = ! isCollapsed" @endif
         >
             <h3 class="text-xl font-bold tracking-tight pointer-events-none">
                 {{ $getHeading() }}

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -7,8 +7,7 @@
         x-on:expand-concealing-component.window="
             if ($event.detail.id === $el.id) {
                 isCollapsed = false
-                $el.scrollIntoView({ behavior: 'smooth', block: 'start' })
-                setTimeout(() => $el.scrollIntoView({behavior: 'smooth', block: 'start', inline: 'start'}), 150)
+                setTimeout(() => $el.scrollIntoView({behavior: 'smooth', block: 'start', inline: 'start'}), 100)
             }
         "
     @endif

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -7,7 +7,7 @@
         x-on:expand-concealing-component.window="
             if ($event.detail.id === $el.id) {
                 isCollapsed = false
-                setTimeout(() => $el.scrollIntoView({behavior: 'smooth', block: 'start', inline: 'start'}), 100)
+                setTimeout(() => $el.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'start' }), 100)
             }
         "
     @endif

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -7,6 +7,7 @@
         x-on:expand-concealing-component.window="
             if ($event.detail.id === $el.id) {
                 isCollapsed = false
+                
                 setTimeout(() => $el.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'start' }), 100)
             }
         "


### PR DESCRIPTION
It is an expected UX to be able to click on the Section header to expand/collapse the section.
This PR also fixes that the section scrolls into focus when it is expanded. It didn't before.