### PR TITLE
Added reorder_indicator for DE/German translation

### DIFF
--- a/packages/tables/resources/lang/de/table.php
+++ b/packages/tables/resources/lang/de/table.php
@@ -117,6 +117,8 @@ return [
         'overview' => ':first bis :last von :total Ergebnissen',
 
     ],
+    
+    'reorder_indicator' => 'Zum Sortieren die Datensätze per Drag & Drop in die richtige Reihenfolge ziehen.',
 
     'selection_indicator' => [
 


### PR DESCRIPTION
This PR adds the `tables::table.reorder_indicator` translation for DE.