### PR TITLE
feature: make position of actions configurable

### DIFF
--- a/packages/tables/docs/05-actions.md
+++ b/packages/tables/docs/05-actions.md
@@ -381,22 +381,9 @@ protected function getTableActions(): array
 }
 ```
 
-## Alignment
-
-By default, the row actions in your table will be aligned to the right in the final cell. To change the default alignment, update the configuration value inside of the package config:
-
-```
-'actions' => [
-    'cell' => [
-        'alignment' => 'right', // `right`, `left` or `center`
-    ],
-]
-```
-
-
 ## Position
 
-By default, the row actions are rendered in the final cell. To change the default position, you may use:
+By default, the row actions in your table are rendered in the final cell. You may change the position by overriding the `getTableActionsPosition()` method:
 
 ```php
 use Filament\Tables\Actions\Position;
@@ -405,6 +392,18 @@ protected function getTableActionsPosition(): ?string
 {
     return Position::BeforeCells;
 }
+```
+
+## Alignment
+
+Row actions are aligned to the right in their cell by default. To change the alignment, update the configuration value inside of the package config:
+
+```
+'actions' => [
+    'cell' => [
+        'alignment' => 'right', // `right`, `left` or `center`
+    ],
+]
 ```
 
 ## Tooltips

--- a/packages/tables/docs/05-actions.md
+++ b/packages/tables/docs/05-actions.md
@@ -394,7 +394,7 @@ By default, the row actions in your table will be aligned to the right in the fi
 ```
 
 
-## Position of row actions
+## Position
 
 By default, the row actions are rendered in the final cell. To change the default position, you may use:
 

--- a/packages/tables/docs/05-actions.md
+++ b/packages/tables/docs/05-actions.md
@@ -393,6 +393,20 @@ By default, the row actions in your table will be aligned to the right in the fi
 ]
 ```
 
+
+## Position of row actions
+
+By default, the row actions are rendered after all cells. To change the default postition, you may use:
+
+```php
+use Filament\Tables\Actions\Position;
+
+protected function getTableActionsPosition(): ?string
+{
+    return Position::BeforeCells;
+}
+```
+
 ## Tooltips
 
 > If you want to use tooltips outside of the admin panel, make sure you have [`@ryangjchandler/alpine-tooltip` installed](https://github.com/ryangjchandler/alpine-tooltip#installation) in your app, including [`tippy.css`](https://atomiks.github.io/tippyjs/v6/getting-started/#1-package-manager). You'll also need to install [`tippy.css`](https://atomiks.github.io/tippyjs/v6/getting-started/#1-package-manager) if you're using a [custom admin theme](/docs/admin/appearance#building-themes).

--- a/packages/tables/docs/05-actions.md
+++ b/packages/tables/docs/05-actions.md
@@ -396,7 +396,7 @@ By default, the row actions in your table will be aligned to the right in the fi
 
 ## Position of row actions
 
-By default, the row actions are rendered after all cells. To change the default postition, you may use:
+By default, the row actions are rendered in the final cell. To change the default position, you may use:
 
 ```php
 use Filament\Tables\Actions\Position;

--- a/packages/tables/resources/views/components/actions-cell.blade.php
+++ b/packages/tables/resources/views/components/actions-cell.blade.php
@@ -3,7 +3,11 @@
     'record',
 ])
 
-<td {{ $attributes->class(['px-4 py-3 whitespace-nowrap filament-tables-actions-cell']) }}>
+<td
+    wire:loading.remove.delay
+    wire:target="{{ implode(',', \Filament\Tables\Table::LOADING_TARGETS) }}"
+    {{ $attributes->class(['px-4 py-3 whitespace-nowrap filament-tables-actions-cell']) }}
+>
     <div
         {{ $attributes->class([
             'flex items-center gap-4',

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -1,7 +1,9 @@
 @php
+    use Filament\Tables\Actions\Position;
     use Filament\Tables\Filters\Layout;
 
     $actions = $getActions();
+    $actionsPosition = $getActionsPosition();
     $columns = $getColumns();
     $content = $getContent();
     $contentFooter = $getContentFooter();
@@ -326,24 +328,34 @@
                         <x-slot name="header">
                             @if ($isReordering)
                                 <th></th>
-                            @elseif ($isSelectionEnabled)
-                                <x-tables::checkbox-cell>
-                                    <x-slot
-                                        name="checkbox"
-                                        x-on:click="toggleSelectRecordsOnPage"
-                                        x-bind:checked="
-                                            if (areRecordsSelected(getRecordsOnPage())) {
-                                                $el.checked = true
+                            @else
+                                @if (count($actions) && (! $isReordering) && $actionsPosition === Position::BeforeCells)
+                                    <th class="w-5"></th>
+                                @endif
 
-                                                return 'checked'
-                                            }
+                                @if ($isSelectionEnabled)
+                                    <x-tables::checkbox-cell>
+                                        <x-slot
+                                            name="checkbox"
+                                            x-on:click="toggleSelectRecordsOnPage"
+                                            x-bind:checked="
+                                                if (areRecordsSelected(getRecordsOnPage())) {
+                                                    $el.checked = true
 
-                                            $el.checked = false
+                                                    return 'checked'
+                                                }
 
-                                            return null
-                                        "
-                                    ></x-slot>
-                                </x-tables::checkbox-cell>
+                                                $el.checked = false
+
+                                                return null
+                                            "
+                                        ></x-slot>
+                                    </x-tables::checkbox-cell>
+                                @endif
+
+                                @if (count($actions) && (! $isReordering) && $actionsPosition === Position::BeforeColumns)
+                                    <th class="w-5"></th>
+                                @endif
                             @endif
 
                             @foreach ($columns as $column)
@@ -360,7 +372,7 @@
                                 </x-tables::header-cell>
                             @endforeach
 
-                            @if (count($actions) && (! $isReordering))
+                            @if (count($actions) && (! $isReordering) && $actionsPosition === Position::AfterCells)
                                 <th class="w-5"></th>
                             @endif
                         </x-slot>
@@ -400,15 +412,35 @@
                             >
                                 @if ($isReordering)
                                     <x-tables::reorder.cell />
-                                @elseif ($isSelectionEnabled)
-                                    <x-tables::checkbox-cell>
-                                        <x-slot
-                                            name="checkbox"
-                                            x-model="selectedRecords"
-                                            :value="$recordKey"
-                                            class="table-row-checkbox"
-                                        ></x-slot>
-                                    </x-tables::checkbox-cell>
+                                @else
+                                    @if (count($actions) && (! $isReordering) && $actionsPosition === Position::BeforeCells)
+                                        <x-tables::actions-cell
+                                            :actions="$actions"
+                                            :record="$record"
+                                            wire:loading.remove.delay
+                                            wire:target="{{ implode(',', \Filament\Tables\Table::LOADING_TARGETS) }}"
+                                        />
+                                    @endif
+
+                                    @if ($isSelectionEnabled)
+                                        <x-tables::checkbox-cell>
+                                            <x-slot
+                                                name="checkbox"
+                                                x-model="selectedRecords"
+                                                :value="$recordKey"
+                                                class="table-row-checkbox"
+                                            ></x-slot>
+                                        </x-tables::checkbox-cell>
+                                    @endif
+
+                                    @if (count($actions) && (! $isReordering) && $actionsPosition === Position::BeforeColumns)
+                                        <x-tables::actions-cell
+                                            :actions="$actions"
+                                            :record="$record"
+                                            wire:loading.remove.delay
+                                            wire:target="{{ implode(',', \Filament\Tables\Table::LOADING_TARGETS) }}"
+                                        />
+                                    @endif
                                 @endif
 
                                 @foreach ($columns as $column)
@@ -435,7 +467,7 @@
                                     </x-tables::cell>
                                 @endforeach
 
-                                @if (count($actions) && (! $isReordering))
+                                @if (count($actions) && (! $isReordering) && $actionsPosition === Position::AfterCells)
                                     <x-tables::actions-cell
                                         :actions="$actions"
                                         :record="$record"

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -417,8 +417,6 @@
                                         <x-tables::actions-cell
                                             :actions="$actions"
                                             :record="$record"
-                                            wire:loading.remove.delay
-                                            wire:target="{{ implode(',', \Filament\Tables\Table::LOADING_TARGETS) }}"
                                         />
                                     @endif
 
@@ -437,8 +435,6 @@
                                         <x-tables::actions-cell
                                             :actions="$actions"
                                             :record="$record"
-                                            wire:loading.remove.delay
-                                            wire:target="{{ implode(',', \Filament\Tables\Table::LOADING_TARGETS) }}"
                                         />
                                     @endif
                                 @endif
@@ -471,8 +467,6 @@
                                     <x-tables::actions-cell
                                         :actions="$actions"
                                         :record="$record"
-                                        wire:loading.remove.delay
-                                        wire:target="{{ implode(',', \Filament\Tables\Table::LOADING_TARGETS) }}"
                                     />
                                 @endif
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -329,7 +329,7 @@
                             @if ($isReordering)
                                 <th></th>
                             @else
-                                @if (count($actions) && (! $isReordering) && $actionsPosition === Position::BeforeCells)
+                                @if (count($actions) && $actionsPosition === Position::BeforeCells)
                                     <th class="w-5"></th>
                                 @endif
 
@@ -353,7 +353,7 @@
                                     </x-tables::checkbox-cell>
                                 @endif
 
-                                @if (count($actions) && (! $isReordering) && $actionsPosition === Position::BeforeColumns)
+                                @if (count($actions) && $actionsPosition === Position::BeforeColumns)
                                     <th class="w-5"></th>
                                 @endif
                             @endif
@@ -413,7 +413,7 @@
                                 @if ($isReordering)
                                     <x-tables::reorder.cell />
                                 @else
-                                    @if (count($actions) && (! $isReordering) && $actionsPosition === Position::BeforeCells)
+                                    @if (count($actions) && $actionsPosition === Position::BeforeCells)
                                         <x-tables::actions-cell
                                             :actions="$actions"
                                             :record="$record"
@@ -433,7 +433,7 @@
                                         </x-tables::checkbox-cell>
                                     @endif
 
-                                    @if (count($actions) && (! $isReordering) && $actionsPosition === Position::BeforeColumns)
+                                    @if (count($actions) && $actionsPosition === Position::BeforeColumns)
                                         <x-tables::actions-cell
                                             :actions="$actions"
                                             :record="$record"

--- a/packages/tables/src/Actions/Position.php
+++ b/packages/tables/src/Actions/Position.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Filament\Tables\Actions;
+
+class Position
+{
+    public const BeforeCells = 'before_cells';
+
+    public const BeforeColumns = 'before_columns';
+
+    public const AfterCells = 'after_cells';
+}

--- a/packages/tables/src/Concerns/HasActions.php
+++ b/packages/tables/src/Concerns/HasActions.php
@@ -242,4 +242,9 @@ trait HasActions
     {
         return [];
     }
+
+    protected function getTableActionsPosition(): ?string
+    {
+        return null;
+    }
 }

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -96,6 +96,7 @@ trait InteractsWithTable
     protected function getTable(): Table
     {
         return $this->makeTable()
+            ->actionsPosition($this->getTableActionsPosition())
             ->content($this->getTableContent())
             ->contentFooter($this->getTableContentFooter())
             ->description($this->getTableDescription())
@@ -106,7 +107,6 @@ trait InteractsWithTable
             ->enablePagination($this->isTablePaginationEnabled())
             ->filtersFormWidth($this->getTableFiltersFormWidth())
             ->filtersLayout($this->getTableFiltersLayout())
-            ->actionsPosition($this->getTableActionsPosition())
             ->recordAction($this->getTableRecordAction())
             ->getRecordUrlUsing($this->getTableRecordUrlUsing())
             ->header($this->getTableHeader())

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -106,6 +106,7 @@ trait InteractsWithTable
             ->enablePagination($this->isTablePaginationEnabled())
             ->filtersFormWidth($this->getTableFiltersFormWidth())
             ->filtersLayout($this->getTableFiltersLayout())
+            ->actionsPosition($this->getTableActionsPosition())
             ->recordAction($this->getTableRecordAction())
             ->getRecordUrlUsing($this->getTableRecordUrlUsing())
             ->header($this->getTableHeader())

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -8,6 +8,7 @@ use Filament\Support\Components\ViewComponent;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\ActionGroup;
 use Filament\Tables\Actions\BulkAction;
+use Filament\Tables\Actions\Position;
 use Filament\Tables\Columns\Column;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\Layout;
@@ -37,6 +38,8 @@ class Table extends ViewComponent
     protected ?string $filtersFormWidth = null;
 
     protected ?string $filtersLayout = null;
+
+    protected ?string $actionsPosition = null;
 
     protected ?string $columnToggleFormWidth = null;
 
@@ -155,6 +158,13 @@ class Table extends ViewComponent
         return $this;
     }
 
+    public function actionsPosition(?string $position): static
+    {
+        $this->actionsPosition = $position;
+
+        return $this;
+    }
+
     public function getRecordUrlUsing(?Closure $callback): static
     {
         $this->getRecordUrlUsing = $callback;
@@ -214,6 +224,11 @@ class Table extends ViewComponent
     public function getActions(): array
     {
         return $this->getLivewire()->getCachedTableActions();
+    }
+
+    public function getActionsPosition(): string
+    {
+        return $this->actionsPosition ?? Position::AfterCells;
     }
 
     public function getAllRecordsCount(): int

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -21,6 +21,8 @@ class Table extends ViewComponent
 {
     use Concerns\BelongsToLivewire;
 
+    protected ?string $actionsPosition = null;
+
     protected ?View $content = null;
 
     protected ?View $contentFooter = null;
@@ -38,8 +40,6 @@ class Table extends ViewComponent
     protected ?string $filtersFormWidth = null;
 
     protected ?string $filtersLayout = null;
-
-    protected ?string $actionsPosition = null;
 
     protected ?string $columnToggleFormWidth = null;
 
@@ -79,6 +79,13 @@ class Table extends ViewComponent
     public static function make(HasTable $livewire): static
     {
         return app(static::class, ['livewire' => $livewire]);
+    }
+
+    public function actionsPosition(?string $position): static
+    {
+        $this->actionsPosition = $position;
+
+        return $this;
     }
 
     public function description(?string $description): static
@@ -154,13 +161,6 @@ class Table extends ViewComponent
     public function recordAction(?string $action): static
     {
         $this->recordAction = $action;
-
-        return $this;
-    }
-
-    public function actionsPosition(?string $position): static
-    {
-        $this->actionsPosition = $position;
 
         return $this;
     }


### PR DESCRIPTION
Makes it possible to configure where the table row actions are, this is especially useful for tables with a lot of columns.

Options
- `Filament\Tables\Actions\Position::BeforeCells` before all cells 
![before-cells](https://user-images.githubusercontent.com/100052/184216159-49568c03-e58c-45c5-8435-848a75903122.png)

- `Filament\Tables\Actions\Position::BeforeColumns` before columns, after checkbox ![before-columns](https://user-images.githubusercontent.com/100052/184216202-a45e22b5-506e-4b44-9b37-1f2bccd579fd.png)
- `Filament\Tables\Actions\Position::AfterCells` after all cells, the current situation
![after-cells](https://user-images.githubusercontent.com/100052/184216630-e0d1bd47-8498-49e4-896f-622817b249cd.png)
 