### PR TITLE
fix: Admin panel registration Livewire boot

### DIFF
--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -11,7 +11,6 @@ use Filament\Http\Responses\Auth\Contracts\LoginResponse as LoginResponseContrac
 use Filament\Http\Responses\Auth\Contracts\LogoutResponse as LogoutResponseContract;
 use Filament\Http\Responses\Auth\LoginResponse;
 use Filament\Http\Responses\Auth\LogoutResponse;
-use Filament\Pages\Dashboard;
 use Filament\Pages\Page;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Resources\Resource;
@@ -19,8 +18,6 @@ use Filament\Tables\Actions\Action as TableAction;
 use Filament\Tables\Actions\ButtonAction;
 use Filament\Tables\Actions\IconButtonAction;
 use Filament\Testing\TestsPages;
-use Filament\Widgets\AccountWidget;
-use Filament\Widgets\FilamentInfoWidget;
 use Filament\Widgets\Widget;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;

--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -190,8 +190,12 @@ class FilamentServiceProvider extends PluginServiceProvider
         }
     }
 
-    protected function registerComponentsFromDirectory(string $baseClass, array &$register, string $directory, string $namespace): void
+    protected function registerComponentsFromDirectory(string $baseClass, array &$register, ?string $directory, ?string $namespace): void
     {
+        if (blank($directory) || blank($namespace)) {
+            return;
+        }
+
         if (Str::of($directory)->startsWith(config('filament.livewire.path'))) {
             return;
         }
@@ -225,9 +229,6 @@ class FilamentServiceProvider extends PluginServiceProvider
         foreach (array_merge($this->livewireComponents, [
             'filament.core.auth.login' => Login::class,
             'filament.core.global-search' => GlobalSearch::class,
-            'filament.core.pages.dashboard' => Dashboard::class,
-            'filament.core.widgets.account-widget' => AccountWidget::class,
-            'filament.core.widgets.filament-info-widget' => FilamentInfoWidget::class,
         ]) as $alias => $class) {
             Livewire::component($alias, $class);
         }

--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -204,7 +204,7 @@ class FilamentServiceProvider extends PluginServiceProvider
 
         $register = array_merge(
             $register,
-            collect($filesystem->allFiles($namespace))
+            collect($filesystem->allFiles($directory))
                 ->map(function (SplFileInfo $file) use ($namespace): string {
                     return (string) Str::of($namespace)
                         ->append('\\', $file->getRelativePathname())

--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -24,6 +24,7 @@ use Filament\Widgets\Widget;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Livewire\Component;
 use Livewire\Livewire;
 use Livewire\Testing\TestableLivewire;
 use ReflectionClass;
@@ -78,9 +79,9 @@ class FilamentServiceProvider extends PluginServiceProvider
 
     public function packageRegistered(): void
     {
-        $this->registerComponents();
-
         parent::packageRegistered();
+
+        $this->registerComponents();
 
         $this->app->scoped('filament', function (): FilamentManager {
             return new FilamentManager();

--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -158,8 +158,14 @@ class FilamentServiceProvider extends PluginServiceProvider
 
             if ($filePath->startsWith(config('filament.pages.path')) && is_subclass_of($fileClass, Page::class)) {
                 $this->pages[] = $fileClass;
-            } elseif ($filePath->startsWith(config('filament.widgets.path')) && is_subclass_of($fileClass, Widget::class)) {
+
+                continue;
+            }
+
+            if ($filePath->startsWith(config('filament.widgets.path')) && is_subclass_of($fileClass, Widget::class)) {
                 $this->widgets[] = $fileClass;
+
+                continue;
             }
 
             if (! is_subclass_of($fileClass, Component::class)) {

--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -24,12 +24,10 @@ use Filament\Widgets\Widget;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Livewire\Component;
 use Livewire\Livewire;
 use Livewire\Testing\TestableLivewire;
 use ReflectionClass;
 use Spatie\LaravelPackageTools\Package;
-use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Symfony\Component\Finder\SplFileInfo;
 
 class FilamentServiceProvider extends PluginServiceProvider

--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -13,6 +13,7 @@ use Filament\Http\Responses\Auth\LoginResponse;
 use Filament\Http\Responses\Auth\LogoutResponse;
 use Filament\Pages\Dashboard;
 use Filament\Pages\Page;
+use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Resources\Resource;
 use Filament\Tables\Actions\Action as TableAction;
 use Filament\Tables\Actions\ButtonAction;
@@ -166,6 +167,10 @@ class FilamentServiceProvider extends PluginServiceProvider
             if ($filePath->startsWith(config('filament.widgets.path')) && is_subclass_of($fileClass, Widget::class)) {
                 $this->widgets[] = $fileClass;
 
+                continue;
+            }
+
+            if (is_subclass_of($fileClass, RelationManager::class)) {
                 continue;
             }
 

--- a/packages/admin/src/PluginServiceProvider.php
+++ b/packages/admin/src/PluginServiceProvider.php
@@ -3,9 +3,14 @@
 namespace Filament;
 
 use Filament\Resources\RelationManagers\RelationGroup;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+use Livewire\Component;
 use Livewire\Livewire;
+use ReflectionClass;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Symfony\Component\Finder\SplFileInfo;
 
 abstract class PluginServiceProvider extends PackageServiceProvider
 {
@@ -99,6 +104,14 @@ abstract class PluginServiceProvider extends PackageServiceProvider
             }
 
             foreach ($resource::getRelations() as $relation) {
+                if ($relation instanceof RelationGroup) {
+                    foreach ($relation->getManagers() as $groupedRelation) {
+                        Livewire::component($groupedRelation::getName(), $groupedRelation);
+                    }
+
+                    continue;
+                }
+
                 Livewire::component($relation::getName(), $relation);
             }
 
@@ -171,5 +184,33 @@ abstract class PluginServiceProvider extends PackageServiceProvider
 
     protected function registerMacros(): void
     {
+    }
+
+    protected function registerLivewireComponentDirectory(string $directory, string $namespace, string $aliasPrefix = ''): void
+    {
+        $filesystem = app(Filesystem::class);
+
+        if (! $filesystem->isDirectory($directory)) {
+            return;
+        }
+
+        collect($filesystem->allFiles($directory))
+            ->map(function (SplFileInfo $file) use ($namespace): string {
+                return (string) Str::of($namespace)
+                    ->append('\\', $file->getRelativePathname())
+                    ->replace(['/', '.php'], ['\\', '']);
+            })
+            ->filter(fn (string $class): bool => is_subclass_of($class, Component::class) && (! (new ReflectionClass($class))->isAbstract()))
+            ->each(function (string $class) use ($namespace, $aliasPrefix): void {
+                $alias = Str::of($class)
+                    ->after($namespace . '\\')
+                    ->replace(['/', '\\'], '.')
+                    ->prepend($aliasPrefix)
+                    ->explode('.')
+                    ->map([Str::class, 'kebab'])
+                    ->implode('.');
+
+                Livewire::component($alias, $class);
+            });
     }
 }

--- a/packages/admin/src/PluginServiceProvider.php
+++ b/packages/admin/src/PluginServiceProvider.php
@@ -185,32 +185,4 @@ abstract class PluginServiceProvider extends PackageServiceProvider
     protected function registerMacros(): void
     {
     }
-
-    protected function registerLivewireComponentDirectory(string $directory, string $namespace, string $aliasPrefix = ''): void
-    {
-        $filesystem = app(Filesystem::class);
-
-        if (! $filesystem->isDirectory($directory)) {
-            return;
-        }
-
-        collect($filesystem->allFiles($directory))
-            ->map(function (SplFileInfo $file) use ($namespace): string {
-                return (string) Str::of($namespace)
-                    ->append('\\', $file->getRelativePathname())
-                    ->replace(['/', '.php'], ['\\', '']);
-            })
-            ->filter(fn (string $class): bool => is_subclass_of($class, Component::class) && (! (new ReflectionClass($class))->isAbstract()))
-            ->each(function (string $class) use ($namespace, $aliasPrefix): void {
-                $alias = Str::of($class)
-                    ->after($namespace . '\\')
-                    ->replace(['/', '\\'], '.')
-                    ->prepend($aliasPrefix)
-                    ->explode('.')
-                    ->map([Str::class, 'kebab'])
-                    ->implode('.');
-
-                Livewire::component($alias, $class);
-            });
-    }
 }

--- a/packages/admin/src/PluginServiceProvider.php
+++ b/packages/admin/src/PluginServiceProvider.php
@@ -3,14 +3,9 @@
 namespace Filament;
 
 use Filament\Resources\RelationManagers\RelationGroup;
-use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Str;
-use Livewire\Component;
 use Livewire\Livewire;
-use ReflectionClass;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
-use Symfony\Component\Finder\SplFileInfo;
 
 abstract class PluginServiceProvider extends PackageServiceProvider
 {


### PR DESCRIPTION
Fixes #3283.

The aim of this PR is improve how Filament components (resources / pages / widgets) are registered.

Instead of looping through the registration directories several times, we only loop through them once if that is possible, and do all the component checks within that loop.