### PR TITLE
Add table actions column label helper

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -4,6 +4,7 @@
 
     $actions = $getActions();
     $actionsPosition = $getActionsPosition();
+    $actionsColumnLabel = $getActionsColumnLabel();
     $columns = $getColumns();
     $content = $getContent();
     $contentFooter = $getContentFooter();

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -406,7 +406,15 @@
                             @endforeach
 
                             @if (count($actions) && (! $isReordering) && $actionsPosition === Position::AfterCells)
-                                <th class="w-5">{{ $actionsColumnLabel }}</th>
+                                @if($actionsColumnLabel)
+                                    <x-tables::header-cell
+                                        alignment="right"
+                                    >
+                                        {{ $actionsColumnLabel }}
+                                    </x-tables::header-cell>
+                                @else
+                                    <th class="w-5"></th>
+                                @endif
                             @endif
                         </x-slot>
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -363,7 +363,7 @@
                                 <th></th>
                             @else
                                 @if (count($actions) && $actionsPosition === Position::BeforeCells)
-                                    @if( $actionsColumnLabel)
+                                    @if ($actionsColumnLabel)
                                         <x-tables::header-cell alignment="right">
                                             {{ $actionsColumnLabel }}
                                         </x-tables::header-cell>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -406,7 +406,7 @@
                             @endforeach
 
                             @if (count($actions) && (! $isReordering) && $actionsPosition === Position::AfterCells)
-                                <th class="w-5"></th>
+                                <th class="w-5">{{ $actionsColumnLabel }}</th>
                             @endif
                         </x-slot>
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -363,7 +363,13 @@
                                 <th></th>
                             @else
                                 @if (count($actions) && $actionsPosition === Position::BeforeCells)
-                                    <th class="w-5"></th>
+                                    @if($actionsColumnLabel)
+                                        <x-tables::header-cell alignment="right">
+                                            {{ $actionsColumnLabel }}
+                                        </x-tables::header-cell>
+                                    @else
+                                        <th class="w-5"></th>
+                                    @endif
                                 @endif
 
                                 @if ($isSelectionEnabled)
@@ -387,7 +393,13 @@
                                 @endif
 
                                 @if (count($actions) && $actionsPosition === Position::BeforeColumns)
-                                    <th class="w-5"></th>
+                                    @if($actionsColumnLabel)
+                                        <x-tables::header-cell alignment="right">
+                                            {{ $actionsColumnLabel }}
+                                        </x-tables::header-cell>
+                                    @else
+                                        <th class="w-5"></th>
+                                    @endif
                                 @endif
                             @endif
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -363,7 +363,7 @@
                                 <th></th>
                             @else
                                 @if (count($actions) && $actionsPosition === Position::BeforeCells)
-                                    @if($actionsColumnLabel)
+                                    @if( $actionsColumnLabel)
                                         <x-tables::header-cell alignment="right">
                                             {{ $actionsColumnLabel }}
                                         </x-tables::header-cell>
@@ -393,7 +393,7 @@
                                 @endif
 
                                 @if (count($actions) && $actionsPosition === Position::BeforeColumns)
-                                    @if($actionsColumnLabel)
+                                    @if ($actionsColumnLabel)
                                         <x-tables::header-cell alignment="right">
                                             {{ $actionsColumnLabel }}
                                         </x-tables::header-cell>
@@ -418,7 +418,7 @@
                             @endforeach
 
                             @if (count($actions) && (! $isReordering) && $actionsPosition === Position::AfterCells)
-                                @if($actionsColumnLabel)
+                                @if ($actionsColumnLabel)
                                     <x-tables::header-cell alignment="right">
                                         {{ $actionsColumnLabel }}
                                     </x-tables::header-cell>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -407,9 +407,7 @@
 
                             @if (count($actions) && (! $isReordering) && $actionsPosition === Position::AfterCells)
                                 @if($actionsColumnLabel)
-                                    <x-tables::header-cell
-                                        alignment="right"
-                                    >
+                                    <x-tables::header-cell alignment="right">
                                         {{ $actionsColumnLabel }}
                                     </x-tables::header-cell>
                                 @else

--- a/packages/tables/src/Concerns/HasActions.php
+++ b/packages/tables/src/Concerns/HasActions.php
@@ -247,4 +247,9 @@ trait HasActions
     {
         return null;
     }
+
+    protected function getTableActionsColumnLabel(): ?string
+    {
+        return null;
+    }
 }

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -50,6 +50,14 @@ class Table extends ViewComponent
         return invade($livewire)->getTableActionsPosition() ?? Position::AfterCells;
     }
 
+    public function getActionsColumnLabel(): ?string
+    {
+        /** @var TableComponent $livewire */
+        $livewire = $this->getLivewire();
+
+        return invade($livewire)->getTableActionsColumnLabel();
+    }
+
     public function getAllRecordsCount(): int
     {
         return $this->getLivewire()->getAllTableRecordsCount();


### PR DESCRIPTION
## Abstract

As discussed in Discord, this PR adds a way to add labels to the action table columns header. This is my first Filament PR so I hope I did everything right here, if not, let me know!

## Implementation 

### Backend
The feature is implemented through a protected method `getTableActionsColumnLabel()` in the `HasActions` trait. This is then accessed in the Table DTO, then constructed and rendered in the table Blade file.

### Frontend
In the view, an if-else condition is made to see if the label is set. If it is, it is rendered through the `header-cell` component, making it have the same styling as the other headers. If no label is set, it defaults to the current behaviour, making it fully backwards compatible.

## Usage

To add a action column header label, simply implement the following method stub in your table class.

```php
protected function getTableActionsColumnLabel(): ?string
{
    return 'My label';
}
```

It will then automatically be rendered in the view. All very Filamenty!

![image](https://user-images.githubusercontent.com/95144705/186205262-d0f0987b-ab17-4bed-9dde-0c46a1af9fcf.png)
