### PR TITLE
add localizeLabel to Table and Form components

### DIFF
--- a/packages/forms/src/Components/Builder/Block.php
+++ b/packages/forms/src/Components/Builder/Block.php
@@ -50,11 +50,11 @@ class Block extends Component
     {
         $label = $this->evaluate($this->label, array_merge(
             $this->labelState ? ['state' => $this->labelState] : [],
-        ));
-
-        return $label ?? (string) Str::of($this->getName())
+        ))??(string) Str::of($this->getName())
             ->kebab()
             ->replace(['-', '_'], ' ')
             ->ucfirst();
+
+        return ($this->isLabelLocalized())?__($label):$label;
     }
 }

--- a/packages/forms/src/Components/Builder/Block.php
+++ b/packages/forms/src/Components/Builder/Block.php
@@ -50,11 +50,11 @@ class Block extends Component
     {
         $label = $this->evaluate($this->label, array_merge(
             $this->labelState ? ['state' => $this->labelState] : [],
-        ))??(string) Str::of($this->getName())
+        )) ?? (string) Str::of($this->getName())
             ->kebab()
             ->replace(['-', '_'], ' ')
             ->ucfirst();
 
-        return ($this->isLabelLocalized())?__($label):$label;
+        return ($this->isLabelLocalized()) ? __($label) : $label;
     }
 }

--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -119,7 +119,8 @@ class CheckboxList extends Field
                 ->kebab()
                 ->replace(['-', '_'], ' ')
                 ->ucfirst();
-            return ($this->isLabelLocalized())?__($label):$label;
+
+            return ($this->isLabelLocalized()) ? __($label) : $label;
         }
 
         return parent::getLabel();

--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -114,11 +114,12 @@ class CheckboxList extends Field
     public function getLabel(): string
     {
         if ($this->label === null && $this->getRelationship()) {
-            return (string) Str::of($this->getRelationshipName())
+            $label = (string) Str::of($this->getRelationshipName())
                 ->before('.')
                 ->kebab()
                 ->replace(['-', '_'], ' ')
                 ->ucfirst();
+            return ($this->isLabelLocalized())?__($label):$label;
         }
 
         return parent::getLabel();

--- a/packages/forms/src/Components/Concerns/HasLabel.php
+++ b/packages/forms/src/Components/Concerns/HasLabel.php
@@ -8,7 +8,9 @@ use Illuminate\Contracts\Support\Htmlable;
 trait HasLabel
 {
     protected bool | Closure $isLabelHidden = false;
+
     protected bool | Closure $isLabelLocalized = false;
+
     protected string | Htmlable | Closure | null $label = null;
 
     public function disableLabel(bool | Closure $condition = true): static
@@ -35,9 +37,10 @@ trait HasLabel
     public function getLabel(): string | Htmlable | null
     {
         $label = $this->evaluate($this->label);
-        if ($this->isLabelLocalized()){
+        if ($this->isLabelLocalized()) {
             return __($label);
         }
+
         return $label;
     }
 
@@ -45,6 +48,7 @@ trait HasLabel
     {
         return $this->evaluate($this->isLabelLocalized);
     }
+
     public function isLabelHidden(): bool
     {
         return $this->evaluate($this->isLabelHidden);

--- a/packages/forms/src/Components/Concerns/HasLabel.php
+++ b/packages/forms/src/Components/Concerns/HasLabel.php
@@ -34,10 +34,11 @@ trait HasLabel
 
     public function getLabel(): string | Htmlable | null
     {
+        $label = $this->evaluate($this->label);
         if ($this->isLabelLocalized()){
-            return __($this->evaluate($this->label));
+            return __($label);
         }
-        return $this->evaluate($this->label);
+        return $label;
     }
 
     public function isLabelLocalized(): bool

--- a/packages/forms/src/Components/Concerns/HasLabel.php
+++ b/packages/forms/src/Components/Concerns/HasLabel.php
@@ -35,7 +35,6 @@ trait HasLabel
     public function getLabel(): string | Htmlable | null
     {
         if ($this->isLabelLocalized()){
-
             return __($this->evaluate($this->label));
         }
         return $this->evaluate($this->label);

--- a/packages/forms/src/Components/Concerns/HasLabel.php
+++ b/packages/forms/src/Components/Concerns/HasLabel.php
@@ -8,12 +8,19 @@ use Illuminate\Contracts\Support\Htmlable;
 trait HasLabel
 {
     protected bool | Closure $isLabelHidden = false;
-
+    protected bool | Closure $isLabelLocalized = false;
     protected string | Htmlable | Closure | null $label = null;
 
     public function disableLabel(bool | Closure $condition = true): static
     {
         $this->isLabelHidden = $condition;
+
+        return $this;
+    }
+
+    public function localizeLabel(bool | Closure $condition = true): static
+    {
+        $this->isLabelLocalized = $condition;
 
         return $this;
     }
@@ -27,9 +34,17 @@ trait HasLabel
 
     public function getLabel(): string | Htmlable | null
     {
+        if ($this->isLabelLocalized()){
+
+            return __($this->evaluate($this->label));
+        }
         return $this->evaluate($this->label);
     }
 
+    public function isLabelLocalized(): bool
+    {
+        return $this->evaluate($this->isLabelLocalized);
+    }
     public function isLabelHidden(): bool
     {
         return $this->evaluate($this->isLabelHidden);

--- a/packages/forms/src/Components/Field.php
+++ b/packages/forms/src/Components/Field.php
@@ -36,14 +36,11 @@ class Field extends Component implements Contracts\HasValidationRules
 
     public function getLabel(): string|Htmlable|null
     {
-        return parent::getLabel() ?? ($this->isLabelLocalized()) ? __((string) Str::of($this->getName())
-            ->afterLast('.')
-            ->kebab()
-            ->replace(['-', '_'], ' ')
-            ->ucfirst()) : (string) Str::of($this->getName())
+        $label = parent::getLabel() ??(string) Str::of($this->getName())
             ->afterLast('.')
             ->kebab()
             ->replace(['-', '_'], ' ')
             ->ucfirst();
+        return  ($this->isLabelLocalized()) ? __($label) : $label;
     }
 }

--- a/packages/forms/src/Components/Field.php
+++ b/packages/forms/src/Components/Field.php
@@ -36,11 +36,12 @@ class Field extends Component implements Contracts\HasValidationRules
 
     public function getLabel(): string|Htmlable|null
     {
-        $label = parent::getLabel() ??(string) Str::of($this->getName())
+        $label = parent::getLabel() ?? (string) Str::of($this->getName())
             ->afterLast('.')
             ->kebab()
             ->replace(['-', '_'], ' ')
             ->ucfirst();
+
         return  ($this->isLabelLocalized()) ? __($label) : $label;
     }
 }

--- a/packages/forms/src/Components/Field.php
+++ b/packages/forms/src/Components/Field.php
@@ -34,9 +34,13 @@ class Field extends Component implements Contracts\HasValidationRules
         return parent::getId() ?? $this->getStatePath();
     }
 
-    public function getLabel(): string | Htmlable | null
+    public function getLabel(): string|Htmlable|null
     {
-        return parent::getLabel() ?? (string) Str::of($this->getName())
+        return parent::getLabel() ?? ($this->isLabelLocalized()) ? __((string) Str::of($this->getName())
+            ->afterLast('.')
+            ->kebab()
+            ->replace(['-', '_'], ' ')
+            ->ucfirst()) : (string) Str::of($this->getName())
             ->afterLast('.')
             ->kebab()
             ->replace(['-', '_'], ' ')

--- a/packages/forms/src/Components/Placeholder.php
+++ b/packages/forms/src/Components/Placeholder.php
@@ -55,10 +55,11 @@ class Placeholder extends Component
 
     public function getLabel(): string | Htmlable | null
     {
-        return parent::getLabel() ?? (string) Str::of($this->getName())
+        $label =parent::getLabel() ?? (string) Str::of($this->getName())
             ->kebab()
             ->replace(['-', '_'], ' ')
             ->ucfirst();
+        return ($this->isLabelLocalized())?__($label):$label;
     }
 
     public function getContent()

--- a/packages/forms/src/Components/Placeholder.php
+++ b/packages/forms/src/Components/Placeholder.php
@@ -55,11 +55,12 @@ class Placeholder extends Component
 
     public function getLabel(): string | Htmlable | null
     {
-        $label =parent::getLabel() ?? (string) Str::of($this->getName())
+        $label = parent::getLabel() ?? (string) Str::of($this->getName())
             ->kebab()
             ->replace(['-', '_'], ' ')
             ->ucfirst();
-        return ($this->isLabelLocalized())?__($label):$label;
+
+        return ($this->isLabelLocalized()) ? __($label) : $label;
     }
 
     public function getContent()

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -392,7 +392,8 @@ class Repeater extends Field
                 ->kebab()
                 ->replace(['-', '_'], ' ')
                 ->ucfirst();
-            return ($this->isLabelLocalized())?__($label):$label;
+
+            return ($this->isLabelLocalized()) ? __($label) : $label;
         }
 
         return parent::getLabel();

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -387,11 +387,12 @@ class Repeater extends Field
     public function getLabel(): string
     {
         if ($this->label === null && $this->hasRelationship()) {
-            return (string) Str::of($this->getRelationshipName())
+            $label = (string) Str::of($this->getRelationshipName())
                 ->before('.')
                 ->kebab()
                 ->replace(['-', '_'], ' ')
                 ->ucfirst();
+            return ($this->isLabelLocalized())?__($label):$label;
         }
 
         return parent::getLabel();

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -678,7 +678,8 @@ class Select extends Field
                 ->kebab()
                 ->replace(['-', '_'], ' ')
                 ->ucfirst();
-            return ($this->isLabelLocalized())?__($label):$label;
+
+            return ($this->isLabelLocalized()) ? __($label) : $label;
         }
 
         return parent::getLabel();

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -673,11 +673,12 @@ class Select extends Field
     public function getLabel(): string
     {
         if ($this->label === null && $this->hasRelationship()) {
-            return (string) Str::of($this->getRelationshipName())
+            $label = (string) Str::of($this->getRelationshipName())
                 ->before('.')
                 ->kebab()
                 ->replace(['-', '_'], ' ')
                 ->ucfirst();
+            return ($this->isLabelLocalized())?__($label):$label;
         }
 
         return parent::getLabel();

--- a/packages/tables/src/Columns/Concerns/HasLabel.php
+++ b/packages/tables/src/Columns/Concerns/HasLabel.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 trait HasLabel
 {
     protected string | Closure | null $label = null;
+    protected bool | Closure $isLabelLocalized = false;
 
     public function label(string | Closure | null $label): static
     {
@@ -15,13 +16,24 @@ trait HasLabel
 
         return $this;
     }
+    public function localizeLabel(bool | Closure $condition = true): static
+    {
+        $this->isLabelLocalized = $condition;
+
+        return $this;
+    }
+    public function isLabelLocalized(): bool
+    {
+        return $this->evaluate($this->isLabelLocalized);
+    }
 
     public function getLabel(): string
     {
-        return $this->evaluate($this->label) ?? (string) Str::of($this->getName())
+        $label = $this->evaluate($this->label) ?? (string) Str::of($this->getName())
             ->before('.')
             ->kebab()
             ->replace(['-', '_'], ' ')
             ->ucfirst();
+        return ($this->isLabelLocalized())?__($label):$label;
     }
 }

--- a/packages/tables/src/Columns/Concerns/HasLabel.php
+++ b/packages/tables/src/Columns/Concerns/HasLabel.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 trait HasLabel
 {
     protected string | Closure | null $label = null;
+
     protected bool | Closure $isLabelLocalized = false;
 
     public function label(string | Closure | null $label): static
@@ -16,12 +17,14 @@ trait HasLabel
 
         return $this;
     }
+
     public function localizeLabel(bool | Closure $condition = true): static
     {
         $this->isLabelLocalized = $condition;
 
         return $this;
     }
+
     public function isLabelLocalized(): bool
     {
         return $this->evaluate($this->isLabelLocalized);
@@ -34,6 +37,7 @@ trait HasLabel
             ->kebab()
             ->replace(['-', '_'], ' ')
             ->ucfirst();
-        return ($this->isLabelLocalized())?__($label):$label;
+
+        return ($this->isLabelLocalized()) ? __($label) : $label;
     }
 }

--- a/packages/tables/src/Filters/Concerns/HasLabel.php
+++ b/packages/tables/src/Filters/Concerns/HasLabel.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 trait HasLabel
 {
     protected string | Closure | null $label = null;
+    protected bool | Closure $isLabelLocalized = false;
 
     public function label(string | Closure | null $label): static
     {
@@ -15,13 +16,24 @@ trait HasLabel
 
         return $this;
     }
+    public function localizeLabel(bool | Closure $condition = true): static
+    {
+        $this->isLabelLocalized = $condition;
+
+        return $this;
+    }
+    public function isLabelLocalized(): bool
+    {
+        return $this->evaluate($this->isLabelLocalized);
+    }
 
     public function getLabel(): string
     {
-        return $this->evaluate($this->label) ?? (string) Str::of($this->getName())
+        $label = $this->evaluate($this->label) ?? (string) Str::of($this->getName())
             ->before('.')
             ->kebab()
             ->replace(['-', '_'], ' ')
             ->ucfirst();
+        return ($this->isLabelLocalized())?__($label):$label;
     }
 }

--- a/packages/tables/src/Filters/Concerns/HasLabel.php
+++ b/packages/tables/src/Filters/Concerns/HasLabel.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 trait HasLabel
 {
     protected string | Closure | null $label = null;
+
     protected bool | Closure $isLabelLocalized = false;
 
     public function label(string | Closure | null $label): static
@@ -16,12 +17,14 @@ trait HasLabel
 
         return $this;
     }
+
     public function localizeLabel(bool | Closure $condition = true): static
     {
         $this->isLabelLocalized = $condition;
 
         return $this;
     }
+
     public function isLabelLocalized(): bool
     {
         return $this->evaluate($this->isLabelLocalized);
@@ -34,6 +37,7 @@ trait HasLabel
             ->kebab()
             ->replace(['-', '_'], ' ')
             ->ucfirst();
-        return ($this->isLabelLocalized())?__($label):$label;
+
+        return ($this->isLabelLocalized()) ? __($label) : $label;
     }
 }


### PR DESCRIPTION
instead of [#3272](https://github.com/filamentphp/filament/pull/3272), I've created this PR that's introduce a new `localizeLabel()` customization to Form and Table components and users can manage the localization of each field on the form or table schema.

```php
Forms\Components\TextInput::make('name')
                    ->localizeLabel()
                    ->required()
                    ->maxLength(255)
```

code above will now return the label using `__()`.