### PR TITLE
Auto register prefix/suffix actions

### DIFF
--- a/packages/forms/src/Components/Concerns/HasActions.php
+++ b/packages/forms/src/Components/Concerns/HasActions.php
@@ -28,8 +28,6 @@ trait HasActions
         return $this->getActions()[$name] ?? null;
     }
 
-    // When the component `HasAffixes`, this is overridden by
-    // `HasAffixes::getActions()` to auto-register affix actions.
     public function getActions(): array
     {
         return $this->actions;

--- a/packages/forms/src/Components/Concerns/HasActions.php
+++ b/packages/forms/src/Components/Concerns/HasActions.php
@@ -14,8 +14,10 @@ trait HasActions
     public function registerActions(array $actions): static
     {
         $this->actions = array_merge(
-            $this->actions,
-            array_map(fn (Action $action): Action => $action->component($this), $actions),
+            $actions,
+            collect($actions)
+                ->mapWithKeys(fn (Action $action): array => [$action->getName() => $action->component($this)])
+                ->all(),
         );
 
         return $this;
@@ -26,6 +28,8 @@ trait HasActions
         return $this->getActions()[$name] ?? null;
     }
 
+    // When the component `HasAffixes`, this is overridden by
+    // `HasAffixes::getActions()` to auto-register affix actions.
     public function getActions(): array
     {
         return $this->actions;

--- a/packages/forms/src/Components/Concerns/HasActions.php
+++ b/packages/forms/src/Components/Concerns/HasActions.php
@@ -13,12 +13,9 @@ trait HasActions
 
     public function registerActions(array $actions): static
     {
-        $this->actions = array_merge(
-            $actions,
-            collect($actions)
-                ->mapWithKeys(fn (Action $action): array => [$action->getName() => $action->component($this)])
-                ->all(),
-        );
+        foreach ($actions as $action) {
+            $this->actions[$action->getName()] = $action->component($this);
+        }
 
         return $this;
     }

--- a/packages/forms/src/Components/Concerns/HasAffixes.php
+++ b/packages/forms/src/Components/Concerns/HasAffixes.php
@@ -33,6 +33,10 @@ trait HasAffixes
 
     public function prefixAction(Action | Closure | null $action): static
     {
+        if ($action instanceof Action) {
+            $this->autoRegisterAction($action);
+        }
+
         $this->prefixAction = $action;
 
         return $this;
@@ -40,6 +44,10 @@ trait HasAffixes
 
     public function suffixAction(Action | Closure | null $action): static
     {
+        if ($action instanceof Action) {
+            $this->autoRegisterAction($action);
+        }
+
         $this->suffixAction = $action;
 
         return $this;
@@ -64,6 +72,15 @@ trait HasAffixes
         $this->suffixIcon = $iconName;
 
         return $this;
+    }
+
+    private function autoRegisterAction(Action $action): void
+    {
+        if (! $this->getAction($action->getName())) {
+            $this->registerActions([
+                $action->getName() => $action,
+            ]);
+        }
     }
 
     public function getPrefixAction(): ?Action

--- a/packages/forms/src/Components/Concerns/HasAffixes.php
+++ b/packages/forms/src/Components/Concerns/HasAffixes.php
@@ -4,6 +4,7 @@ namespace Filament\Forms\Components\Concerns;
 
 use Closure;
 use Filament\Forms\Components\Actions\Action;
+use Illuminate\Support\Arr;
 
 trait HasAffixes
 {
@@ -33,10 +34,6 @@ trait HasAffixes
 
     public function prefixAction(Action | Closure | null $action): static
     {
-        if ($action instanceof Action) {
-            $this->autoRegisterAction($action);
-        }
-
         $this->prefixAction = $action;
 
         return $this;
@@ -44,10 +41,6 @@ trait HasAffixes
 
     public function suffixAction(Action | Closure | null $action): static
     {
-        if ($action instanceof Action) {
-            $this->autoRegisterAction($action);
-        }
-
         $this->suffixAction = $action;
 
         return $this;
@@ -74,23 +67,14 @@ trait HasAffixes
         return $this;
     }
 
-    private function autoRegisterAction(Action $action): void
-    {
-        if (! $this->getAction($action->getName())) {
-            $this->registerActions([
-                $action->getName() => $action,
-            ]);
-        }
-    }
-
     public function getPrefixAction(): ?Action
     {
-        return $this->evaluate($this->prefixAction);
+        return $this->evaluate($this->prefixAction)?->component($this);
     }
 
     public function getSuffixAction(): ?Action
     {
-        return $this->evaluate($this->suffixAction);
+        return $this->evaluate($this->suffixAction)?->component($this);
     }
 
     public function getPrefixLabel()
@@ -116,5 +100,17 @@ trait HasAffixes
     public function getSuffixIcon()
     {
         return $this->evaluate($this->suffixIcon);
+    }
+
+    public function getActions(): array
+    {
+        $prefixAction = $this->getPrefixAction();
+        $suffixAction = $this->getSuffixAction();
+
+        return array_merge(
+            parent::getActions(),
+            $prefixAction ? [$prefixAction->getName() => $prefixAction->component($this)] : [],
+            $suffixAction ? [$suffixAction->getName() => $suffixAction->component($this)] : [],
+        );
     }
 }

--- a/tests/src/Forms/ActionsTest.php
+++ b/tests/src/Forms/ActionsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Filament\Forms\Components\Actions\Action;
+use Filament\Forms\Components\TextInput;
+use Filament\Tests\TestCase;
+use Illuminate\Support\Str;
+
+uses(TestCase::class);
+
+it('can register actions', function () {
+    $action = Action::make($actionName = Str::random());
+
+    $component = TextInput::make('name')
+        ->registerActions([$action]);
+
+    expect($component->getAction($actionName))
+        ->toBe($action);
+});
+
+it('can auto-register actions from affixes', function () {
+    $component = TextInput::make('name')
+        ->prefixAction(
+            $prefixAction = Action::make($prefixActionName = Str::random()),
+        )
+        ->suffixAction(
+            $suffixAction = Action::make($suffixActionName = Str::random()),
+        );
+
+    expect($component)
+        ->getAction($prefixActionName)->toBe($prefixAction)
+        ->getAction($suffixActionName)->toBe($suffixAction);
+});

--- a/tests/src/Forms/FieldTest.php
+++ b/tests/src/Forms/FieldTest.php
@@ -40,13 +40,3 @@ it('has state binding modifiers', function () {
     expect($field)
         ->applyStateBindingModifiers($expression = Str::random())->toBe(implode('.', array_merge([$expression], $modifiers)));
 });
-
-it('can auto register actions', function () {
-    $component = TextInput::make('name')
-        ->prefixAction(
-            Action::make('test')
-        );
-
-    expect($component->getActions())
-        ->toHaveKey('test');
-});

--- a/tests/src/Forms/FieldTest.php
+++ b/tests/src/Forms/FieldTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Filament\Forms\ComponentContainer;
+use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\Field;
+use Filament\Forms\Components\TextInput;
 use Filament\Tests\Forms\Fixtures\Livewire;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Str;
@@ -37,4 +39,14 @@ it('has state binding modifiers', function () {
 
     expect($field)
         ->applyStateBindingModifiers($expression = Str::random())->toBe(implode('.', array_merge([$expression], $modifiers)));
+});
+
+it('can auto register actions', function () {
+    $component = TextInput::make('name')
+        ->prefixAction(
+            Action::make('test')
+        );
+
+    expect($component->getActions())
+        ->toHaveKey('test');
 });


### PR DESCRIPTION
As mentioned in #2641, prefix/suffix actions are very clunky and requires registering the action before referencing it. This will automatically register the action if it's not already.