### PR TITLE
Support action groups in table header actions array

### DIFF
--- a/packages/admin/src/Resources/Table.php
+++ b/packages/admin/src/Resources/Table.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Resources;
 
+use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\ActionGroup;
 use Illuminate\Support\Arr;
 
@@ -192,6 +193,12 @@ class Table
 
     public function getHeaderActions(): array
     {
-        return $this->headerActions;
+        return array_filter($this->headerActions, function (Action | ActionGroup $action) {
+            if ($action instanceof ActionGroup) {
+                return count(array_filter($action->getActions(), fn (Action $groupedAction) => ! $groupedAction->isHidden()));
+            }
+
+            return ! $action->isHidden();
+        });
     }
 }

--- a/packages/tables/src/Actions/ActionGroup.php
+++ b/packages/tables/src/Actions/ActionGroup.php
@@ -7,7 +7,6 @@ use Filament\Support\Actions\Concerns\InteractsWithRecord;
 
 class ActionGroup extends BaseActionGroup
 {
-    use Concerns\BelongsToTable;
     use InteractsWithRecord;
 
     protected string $view = 'tables::actions.group';

--- a/packages/tables/src/Actions/ActionGroup.php
+++ b/packages/tables/src/Actions/ActionGroup.php
@@ -7,6 +7,7 @@ use Filament\Support\Actions\Concerns\InteractsWithRecord;
 
 class ActionGroup extends BaseActionGroup
 {
+    use Concerns\BelongsToTable;
     use InteractsWithRecord;
 
     protected string $view = 'tables::actions.group';

--- a/packages/tables/src/Concerns/HasHeader.php
+++ b/packages/tables/src/Concerns/HasHeader.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Concerns;
 
 use Closure;
 use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\ActionGroup;
 use Illuminate\Contracts\View\View;
 
 trait HasHeader
@@ -18,10 +19,10 @@ trait HasHeader
         );
 
         $this->cachedTableHeaderActions = collect($actions)
-            ->mapWithKeys(function (Action $action): array {
+            ->mapWithKeys(function (Action | ActionGroup $action): array {
                 $action->table($this->getCachedTable());
 
-                return [$action->getName() => $action];
+                return [$action instanceof Action ? $action->getName() : null => $action];
             })
             ->toArray();
     }
@@ -29,7 +30,7 @@ trait HasHeader
     public function getCachedTableHeaderActions(): array
     {
         return collect($this->cachedTableHeaderActions)
-            ->filter(fn (Action $action): bool => ! $action->isHidden())
+            ->filter(fn (Action | ActionGroup $action): bool => ! $action->isHidden())
             ->toArray();
     }
 

--- a/packages/tables/src/Concerns/HasHeader.php
+++ b/packages/tables/src/Concerns/HasHeader.php
@@ -14,15 +14,21 @@ trait HasHeader
     public function cacheTableHeaderActions(): void
     {
         $actions = Action::configureUsing(
-            fn (Action $action) => $this->configureTableAction($action->button()),
-            fn (): array => $this->getTableHeaderActions(),
+            Closure::fromCallable([$this, 'configureTableAction']),
+            fn (): array => $this->getTableActions(),
         );
 
         $this->cachedTableHeaderActions = collect($actions)
-            ->mapWithKeys(function (Action | ActionGroup $action): array {
-                $action->table($this->getCachedTable());
+            ->mapWithKeys(function (Action | ActionGroup $action, int $index): array {
+                if ($action instanceof ActionGroup) {
+                    foreach ($action->getActions() as $groupedAction) {
+                        $groupedAction->table($this->getCachedTable());
+                    }
 
-                return [$action instanceof Action ? $action->getName() : null => $action];
+                    return [$index => $action];
+                }
+
+                return [$action->getName() => $action];
             })
             ->toArray();
     }

--- a/packages/tables/src/Concerns/HasHeader.php
+++ b/packages/tables/src/Concerns/HasHeader.php
@@ -15,7 +15,7 @@ trait HasHeader
     {
         $actions = Action::configureUsing(
             Closure::fromCallable([$this, 'configureTableAction']),
-            fn (): array => $this->getTableActions(),
+            fn (): array => $this->getTableHeaderActions(),
         );
 
         $this->cachedTableHeaderActions = collect($actions)

--- a/packages/tables/src/Concerns/HasHeader.php
+++ b/packages/tables/src/Concerns/HasHeader.php
@@ -28,6 +28,8 @@ trait HasHeader
                     return [$index => $action];
                 }
 
+                $action->table($this->getCachedTable());
+
                 return [$action->getName() => $action];
             })
             ->toArray();

--- a/packages/tables/src/Concerns/HasHeader.php
+++ b/packages/tables/src/Concerns/HasHeader.php
@@ -15,7 +15,7 @@ trait HasHeader
     {
         $actions = Action::configureUsing(
             Closure::fromCallable([$this, 'configureTableAction']),
-            fn (): array => $this->getTableActions(),
+            fn (): array => $this->getTableHeaderActions(),
         );
 
         $this->cachedTableHeaderActions = collect($actions)
@@ -37,14 +37,34 @@ trait HasHeader
 
     public function getCachedTableHeaderActions(): array
     {
-        return collect($this->cachedTableHeaderActions)
-            ->filter(fn (Action | ActionGroup $action): bool => ! $action->isHidden())
-            ->toArray();
+        return $this->cachedTableHeaderActions;
     }
 
     public function getCachedTableHeaderAction(string $name): ?Action
     {
-        return $this->getCachedTableHeaderActions()[$name] ?? null;
+        $actions = $this->getCachedTableHeaderActions();
+
+        $action = $actions[$name] ?? null;
+
+        if ($action) {
+            return $action;
+        }
+
+        foreach ($actions as $action) {
+            if (! $action instanceof ActionGroup) {
+                continue;
+            }
+
+            $groupedAction = $action->getActions()[$name] ?? null;
+
+            if (! $groupedAction) {
+                continue;
+            }
+
+            return $groupedAction;
+        }
+
+        return null;
     }
 
     protected function getTableDescription(): ?string


### PR DESCRIPTION
Since action groups don't have a name, caching probably won't work. Any better solution?