### PR TITLE
Update CreateAction.php - Reset Record After Creation

### DIFF
--- a/packages/admin/src/Pages/Concerns/HasActions.php
+++ b/packages/admin/src/Pages/Concerns/HasActions.php
@@ -62,6 +62,8 @@ trait HasActions
         } finally {
             $this->mountedAction = null;
 
+            $action->record(null);
+
             $action->resetArguments();
             $action->resetFormData();
 

--- a/packages/tables/src/Actions/CreateAction.php
+++ b/packages/tables/src/Actions/CreateAction.php
@@ -86,7 +86,7 @@ class CreateAction extends Action
 
                 return;
             }
-            $this->record(null); // Ensure the record is reset to solve issue #3070
+
             $this->success();
         });
     }

--- a/packages/tables/src/Actions/CreateAction.php
+++ b/packages/tables/src/Actions/CreateAction.php
@@ -86,7 +86,7 @@ class CreateAction extends Action
 
                 return;
             }
-
+            $this->record(null); // Ensure the record is reset to solve issue #3070
             $this->success();
         });
     }

--- a/packages/tables/src/Concerns/HasActions.php
+++ b/packages/tables/src/Concerns/HasActions.php
@@ -93,6 +93,7 @@ trait HasActions
         } finally {
             $this->mountedTableAction = null;
 
+            $action->record(null);
             $this->mountedTableActionRecord(null);
 
             $action->resetArguments();


### PR DESCRIPTION
Ensure the relation manger record is reset to null after creation to avoid changing the previous record when creating a new one.
Fixes https://github.com/filamentphp/filament/issues/3070
Fixes https://github.com/filamentphp/filament/issues/3307