### PR TITLE
Prevent lazy and debounce modifiers on entangled fields

### DIFF
--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -42,11 +42,7 @@
                 @else
                     x-data="textInputFormComponent({
                         {{ $hasMask() ? "getMaskOptionsUsing: (IMask) => ({$getJsonMaskConfiguration()})," : null }}
-                        state: $wire.{{
-                            $isLazy() ?
-                                'entangle(\'' . $getStatePath() . '\').defer' :
-                                $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')')
-                        }},
+                        state: $wire.{{ $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')') }},
                     })"
                     type="text"
                     wire:ignore

--- a/packages/forms/src/Concerns/HasStateBindingModifiers.php
+++ b/packages/forms/src/Concerns/HasStateBindingModifiers.php
@@ -41,6 +41,10 @@ trait HasStateBindingModifiers
     public function applyStateBindingModifiers(string $expression): string
     {
         $modifiers = $this->getStateBindingModifiers();
+        
+        if(str_starts_with($expression, 'entangle') && (in_array('lazy', $modifiers) || in_array('debounce', $modifiers))) {
+            $modifiers = ['defer'];
+        }
 
         return implode('.', array_merge([$expression], $modifiers));
     }

--- a/packages/forms/src/Concerns/HasStateBindingModifiers.php
+++ b/packages/forms/src/Concerns/HasStateBindingModifiers.php
@@ -41,8 +41,8 @@ trait HasStateBindingModifiers
     public function applyStateBindingModifiers(string $expression): string
     {
         $modifiers = $this->getStateBindingModifiers();
-        
-        if(str_starts_with($expression, 'entangle') && (in_array('lazy', $modifiers) || in_array('debounce', $modifiers))) {
+
+        if (str_starts_with($expression, 'entangle') && (in_array('lazy', $modifiers) || in_array('debounce', $modifiers))) {
             $modifiers = ['defer'];
         }
 

--- a/packages/forms/src/Concerns/HasStateBindingModifiers.php
+++ b/packages/forms/src/Concerns/HasStateBindingModifiers.php
@@ -3,6 +3,7 @@
 namespace Filament\Forms\Concerns;
 
 use Filament\Forms\Components\Component;
+use Illuminate\Support\Str;
 
 trait HasStateBindingModifiers
 {
@@ -42,8 +43,8 @@ trait HasStateBindingModifiers
     {
         $modifiers = $this->getStateBindingModifiers();
 
-        if (str_starts_with($expression, 'entangle') && (in_array('lazy', $modifiers) || in_array('debounce', $modifiers))) {
-            $modifiers = ['defer'];
+        if (Str::of($expression)->contains('entangle') && ($this->isLazy() || $this->getDebounce())) {
+            $modifiers = [];
         }
 
         return implode('.', array_merge([$expression], $modifiers));
@@ -55,8 +56,8 @@ trait HasStateBindingModifiers
             return $this->stateBindingModifiers;
         }
 
-        if ($this->debounce) {
-            return ['debounce', $this->debounce];
+        if ($debounce = $this->getDebounce()) {
+            return ['debounce', $debounce];
         }
 
         if ($this instanceof Component) {


### PR DESCRIPTION
The current implementation allows the user to add `lazy` and `debounce` modifiers to `entangled` fields, thus breaking functionality.
( Did it myself, added lazy to a toggle and wondered why Alpine complained about an undefined value)
This PR fixes that.

With this we also can remove the isLazy() check, on text-input and forget about it on future fields.