### PR TITLE
Fix restore page action bug

### DIFF
--- a/packages/tables/src/Actions/RestoreAction.php
+++ b/packages/tables/src/Actions/RestoreAction.php
@@ -46,7 +46,11 @@ class RestoreAction extends Action
             $this->success();
         });
 
-        $this->visible(static function (Model $record): bool {
+        $this->visible(static function (?Model $record): bool {
+            if (! $record) {
+                return false;
+            }
+
             if (! method_exists($record, 'trashed')) {
                 return false;
             }


### PR DESCRIPTION
Fixes #3364

A quick potential fix. For some reason, after the record is restored, the injected `$record` parameter into the `visible` helper method on the page action is `null`. Can take a deeper look soon if necessary.