### PR TITLE
chore: Null coalescing

### DIFF
--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -103,9 +103,9 @@ class FilamentServiceProvider extends PluginServiceProvider
 
     protected function registerComponents(): void
     {
-        $this->pages = config('filament.pages.register', []);
-        $this->resources = config('filament.resources.register', []);
-        $this->widgets = config('filament.widgets.register', []);
+        $this->pages = config('filament.pages.register') ?? [];
+        $this->resources = config('filament.resources.register') ?? [];
+        $this->widgets = config('filament.widgets.register') ?? [];
 
         $directory = config('filament.livewire.path');
         $namespace = config('filament.livewire.namespace');
@@ -274,7 +274,7 @@ class FilamentServiceProvider extends PluginServiceProvider
 
     protected function mergeConfigFrom($path, $key): void
     {
-        $config = $this->app['config']->get($key, []);
+        $config = $this->app['config']->get($key) ?? [];
 
         $this->app['config']->set($key, $this->mergeConfig(require $path, $config));
     }

--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -227,7 +227,7 @@ trait HasState
         $this->mutateDehydratedState($state);
 
         if ($statePath = $this->getStatePath()) {
-            return data_get($state, $statePath, []);
+            return data_get($state, $statePath) ?? [];
         }
 
         return $state;

--- a/packages/notifications/src/Http/Livewire/Notifications.php
+++ b/packages/notifications/src/Http/Livewire/Notifications.php
@@ -23,7 +23,7 @@ class Notifications extends Component
 
     public function pullNotificationsFromSession(): void
     {
-        foreach (session()->pull('filament.notifications', []) as $notification) {
+        foreach (session()->pull('filament.notifications') ?? [] as $notification) {
             $notification = Notification::fromArray($notification);
 
             $this->notifications->put(

--- a/packages/notifications/src/NotificationsServiceProvider.php
+++ b/packages/notifications/src/NotificationsServiceProvider.php
@@ -35,7 +35,7 @@ class NotificationsServiceProvider extends PackageServiceProvider
                 return $response;
             }
 
-            if (count(session()->get('filament.notifications', [])) > 0) {
+            if (count(session()->get('filament.notifications') ?? []) > 0) {
                 $component->emit('notificationsSent');
             }
 

--- a/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatablePluginServiceProvider.php
+++ b/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatablePluginServiceProvider.php
@@ -56,7 +56,7 @@ class SpatieLaravelTranslatablePluginServiceProvider extends ServiceProvider
 
     protected function mergeConfigFrom($path, $key): void
     {
-        $config = $this->app['config']->get($key, []);
+        $config = $this->app['config']->get($key) ?? [];
 
         $this->app['config']->set($key, $this->mergeConfig(require $path, $config));
     }


### PR DESCRIPTION
This PR updates a few instances of defaults in methods to use PHP's null coalescing operator instead.
As you expressed your preference of using a language feature over a framework feature, @danharrin, and I encountered these few remaining cases, I thought I might as well clean it up. 😄