### PR TITLE
feature: Configure UI icons with service provider

### DIFF
--- a/packages/tables/resources/views/components/filters/trigger.blade.php
+++ b/packages/tables/resources/views/components/filters/trigger.blade.php
@@ -1,5 +1,6 @@
 <x-tables::icon-button
-    icon="heroicon-o-filter"
+    icon="heroicon-s-filter"
+    color="secondary"
     x-on:click="$refs.popoverPanel.toggle"
     :label="__('tables::table.buttons.filter.label')"
     {{ $attributes->class(['filament-tables-filters-trigger']) }}

--- a/packages/tables/resources/views/components/toggleable/trigger.blade.php
+++ b/packages/tables/resources/views/components/toggleable/trigger.blade.php
@@ -1,5 +1,6 @@
 <x-tables::icon-button
-    icon="heroicon-o-view-boards"
+    icon="heroicon-s-view-boards"
+    color="secondary"
     x-on:click="$refs.toggleablePanel.toggle"
     :label="__('tables::table.buttons.toggle_columns.label')"
     {{ $attributes->class(['filament-tables-column-toggling-trigger']) }}


### PR DESCRIPTION
As Heroicons explains and Tailwind UI shows, the table filter and column toggle icons should use the 20px variants:

- https://tailwindui.com/components/ecommerce/components/category-filters#component-e799517f86cc2fc79bf0eebb45c16eea
- https://tailwindui.com/components/ecommerce/components/category-filters#component-8dbbe78f722647bcb452fab9ba8a3b9a

Also, I've updated the color to use the secondary color instead of primary, since they're not primary actions. Having a lot of buttons with the primary/CTA color is bad design practice.

## Screenshots

### Before

<img width="168" alt="Screen Shot 2022-08-19 at 11 40 45" src="https://user-images.githubusercontent.com/44533235/185591670-702a404c-c943-4a4f-a86e-05d4d50dce3f.png">


### After

<img width="168" alt="Screen Shot 2022-08-19 at 11 39 42" src="https://user-images.githubusercontent.com/44533235/185591613-977a6122-3a09-42ff-9d3c-dbaa87f9f419.png">

## Icons to consider

- Table filter trigger
- Table column toggle trigger
- Global search input
- Sidebar open button
- Dashboard page
- Pagination buttons
- Table column sort indicator
- Table search input
- User menu user item
- User menu dark mode toggle
- User menu light mode toggle
- User menu sign out button