### PR TITLE
Fix: Correct abnormal breakpoint in Filepond style

### DIFF
--- a/packages/forms/resources/css/components/file-upload.css
+++ b/packages/forms/resources/css/components/file-upload.css
@@ -45,9 +45,10 @@
 
 .filepond--root[data-style-panel-layout='grid'] .filepond--item {
     width: calc(50% - 0.5em);
+    display: inline;
 }
 
-@media screen(md) {
+@media screen(lg) {
     .filepond--root[data-style-panel-layout='grid'] .filepond--item {
         width: calc(33.33% - 0.5em);
     }

--- a/packages/forms/resources/css/components/file-upload.css
+++ b/packages/forms/resources/css/components/file-upload.css
@@ -47,7 +47,7 @@
     width: calc(50% - 0.5em);
 }
 
-@media (min-width: 50em) {
+@media screen(md) {
     .filepond--root[data-style-panel-layout='grid'] .filepond--item {
         width: calc(33.33% - 0.5em);
     }


### PR DESCRIPTION
Found this strange break-point to be inconsistent with Tailwind's breakpoints. And upon Dan's suggestion, I fixed it to the nearest Tailwind's breakpoint (`md`). 🙂

![image](https://user-images.githubusercontent.com/81492351/182129510-fcfd65ca-8c95-49a5-9959-4a2ea552317a.png)
