### PR TITLE
ColorPicker fixes

### DIFF
--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -45,6 +45,7 @@
                 type="text"
                 dusk="filament.forms.{{ $getStatePath() }}"
                 id="{{ $getId() }}"
+                {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
                 x-on:click="togglePanelVisibility()"
                 x-on:keydown.enter.stop.prevent="togglePanelVisibility()"
                 autocomplete="off"

--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -45,7 +45,7 @@
                 type="text"
                 dusk="filament.forms.{{ $getStatePath() }}"
                 id="{{ $getId() }}"
-                {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"
+                x-model="state"
                 x-on:click="togglePanelVisibility()"
                 x-on:keydown.enter.stop.prevent="togglePanelVisibility()"
                 autocomplete="off"

--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -77,6 +77,8 @@
                 x-cloak
                 x-ref="panel"
                 x-float.placement.bottom-start.offset.flip.shift="{ offset: 8 }"
+                wire:ignore.self
+                wire:key="{{ $this->id }}.{{ $getStatePath() }}.panel"
                 @class([
                     'hidden absolute z-10 shadow-lg',
                     'opacity-70 pointer-events-none' => $isDisabled(),


### PR DESCRIPTION
**Problem**
When calling ```$this->form->getState();``` the ColorPicker value becomes empty. Also when reactive, the panel gets hidden.

https://user-images.githubusercontent.com/10496485/183253012-04f87993-82f1-4c4c-a105-1b1f1031fe9b.mov

**Fix**

Added the wire:model attribute. and added an ignore to the colorpalette panel.

