### PR TITLE
hiddenOn() / visibleOn() for actions

### DIFF
--- a/packages/admin/docs/02-resources/01-getting-started.md
+++ b/packages/admin/docs/02-resources/01-getting-started.md
@@ -139,11 +139,11 @@ To view a full list of available [layout components](../../forms/layout), see th
 
 You may also build your own completely [custom layout components](../../forms/layout#building-custom-layout-components).
 
-### Hiding components based on the page
+### Hiding components contextually
 
-The `hiddenOn()` method of form components allows you to dynamically hide fields based on the current page.
+The `hiddenOn()` method of form components allows you to dynamically hide fields based on the current page or action.
 
-In this example, we hide the `password` field on the `EditUser` resource page:
+In this example, we hide the `password` field on the `edit` page:
 
 ```php
 use Livewire\Component;
@@ -151,10 +151,10 @@ use Livewire\Component;
 Forms\Components\TextInput::make('password')
     ->password()
     ->required()
-    ->hiddenOn(Pages\EditUser::class),
+    ->hiddenOn('edit'),
 ```
 
-Alternatively, we have a `visibleOn()` shortcut method for only showing a field on one page:
+Alternatively, we have a `visibleOn()` shortcut method for only showing a field on one page or action:
 
 ```php
 use Livewire\Component;
@@ -162,7 +162,7 @@ use Livewire\Component;
 Forms\Components\TextInput::make('password')
     ->password()
     ->required()
-    ->visibleOn(Pages\CreateUser::class),
+    ->visibleOn('create'),
 ```
 
 ## Tables

--- a/packages/admin/src/Pages/Concerns/HasActions.php
+++ b/packages/admin/src/Pages/Concerns/HasActions.php
@@ -77,6 +77,12 @@ trait HasActions
     {
         $this->mountedAction = $name;
 
+        /**
+         * in cases where page action is used on the same page as a table action,
+         * the modal will still have old mountedTableAction value.
+         **/
+        $this->mountedTableAction = null;
+
         $action = $this->getMountedAction();
 
         if (! $action) {

--- a/packages/admin/src/Pages/Concerns/HasActions.php
+++ b/packages/admin/src/Pages/Concerns/HasActions.php
@@ -77,12 +77,6 @@ trait HasActions
     {
         $this->mountedAction = $name;
 
-        /**
-         * in cases where page action is used on the same page as a table action,
-         * the modal will still have old mountedTableAction value.
-         **/
-        $this->mountedTableAction = null;
-
         $action = $this->getMountedAction();
 
         if (! $action) {
@@ -201,7 +195,8 @@ trait HasActions
         return $this->makeForm()
             ->schema($action->getFormSchema())
             ->statePath('mountedActionData')
-            ->model($this->getMountedActionFormModel());
+            ->model($this->getMountedActionFormModel())
+            ->context($this->mountedAction);
     }
 
     protected function getMountedActionFormModel(): Model | string | null

--- a/packages/admin/src/Resources/Pages/CreateRecord.php
+++ b/packages/admin/src/Resources/Pages/CreateRecord.php
@@ -158,6 +158,7 @@ class CreateRecord extends Page implements HasFormActions
     {
         return [
             'form' => $this->makeForm()
+                ->context('create')
                 ->model($this->getModel())
                 ->schema($this->getFormSchema())
                 ->statePath('data')

--- a/packages/admin/src/Resources/Pages/EditRecord.php
+++ b/packages/admin/src/Resources/Pages/EditRecord.php
@@ -286,6 +286,7 @@ class EditRecord extends Page implements HasFormActions
     {
         return [
             'form' => $this->makeForm()
+                ->context('edit')
                 ->model($this->getRecord())
                 ->schema($this->getFormSchema())
                 ->statePath('data')

--- a/packages/admin/src/Resources/Pages/ViewRecord.php
+++ b/packages/admin/src/Resources/Pages/ViewRecord.php
@@ -169,6 +169,7 @@ class ViewRecord extends Page
     {
         return [
             'form' => $this->makeForm()
+                ->context('view')
                 ->disabled()
                 ->model($this->getRecord())
                 ->schema($this->getFormSchema())

--- a/packages/forms/src/ComponentContainer.php
+++ b/packages/forms/src/ComponentContainer.php
@@ -16,6 +16,7 @@ class ComponentContainer extends ViewComponent
     use Concerns\Cloneable;
     use Concerns\HasColumns;
     use Concerns\HasComponents;
+    use Concerns\HasContext;
     use Concerns\HasFieldWrapper;
     use Concerns\HasInlineLabels;
     use Concerns\HasState;

--- a/packages/forms/src/Components/Component.php
+++ b/packages/forms/src/Components/Component.php
@@ -35,6 +35,7 @@ class Component extends ViewComponent
     protected function getDefaultEvaluationParameters(): array
     {
         return array_merge(parent::getDefaultEvaluationParameters(), [
+            'context' => $this->getContainer()->getContext(),
             'get' => $this->getGetCallback(),
             'livewire' => $this->getLivewire(),
             'model' => $this->getModel(),

--- a/packages/forms/src/Components/Concerns/CanBeHidden.php
+++ b/packages/forms/src/Components/Concerns/CanBeHidden.php
@@ -19,11 +19,11 @@ trait CanBeHidden
         return $this;
     }
 
-    public function hiddenOn(string | array $livewireClass): static
+    public function hiddenOn(string | array $contexts): static
     {
-        $this->hidden(static function (HasForms $livewire) use ($livewireClass): bool {
-            foreach (Arr::wrap($livewireClass) as $class) {
-                if ($livewire instanceof $class) {
+        $this->hidden(static function (string $context, HasForms $livewire) use ($contexts): bool {
+            foreach (Arr::wrap($contexts) as $hiddenContext) {
+                if (in_array($hiddenContext, [$context, $livewire::class])) {
                     return true;
                 }
             }
@@ -82,11 +82,11 @@ trait CanBeHidden
         return $this;
     }
 
-    public function visibleOn(string | array $livewireClass): static
+    public function visibleOn(string | array $contexts): static
     {
-        $this->visible(static function (HasForms $livewire) use ($livewireClass): bool {
-            foreach (Arr::wrap($livewireClass) as $class) {
-                if ($livewire instanceof $class) {
+        $this->visible(static function (string $context, HasForms $livewire) use ($contexts): bool {
+            foreach (Arr::wrap($contexts) as $visibleContext) {
+                if (in_array($visibleContext, [$context, $livewire::class])) {
                     return true;
                 }
             }

--- a/packages/forms/src/Concerns/HasContext.php
+++ b/packages/forms/src/Concerns/HasContext.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Filament\Forms\Concerns;
+
+trait HasContext
+{
+    protected ?string $context = null;
+
+    public function context(?string $context = null): static
+    {
+        $this->context = $context;
+
+        return $this;
+    }
+
+    public function getContext(): string
+    {
+        if (filled($this->context)) {
+            return $this->context;
+        }
+
+        if ($this->getParentComponent()) {
+            return $this->getParentComponent()->getContainer()->getContext();
+        }
+
+        return $this->getLivewire()::class;
+    }
+}

--- a/packages/forms/src/Concerns/HasFormComponentActions.php
+++ b/packages/forms/src/Concerns/HasFormComponentActions.php
@@ -38,7 +38,8 @@ trait HasFormComponentActions
         return $this->makeForm()
             ->schema($action->getFormSchema())
             ->model($this->getMountedFormComponentActionComponent()->getActionFormModel())
-            ->statePath('mountedFormComponentActionData');
+            ->statePath('mountedFormComponentActionData')
+            ->context($this->mountedFormComponentAction);
     }
 
     public function callMountedFormComponentAction(?string $arguments = null)

--- a/packages/tables/src/Concerns/HasActions.php
+++ b/packages/tables/src/Concerns/HasActions.php
@@ -184,7 +184,8 @@ trait HasActions
         return $this->makeForm()
             ->schema($action->getFormSchema())
             ->model($this->getMountedTableActionRecord() ?? $this->getTableQuery()->getModel()::class)
-            ->statePath('mountedTableActionData');
+            ->statePath('mountedTableActionData')
+            ->context($this->mountedTableAction);
     }
 
     public function getMountedTableActionRecord(): ?Model

--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -160,7 +160,8 @@ trait HasBulkActions
         return $this->makeForm()
             ->schema($action->getFormSchema())
             ->model($this->getTableQuery()->getModel()::class)
-            ->statePath('mountedTableBulkActionData');
+            ->statePath('mountedTableBulkActionData')
+            ->context($this->mountedTableBulkAction);
     }
 
     public function getCachedTableBulkAction(string $name): ?BulkAction


### PR DESCRIPTION
As highlighted in discussion #3171 there is an issue where the `mountedTableAction` is set by the edit modal, and then when opening the create modal the `mountedTableAction` is still set to `edit`. This will fix this issue.

I understand that this might not be the prettiest way of accomplishing this, but we either have to merge the `mountedAction` and `mountedTableAction` or reference one in the others code...

Another alternative solution would be to under it when closing the modal, but when i tried hooking into the `close-modal` event nothing got triggered. 