### PR TITLE
Fix attach/associate action select translation

### DIFF
--- a/packages/support/resources/lang/ar/actions/associate.php
+++ b/packages/support/resources/lang/ar/actions/associate.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'السجلات',
                 ],
 

--- a/packages/support/resources/lang/ar/actions/attach.php
+++ b/packages/support/resources/lang/ar/actions/attach.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'سجلات',
                 ],
 

--- a/packages/support/resources/lang/cs/actions/associate.php
+++ b/packages/support/resources/lang/cs/actions/associate.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Záznamy',
+                'record_id' => [
+                    'label' => 'Záznam',
                 ],
 
             ],

--- a/packages/support/resources/lang/cs/actions/attach.php
+++ b/packages/support/resources/lang/cs/actions/attach.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Záznamy',
+                'record_id' => [
+                    'label' => 'Záznam',
                 ],
 
             ],

--- a/packages/support/resources/lang/de/actions/associate.php
+++ b/packages/support/resources/lang/de/actions/associate.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Einträge',
+                'record_id' => [
+                    'label' => 'Eintrag',
                 ],
 
             ],

--- a/packages/support/resources/lang/de/actions/attach.php
+++ b/packages/support/resources/lang/de/actions/attach.php
@@ -26,8 +26,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Einträge',
+                'record_id' => [
+                    'label' => 'Eintrag',
                 ],
 
             ],

--- a/packages/support/resources/lang/en/actions/associate.php
+++ b/packages/support/resources/lang/en/actions/associate.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Records',
+                'record_id' => [
+                    'label' => 'Record',
                 ],
 
             ],

--- a/packages/support/resources/lang/en/actions/attach.php
+++ b/packages/support/resources/lang/en/actions/attach.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Records',
+                'record_id' => [
+                    'label' => 'Record',
                 ],
 
             ],

--- a/packages/support/resources/lang/es/actions/associate.php
+++ b/packages/support/resources/lang/es/actions/associate.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Registros',
+                'record_id' => [
+                    'label' => 'Registro',
                 ],
 
             ],

--- a/packages/support/resources/lang/es/actions/attach.php
+++ b/packages/support/resources/lang/es/actions/attach.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Registros',
+                'record_id' => [
+                    'label' => 'Registro',
                 ],
 
             ],

--- a/packages/support/resources/lang/fa/actions/associate.php
+++ b/packages/support/resources/lang/fa/actions/associate.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'رکوردها',
                 ],
 

--- a/packages/support/resources/lang/fa/actions/attach.php
+++ b/packages/support/resources/lang/fa/actions/attach.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'رکوردها',
                 ],
 

--- a/packages/support/resources/lang/fr/actions/associate.php
+++ b/packages/support/resources/lang/fr/actions/associate.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'Enregistrements',
                 ],
 

--- a/packages/support/resources/lang/fr/actions/attach.php
+++ b/packages/support/resources/lang/fr/actions/attach.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Enregistrements',
+                'record_id' => [
+                    'label' => 'Enregistrement',
                 ],
 
             ],

--- a/packages/support/resources/lang/hi/actions/attach.php
+++ b/packages/support/resources/lang/hi/actions/attach.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'रिकार्ड्स',
                 ],
 

--- a/packages/support/resources/lang/hu/actions/associate.php
+++ b/packages/support/resources/lang/hu/actions/associate.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'Elemek',
                 ],
 

--- a/packages/support/resources/lang/hu/actions/attach.php
+++ b/packages/support/resources/lang/hu/actions/attach.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'Elemek',
                 ],
 

--- a/packages/support/resources/lang/hy/actions/associate.php
+++ b/packages/support/resources/lang/hy/actions/associate.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'Գրառումներ',
                 ],
 

--- a/packages/support/resources/lang/hy/actions/attach.php
+++ b/packages/support/resources/lang/hy/actions/attach.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'Գրառումներ',
                 ],
 

--- a/packages/support/resources/lang/id/actions/associate.php
+++ b/packages/support/resources/lang/id/actions/associate.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'Data',
                 ],
 

--- a/packages/support/resources/lang/id/actions/attach.php
+++ b/packages/support/resources/lang/id/actions/attach.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'Data',
                 ],
 

--- a/packages/support/resources/lang/it/actions/associate.php
+++ b/packages/support/resources/lang/it/actions/associate.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Records',
+                'record_id' => [
+                    'label' => 'Record',
                 ],
 
             ],

--- a/packages/support/resources/lang/it/actions/attach.php
+++ b/packages/support/resources/lang/it/actions/attach.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Records',
+                'record_id' => [
+                    'label' => 'Record',
                 ],
 
             ],

--- a/packages/support/resources/lang/ja/actions/associate.php
+++ b/packages/support/resources/lang/ja/actions/associate.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'レコード',
                 ],
 

--- a/packages/support/resources/lang/ja/actions/attach.php
+++ b/packages/support/resources/lang/ja/actions/attach.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'Records',
                 ],
 

--- a/packages/support/resources/lang/kh/actions/attach.php
+++ b/packages/support/resources/lang/kh/actions/attach.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'កំណត់ត្រា',
                 ],
 

--- a/packages/support/resources/lang/ko/actions/attach.php
+++ b/packages/support/resources/lang/ko/actions/attach.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => '기록',
                 ],
 

--- a/packages/support/resources/lang/ku/actions/attach.php
+++ b/packages/support/resources/lang/ku/actions/attach.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'تۆمارەکان',
                 ],
 

--- a/packages/support/resources/lang/ms/actions/attach.php
+++ b/packages/support/resources/lang/ms/actions/attach.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'Rekod',
                 ],
 

--- a/packages/support/resources/lang/my/actions/associate.php
+++ b/packages/support/resources/lang/my/actions/associate.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'မှတ်တမ်းများ',
                 ],
 

--- a/packages/support/resources/lang/my/actions/attach.php
+++ b/packages/support/resources/lang/my/actions/attach.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'မှတ်တမ်းများ',
                 ],
 

--- a/packages/support/resources/lang/nl/actions/associate.php
+++ b/packages/support/resources/lang/nl/actions/associate.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Records',
+                'record_id' => [
+                    'label' => 'Record',
                 ],
 
             ],

--- a/packages/support/resources/lang/nl/actions/attach.php
+++ b/packages/support/resources/lang/nl/actions/attach.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Records',
+                'record_id' => [
+                    'label' => 'Record',
                 ],
 
             ],

--- a/packages/support/resources/lang/pl/actions/associate.php
+++ b/packages/support/resources/lang/pl/actions/associate.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Rekordy',
+                'record_id' => [
+                    'label' => 'Rekord',
                 ],
 
             ],

--- a/packages/support/resources/lang/pl/actions/attach.php
+++ b/packages/support/resources/lang/pl/actions/attach.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Rekordy',
+                'record_id' => [
+                    'label' => 'Rekord',
                 ],
 
             ],

--- a/packages/support/resources/lang/pt_BR/actions/attach.php
+++ b/packages/support/resources/lang/pt_BR/actions/attach.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Registros',
+                'record_id' => [
+                    'label' => 'Registro',
                 ],
 
             ],

--- a/packages/support/resources/lang/pt_PT/actions/attach.php
+++ b/packages/support/resources/lang/pt_PT/actions/attach.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Registos',
+                'record_id' => [
+                    'label' => 'Registo',
                 ],
 
             ],

--- a/packages/support/resources/lang/ro/actions/associate.php
+++ b/packages/support/resources/lang/ro/actions/associate.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Înregistrări',
+                'record_id' => [
+                    'label' => 'Înregistrare',
                 ],
 
             ],

--- a/packages/support/resources/lang/ro/actions/attach.php
+++ b/packages/support/resources/lang/ro/actions/attach.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Înregistrări',
+                'record_id' => [
+                    'label' => 'Înregistrare',
                 ],
 
             ],

--- a/packages/support/resources/lang/ru/actions/associate.php
+++ b/packages/support/resources/lang/ru/actions/associate.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Записи',
+                'record_id' => [
+                    'label' => 'Запись',
                 ],
 
             ],

--- a/packages/support/resources/lang/ru/actions/attach.php
+++ b/packages/support/resources/lang/ru/actions/attach.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Записи',
+                'record_id' => [
+                    'label' => 'Запись',
                 ],
 
             ],

--- a/packages/support/resources/lang/sv/actions/associate.php
+++ b/packages/support/resources/lang/sv/actions/associate.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'Rader',
                 ],
 

--- a/packages/support/resources/lang/sv/actions/attach.php
+++ b/packages/support/resources/lang/sv/actions/attach.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'Rader',
                 ],
 

--- a/packages/support/resources/lang/tr/actions/associate.php
+++ b/packages/support/resources/lang/tr/actions/associate.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Kayıtlar',
+                'record_id' => [
+                    'label' => 'Kayıt',
                 ],
 
             ],

--- a/packages/support/resources/lang/tr/actions/attach.php
+++ b/packages/support/resources/lang/tr/actions/attach.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Kayıtlar',
+                'record_id' => [
+                    'label' => 'Kayıt',
                 ],
 
             ],

--- a/packages/support/resources/lang/uk/actions/associate.php
+++ b/packages/support/resources/lang/uk/actions/associate.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Записи',
+                'record_id' => [
+                    'label' => 'Запись',
                 ],
 
             ],

--- a/packages/support/resources/lang/uk/actions/attach.php
+++ b/packages/support/resources/lang/uk/actions/attach.php
@@ -12,8 +12,8 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
-                    'label' => 'Записи',
+                'record_id' => [
+                    'label' => 'Запись',
                 ],
 
             ],

--- a/packages/support/resources/lang/vi/actions/associate.php
+++ b/packages/support/resources/lang/vi/actions/associate.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'Danh sách',
                 ],
 

--- a/packages/support/resources/lang/vi/actions/attach.php
+++ b/packages/support/resources/lang/vi/actions/attach.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => 'Danh sách',
                 ],
 

--- a/packages/support/resources/lang/zh_CN/actions/associate.php
+++ b/packages/support/resources/lang/zh_CN/actions/associate.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => '记录',
                 ],
 

--- a/packages/support/resources/lang/zh_CN/actions/attach.php
+++ b/packages/support/resources/lang/zh_CN/actions/attach.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => '记录',
                 ],
 

--- a/packages/support/resources/lang/zh_TW/actions/associate.php
+++ b/packages/support/resources/lang/zh_TW/actions/associate.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => '資料',
                 ],
 

--- a/packages/support/resources/lang/zh_TW/actions/attach.php
+++ b/packages/support/resources/lang/zh_TW/actions/attach.php
@@ -12,7 +12,7 @@ return [
 
             'fields' => [
 
-                'record_ids' => [
+                'record_id' => [
                     'label' => '資料',
                 ],
 


### PR DESCRIPTION
The attach/associate action select only selects a single value at a time and the translation key ends with `record_id`, but all translation files contain `record_ids`. (https://github.com/filamentphp/filament/blob/d4c5fb0b0fb15f1d625a452d5e6d7f7683ae0d11/packages/tables/src/Actions/AttachAction.php#L197)

I renamed and translated all languages that I could read and verify that the singular form resembles the plural form. For the others I just renamed the translation string as I think plural instead of singular is still better than a missing translation string.