### PR TITLE
Break words in rich editor

### DIFF
--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -295,7 +295,7 @@
                 x-ref="trix"
                 dusk="filament.forms.{{ $getStatePath() }}"
                 {{ $getExtraInputAttributeBag()->class([
-                    'bg-white block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600 prose max-w-none',
+                    'bg-white block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600 prose max-w-none break-words',
                     'dark:prose-invert dark:bg-gray-700 dark:focus:border-primary-600' => config('forms.dark_mode'),
                     'border-gray-300' => ! $errors->has($getStatePath()),
                     'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),


### PR DESCRIPTION
Firefox doesn't break words by default, and thus Rich Editor is overflowing.

![](https://cdn.discordapp.com/attachments/883083792653381695/1005037700333715506/unknown.png)

