### PR TITLE
feature: allow configuring "close on backdrop click" for modals

### DIFF
--- a/packages/support/config/filament-support.php
+++ b/packages/support/config/filament-support.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    'modal' => [
+        'is_closed_by_clicking_away' => true,
+    ],
+
+];

--- a/packages/support/config/support.php
+++ b/packages/support/config/support.php
@@ -1,9 +1,0 @@
-<?php
-
-return [
-
-    'modal' => [
-        'close_on_backdrop_click' => true,
-    ],
-
-];

--- a/packages/support/config/support.php
+++ b/packages/support/config/support.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    'modal' => [
+        'close_on_backdrop_click' => true,
+    ],
+
+];

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -47,7 +47,7 @@
         class="fixed inset-0 z-40 flex items-center min-h-screen p-4 overflow-y-auto transition"
     >
         <div
-            @if(config('support.modal.close_on_backdrop_click'))
+            @if (config('filament-support.modal.is_closed_by_clicking_away', true))
                 @if (filled($id))
                     x-on:click="$dispatch('{{ $closeEventName }}', { id: '{{ $id }}' })"
                 @else
@@ -57,7 +57,7 @@
             aria-hidden="true"
             @class([
                 'fixed inset-0 w-full h-full bg-black/50 filament-modal-close-overlay',
-                'cursor-pointer' => config('support.modal.close_on_backdrop_click')
+                'cursor-pointer' => config('filament-support.modal.is_closed_by_clicking_away', true)
             ])
         ></div>
 

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -47,8 +47,18 @@
         class="fixed inset-0 z-40 flex items-center min-h-screen p-4 overflow-y-auto transition"
     >
         <div
+            @if(config('support.modal.close_on_backdrop_click'))
+                @if (filled($id))
+                    x-on:click="$dispatch('{{ $closeEventName }}', { id: '{{ $id }}' })"
+                @else
+                    x-on:click="isOpen = false"
+                @endif
+            @endif
             aria-hidden="true"
-            class="fixed inset-0 w-full h-full bg-black/50 filament-modal-close-overlay"
+            @class([
+                'fixed inset-0 w-full h-full bg-black/50 filament-modal-close-overlay',
+                'cursor-pointer' => config('support.modal.close_on_backdrop_click')
+            ])
         ></div>
 
         <div

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -47,13 +47,8 @@
         class="fixed inset-0 z-40 flex items-center min-h-screen p-4 overflow-y-auto transition"
     >
         <div
-            @if (filled($id))
-                x-on:click="$dispatch('{{ $closeEventName }}', { id: '{{ $id }}' })"
-            @else
-                x-on:click="isOpen = false"
-            @endif
             aria-hidden="true"
-            class="fixed inset-0 w-full h-full bg-black/50 cursor-pointer filament-modal-close-overlay"
+            class="fixed inset-0 w-full h-full bg-black/50 filament-modal-close-overlay"
         ></div>
 
         <div

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -18,6 +18,7 @@ class SupportServiceProvider extends PackageServiceProvider
     {
         $package
             ->name('filament-support')
+            ->hasConfigFile()
             ->hasTranslations()
             ->hasViews();
     }


### PR DESCRIPTION
As discussed in #3089 

This stops modals from closing when clicking the backdrop.

I wasn't sure to remove the `filament-modal-close-overlay` class, so I left it in.