### PR TITLE
Add default value fallback for $get()

### DIFF
--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -231,12 +231,13 @@ trait HasState
 
     protected function getGetCallback(): Closure
     {
-        return function (Component | string $path, bool $isAbsolute = false) {
+        return function (Component | string $path, bool $isAbsolute = false, $default = null) {
             $livewire = $this->getLivewire();
 
             return data_get(
                 $livewire,
-                $this->generateStatePathForCallback($path, $isAbsolute)
+                $this->generateStatePathForCallback($path, $isAbsolute),
+                $default
             );
         };
     }


### PR DESCRIPTION
And maybe move the $default parameter to the 2nd parameter so it's similar to `data_get()` for v3?