### PR TITLE
Add new debounce test to StateBindingModifiersTest

### DIFF
--- a/tests/src/Forms/StateBindingModifiersTest.php
+++ b/tests/src/Forms/StateBindingModifiersTest.php
@@ -33,6 +33,15 @@ test('component state binding can be lazy', function () {
         ->getStateBindingModifiers()->toBe(['lazy']);
 });
 
+test('component state binding can be debounce', function () {
+    $component = (new Component())
+        ->container(ComponentContainer::make(Livewire::make()))
+        ->debounce('750ms');
+
+    expect($component)
+        ->getStateBindingModifiers()->toBe(array('debounce', '750ms'));
+});
+
 test('components inherit their state binding modifiers', function () {
     $component = (new Component())
         ->container(

--- a/tests/src/Forms/StateBindingModifiersTest.php
+++ b/tests/src/Forms/StateBindingModifiersTest.php
@@ -33,13 +33,13 @@ test('component state binding can be lazy', function () {
         ->getStateBindingModifiers()->toBe(['lazy']);
 });
 
-test('component state binding can be debounce', function () {
+test('component state binding can be debounced', function () {
     $component = (new Component())
         ->container(ComponentContainer::make(Livewire::make()))
         ->debounce('750ms');
 
     expect($component)
-        ->getStateBindingModifiers()->toBe(array('debounce', '750ms'));
+        ->getStateBindingModifiers()->toBe(['debounce', '750ms']);
 });
 
 test('components inherit their state binding modifiers', function () {


### PR DESCRIPTION
Added a new test for the new StateBindingModifier  `debounce()`. From this PR https://github.com/filamentphp/filament/pull/3022.