### PR TITLE
fix: Bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -78,7 +78,7 @@ body:
       validations:
           required: true
     - type: input
-      id: repository
+      id: reproduction
       attributes:
           label: Reproduction repository
           description: The URL of a public Git repository which contains the minimal amount of code to reproduce the problem. This allows us to fix the problem much quicker.


### PR DESCRIPTION
Apparently, GitHub pre-fills the field with id `repository` with this repository's name.