### PR TITLE
Add pagination methods to table LOADING_TARGETS

### DIFF
--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -64,7 +64,7 @@ class Table extends ViewComponent
 
     protected string $viewIdentifier = 'table';
 
-    public const LOADING_TARGETS = ['gotoPage', 'tableFilters', 'resetTableFiltersForm', 'tableSearchQuery', 'tableRecordsPerPage', '$set'];
+    public const LOADING_TARGETS = ['previousPage', 'nextPage', 'gotoPage', 'tableFilters', 'resetTableFiltersForm', 'tableSearchQuery', 'tableRecordsPerPage', '$set'];
 
     final public function __construct(HasTable $livewire)
     {


### PR DESCRIPTION
I'm just wondering if there's a reason that the previous/nextPage methods aren't in the LOADING_TARGETS array on the Table object because it means that the previous and next buttons don't show the loading state on the table. If the next page doesn't load very quickly for whatever reason, it can lead the user to think that nothing is happening.

If there's a specific reason for them not being in there then let me know and maybe I can look into a workaround.