### PR TITLE
allow return type string for getRawState()

### DIFF
--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -233,7 +233,7 @@ trait HasState
         return $state;
     }
 
-    public function getRawState(): array
+    public function getRawState(): array|string
     {
         return data_get($this->getLivewire(), $this->getStatePath()) ?? [];
     }


### PR DESCRIPTION
I am getting this error message:

```
Filament\Forms\ComponentContainer::getRawState(): Return value must be of type array, string returned
(View: /var/www/html/vendor/filament/forms/resources/views/components/repeater.blade.php)
```

when trying to define the following Repeater:

```php
Repeater::make('vendor_countries')
     ->schema([
        TextInput::make('')->required()->unique(),
    ]), 
```

Note the empty string as parameter to TextInput::make. This was a valid definition prior to filament <2.15 and should still be in my opinion. I have flat data in the array/json instead of key/value. This Pull Request fixes the issue (for me).