### PR TITLE
Modularity by wildcard

### DIFF
--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -217,21 +217,17 @@ class FilamentServiceProvider extends PluginServiceProvider
             $register,
             collect($filesystem->allFiles($directory))
                 ->map(function (SplFileInfo $file) use ($namespace): string {
-                    $subPath = null;
-                    
-                    if ($namespace->contains('*')) {
-                        $subPath = str_ireplace(
-                            ['\\' . $namespace->before('*'), $namespace->after('*')],
-                            ['', ''],
-                            Str::of($file->getPath())
-                                ->after(base_path())
-                                ->replace(['/'], ['\\']),
-                        );
-                    }
+                    $variableNamespace = $namespace->contains('*') ? str_ireplace(
+                        ['\\' . $namespace->before('*'), $namespace->after('*')],
+                        ['', ''],
+                        Str::of($file->getPath())
+                            ->after(base_path())
+                            ->replace(['/'], ['\\']),
+                    ) : null;
                     
                     return (string) $namespace
                         ->append('\\', $file->getRelativePathname())
-                        ->replace('*', $subPath)
+                        ->replace('*', $variableNamespace)
                         ->replace(['/', '.php'], ['\\', '']);
                 })
                 ->filter(fn (string $class): bool => is_subclass_of($class, $baseClass) && (! (new ReflectionClass($class))->isAbstract()))


### PR DESCRIPTION
Many Laravels developers implement modularity in their apps using packages like https://github.com/nWidart/laravel-modules or manually by special folders structure (like me).

Assuming structure like this:
`app/Modules/ModuleName/*` 
I would like to have a dedicated folder for Filament:
`app/Modules/ModuleName/Filament/*` 

It is possible to achieve this in Laravel Nova using a provider `Nova::resourcesIn(app_path('Modules/*/Nova'))`.

Filament allows only manual registering resource classes using the `register` config.

This PR provides auto wildcard registering:

```php
'resources' => [
    'namespace' => 'App\\Modules\\*\\Filament\\Resources',
    'path' => app_path('Modules/*/Filament/Resources'),
    'register' => [ ],
],
```

Implementing a wildcard is tricky only for namespace because `allFiles` method under a hood uses the native `glob` so no tweaking is needed. 
