### PR TITLE
Ability to set step start

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -10,7 +10,7 @@
         step: null,
 
         init: function () {
-            this.step = this.getSteps()[{{ $getStartOnStep() }}]
+            this.step = this.getSteps()[{{ ($getStartOnStep() - 1) }}]
         },
 
         nextStep: function () {

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -10,7 +10,7 @@
         step: null,
 
         init: function () {
-            this.step = this.getSteps()[{{ ($getStartOnStep() - 1) }}]
+            this.step = this.getSteps()[{{ $getStartOnStep() }} - 1]
         },
 
         nextStep: function () {

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -10,7 +10,7 @@
         step: null,
 
         init: function () {
-            this.step = this.getSteps()[0]
+            this.step = this.getSteps()[{{ $getStartOnStep() }}]
         },
 
         nextStep: function () {

--- a/packages/forms/src/Components/Wizard.php
+++ b/packages/forms/src/Components/Wizard.php
@@ -16,7 +16,7 @@ class Wizard extends Component
 
     protected string | Htmlable | null $submitAction = null;
 
-    public int | null $startOnStep = 0;
+    public int | Closure $startStep = 1;
 
     protected string $view = 'forms::components.wizard';
 
@@ -67,16 +67,16 @@ class Wizard extends Component
         return $this;
     }
 
-    public function startOnStep(int $startOnStep): static
+    public function startOnStep(int | Closure $startStep): static
     {
-        $this->startOnStep = $startOnStep - 1;
+        $this->startStep = $startStep;
 
         return $this;
     }
 
-    public function getStartOnStep()
+    public function getStartStep(): int
     {
-        return $this->evaluate($this->startOnStep);
+        return $this->evaluate($this->startStep);
     }
 
     public function cancelAction(string | Htmlable | null $action): static

--- a/packages/forms/src/Components/Wizard.php
+++ b/packages/forms/src/Components/Wizard.php
@@ -16,6 +16,8 @@ class Wizard extends Component
 
     protected string | Htmlable | null $submitAction = null;
 
+    public int | null $startOnStep = 0;
+
     protected string $view = 'forms::components.wizard';
 
     final public function __construct(array | Closure $steps = [])
@@ -63,6 +65,18 @@ class Wizard extends Component
         $this->childComponents($steps);
 
         return $this;
+    }
+
+    public function startOnStep(int $startOnStep): static
+    {
+        $this->startOnStep = $startOnStep - 1;
+
+        return $this;
+    }
+
+    public function getStartOnStep()
+    {
+        return $this->evaluate($this->startOnStep);
     }
 
     public function cancelAction(string | Htmlable | null $action): static


### PR DESCRIPTION
This allows you to set the step start on a wizard, for example if you have a wizard that saves in between, you might want to start the wizard in a later step automatically and not at the start (going through the whole wizard again).