### PR TITLE
update fa language

### DIFF
--- a/packages/support/resources/lang/fa/actions/associate.php
+++ b/packages/support/resources/lang/fa/actions/associate.php
@@ -13,7 +13,7 @@ return [
             'fields' => [
 
                 'record_id' => [
-                    'label' => 'رکوردها',
+                    'label' => 'رکورد',
                 ],
 
             ],

--- a/packages/support/resources/lang/fa/actions/attach.php
+++ b/packages/support/resources/lang/fa/actions/attach.php
@@ -13,7 +13,7 @@ return [
             'fields' => [
 
                 'record_id' => [
-                    'label' => 'رکوردها',
+                    'label' => 'رکورد',
                 ],
 
             ],

--- a/packages/support/resources/lang/fa/actions/edit.php
+++ b/packages/support/resources/lang/fa/actions/edit.php
@@ -4,11 +4,11 @@ return [
 
     'single' => [
 
-        'label' => 'اصلاح',
+        'label' => 'ویرایش',
 
         'modal' => [
 
-            'heading' => 'اصلاح :label',
+            'heading' => 'ویرایش :label',
 
             'actions' => [
 


### PR DESCRIPTION
update fa translation according to this PR https://github.com/filamentphp/filament/pull/3547
in associate.php and attach.php

in the edit translation, the word `اصلاح` is an Arabic word and in Farsi we usually use `ویرایش` instead.