### PR TITLE
fix: capitalized sorting order not working on table

### DIFF
--- a/packages/admin/src/Resources/Table.php
+++ b/packages/admin/src/Resources/Table.php
@@ -56,7 +56,7 @@ class Table
     public function defaultSort(string $column, string $direction = 'asc'): static
     {
         $this->defaultSortColumn = $column;
-        $this->defaultSortDirection = $direction;
+        $this->defaultSortDirection = strtolower($direction);
 
         return $this;
     }


### PR DESCRIPTION
Closes #3083.

Using `ASC` or `DESC` was causing the problem since we were explicitly checking against the lowercase version. 