### PR TITLE
Separate user-avatar

### DIFF
--- a/packages/admin/resources/views/components/layouts/app/topbar/user-menu.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/topbar/user-menu.blade.php
@@ -49,12 +49,10 @@
 >
     <button
         x-on:click="$refs.panel.toggle"
-        @class([
-            'block flex-shrink-0 w-10 h-10 rounded-full bg-gray-200 bg-cover bg-center',
-            'dark:bg-gray-900' => config('filament.dark_mode'),
-        ])
-        style="background-image: url('{{ \Filament\Facades\Filament::getUserAvatarUrl($user) }}')"
-    ></button>
+        class="block flex-shrink-0"
+    >
+        <x-filament::user-avatar :user="$user" />
+    </button>
 
     <div
         x-ref="panel"

--- a/packages/admin/resources/views/components/user-avatar.blade.php
+++ b/packages/admin/resources/views/components/user-avatar.blade.php
@@ -2,7 +2,8 @@
     'user' => \Filament\Facades\Filament::auth()->user(),
 ])
 
-<div {{ $attributes->class([
+<div
+    {{ $attributes->class([
         'w-10 h-10 rounded-full bg-gray-200 bg-cover bg-center',
         'dark:bg-gray-900' => config('filament.dark_mode'),
     ]) }}

--- a/packages/admin/resources/views/components/user-avatar.blade.php
+++ b/packages/admin/resources/views/components/user-avatar.blade.php
@@ -1,0 +1,10 @@
+@props([
+    'user' => \Filament\Facades\Filament::auth()->user(),
+])
+
+<div {{ $attributes->class([
+        'w-10 h-10 rounded-full bg-gray-200 bg-cover bg-center',
+        'dark:bg-gray-900' => config('filament.dark_mode'),
+    ]) }}
+    style="background-image: url('{{ \Filament\Facades\Filament::getUserAvatarUrl($user) }}')"
+></div>

--- a/packages/admin/resources/views/widgets/account-widget.blade.php
+++ b/packages/admin/resources/views/widgets/account-widget.blade.php
@@ -5,10 +5,7 @@
         @endphp
 
         <div class="h-12 flex items-center space-x-4 rtl:space-x-reverse">
-            <div
-                class="w-10 h-10 rounded-full bg-gray-200 bg-cover bg-center"
-                style="background-image: url('{{ \Filament\Facades\Filament::getUserAvatarUrl($user) }}')"
-            ></div>
+            <x-filament::user-avatar :user="$user" />
 
             <div>
                 <h2 class="text-lg sm:text-xl font-bold tracking-tight">


### PR DESCRIPTION
Uses the same component in `user-menu` and `account-widget`

If you do not have images or do not want to use a 3rd party service (Greetings from the GDPR), this simplifies overriding the avatar when you do not want the background-image-`getUserAvatarUrl()` thing.