### PR TITLE
Add support for descriptions to Text Columns

### DIFF
--- a/packages/tables/docs/03-columns.md
+++ b/packages/tables/docs/03-columns.md
@@ -51,18 +51,13 @@ TextColumn::make('title')->label('Post title')
 
 ### Setting a description
 
-You can display a description of the column below or above the actual column text using the `description()` method. By default, the description is displayed below the column text, but you can change the position by using the `showDescriptionOnTop()` method.
+You can display a description of the column below or above the actual column text using the `description()` method. By default, the description is displayed below the column text, but you can change the position by using the `descriptionPosition()` method and passing `above` as it's parameter. Accepted values are `above` and `below`. You may also update the position by passing it as the second argument to the `description()` method. 
 
 ```php
 use Filament\Tables\Columns\TextColumn;
 
 TextColumn::make('title')
-    ->description(fn(Post $record) => $record->description);
-
-// Show the description above the actual column content:
-TextColumn::make('title')
-    ->description(fn(Post $record) => $record->description)
-    ->showDescriptionOnTop();
+    ->description(fn(Post $record) => $record->description, descriptionPosition: 'below');
 ```
 
 ### Sorting

--- a/packages/tables/docs/03-columns.md
+++ b/packages/tables/docs/03-columns.md
@@ -49,6 +49,22 @@ use Filament\Tables\Columns\TextColumn;
 TextColumn::make('title')->label('Post title')
 ```
 
+### Setting a description
+
+You can display a description of the column below or above the actual column text using the `description()` method. By default, the description is displayed below the column text, but you can change the position by using the `showDescriptionOnTop()` method.
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('title')
+    ->description(fn(Post $record) => $record->description);
+
+// Show the description above the actual column content:
+TextColumn::make('title')
+    ->description(fn(Post $record) => $record->description)
+    ->showDescriptionOnTop();
+```
+
 ### Sorting
 
 Columns may be sortable, by clicking on the column label. To make a column sortable, you must use the `sortable()` method:

--- a/packages/tables/docs/03-columns.md
+++ b/packages/tables/docs/03-columns.md
@@ -49,17 +49,6 @@ use Filament\Tables\Columns\TextColumn;
 TextColumn::make('title')->label('Post title')
 ```
 
-### Setting a description
-
-You can display a description of the column below or above the actual column text using the `description()` method. By default, the description is displayed below the column text, but you can change the position by using the `descriptionPosition()` method and passing `above` as it's parameter. Accepted values are `above` and `below`. You may also update the position by passing it as the second argument to the `description()` method. 
-
-```php
-use Filament\Tables\Columns\TextColumn;
-
-TextColumn::make('title')
-    ->description(fn(Post $record) => $record->description, descriptionPosition: 'below');
-```
-
 ### Sorting
 
 Columns may be sortable, by clicking on the column label. To make a column sortable, you must use the `sortable()` method:
@@ -344,6 +333,24 @@ TextColumn::make('users_avg_age')->avg('users', 'age')
 In this example, `users` is the name of the relationship, while `age` is the field that is being averaged. The name of the column must be `users_avg_age`, as this is the convention that [Laravel uses](https://laravel.com/docs/9.x/eloquent-relationships#other-aggregate-functions) for storing the result.
 
 ## Text column
+
+You can display a description below the contents of a text column using the `description()` method:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('title')
+    ->description(fn (Post $record): string => $record->description);
+```
+
+By default, the description is displayed below the main text, but you can move it above using the second parameter:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('title')
+    ->description(fn (Post $record): string => $record->description, position: 'above');
+```
 
 You may use the `date()` and `dateTime()` methods to format the column's state using [PHP date formatting tokens](https://www.php.net/manual/en/datetime.format.php):
 

--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -5,13 +5,13 @@
         'whitespace-normal' => $canWrap(),
     ]) }}
 >
-    @if(($showDescriptionOnTop = $getShowDescriptionOnTop()) && ($description = $getDescription()))
+    @if(($descriptionPosition = $getDescriptionPosition()) === 'above' && ($description = $getDescription()))
         <span class="block text-sm text-gray-400"> {!! \Illuminate\Support\Str::of($description)->markdown()->sanitizeHtml() !!}</span>
     @endif
 
     {{ $getFormattedState() }}
 
-    @if(! $showDescriptionOnTop && ($description = $getDescription()))
+    @if($descriptionPosition === 'below' && ($description = $getDescription()))
         <span class="block text-sm text-gray-400">{!! \Illuminate\Support\Str::of($description)->markdown()->sanitizeHtml() !!}</span>
     @endif
 </div>

--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -5,5 +5,13 @@
         'whitespace-normal' => $canWrap(),
     ]) }}
 >
+    @if(($showDescriptionOnTop = $getShowDescriptionOnTop()) && ($description = $getDescription()))
+        <span class="block text-sm text-gray-400">{{ $description }}</span>
+    @endif
+
     {{ $getFormattedState() }}
+
+    @if(! $showDescriptionOnTop && ($description = $getDescription()))
+        <span class="block text-sm text-gray-400">{{ $description }}</span>
+    @endif
 </div>

--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -6,12 +6,12 @@
     ]) }}
 >
     @if(($showDescriptionOnTop = $getShowDescriptionOnTop()) && ($description = $getDescription()))
-        <span class="block text-sm text-gray-400">{{ $description }}</span>
+        <span class="block text-sm text-gray-400"> {!! \Illuminate\Support\Str::of($description)->markdown()->sanitizeHtml() !!}</span>
     @endif
 
     {{ $getFormattedState() }}
 
     @if(! $showDescriptionOnTop && ($description = $getDescription()))
-        <span class="block text-sm text-gray-400">{{ $description }}</span>
+        <span class="block text-sm text-gray-400">{!! \Illuminate\Support\Str::of($description)->markdown()->sanitizeHtml() !!}</span>
     @endif
 </div>

--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -11,12 +11,16 @@
     ]) }}
 >
     @if (filled($description) && $descriptionPosition = 'above')
-        <span class="block text-sm text-gray-400"> {!! \Illuminate\Support\Str::of($description)->markdown()->sanitizeHtml() !!}</span>
+        <span class="block text-sm text-gray-400">
+            {!! \Illuminate\Support\Str::of($description)->markdown()->sanitizeHtml() !!}
+        </span>
     @endif
 
     {{ $getFormattedState() }}
 
     @if (filled($description) && $descriptionPosition = 'below')
-        <span class="block text-sm text-gray-400">{!! \Illuminate\Support\Str::of($description)->markdown()->sanitizeHtml() !!}</span>
+        <span class="block text-sm text-gray-400">
+            {!! \Illuminate\Support\Str::of($description)->markdown()->sanitizeHtml() !!}
+        </span>
     @endif
 </div>

--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -1,3 +1,8 @@
+@php
+    $description = $getDescription();
+    $descriptionPosition = $getDescriptionPosition();
+@endphp
+
 <div
     {{ $attributes->merge($getExtraAttributes())->class([
         'px-4 py-3 filament-tables-text-column',
@@ -5,13 +10,13 @@
         'whitespace-normal' => $canWrap(),
     ]) }}
 >
-    @if(($descriptionPosition = $getDescriptionPosition()) === 'above' && ($description = $getDescription()))
+    @if (filled($description) && $descriptionPosition = 'above')
         <span class="block text-sm text-gray-400"> {!! \Illuminate\Support\Str::of($description)->markdown()->sanitizeHtml() !!}</span>
     @endif
 
     {{ $getFormattedState() }}
 
-    @if($descriptionPosition === 'below' && ($description = $getDescription()))
+    @if (filled($description) && $descriptionPosition = 'below')
         <span class="block text-sm text-gray-400">{!! \Illuminate\Support\Str::of($description)->markdown()->sanitizeHtml() !!}</span>
     @endif
 </div>

--- a/packages/tables/src/Columns/Concerns/HasDescription.php
+++ b/packages/tables/src/Columns/Concerns/HasDescription.php
@@ -7,14 +7,21 @@ use Illuminate\Support\HtmlString;
 
 trait HasDescription
 {
-    protected string | Closure | null $description = null;
+    protected string | HtmlString | Closure | null $description = null;
 
     protected string | Closure | null $descriptionPosition = null;
 
-    public function description(string | Closure | HtmlString | null $description, string | Closure | null $descriptionPosition = 'below'): static
+    public function description(string | HtmlString | Closure | null $description, string | Closure | null $position = 'below'): static
     {
         $this->description = $description;
-        $this->descriptionPosition($descriptionPosition);
+        $this->descriptionPosition($position);
+
+        return $this;
+    }
+
+    public function descriptionPosition(string | Closure | null $position): static
+    {
+        $this->descriptionPosition = $position;
 
         return $this;
     }
@@ -22,13 +29,6 @@ trait HasDescription
     public function getDescription(): string | HtmlString | null
     {
         return $this->evaluate($this->description);
-    }
-
-    public function descriptionPosition(string | Closure | null $descriptionPosition): static
-    {
-        $this->descriptionPosition = $descriptionPosition;
-
-        return $this;
     }
 
     public function getDescriptionPosition(): string

--- a/packages/tables/src/Columns/Concerns/HasDescription.php
+++ b/packages/tables/src/Columns/Concerns/HasDescription.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Filament\Tables\Columns\Concerns;
+
+use Closure;
+
+trait HasDescription
+{
+    protected string | Closure | null $description = null;
+
+    protected bool | Closure | null $showDescriptionOnTop = null;
+
+    public function description(string | Closure | null $description): static
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->evaluate($this->description);
+    }
+
+    public function showDescriptionOnTop(bool | Closure | null $showDescriptionOnTop = true): static
+    {
+        $this->showDescriptionOnTop = $showDescriptionOnTop;
+
+        return $this;
+    }
+
+    public function getShowDescriptionOnTop(): bool
+    {
+        return $this->evaluate($this->showDescriptionOnTop) ?? false;
+    }
+}

--- a/packages/tables/src/Columns/Concerns/HasDescription.php
+++ b/packages/tables/src/Columns/Concerns/HasDescription.php
@@ -9,12 +9,12 @@ trait HasDescription
 {
     protected string | Closure | null $description = null;
 
-    protected bool | Closure | null $showDescriptionOnTop = null;
+    protected string | Closure | null $descriptionPosition = 'below';
 
-    public function description(string | Closure | HtmlString | null $description, bool | Closure | null $showDescriptionOnTop = false): static
+    public function description(string | Closure | HtmlString | null $description, string | Closure | null $descriptionPosition = 'below'): static
     {
         $this->description = $description;
-        $this->showDescriptionOnTop($showDescriptionOnTop);
+        $this->descriptionPosition($descriptionPosition);
 
         return $this;
     }
@@ -24,15 +24,15 @@ trait HasDescription
         return $this->evaluate($this->description);
     }
 
-    public function showDescriptionOnTop(bool | Closure | null $showDescriptionOnTop = true): static
+    public function descriptionPosition(string | Closure | null $descriptionPosition = 'string'): static
     {
-        $this->showDescriptionOnTop = $showDescriptionOnTop;
+        $this->descriptionPosition = $descriptionPosition;
 
         return $this;
     }
 
-    public function getShowDescriptionOnTop(): bool
+    public function getDescriptionPosition(): string
     {
-        return $this->evaluate($this->showDescriptionOnTop) ?? false;
+        return $this->evaluate($this->descriptionPosition) ?? 'below';
     }
 }

--- a/packages/tables/src/Columns/Concerns/HasDescription.php
+++ b/packages/tables/src/Columns/Concerns/HasDescription.php
@@ -3,6 +3,7 @@
 namespace Filament\Tables\Columns\Concerns;
 
 use Closure;
+use Illuminate\Support\HtmlString;
 
 trait HasDescription
 {
@@ -10,7 +11,7 @@ trait HasDescription
 
     protected bool | Closure | null $showDescriptionOnTop = null;
 
-    public function description(string | Closure | null $description, bool | Closure | null $showDescriptionOnTop = false): static
+    public function description(string | Closure | HtmlString | null $description, bool | Closure | null $showDescriptionOnTop = false): static
     {
         $this->description = $description;
         $this->showDescriptionOnTop($showDescriptionOnTop);
@@ -18,7 +19,7 @@ trait HasDescription
         return $this;
     }
 
-    public function getDescription(): ?string
+    public function getDescription(): string | HtmlString | null
     {
         return $this->evaluate($this->description);
     }

--- a/packages/tables/src/Columns/Concerns/HasDescription.php
+++ b/packages/tables/src/Columns/Concerns/HasDescription.php
@@ -9,7 +9,7 @@ trait HasDescription
 {
     protected string | Closure | null $description = null;
 
-    protected string | Closure | null $descriptionPosition = 'below';
+    protected string | Closure | null $descriptionPosition = null;
 
     public function description(string | Closure | HtmlString | null $description, string | Closure | null $descriptionPosition = 'below'): static
     {
@@ -24,7 +24,7 @@ trait HasDescription
         return $this->evaluate($this->description);
     }
 
-    public function descriptionPosition(string | Closure | null $descriptionPosition = 'string'): static
+    public function descriptionPosition(string | Closure | null $descriptionPosition): static
     {
         $this->descriptionPosition = $descriptionPosition;
 

--- a/packages/tables/src/Columns/Concerns/HasDescription.php
+++ b/packages/tables/src/Columns/Concerns/HasDescription.php
@@ -10,9 +10,10 @@ trait HasDescription
 
     protected bool | Closure | null $showDescriptionOnTop = null;
 
-    public function description(string | Closure | null $description): static
+    public function description(string | Closure | null $description, bool | Closure | null $showDescriptionOnTop = false): static
     {
         $this->description = $description;
+        $this->showDescriptionOnTop($showDescriptionOnTop);
 
         return $this;
     }

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -7,6 +7,7 @@ use Closure;
 class TextColumn extends Column
 {
     use Concerns\CanFormatState;
+    use Concerns\HasDescription;
 
     protected string $view = 'tables::columns.text-column';
 


### PR DESCRIPTION
This PR allows you to add a description above or below the label in a regular text column. I've wanted this on several occasions already and I think it should really be a core feature. It's both very useful and beautiful at the same time. 

```php
TextColumn::make('title')
    ->description(fn(Model $record) => $record->description)
```

By default, the description is shown below the actual label. However, you can choose to display the description above the label using the `->showDescriptionOnTop()` method:

```php
TextColumn::make('title')
    ->description(fn(Model $record) => $record->description)
    ->showDescriptionOnTop()
```

Example below: 

<img width="866" alt="Schermafbeelding 2022-07-30 om 16 08 07" src="https://user-images.githubusercontent.com/59207045/181918135-1d305a14-9b41-4951-a627-d82a1dd57a4e.png">

Example on top:

<img width="866" alt="Schermafbeelding 2022-07-30 om 16 06 21" src="https://user-images.githubusercontent.com/59207045/181918151-6f1ba5f1-bf4f-4926-b0dc-db9cdae97e61.png">

Looks also fine in dark mode:

<img width="866" alt="Schermafbeelding 2022-07-30 om 16 11 37" src="https://user-images.githubusercontent.com/59207045/181918237-cffe368b-8ec4-4bc2-a51f-ac7a90a009ef.png">

Thanks!

 