### PR TITLE
Give default items an uuid

### DIFF
--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -172,7 +172,7 @@ class Repeater extends Field
             }
 
             foreach (range(1, $count) as $index) {
-                $items[] = [];
+                $items[(string) Str::uuid()] = [];
             }
 
             return $items;


### PR DESCRIPTION
In the current version when re-ordering a repeater field it will throw the following error:

`Filament\Forms\ComponentContainer::getRawState(): Return value must be of type array, int returned`

Giving the default item an uuid fixes this.