### PR TITLE
Fixed translated direction problem

### DIFF
--- a/packages/admin/resources/lang/tr/layout.php
+++ b/packages/admin/resources/lang/tr/layout.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'direction' => 'soldan sağa',
+    'direction' => 'ltr',
 
     'buttons' => [
 


### PR DESCRIPTION
The layout direction should be ltr or rtl. It is translated in Turkish translation files.