### PR TITLE
Adding table bulk assertions for icon, label and color

### DIFF
--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -63,6 +63,18 @@ namespace Livewire\Testing {
 
         public function assertTableActionDoesNotHaveLabel(string $name, string $label): static {}
 
+        public function assertTableBulkActionHasIcon(string $name, string $icon): static {}
+
+        public function assertTableBulkActionDoesNotHaveIcon(string $name, string $icon): static {}
+
+        public function assertTableBulkActionHasLabel(string $name, string $label): static {}
+
+        public function assertTableBulkActionDoesNotHaveLabel(string $name, string $label): static {}
+
+        public function assertTableBulkActionHasColor(string $name, string $color): static {}
+
+        public function assertTableBulkActionDoesNotHaveColor(string $name, string $color): static {}
+
         public function assertTableBulkActionHeld(string $name): static {}
 
         public function assertHasTableBulkActionErrors(array $keys = []): static {}

--- a/packages/tables/src/Testing/TestsBulkActions.php
+++ b/packages/tables/src/Testing/TestsBulkActions.php
@@ -223,6 +223,126 @@ class TestsBulkActions
         };
     }
 
+    public function assertTableBulkActionHasIcon(): Closure
+    {
+        return function (string $name, string $icon, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableBulkActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $action = $livewire->getCachedTableBulkAction($name);
+
+            Assert::assertTrue(
+                $action->getIcon() === $icon,
+                "Failed asserting that a table bulk action with name [{$name}] has icon [{$icon}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableBulkActionDoesNotHaveIcon(): Closure
+    {
+        return function (string $name, string $icon, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableBulkActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $action = $livewire->getCachedTableBulkAction($name);
+
+            Assert::assertFalse(
+                $action->getIcon() === $icon,
+                "Failed asserting that a table bulk action with name [{$name}] does not have icon [{$icon}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableBulkActionHasLabel(): Closure
+    {
+        return function (string $name, string $label, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableBulkActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $action = $livewire->getCachedTableBulkAction($name);
+
+            Assert::assertTrue(
+                $action->getLabel() === $label,
+                "Failed asserting that a table action with name [{$name}] has label [{$label}] on the [{$livewireClass}] component for record [{$record}]."
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableBulkActionDoesNotHaveLabel(): Closure
+    {
+        return function (string $name, string $label, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableBulkActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $action = $livewire->getCachedTableBulkAction($name);
+
+            Assert::assertFalse(
+                $action->getLabel() === $label,
+                "Failed asserting that a table action with name [{$name}] does not have label [{$label}] on the [{$livewireClass}] component for record [{$record}]."
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableBulkActionHasColor(): Closure
+    {
+        return function (string $name, string $color, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableBulkActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $action = $livewire->getCachedTableBulkAction($name);
+
+            Assert::assertTrue(
+                $action->getColor() === $color,
+                "Failed asserting that a table action with name [{$name}] has color [{$color}] on the [{$livewireClass}] component for record [{$record}]."
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableBulkActionDoesNotHaveColor(): Closure
+    {
+        return function (string $name, string $color, $record = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableBulkActionExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $action = $livewire->getCachedTableBulkAction($name);
+
+            Assert::assertFalse(
+                $action->getColor() === $color,
+                "Failed asserting that a table action with name [{$name}] does not have color [{$color}] on the [{$livewireClass}] component for record [{$record}]."
+            );
+
+            return $this;
+        };
+    }
+
     public function assertTableBulkActionHeld(): Closure
     {
         return function (string $name): static {

--- a/packages/tables/src/Testing/TestsBulkActions.php
+++ b/packages/tables/src/Testing/TestsBulkActions.php
@@ -276,7 +276,7 @@ class TestsBulkActions
 
             Assert::assertTrue(
                 $action->getLabel() === $label,
-                "Failed asserting that a table action with name [{$name}] has label [{$label}] on the [{$livewireClass}] component for record [{$record}]."
+                "Failed asserting that a table bulk action with name [{$name}] has label [{$label}] on the [{$livewireClass}] component for record [{$record}]."
             );
 
             return $this;
@@ -296,7 +296,7 @@ class TestsBulkActions
 
             Assert::assertFalse(
                 $action->getLabel() === $label,
-                "Failed asserting that a table action with name [{$name}] does not have label [{$label}] on the [{$livewireClass}] component for record [{$record}]."
+                "Failed asserting that a table bulk action with name [{$name}] does not have label [{$label}] on the [{$livewireClass}] component for record [{$record}]."
             );
 
             return $this;
@@ -316,7 +316,7 @@ class TestsBulkActions
 
             Assert::assertTrue(
                 $action->getColor() === $color,
-                "Failed asserting that a table action with name [{$name}] has color [{$color}] on the [{$livewireClass}] component for record [{$record}]."
+                "Failed asserting that a table bulk action with name [{$name}] has color [{$color}] on the [{$livewireClass}] component for record [{$record}]."
             );
 
             return $this;
@@ -336,7 +336,7 @@ class TestsBulkActions
 
             Assert::assertFalse(
                 $action->getColor() === $color,
-                "Failed asserting that a table action with name [{$name}] does not have color [{$color}] on the [{$livewireClass}] component for record [{$record}]."
+                "Failed asserting that a table bulk action with name [{$name}] does not have color [{$color}] on the [{$livewireClass}] component for record [{$record}]."
             );
 
             return $this;

--- a/tests/src/Tables/BulkActionTest.php
+++ b/tests/src/Tables/BulkActionTest.php
@@ -104,4 +104,3 @@ it('can have a color', function () {
         ->assertTableBulkActionHasColor('has-color', 'primary')
         ->assertTableBulkActionDoesNotHaveColor('has-color', 'secondary');
 });
-

--- a/tests/src/Tables/BulkActionTest.php
+++ b/tests/src/Tables/BulkActionTest.php
@@ -86,3 +86,22 @@ it('can disable a bulk action', function () {
         ->assertTableBulkActionEnabled('enabled')
         ->assertTableBulkActionDisabled('disabled');
 });
+
+it('can have an icon', function () {
+    livewire(PostsTable::class)
+        ->assertTableBulkActionHasIcon('has-icon', 'heroicon-s-pencil')
+        ->assertTableBulkActionDoesNotHaveIcon('has-icon', 'heroicon-o-trash');
+});
+
+it('can have a label', function () {
+    livewire(PostsTable::class)
+        ->assertTableBulkActionHasLabel('has-label', 'My Action')
+        ->assertTableBulkActionDoesNotHaveLabel('has-label', 'My Other Action');
+});
+
+it('can have a color', function () {
+    livewire(PostsTable::class)
+        ->assertTableBulkActionHasColor('has-color', 'primary')
+        ->assertTableBulkActionDoesNotHaveColor('has-color', 'secondary');
+});
+

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -116,6 +116,12 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
             Tables\Actions\BulkAction::make('enabled'),
             Tables\Actions\BulkAction::make('disabled')
                 ->disabled(),
+            Tables\Actions\BulkAction::make('has-icon')
+                ->icon('heroicon-s-pencil'),
+            Tables\Actions\BulkAction::make('has-label')
+                ->label('My Action'),
+            Tables\Actions\BulkAction::make('has-color')
+                ->color('primary'),
         ];
     }
 


### PR DESCRIPTION
```
assertTableBulkActionHasIcon(string $name, string $icon)
assertTableBulkActionDoesNotHaveIcon(string $name, string $icon)
assertTableBulkActionHasLabel(string $name, string $label)
assertTableBulkActionDoesNotHaveLabel(string $name, string $label)
assertTableBulkActionHasColor(string $name, string $color)
assertTableBulkActionDoesNotHaveColor(string $name, string $color)
```