### PR TITLE
Allow Toggle Field to have different onColor & offColor

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -766,6 +766,16 @@ Toggle::make('is_admin')
     ->offIcon('heroicon-s-user')
 ```
 
+You may also customize the color representing each state. These may be either `primary`, `secondary`, `success`, `warning` or `danger`:
+
+```php
+use Filament\Forms\Components\Toggle;
+
+Toggle::make('is_admin')
+    ->onColor('success')
+    ->offColor('danger')
+```
+
 ![](https://user-images.githubusercontent.com/41773797/147613184-9086c102-ad71-4c4e-9170-9a4201a80c66.png)
 
 If you're saving the boolean value using Eloquent, you should be sure to add a `boolean` [cast](https://laravel.com/docs/eloquent-mutators#attribute-casting) to the model property:

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -1,3 +1,21 @@
+@php
+    $offColorClass = match ($getOffColor()) {
+        'danger' => 'bg-danger-500',
+        'primary' => 'bg-primary-500',
+        'success' => 'bg-success-500',
+        'warning' => 'bg-warning-500',
+        default => 'bg-gray-200',
+    };
+
+     $onColorClass = match ($getOnColor()) {
+        'danger' => 'bg-danger-500',
+        'primary' => 'bg-primary-500',
+        'success' => 'bg-success-500',
+        'warning' => 'bg-warning-500',
+        default => 'bg-primary-600',
+    };
+@endphp
+
 <x-dynamic-component
     :component="$getFieldWrapperView()"
     :id="$getId()"
@@ -19,8 +37,8 @@
                 x-bind:aria-checked="state.toString()"
                 x-on:click="state = ! state"
                 x-bind:class="{
-                    'bg-primary-600': state,
-                    'bg-gray-200 @if (config('forms.dark_mode')) dark:bg-white/10 @endif': ! state,
+                    '{{$onColorClass}}': state,
+                    '{{$offColorClass}} @if (config('forms.dark_mode')) dark:bg-white/10 @endif': ! state,
                 }"
                 {!! $isAutofocused() ? 'autofocus' : null !!}
                 {!! $isDisabled() ? 'disabled' : null !!}

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -19,20 +19,20 @@
                 x-bind:aria-checked="state.toString()"
                 x-on:click="state = ! state"
                 x-bind:class="{
-                    '{{match ($getOnColor()) {
+                    '{{ match ($getOnColor()) {
                         'danger' => 'bg-danger-500',
                         'primary' => 'bg-primary-500',
                         'success' => 'bg-success-500',
                         'warning' => 'bg-warning-500',
                         default => 'bg-primary-600',
-                    }}}': state,
-                    '{{match ($getOffColor()) {
+                    } }}': state,
+                    '{{ match ($getOffColor()) {
                         'danger' => 'bg-danger-500',
                         'primary' => 'bg-primary-500',
                         'success' => 'bg-success-500',
                         'warning' => 'bg-warning-500',
                         default => 'bg-gray-200',
-                    }}} @if (config('forms.dark_mode')) dark:bg-white/10 @endif': ! state,
+                    } }} @if (config('forms.dark_mode')) dark:bg-white/10 @endif': ! state,
                 }"
                 {!! $isAutofocused() ? 'autofocus' : null !!}
                 {!! $isDisabled() ? 'disabled' : null !!}

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -21,7 +21,7 @@
                 x-bind:class="{
                     '{{ match ($getOnColor()) {
                         'danger' => 'bg-danger-500',
-                        'primary' => 'bg-primary-500',
+                        'secondary' => 'bg-gray-500',
                         'success' => 'bg-success-500',
                         'warning' => 'bg-warning-500',
                         default => 'bg-primary-600',

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -1,21 +1,3 @@
-@php
-    $offColorClass = match ($getOffColor()) {
-        'danger' => 'bg-danger-500',
-        'primary' => 'bg-primary-500',
-        'success' => 'bg-success-500',
-        'warning' => 'bg-warning-500',
-        default => 'bg-gray-200',
-    };
-
-     $onColorClass = match ($getOnColor()) {
-        'danger' => 'bg-danger-500',
-        'primary' => 'bg-primary-500',
-        'success' => 'bg-success-500',
-        'warning' => 'bg-warning-500',
-        default => 'bg-primary-600',
-    };
-@endphp
-
 <x-dynamic-component
     :component="$getFieldWrapperView()"
     :id="$getId()"
@@ -37,8 +19,20 @@
                 x-bind:aria-checked="state.toString()"
                 x-on:click="state = ! state"
                 x-bind:class="{
-                    '{{$onColorClass}}': state,
-                    '{{$offColorClass}} @if (config('forms.dark_mode')) dark:bg-white/10 @endif': ! state,
+                    '{{match ($getOnColor()) {
+                        'danger' => 'bg-danger-500',
+                        'primary' => 'bg-primary-500',
+                        'success' => 'bg-success-500',
+                        'warning' => 'bg-warning-500',
+                        default => 'bg-primary-600',
+                    }}}': state,
+                    '{{match ($getOffColor()) {
+                        'danger' => 'bg-danger-500',
+                        'primary' => 'bg-primary-500',
+                        'success' => 'bg-success-500',
+                        'warning' => 'bg-warning-500',
+                        default => 'bg-gray-200',
+                    }}} @if (config('forms.dark_mode')) dark:bg-white/10 @endif': ! state,
                 }"
                 {!! $isAutofocused() ? 'autofocus' : null !!}
                 {!! $isDisabled() ? 'disabled' : null !!}

--- a/packages/forms/src/Components/Toggle.php
+++ b/packages/forms/src/Components/Toggle.php
@@ -88,18 +88,8 @@ class Toggle extends Field
         return (bool) $this->getOffIcon();
     }
 
-    public function hasOffColor(): bool
-    {
-        return (bool) $this->getOffColor();
-    }
-
     public function hasOnIcon(): bool
     {
         return (bool) $this->getOnIcon();
-    }
-
-    public function hasOnColor(): bool
-    {
-        return (bool) $this->getOnColor();
     }
 }

--- a/packages/forms/src/Components/Toggle.php
+++ b/packages/forms/src/Components/Toggle.php
@@ -15,7 +15,11 @@ class Toggle extends Field
 
     protected string | Closure | null $offIcon = null;
 
+    protected string | Closure | null $offColor = null;
+
     protected string | Closure | null $onIcon = null;
+
+    protected string | Closure | null $onColor = null;
 
     protected function setUp(): void
     {
@@ -37,9 +41,24 @@ class Toggle extends Field
         return $this;
     }
 
+    public function offColor(string | Closure | null $color): static
+    {
+        $this->offColor = $color;
+
+        return $this;
+    }
+
+
     public function onIcon(string | Closure | null $icon): static
     {
         $this->onIcon = $icon;
+
+        return $this;
+    }
+
+    public function onColor(string | Closure | null $color): static
+    {
+        $this->onColor = $color;
 
         return $this;
     }
@@ -49,9 +68,19 @@ class Toggle extends Field
         return $this->evaluate($this->offIcon);
     }
 
+    public function getOffColor(): ?string
+    {
+        return $this->evaluate($this->offColor);
+    }
+
     public function getOnIcon(): ?string
     {
         return $this->evaluate($this->onIcon);
+    }
+
+    public function getOnColor(): ?string
+    {
+        return $this->evaluate($this->onColor);
     }
 
     public function hasOffIcon(): bool
@@ -59,8 +88,18 @@ class Toggle extends Field
         return (bool) $this->getOffIcon();
     }
 
+    public function hasOffColor(): bool
+    {
+        return (bool) $this->getOffColor();
+    }
+
     public function hasOnIcon(): bool
     {
         return (bool) $this->getOnIcon();
+    }
+
+    public function hasOnColor(): bool
+    {
+        return (bool) $this->getOnColor();
     }
 }


### PR DESCRIPTION
The `BooleanColumn` supports both icons and colors.

The toggle field only supports icons. This pull request adds he same functionality to the toggle that already exists on the boolean column

so now you would be able todo something like this:

```PHP
    Toggle::make('is_paid')
        ->onColor('success')
        ->offColor('danger')
        ->onIcon('heroicon-s-check')
        ->offIcon('heroicon-s-x'),
```