### PR TITLE
feature: add useful info to new `about` command

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -32,7 +32,7 @@ jobs:
                   coverage: none
             - name: Install dependencies
               run: |
-                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "filament/support" --no-interaction --no-update
                   composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
             - name: Run PHPStan
               run: ./vendor/bin/phpstan --error-format=github

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
                   coverage: none
             - name: Install dependencies
               run: |
-                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "filament/support" --no-interaction --no-update
                   composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
             - name: Execute tests
               run: ./vendor/bin/pest --verbose

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "license": "MIT",
     "require": {
         "php": "^8.0",
-        "ext-intl": "*"
+        "ext-intl": "*",
+        "composer-runtime-api": "^2.1"
     },
     "require-dev": {
         "akaunting/laravel-money": "^1.2|^2.0|^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "769a69a0c6d85a80f733fdf36daa54c4",
+    "content-hash": "21c2313cf9ce7f9b707716871a2468c0",
     "packages": [],
     "packages-dev": [
         {
@@ -12906,8 +12906,9 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^8.0",
-        "ext-intl": "*"
+        "ext-intl": "*",
+        "composer-runtime-api": "^2.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Filament\Support;
 
+use Composer\InstalledVersions;
+use Filament\Facades\Filament;
 use Filament\Support\Testing\TestsActions;
 use HtmlSanitizer\Sanitizer;
 use HtmlSanitizer\SanitizerInterface;
@@ -11,6 +13,7 @@ use Illuminate\Support\Stringable;
 use Livewire\Testing\TestableLivewire;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Illuminate\Foundation\Console\AboutCommand;
 
 class SupportServiceProvider extends PackageServiceProvider
 {
@@ -60,5 +63,17 @@ class SupportServiceProvider extends PackageServiceProvider
             /** @phpstan-ignore-next-line */
             return new Stringable(Str::sanitizeHtml($this->value));
         });
+
+        if (class_exists(AboutCommand::class)) {
+            AboutCommand::add('Filament', [
+                'Version' => InstalledVersions::getPrettyVersion('filament/support'),
+                'Packages' => collect([
+                    'admin' => InstalledVersions::isInstalled('filament/filament'),
+                    'forms' => InstalledVersions::isInstalled('filament/forms'),
+                    'tables' => InstalledVersions::isInstalled('filament/tables'),
+                ])->filter()->keys()->join(', '),
+                'Views' => is_dir(resource_path('views/vendor/filament')) ? '<fg=red;options=bold>PUBLISHED</>' : '<fg=green;options=bold>NOT PUBLISHED</>',
+            ]);
+        }
     }
 }

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -64,14 +64,27 @@ class SupportServiceProvider extends PackageServiceProvider
         });
 
         if (class_exists(AboutCommand::class)) {
+            $packages = [
+                'filament',
+                'forms',
+                'tables',
+                'support',
+            ];
+
             AboutCommand::add('Filament', [
                 'Version' => InstalledVersions::getPrettyVersion('filament/support'),
-                'Packages' => collect([
-                    'admin' => InstalledVersions::isInstalled('filament/filament'),
-                    'forms' => InstalledVersions::isInstalled('filament/forms'),
-                    'tables' => InstalledVersions::isInstalled('filament/tables'),
-                ])->filter()->keys()->join(', '),
-                'Views' => is_dir(resource_path('views/vendor/filament')) ? '<fg=red;options=bold>PUBLISHED</>' : '<fg=green;options=bold>NOT PUBLISHED</>',
+                'Packages' => collect($packages)
+                    ->filter(fn (string $package): bool => InstalledVersions::isInstalled("filament/{$package}"))
+                    ->join(', '),
+                'Views' => function () use ($packages): string {
+                    $publishedViewPaths = collect($packages)->filter(fn (string $package): bool => is_dir(resource_path("views/vendor/{$package}")));
+
+                    if (! $publishedViewPaths->count()) {
+                        return '<fg=green;options=bold>NOT PUBLISHED</>';
+                    }
+
+                    return "<fg=red;options=bold>PUBLISHED:</> {$publishedViewPaths->join(', ')}";
+                },
             ]);
         }
     }

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -3,17 +3,16 @@
 namespace Filament\Support;
 
 use Composer\InstalledVersions;
-use Filament\Facades\Filament;
 use Filament\Support\Testing\TestsActions;
 use HtmlSanitizer\Sanitizer;
 use HtmlSanitizer\SanitizerInterface;
+use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Livewire\Testing\TestableLivewire;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
-use Illuminate\Foundation\Console\AboutCommand;
 
 class SupportServiceProvider extends PackageServiceProvider
 {

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -65,7 +65,7 @@ class SupportServiceProvider extends PackageServiceProvider
 
         if (class_exists(AboutCommand::class)) {
             AboutCommand::add('Filament', [
-                'Version' => InstalledVersions::getPrettyVersion('filament/filament'),
+                'Version' => InstalledVersions::getPrettyVersion('filament/support'),
                 'Packages' => collect([
                     'admin' => InstalledVersions::isInstalled('filament/filament'),
                     'forms' => InstalledVersions::isInstalled('filament/forms'),

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -65,7 +65,7 @@ class SupportServiceProvider extends PackageServiceProvider
 
         if (class_exists(AboutCommand::class)) {
             AboutCommand::add('Filament', [
-                'Version' => InstalledVersions::getPrettyVersion('filament/support'),
+                'Version' => InstalledVersions::getPrettyVersion('filament/filament'),
                 'Packages' => collect([
                     'admin' => InstalledVersions::isInstalled('filament/filament'),
                     'forms' => InstalledVersions::isInstalled('filament/forms'),


### PR DESCRIPTION
Should be backwards compatible with the `class_exists` check.

Replaces #2869.