### PR TITLE
#2969: Ignore the timezone on a date only input.

### DIFF
--- a/packages/forms/src/Components/DatePicker.php
+++ b/packages/forms/src/Components/DatePicker.php
@@ -2,6 +2,8 @@
 
 namespace Filament\Forms\Components;
 
+use Closure;
+
 class DatePicker extends DateTimePicker
 {
     public function hasTime(): bool

--- a/packages/forms/src/Components/DatePicker.php
+++ b/packages/forms/src/Components/DatePicker.php
@@ -8,4 +8,8 @@ class DatePicker extends DateTimePicker
     {
         return false;
     }
+    
+    public function timezone( Closure|string|null $timezone ): static {
+        return $this;
+    }
 }


### PR DESCRIPTION
The DatePicker just creates a datetime with ```2022-06-04 00:00:00``` (Europe/Amsterdam) and converts it to UTC which is ```2022-06-03 22:00:00,``` and then converts it to a date only ```2022-06-03```. This doesnt make any sense when you want a date only so the timezone must be ignored.

#2969