### PR TITLE
Allow javascript callback for chart options

### DIFF
--- a/packages/admin/resources/views/widgets/chart-widget.blade.php
+++ b/packages/admin/resources/views/widgets/chart-widget.blade.php
@@ -49,7 +49,7 @@
                         return this.chart = new Chart($el, {
                             type: '{{ $this->getType() }}',
                             data: this.applyColorToData(data),
-                            options: {{ json_encode($this->getOptions()) }} ?? {},
+                            options: {{ str_replace('"!!', '', str_replace('!!"', '', json_encode($this->getOptions()))) }} ?? {},
                         })
                     },
 

--- a/packages/admin/resources/views/widgets/chart-widget.blade.php
+++ b/packages/admin/resources/views/widgets/chart-widget.blade.php
@@ -49,7 +49,7 @@
                         return this.chart = new Chart($el, {
                             type: '{{ $this->getType() }}',
                             data: this.applyColorToData(data),
-                            options: {{ str_replace('"!!', '', str_replace('!!"', '', str_replace('rn', '', str_replace('\\', '', json_encode($this->getOptions()))))) }} ?? {},
+                            options: {{ str_replace('"!!', '', str_replace('!!"', '', str_replace("\\r\\n", '', json_encode($this->getOptions())))) }} ?? {},
                         })
                     },
 

--- a/packages/admin/resources/views/widgets/chart-widget.blade.php
+++ b/packages/admin/resources/views/widgets/chart-widget.blade.php
@@ -49,7 +49,7 @@
                         return this.chart = new Chart($el, {
                             type: '{{ $this->getType() }}',
                             data: this.applyColorToData(data),
-                            options: {{ str_replace('"!!', '', str_replace('!!"', '', str_replace('\r\n', '', json_encode($this->getOptions())))) }} ?? {},
+                            options: {{ str_replace('"!!', '', str_replace('!!"', '', str_replace('rn', '', str_replace('\\', '', json_encode($this->getOptions()))))) }} ?? {},
                         })
                     },
 

--- a/packages/admin/resources/views/widgets/chart-widget.blade.php
+++ b/packages/admin/resources/views/widgets/chart-widget.blade.php
@@ -49,7 +49,7 @@
                         return this.chart = new Chart($el, {
                             type: '{{ $this->getType() }}',
                             data: this.applyColorToData(data),
-                            options: {{ str_replace('"!!', '', str_replace('!!"', '', str_replace("\\r\\n", '', json_encode($this->getOptions())))) }} ?? {},
+                            options: {{ preg_replace('/\s+/', ' ', str_replace('\\', '', str_replace('"!!', '', str_replace('!!"', '', str_replace("\\r\\n", '', json_encode($this->getOptions())))))) }} ?? {},
                         })
                     },
 

--- a/packages/admin/resources/views/widgets/chart-widget.blade.php
+++ b/packages/admin/resources/views/widgets/chart-widget.blade.php
@@ -49,7 +49,7 @@
                         return this.chart = new Chart($el, {
                             type: '{{ $this->getType() }}',
                             data: this.applyColorToData(data),
-                            options: {{ str_replace('"!!', '', str_replace('!!"', '', json_encode($this->getOptions()))) }} ?? {},
+                            options: {{ str_replace('"!!', '', str_replace('!!"', '', str_replace('\r\n', '', json_encode($this->getOptions())))) }} ?? {},
                         })
                     },
 


### PR DESCRIPTION
The idea is by wrapping javascript callback inside `!!` then we remove the rendered `"!!` and `!!"` in the frontend.

For example:

```
public static ?array $options = [
    'scales' => [
        'x' => [
            'ticks' => [
                'callback' => "!!
                    function(value, index, ticks) {
                        return '$' + value;
                    }
               !!"
            ],
        ],
    ],
];
```

I know the code is ugly but if someone can make better PR please do it. Chart.js brings a lot of functionalities through callbacks.

Anyone can improve if `!!` or create better PR if this is not acceptable.