### PR TITLE
fix: remove padding when sidebar is collapsed

### DIFF
--- a/packages/admin/resources/views/components/layouts/app.blade.php
+++ b/packages/admin/resources/views/components/layouts/app.blade.php
@@ -18,9 +18,10 @@
         @if (config('filament.layout.sidebar.is_collapsible_on_desktop'))
             <div
                 x-data="{}"
-                class="flex-col flex-1 hidden w-screen h-full space-y-6 transition-all filament-main lg:pl-[var(--sidebar-width)] rtl:lg:pl-0 rtl:lg:pr-[var(--sidebar-width)]"
+                class="flex-col flex-1 hidden w-screen h-full space-y-6 transition-all filament-main rtl:lg:pl-0"
                 x-bind:class="{
-                    'lg:pl-[5.4rem] rtl:lg:pr-[5.4rem]': ! $store.sidebar.isOpen
+                    'lg:pl-[5.4rem] rtl:lg:pr-[5.4rem]': ! $store.sidebar.isOpen,
+                    'lg:pl-[var(--sidebar-width)] rtl:lg:pr-[var(--sidebar-width)]': $store.sidebar.isOpen,
                 }"
                 x-bind:style="'display: flex'" {{-- Mimics `x-cloak`, as using `x-cloak` causes visual issues with chart widgets --}}
             >


### PR DESCRIPTION
I'm not sure why, but when using a custom theme, the class order is different and the padding using `--sidebar-width` has priority over the other one, which causes the layout to not shift when we collapse the sidebar.

![image](https://user-images.githubusercontent.com/16060559/185147922-3547a750-3835-4a24-9ba0-602b22240f42.png)

I figured that instead of debugging why would the class order change, I'd just fix the template. So this PR removes the padding that uses `--sidebar-width` when the sidebar is collapsed.
