### PR TITLE
Use Filament auth middleware for LW requests.

### DIFF
--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -218,6 +218,7 @@ class FilamentServiceProvider extends PluginServiceProvider
     protected function bootLivewireComponents(): void
     {
         Livewire::addPersistentMiddleware([
+            ...config('filament.middleware.auth'),
             DispatchServingFilamentEvent::class,
             MirrorConfigToSubpackages::class,
         ]);

--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -5,6 +5,7 @@ namespace Filament;
 use Filament\Facades\Filament;
 use Filament\Http\Livewire\Auth\Login;
 use Filament\Http\Livewire\GlobalSearch;
+use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Filament\Http\Middleware\MirrorConfigToSubpackages;
 use Filament\Http\Responses\Auth\Contracts\LoginResponse as LoginResponseContract;
@@ -218,7 +219,7 @@ class FilamentServiceProvider extends PluginServiceProvider
     protected function bootLivewireComponents(): void
     {
         Livewire::addPersistentMiddleware([
-            ...config('filament.middleware.auth'),
+            Authenticate::class,
             DispatchServingFilamentEvent::class,
             MirrorConfigToSubpackages::class,
         ]);


### PR DESCRIPTION
When using a custom auth guard, users are not authenticated during Livewire requests.

I expected issues with the `Login` component, but it's working fine for me. Any other cases, where this global approach could lead to issues?

Reproduction Repo: https://github.com/utsavsomaiya/demo
Create request is not authenticated.