### PR TITLE
Make collapsible repeater headers clickable

### DIFF
--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -72,7 +72,7 @@
                         >
                             @if ((! $isItemMovementDisabled) || (! $isItemDeletionDisabled) || $isCloneable || $isCollapsible || $hasItemLabels)
                                 <header
-                                    @if($isCollapsible) x-on:click.stop="isCollapsed = ! isCollapsed" @endif
+                                    @if ($isCollapsible) x-on:click.stop="isCollapsed = ! isCollapsed" @endif
                                     @class([
                                         'flex items-center h-10 overflow-hidden border-b bg-gray-50 rounded-t-xl',
                                         'dark:bg-gray-800 dark:border-gray-700' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -71,12 +71,17 @@
                             ])
                         >
                             @if ((! $isItemMovementDisabled) || (! $isItemDeletionDisabled) || $isCloneable || $isCollapsible || $hasItemLabels)
-                                <header @class([
-                                    'flex items-center h-10 overflow-hidden border-b bg-gray-50 rounded-t-xl',
-                                    'dark:bg-gray-800 dark:border-gray-700' => config('forms.dark_mode'),
-                                ])>
+                                <header
+                                    @if($isCollapsible) x-on:click.stop="isCollapsed = ! isCollapsed" @endif
+                                    @class([
+                                        'flex items-center h-10 overflow-hidden border-b bg-gray-50 rounded-t-xl',
+                                        'dark:bg-gray-800 dark:border-gray-700' => config('forms.dark_mode'),
+                                        'cursor-pointer' => $isCollapsible,
+                                    ])
+                                >
                                     @unless ($isItemMovementDisabled)
                                         <button
+                                            x-on:click.stop
                                             wire:sortable.handle
                                             wire:keydown.prevent.arrow-up="dispatchFormEvent('repeater::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
                                             wire:keydown.prevent.arrow-down="dispatchFormEvent('repeater::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
@@ -129,7 +134,7 @@
                                         @unless ($isItemDeletionDisabled)
                                             <li>
                                                 <button
-                                                    wire:click="dispatchFormEvent('repeater::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                    wire:click.stop="dispatchFormEvent('repeater::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
                                                     type="button"
                                                     @class([
                                                         'flex items-center justify-center flex-none w-10 h-10 text-danger-600 transition hover:text-danger-500',
@@ -148,7 +153,7 @@
                                         @if ($isCollapsible)
                                             <li>
                                                 <button
-                                                    x-on:click="isCollapsed = ! isCollapsed"
+                                                    x-on:click.stop="isCollapsed = ! isCollapsed"
                                                     type="button"
                                                     @class([
                                                         'flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-300',


### PR DESCRIPTION
Just like Sections, it is nicer UX if the Repeaters header is clickable to collapse/expand the content.