### PR TITLE
German translation: Correct doubled word

### DIFF
--- a/packages/tables/resources/lang/de/table.php
+++ b/packages/tables/resources/lang/de/table.php
@@ -132,7 +132,7 @@ return [
 
         ],
 
-        'selected_count' => '1 Datensatz ausgewählt ausgewählt.|:count Datensätze ausgewählt.',
+        'selected_count' => '1 Datensatz ausgewählt.|:count Datensätze ausgewählt.',
     ],
 
 ];


### PR DESCRIPTION
This PR will clear a doubled word inside the german table translation.
Thanks!