### PR TITLE
fix production error on environments with Composer version 1

### DIFF
--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -52,7 +52,7 @@ class SupportServiceProvider extends PackageServiceProvider
             return new Stringable(Str::sanitizeHtml($this->value));
         });
 
-        if (class_exists(AboutCommand::class)) {
+        if (class_exists(AboutCommand::class) && class_exists(InstalledVersions::class)) {
             $packages = [
                 'filament',
                 'forms',


### PR DESCRIPTION
The `Composer\InstalledVersions` Class was first introduced in the composer-runtime-api 2.0.
Environments running on Composer 1 would therefore throw a Fatal Error because the class was not found.