### PR TITLE
Adding further table and page action assertions

### DIFF
--- a/packages/admin/.stubs.php
+++ b/packages/admin/.stubs.php
@@ -31,6 +31,18 @@ namespace Livewire\Testing {
 
         public function assertPageActionDisabled(string $name): static {}
 
+        public function assertPageActionHasIcon(string $name, string $icon): static {}
+
+        public function assertPageActionDoesNotHaveIcon(string $name, string $icon): static {}
+
+        public function assertPageActionHasLabel(string $name, string $label): static {}
+
+        public function assertPageActionHasColor(string $name, string $color): static {}
+
+        public function assertPageActionDoesNotHaveColor(string $name, string $color): static {}
+
+        public function assertPageActionDoesNotHaveLabel(string $name, string $label): static {}
+
         public function assertPageActionHeld(string $name): static {}
 
         public function assertHasPageActionErrors(array $keys = []): static {}

--- a/packages/admin/src/Testing/TestsPageActions.php
+++ b/packages/admin/src/Testing/TestsPageActions.php
@@ -218,7 +218,7 @@ class TestsPageActions
             $action = $livewire->getCachedAction($name);
 
             Assert::assertTrue(
-                $action->getIcon() == $icon,
+                $action->getIcon() === $icon,
                 message: "Failed asserting that an action with name [{$name}] has icon [{$icon}] on the [{$livewireClass}] component.",
             );
 
@@ -238,7 +238,7 @@ class TestsPageActions
             $action = $livewire->getCachedAction($name);
 
             Assert::assertFalse(
-                $action->getIcon() == $icon,
+                $action->getIcon() === $icon,
                 message: "Failed asserting that an action with name [{$name}] does not have icon [{$icon}] on the [{$livewireClass}] component.",
             );
 
@@ -258,7 +258,7 @@ class TestsPageActions
             $action = $livewire->getCachedAction($name);
 
             Assert::assertTrue(
-                $action->getLabel() == $label,
+                $action->getLabel() === $label,
                 message: "Failed asserting that an action with name [{$name}] has label [{$label}] on the [{$livewireClass}] component.",
             );
 
@@ -278,7 +278,7 @@ class TestsPageActions
             $action = $livewire->getCachedAction($name);
 
             Assert::assertFalse(
-                $action->getLabel() == $label,
+                $action->getLabel() === $label,
                 message: "Failed asserting that an action with name [{$name}] does not have label [{$label}] on the [{$livewireClass}] component.",
             );
 
@@ -298,7 +298,7 @@ class TestsPageActions
             $action = $livewire->getCachedAction($name);
 
             Assert::assertTrue(
-                $action->getColor() == $color,
+                $action->getColor() === $color,
                 message: "Failed asserting that an action with name [{$name}] has color [{$color}] on the [{$livewireClass}] component.",
             );
 
@@ -318,7 +318,7 @@ class TestsPageActions
             $action = $livewire->getCachedAction($name);
 
             Assert::assertFalse(
-                $action->getColor() == $color,
+                $action->getColor() === $color,
                 message: "Failed asserting that an action with name [{$name}] does not have color [{$color}] on the [{$livewireClass}] component.",
             );
 

--- a/packages/admin/src/Testing/TestsPageActions.php
+++ b/packages/admin/src/Testing/TestsPageActions.php
@@ -206,6 +206,126 @@ class TestsPageActions
         };
     }
 
+    public function assertPageActionHasIcon(): Closure
+    {
+        return function (string $name, string $icon, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertPageActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $action = $livewire->getCachedAction($name);
+
+            Assert::assertTrue(
+                $action->getIcon() == $icon,
+                message: "Failed asserting that an action with name [{$name}] has icon [{$icon}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertPageActionDoesNotHaveIcon(): Closure
+    {
+        return function (string $name, string $icon, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertPageActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $action = $livewire->getCachedAction($name);
+
+            Assert::assertFalse(
+                $action->getIcon() == $icon,
+                message: "Failed asserting that an action with name [{$name}] does not have icon [{$icon}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertPageActionHasLabel(): Closure
+    {
+        return function (string $name, string $label, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertPageActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $action = $livewire->getCachedAction($name);
+
+            Assert::assertTrue(
+                $action->getLabel() == $label,
+                message: "Failed asserting that an action with name [{$name}] has label [{$label}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertPageActionDoesNotHaveLabel(): Closure
+    {
+        return function (string $name, string $label, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertPageActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $action = $livewire->getCachedAction($name);
+
+            Assert::assertFalse(
+                $action->getLabel() == $label,
+                message: "Failed asserting that an action with name [{$name}] does not have label [{$label}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertPageActionHasColor(): Closure
+    {
+        return function (string $name, string $color, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertPageActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $action = $livewire->getCachedAction($name);
+
+            Assert::assertTrue(
+                $action->getColor() == $color,
+                message: "Failed asserting that an action with name [{$name}] has color [{$color}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertPageActionDoesNotHaveColor(): Closure
+    {
+        return function (string $name, string $color, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertPageActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $action = $livewire->getCachedAction($name);
+
+            Assert::assertFalse(
+                $action->getColor() == $color,
+                message: "Failed asserting that an action with name [{$name}] does not have color [{$color}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
     public function assertPageActionHeld(): Closure
     {
         return function (string $name): static {

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -51,6 +51,18 @@ namespace Livewire\Testing {
 
         public function assertTableBulkActionDisabled(string $name): static {}
 
+        public function assertTableActionHasIcon(string $name, string $icon): static {}
+
+        public function assertTableActionDoesNotHaveIcon(string $name, string $icon): static {}
+
+        public function assertTableActionHasLabel(string $name, string $label): static {}
+
+        public function assertTableActionHasColor(string $name, string $color): static {}
+
+        public function assertTableActionDoesNotHaveColor(string $name, string $color): static {}
+
+        public function assertTableActionDoesNotHaveLabel(string $name, string $label): static {}
+
         public function assertTableBulkActionHeld(string $name): static {}
 
         public function assertHasTableBulkActionErrors(array $keys = []): static {}

--- a/packages/tables/src/Testing/TestsActions.php
+++ b/packages/tables/src/Testing/TestsActions.php
@@ -243,6 +243,168 @@ class TestsActions
         };
     }
 
+    public function assertTableActionHasIcon(): Closure
+    {
+        return function (string $name, string $icon, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            if (! $record instanceof Model) {
+                $record = $livewire->getTableRecord($record);
+            }
+
+            $action = $livewire->getCachedTableAction($name) ?? $livewire->getCachedTableEmptyStateAction($name) ?? $livewire->getCachedTableHeaderAction($name);
+            $action->record($record);
+
+            Assert::assertTrue(
+                $action->getIcon() == $icon,
+                message: filled($record) ?
+                    "Failed asserting that a table action with name [{$name}] has icon [{$icon}] on the [{$livewireClass}] component for record [{$record}]." :
+                    "Failed asserting that a table action with name [{$name}] has icon [{$icon}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableActionDoesNotHaveIcon(): Closure
+    {
+        return function (string $name, string $icon, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            if (! $record instanceof Model) {
+                $record = $livewire->getTableRecord($record);
+            }
+
+            $action = $livewire->getCachedTableAction($name) ?? $livewire->getCachedTableEmptyStateAction($name) ?? $livewire->getCachedTableHeaderAction($name);
+            $action->record($record);
+
+            Assert::assertFalse(
+                $action->getIcon() == $icon,
+                message: filled($record) ?
+                    "Failed asserting that a table action with name [{$name}] does not have icon [{$icon}] on the [{$livewireClass}] component for record [{$record}]." :
+                    "Failed asserting that a table action with name [{$name}] does not have icon [{$icon}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableActionHasLabel(): Closure
+    {
+        return function (string $name, string $label, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            if (! $record instanceof Model) {
+                $record = $livewire->getTableRecord($record);
+            }
+
+            $action = $livewire->getCachedTableAction($name) ?? $livewire->getCachedTableEmptyStateAction($name) ?? $livewire->getCachedTableHeaderAction($name);
+            $action->record($record);
+
+            Assert::assertTrue(
+                $action->getLabel() == $label,
+                message: filled($record) ?
+                    "Failed asserting that a table action with name [{$name}] has label [{$label}] on the [{$livewireClass}] component for record [{$record}]." :
+                    "Failed asserting that a table action with name [{$name}] has label [{$label}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableActionDoesNotHaveLabel(): Closure
+    {
+        return function (string $name, string $label, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            if (! $record instanceof Model) {
+                $record = $livewire->getTableRecord($record);
+            }
+
+            $action = $livewire->getCachedTableAction($name) ?? $livewire->getCachedTableEmptyStateAction($name) ?? $livewire->getCachedTableHeaderAction($name);
+            $action->record($record);
+
+            Assert::assertFalse(
+                $action->getLabel() == $label,
+                message: filled($record) ?
+                    "Failed asserting that a table action with name [{$name}] does not have label [{$label}] on the [{$livewireClass}] component for record [{$record}]." :
+                    "Failed asserting that a table action with name [{$name}] does not have label [{$label}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableActionHasColor(): Closure
+    {
+        return function (string $name, string $color, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            if (! $record instanceof Model) {
+                $record = $livewire->getTableRecord($record);
+            }
+
+            $action = $livewire->getCachedTableAction($name) ?? $livewire->getCachedTableEmptyStateAction($name) ?? $livewire->getCachedTableHeaderAction($name);
+            $action->record($record);
+
+            Assert::assertTrue(
+                $action->getColor() == $color,
+                message: filled($record) ?
+                    "Failed asserting that a table action with name [{$name}] has color [{$color}] on the [{$livewireClass}] component for record [{$record}]." :
+                    "Failed asserting that a table action with name [{$name}] has color [{$color}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableActionDoesNotHaveColor(): Closure
+    {
+        return function (string $name, string $color, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            if (! $record instanceof Model) {
+                $record = $livewire->getTableRecord($record);
+            }
+
+            $action = $livewire->getCachedTableAction($name) ?? $livewire->getCachedTableEmptyStateAction($name) ?? $livewire->getCachedTableHeaderAction($name);
+            $action->record($record);
+
+            Assert::assertFalse(
+                $action->getColor() == $color,
+                message: filled($record) ?
+                    "Failed asserting that a table action with name [{$name}] does not have color [{$color}] on the [{$livewireClass}] component for record [{$record}]." :
+                    "Failed asserting that a table action with name [{$name}] does not have color [{$color}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
     public function assertTableActionHeld(): Closure
     {
         return function (string $name): static {

--- a/packages/tables/src/Testing/TestsActions.php
+++ b/packages/tables/src/Testing/TestsActions.php
@@ -260,7 +260,7 @@ class TestsActions
             $action->record($record);
 
             Assert::assertTrue(
-                $action->getIcon() == $icon,
+                $action->getIcon() === $icon,
                 message: filled($record) ?
                     "Failed asserting that a table action with name [{$name}] has icon [{$icon}] on the [{$livewireClass}] component for record [{$record}]." :
                     "Failed asserting that a table action with name [{$name}] has icon [{$icon}] on the [{$livewireClass}] component.",
@@ -287,7 +287,7 @@ class TestsActions
             $action->record($record);
 
             Assert::assertFalse(
-                $action->getIcon() == $icon,
+                $action->getIcon() === $icon,
                 message: filled($record) ?
                     "Failed asserting that a table action with name [{$name}] does not have icon [{$icon}] on the [{$livewireClass}] component for record [{$record}]." :
                     "Failed asserting that a table action with name [{$name}] does not have icon [{$icon}] on the [{$livewireClass}] component.",
@@ -314,7 +314,7 @@ class TestsActions
             $action->record($record);
 
             Assert::assertTrue(
-                $action->getLabel() == $label,
+                $action->getLabel() === $label,
                 message: filled($record) ?
                     "Failed asserting that a table action with name [{$name}] has label [{$label}] on the [{$livewireClass}] component for record [{$record}]." :
                     "Failed asserting that a table action with name [{$name}] has label [{$label}] on the [{$livewireClass}] component.",
@@ -341,7 +341,7 @@ class TestsActions
             $action->record($record);
 
             Assert::assertFalse(
-                $action->getLabel() == $label,
+                $action->getLabel() === $label,
                 message: filled($record) ?
                     "Failed asserting that a table action with name [{$name}] does not have label [{$label}] on the [{$livewireClass}] component for record [{$record}]." :
                     "Failed asserting that a table action with name [{$name}] does not have label [{$label}] on the [{$livewireClass}] component.",
@@ -368,7 +368,7 @@ class TestsActions
             $action->record($record);
 
             Assert::assertTrue(
-                $action->getColor() == $color,
+                $action->getColor() === $color,
                 message: filled($record) ?
                     "Failed asserting that a table action with name [{$name}] has color [{$color}] on the [{$livewireClass}] component for record [{$record}]." :
                     "Failed asserting that a table action with name [{$name}] has color [{$color}] on the [{$livewireClass}] component.",
@@ -395,7 +395,7 @@ class TestsActions
             $action->record($record);
 
             Assert::assertFalse(
-                $action->getColor() == $color,
+                $action->getColor() === $color,
                 message: filled($record) ?
                     "Failed asserting that a table action with name [{$name}] does not have color [{$color}] on the [{$livewireClass}] component for record [{$record}]." :
                     "Failed asserting that a table action with name [{$name}] does not have color [{$color}] on the [{$livewireClass}] component.",

--- a/tests/src/Admin/Fixtures/Pages/PageActions.php
+++ b/tests/src/Admin/Fixtures/Pages/PageActions.php
@@ -49,7 +49,7 @@ class PageActions extends Page
             Action::make('has-label')
                 ->label('My Action'),
             Action::make('has-color')
-                ->color('primary')
+                ->color('primary'),
         ];
     }
 }

--- a/tests/src/Admin/Fixtures/Pages/PageActions.php
+++ b/tests/src/Admin/Fixtures/Pages/PageActions.php
@@ -44,6 +44,12 @@ class PageActions extends Page
             Action::make('enabled'),
             Action::make('disabled')
                 ->disabled(),
+            Action::make('has-icon')
+                ->icon('heroicon-s-pencil'),
+            Action::make('has-label')
+                ->label('My Action'),
+            Action::make('has-color')
+                ->color('primary')
         ];
     }
 }

--- a/tests/src/Admin/Pages/ActionTest.php
+++ b/tests/src/Admin/Pages/ActionTest.php
@@ -69,3 +69,21 @@ it('can disable an action', function () {
         ->assertPageActionEnabled('enabled')
         ->assertPageActionDisabled('disabled');
 });
+
+it('can have an icon', function() {
+    livewire(PageActions::class)
+        ->assertPageActionHasIcon('has-icon', 'heroicon-s-pencil')
+        ->assertPageActionDoesNotHaveIcon('has-icon', 'heroicon-o-trash');
+});
+
+it('can have a label', function() {
+    livewire(PageActions::class)
+        ->assertPageActionHasLabel('has-label', 'My Action')
+        ->assertPageActionDoesNotHaveLabel('has-label', 'My Other Action');
+});
+
+it('can have a color', function() {
+    livewire(PageActions::class)
+        ->assertPageActionHasColor('has-color', 'primary')
+        ->assertPageActionDoesNotHaveColor('has-color', 'secondary');
+});

--- a/tests/src/Admin/Pages/ActionTest.php
+++ b/tests/src/Admin/Pages/ActionTest.php
@@ -70,19 +70,19 @@ it('can disable an action', function () {
         ->assertPageActionDisabled('disabled');
 });
 
-it('can have an icon', function() {
+it('can have an icon', function () {
     livewire(PageActions::class)
         ->assertPageActionHasIcon('has-icon', 'heroicon-s-pencil')
         ->assertPageActionDoesNotHaveIcon('has-icon', 'heroicon-o-trash');
 });
 
-it('can have a label', function() {
+it('can have a label', function () {
     livewire(PageActions::class)
         ->assertPageActionHasLabel('has-label', 'My Action')
         ->assertPageActionDoesNotHaveLabel('has-label', 'My Other Action');
 });
 
-it('can have a color', function() {
+it('can have a color', function () {
     livewire(PageActions::class)
         ->assertPageActionHasColor('has-color', 'primary')
         ->assertPageActionDoesNotHaveColor('has-color', 'secondary');

--- a/tests/src/Tables/ActionTest.php
+++ b/tests/src/Tables/ActionTest.php
@@ -74,3 +74,21 @@ it('can disable an action', function () {
         ->assertTableActionEnabled('enabled')
         ->assertTableActionDisabled('disabled');
 });
+
+it('can have an icon', function() {
+    livewire(PostsTable::class)
+        ->assertTableActionHasIcon('has-icon', 'heroicon-s-pencil')
+        ->assertTableActionDoesNotHaveIcon('has-icon', 'heroicon-o-trash');
+});
+
+it('can have a label', function() {
+    livewire(PostsTable::class)
+        ->assertTableActionHasLabel('has-label', 'My Action')
+        ->assertTableActionDoesNotHaveLabel('has-label', 'My Other Action');
+});
+
+it('can have a color', function() {
+    livewire(PostsTable::class)
+        ->assertTableActionHasColor('has-color', 'primary')
+        ->assertTableActionDoesNotHaveColor('has-color', 'secondary');
+});

--- a/tests/src/Tables/ActionTest.php
+++ b/tests/src/Tables/ActionTest.php
@@ -75,19 +75,19 @@ it('can disable an action', function () {
         ->assertTableActionDisabled('disabled');
 });
 
-it('can have an icon', function() {
+it('can have an icon', function () {
     livewire(PostsTable::class)
         ->assertTableActionHasIcon('has-icon', 'heroicon-s-pencil')
         ->assertTableActionDoesNotHaveIcon('has-icon', 'heroicon-o-trash');
 });
 
-it('can have a label', function() {
+it('can have a label', function () {
     livewire(PostsTable::class)
         ->assertTableActionHasLabel('has-label', 'My Action')
         ->assertTableActionDoesNotHaveLabel('has-label', 'My Other Action');
 });
 
-it('can have a color', function() {
+it('can have a color', function () {
     livewire(PostsTable::class)
         ->assertTableActionHasColor('has-color', 'primary')
         ->assertTableActionDoesNotHaveColor('has-color', 'secondary');

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -69,6 +69,12 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
             Tables\Actions\Action::make('enabled'),
             Tables\Actions\Action::make('disabled')
                 ->disabled(),
+            Tables\Actions\Action::make('has-icon')
+                ->icon('heroicon-s-pencil'),
+            Tables\Actions\Action::make('has-label')
+                ->label('My Action'),
+            Tables\Actions\Action::make('has-color')
+                ->color('primary')
         ];
     }
 

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -74,7 +74,7 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
             Tables\Actions\Action::make('has-label')
                 ->label('My Action'),
             Tables\Actions\Action::make('has-color')
-                ->color('primary')
+                ->color('primary'),
         ];
     }
 


### PR DESCRIPTION
Includes:

 ```
assertPageActionHasIcon(string $name, string $icon)
assertPageActionDoesNotHaveIcon(string $name, string $icon)
assertPageActionHasLabel(string $name, string $label)
assertPageActionDoesNotHaveLabel(string $name, string $label)
assertPageActionHasColor(string $name, string $color)
assertPageActionDoesNotHaveColor(string $name, string $color)
assertTableActionHasIcon(string $name, string $icon)
assertTableActionDoesNotHaveIcon(string $name, string $icon)
assertTableActionHasLabel(string $name, string $label)
assertTableActionDoesNotHaveLabel(string $name, string $label)
assertTableActionHasColor(string $name, string $color)
assertTableActionDoesNotHaveColor(string $name, string $color)
```