### PR TITLE
fix: PageClass property nullable by default

### DIFF
--- a/packages/admin/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/admin/src/Resources/RelationManagers/RelationManager.php
@@ -24,7 +24,7 @@ class RelationManager extends Component implements Tables\Contracts\HasRelations
 
     public Model $ownerRecord;
 
-    public string $pageClass;
+    public ?string $pageClass = null;
 
     protected static ?string $recordTitleAttribute = null;
 


### PR DESCRIPTION
Makes the `$pageClass` property `null` by default, to allow for the `RelationManager` getting used without being mounted on any page. Previously the `RelationManager` would break if it's being used independently from a page, by example when testing.