### PR TITLE
Move upgrade command to support package

### DIFF
--- a/packages/forms/docs/01-installation.md
+++ b/packages/forms/docs/01-installation.md
@@ -240,7 +240,6 @@ To do this automatically, we recommend adding these commands to your `composer.j
 ```json
 "post-update-cmd": [
     // ...
-    "@php artisan config:clear",
-    "@php artisan view:clear"
+    "@php artisan filament:upgrade"
 ],
 ```

--- a/packages/notifications/docs/01-installation.md
+++ b/packages/notifications/docs/01-installation.md
@@ -219,7 +219,6 @@ To do this automatically, we recommend adding these commands to your `composer.j
 ```json
 "post-update-cmd": [
     // ...
-    "@php artisan config:clear",
-    "@php artisan view:clear"
+    "@php artisan filament:upgrade"
 ],
 ```

--- a/packages/tables/docs/01-installation.md
+++ b/packages/tables/docs/01-installation.md
@@ -251,7 +251,6 @@ To do this automatically, we recommend adding these commands to your `composer.j
 ```json
 "post-update-cmd": [
     // ...
-    "@php artisan config:clear",
-    "@php artisan view:clear"
+    "@php artisan filament:upgrade"
 ],
 ```


### PR DESCRIPTION
Not sure if it was intended to only use the `php artisan filament:upgrade` command for the admin panel. I think it should be used for all packages.