### PR TITLE
CHG: Make filament app.js defer

### DIFF
--- a/packages/admin/resources/views/components/layouts/base.blade.php
+++ b/packages/admin/resources/views/components/layouts/base.blade.php
@@ -98,7 +98,7 @@
 
         {{ \Filament\Facades\Filament::renderHook('scripts.start') }}
 
-        <script src="{{ route('filament.asset', [
+        <script defer src="{{ route('filament.asset', [
             'id' => Filament\get_asset_id('app.js'),
             'file' => 'app.js',
         ]) }}"></script>

--- a/packages/admin/resources/views/components/layouts/base.blade.php
+++ b/packages/admin/resources/views/components/layouts/base.blade.php
@@ -78,6 +78,8 @@
 
         {{ $slot }}
 
+        {{ \Filament\Facades\Filament::renderHook('scripts.start') }}
+
         @livewireScripts
 
         <script>
@@ -86,17 +88,15 @@
 
         @foreach (\Filament\Facades\Filament::getBeforeCoreScripts() as $name => $path)
             @if (Str::of($path)->startsWith(['http://', 'https://']))
-                <script src="{{ $path }}"></script>
+                <script defer src="{{ $path }}"></script>
             @else
-                <script src="{{ route('filament.asset', [
+                <script defer src="{{ route('filament.asset', [
                     'file' => "{$name}.js",
                 ]) }}"></script>
             @endif
         @endforeach
 
         @stack('beforeCoreScripts')
-
-        {{ \Filament\Facades\Filament::renderHook('scripts.start') }}
 
         <script defer src="{{ route('filament.asset', [
             'id' => Filament\get_asset_id('app.js'),
@@ -105,17 +105,17 @@
 
         @foreach (\Filament\Facades\Filament::getScripts() as $name => $path)
             @if (Str::of($path)->startsWith(['http://', 'https://']))
-                <script src="{{ $path }}"></script>
+                <script defer src="{{ $path }}"></script>
             @else
-                <script src="{{ route('filament.asset', [
+                <script defer src="{{ route('filament.asset', [
                     'file' => "{$name}.js",
                 ]) }}"></script>
             @endif
         @endforeach
 
-        {{ \Filament\Facades\Filament::renderHook('scripts.end') }}
-
         @stack('scripts')
+
+        {{ \Filament\Facades\Filament::renderHook('scripts.end') }}
 
         {{ \Filament\Facades\Filament::renderHook('body.end') }}
     </body>


### PR DESCRIPTION
As discussed in discord, I just added `defer` to the script-tag. The reason is, because Alpine.js recomends adding `defer` to its script include and I have some third party JS Scripts, which will not work, if Alpine isn't loaded `defer`. 

See https://github.com/wireui/wireui/issues/326