### PR TITLE
Change to use contract

### DIFF
--- a/packages/admin/src/Commands/MakeUserCommand.php
+++ b/packages/admin/src/Commands/MakeUserCommand.php
@@ -8,7 +8,6 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\UserProvider;
-use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Facades\Hash;
 
 class MakeUserCommand extends Command

--- a/packages/admin/src/Commands/MakeUserCommand.php
+++ b/packages/admin/src/Commands/MakeUserCommand.php
@@ -5,6 +5,7 @@ namespace Filament\Commands;
 use Filament\Facades\Filament;
 use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Foundation\Auth\User;
@@ -27,12 +28,12 @@ class MakeUserCommand extends Command
         ];
     }
 
-    protected function createUser(): User
+    protected function createUser(): Authenticatable
     {
         return static::getUserModel()::create($this->getUserData());
     }
 
-    protected function sendSuccessMessage(User $user): void
+    protected function sendSuccessMessage(Authenticatable $user): void
     {
         $loginUrl = route('filament.auth.login');
         $this->info('Success! ' . ($user->getAttribute('email') ?? $user->getAttribute('username') ?? 'You') . " may now log in at {$loginUrl}.");


### PR DESCRIPTION
In projects using some User models which extend some other base class than `Illuminate\Foundation\Auth\User` filament:user command returns error:

`Filament\Commands\MakeUserCommand::createUser(): Return value must be of type Illuminate\Foundation\Auth\User, App\Models\User returned`

This PR changes type hints to an Authenticatable contracts instead of a User class directly, which fixes the problem