### PR TITLE
Fix broken filterTable testing helper

### DIFF
--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -33,7 +33,7 @@ namespace Livewire\Testing {
 
         public function searchTable(?string $search = null): static {}
 
-        public function filterTable(string $name, ?array $data = null): static {}
+        public function filterTable(string $name, mixed $data = null): static {}
 
         public function resetTableFilters(): static {}
 

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -33,7 +33,7 @@ namespace Livewire\Testing {
 
         public function searchTable(?string $search = null): static {}
 
-        public function filterTable(string $name, mixed $data = null): static {}
+        public function filterTable(string $name, $data = null): static {}
 
         public function resetTableFilters(): static {}
 

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -5,7 +5,6 @@ namespace Filament\Tables\Concerns;
 use Filament\Forms;
 use Filament\Forms\ComponentContainer;
 use Filament\Tables\Filters\BaseFilter;
-use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\Layout;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -36,7 +35,7 @@ trait HasFilters
             ->toArray();
     }
 
-    public function getCachedTableFilter(string $name): ?Filter
+    public function getCachedTableFilter(string $name): ?BaseFilter
     {
         return $this->getCachedTableFilters()[$name] ?? null;
     }

--- a/packages/tables/src/Testing/TestsFilters.php
+++ b/packages/tables/src/Testing/TestsFilters.php
@@ -5,7 +5,6 @@ namespace Filament\Tables\Testing;
 use Closure;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\BaseFilter;
-use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\MultiSelectFilter;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Filters\TernaryFilter;
@@ -78,7 +77,7 @@ class TestsFilters
             $action = $livewire->getCachedTableFilter($name);
 
             Assert::assertInstanceOf(
-                Filter::class,
+                BaseFilter::class,
                 $action,
                 message: "Failed asserting that a table filter with name [{$name}] exists on the [{$livewireClass}] component.",
             );

--- a/packages/tables/src/Testing/TestsFilters.php
+++ b/packages/tables/src/Testing/TestsFilters.php
@@ -8,6 +8,7 @@ use Filament\Tables\Filters\BaseFilter;
 use Filament\Tables\Filters\MultiSelectFilter;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Filters\TernaryFilter;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Testing\Assert;
 use Livewire\Testing\TestableLivewire;
@@ -40,9 +41,12 @@ class TestsFilters
                     $data = ['value' => $data];
                 }
             } elseif ($filter instanceof MultiSelectFilter) {
-                $data = ['values' => Arr::wrap($data ?? [])];
+                $data = ['values' => array_map(
+                    fn ($record) => $record instanceof Model ? $record->getKey() : $record,
+                    Arr::wrap($data ?? []),
+                )];
             } elseif ($filter instanceof SelectFilter) {
-                $data = ['value' => $data];
+                $data = ['value' => $data instanceof Model ? $data->getKey() : $data];
             } else {
                 $data = ['isActive' => $data === true || $data === null];
             }

--- a/tests/src/Tables/FilterTest.php
+++ b/tests/src/Tables/FilterTest.php
@@ -7,7 +7,7 @@ use function Pest\Livewire\livewire;
 
 uses(TestCase::class);
 
-it('can filter records', function () {
+it('can filter records by boolean column', function () {
     $posts = Post::factory()->count(10)->create();
 
     livewire(PostsTable::class)
@@ -15,6 +15,18 @@ it('can filter records', function () {
         ->filterTable('is_published')
         ->assertCanSeeTableRecords($posts->where('is_published', true))
         ->assertCanNotSeeTableRecords($posts->where('is_published', false));
+});
+
+it('can filter records by relationship', function () {
+    $posts = Post::factory()->count(10)->create();
+
+    $author = $posts->first()->author;
+
+    livewire(PostsTable::class)
+        ->assertCanSeeTableRecords($posts)
+        ->filterTable('author', $author)
+        ->assertCanSeeTableRecords($posts->where('author_id', $author->getKey()))
+        ->assertCanNotSeeTableRecords($posts->where('author_id', '!=', $author->getKey()));
 });
 
 it('can reset filters', function () {

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -31,6 +31,8 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
         return [
             Tables\Filters\Filter::make('is_published')
                 ->query(fn (Builder $query) => $query->where('is_published', true)),
+            Tables\Filters\SelectFilter::make('author')
+                ->relationship('author', 'name'),
         ];
     }
 


### PR DESCRIPTION
Currently it's not possible to use the `filterTable()` testing helper in the way described in the docs for anything other than a basic `Filter` filter) 

[https://github.com/filamentphp/filament/blob/c104493ffabed3f10c00bd3bd7d03dc435c82aab/packages/tables/docs/06-testing.md?plain=1#L114-L130](https://github.com/filamentphp/filament/blob/c104493ffabed3f10c00bd3bd7d03dc435c82aab/packages/tables/docs/06-testing.md?plain=1#L114-L130)

This is due to a few incorrect parameter/return types referencing `Filter` instead of `BaseFilter`. This PR fixes those.

May also be worth it to document the usage of testing a `MultiSelectFilter` with an example by passing in an array, although I'll leave this one for the reviewer to decide and implement how they wish.