### PR TITLE
Allow orderby (and other mysql stuff) in filters

### DIFF
--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -91,14 +91,14 @@ trait HasFilters
             );
         }
 
-        return $query->where(function (Builder $query) use ($data) {
-            foreach ($this->getCachedTableFilters() as $filter) {
-                $filter->apply(
-                    $query,
-                    $data[$filter->getName()] ?? [],
-                );
-            }
-        });
+        foreach ($this->getCachedTableFilters() as $filter) {
+            $filter->apply(
+                $query,
+                $data[$filter->getName()] ?? [],
+            );
+        }
+
+        return $query;
     }
 
     protected function getTableFilters(): array


### PR DESCRIPTION
I might be completely incorrect, but I think this would allow users to use filters for ordering their tables. I do understand this might not be wanted so feel free to decline the PR if that's the case.

Especially nifty if you're using the Layout::AboveContent, which with a little bit of css might give a filter the look of being an order dropdown instead of a filter.

Currently doing:

```php
Filter::make('Sorteervolgorde')
    ->form([
        Select::make('Sorteervolgorde')
            ->disablePlaceholderSelection()
            ->options([
                'newestFirst'       => 'Nieuwste eerst',
                'oldestFirst'       => 'Oudste eerst',
            ]),
    ])
    ->query(function (Builder $query, array $data): Builder {
        return $query
            ->when($data['Sorteervolgorde'] === 'newestFirst',
                fn(Builder $query) => $query->orderBy('id', 'DESC'))
            ->when($data['Sorteervolgorde'] === 'oldestFirst',
                fn(Builder $query) => $query->orderBy('id'));
    }),
```

Is not possible as the current implementation only allows where queries. This change would allow this example to work.