### PR TITLE
Fix wire:ignore fields: Change border colors on validation errors

### DIFF
--- a/packages/admin/resources/views/components/form/index.blade.php
+++ b/packages/admin/resources/views/components/form/index.blade.php
@@ -1,10 +1,5 @@
 <form
-    x-data="{
-        isUploadingFile: false,
-        get validationErrors() {
-            return $wire.__instance.serverMemo.errors
-        }
-    }"
+    x-data="{ isUploadingFile: false }"
     x-on:submit="if (isUploadingFile) $event.preventDefault()"
     x-on:file-upload-started="isUploadingFile = true"
     x-on:file-upload-finished="isUploadingFile = false"

--- a/packages/admin/resources/views/components/form/index.blade.php
+++ b/packages/admin/resources/views/components/form/index.blade.php
@@ -1,5 +1,10 @@
 <form
-    x-data="{ isUploadingFile: false }"
+    x-data="{
+        isUploadingFile: false,
+        get validationErrors() {
+            return $wire.__instance.serverMemo.errors
+        }
+    }"
     x-on:submit="if (isUploadingFile) $event.preventDefault()"
     x-on:file-upload-started="isUploadingFile = true"
     x-on:file-upload-finished="isUploadingFile = false"

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -219,9 +219,9 @@
                         class="tracking-normal overflow-y-hidden font-mono block absolute bg-transparent top-0 text-sm left-0 block z-1 w-full h-full min-h-full resize-none transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600 caret-black"
                         x-bind:class="{
                             'dark:caret-white dark:focus:border-primary-600': @js(config('forms.dark_mode')),
-                            'border-gray-300': ! (@js($getStatePath()) in validationErrors),
-                            'dark:border-gray-600': ! (@js($getStatePath()) in validationErrors) && @js(config('forms.dark_mode')),
-                            'border-danger-600 ring-danger-600': @js($getStatePath()) in validationErrors,
+                            'border-gray-300': ! (@js($getStatePath()) in $wire.__instance.serverMemo.errors),
+                            'dark:border-gray-600': ! (@js($getStatePath()) in $wire.__instance.serverMemo.errors) && @js(config('forms.dark_mode')),
+                            'border-danger-600 ring-danger-600': @js($getStatePath()) in $wire.__instance.serverMemo.errors,
                         }"
                     ></textarea>
                 </file-attachment>

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -216,13 +216,13 @@
                         @if (! $isConcealed())
                             {!! $isRequired() ? 'required' : null !!}
                         @endif
-                        @class([
-                            'tracking-normal overflow-y-hidden font-mono block absolute bg-transparent top-0 text-sm left-0 block z-1 w-full h-full min-h-full resize-none transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600 caret-black',
-                            'dark:caret-white dark:focus:border-primary-600' => config('forms.dark_mode'),
-                            'border-gray-300' => ! $errors->has($getStatePath()),
-                            'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
-                            'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
-                        ])
+                        class="tracking-normal overflow-y-hidden font-mono block absolute bg-transparent top-0 text-sm left-0 block z-1 w-full h-full min-h-full resize-none transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600 caret-black"
+                        x-bind:class="{
+                            'dark:caret-white dark:focus:border-primary-600': @js(config('forms.dark_mode')),
+                            'border-gray-300': ! (@js($getStatePath()) in validationErrors),
+                            'dark:border-gray-600': ! (@js($getStatePath()) in validationErrors) && @js(config('forms.dark_mode')),
+                            'border-danger-600 ring-danger-600': @js($getStatePath()) in validationErrors,
+                        }"
                     ></textarea>
                 </file-attachment>
 

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -297,10 +297,12 @@
                 {{ $getExtraInputAttributeBag()->class([
                     'bg-white block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600 prose max-w-none break-words',
                     'dark:prose-invert dark:bg-gray-700 dark:focus:border-primary-600' => config('forms.dark_mode'),
-                    'border-gray-300' => ! $errors->has($getStatePath()),
-                    'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
-                    'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
                 ]) }}
+                x-bind:class="{
+                    'border-gray-300': ! (@js($getStatePath()) in validationErrors),
+                    'dark:border-gray-600': ! (@js($getStatePath()) in validationErrors) && @js(config('forms.dark_mode')),
+                    'border-danger-600 ring-danger-600': (@js($getStatePath()) in validationErrors),
+                }"
             ></trix-editor>
         @else
             <div x-html="state" @class([

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -299,9 +299,9 @@
                     'dark:prose-invert dark:bg-gray-700 dark:focus:border-primary-600' => config('forms.dark_mode'),
                 ]) }}
                 x-bind:class="{
-                    'border-gray-300': ! (@js($getStatePath()) in validationErrors),
-                    'dark:border-gray-600': ! (@js($getStatePath()) in validationErrors) && @js(config('forms.dark_mode')),
-                    'border-danger-600 ring-danger-600': (@js($getStatePath()) in validationErrors),
+                    'border-gray-300': ! (@js($getStatePath()) in $wire.__instance.serverMemo.errors),
+                    'dark:border-gray-600': ! (@js($getStatePath()) in $wire.__instance.serverMemo.errors) && @js(config('forms.dark_mode')),
+                    'border-danger-600 ring-danger-600': (@js($getStatePath()) in $wire.__instance.serverMemo.errors),
                 }"
             ></trix-editor>
         @else

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -1,27 +1,6 @@
 <div
     @if ($isCollapsible())
-        x-data="{
-            isCollapsed: @js($isCollapsed()),
-            get containsErrors() {
-                return $el.getElementsByClassName('filament-forms-field-wrapper-error-message')[0] ? true : false
-            },
-            toggle() {
-                if(this.containsErrors && ! this.isCollapsed) {
-                    return
-                }
-
-                this.isCollapsed = ! this.isCollapsed
-
-                if (this.isCollapsed) {
-                    return
-                }
-
-                setTimeout(
-                    () => $el.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'start' }),
-                    100,
-                )
-            }
-         }"
+        x-data="{ isCollapsed: {{ $isCollapsed() ? 'true' : 'false' }} }"
         x-on:open-form-section.window="if ($event.detail.id == $el.id) isCollapsed = false"
         x-on:collapse-form-section.window="if ($event.detail.id == $el.id) isCollapsed = true"
         x-on:toggle-form-section.window="if ($event.detail.id == $el.id) isCollapsed = ! isCollapsed"
@@ -30,8 +9,6 @@
                 isCollapsed = false
 
                 setTimeout(() => $el.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'start' }), 100)
-            } else {
-               isCollapsed = !containsErrors ?? isCollapsed
             }
         "
     @endif
@@ -49,7 +26,18 @@
         ])
         @if ($isCollapsible())
             x-bind:class="{ 'rounded-b-xl': isCollapsed }"
-            x-on:click="toggle()"
+            x-on:click="
+                isCollapsed = ! isCollapsed
+
+                if (isCollapsed) {
+                    return
+                }
+
+                setTimeout(
+                    () => $el.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'start' }),
+                    100,
+                )
+            "
         @endif
     >
         <div
@@ -70,7 +58,7 @@
         </div>
 
         @if ($isCollapsible())
-            <button x-on:click.stop="toggle()"
+            <button x-on:click.stop="isCollapsed = ! isCollapsed"
                 x-bind:class="{
                     '-rotate-180': !isCollapsed,
                 }" type="button"

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -1,14 +1,37 @@
 <div
     @if ($isCollapsible())
-        x-data="{ isCollapsed: {{ $isCollapsed() ? 'true' : 'false' }} }"
+        x-data="{
+            isCollapsed: @js($isCollapsed()),
+            get containsErrors() {
+                return $el.getElementsByClassName('filament-forms-field-wrapper-error-message')[0] ? true : false
+            },
+            toggle() {
+                if(this.containsErrors && ! this.isCollapsed) {
+                    return
+                }
+
+                this.isCollapsed = ! this.isCollapsed
+
+                if (this.isCollapsed) {
+                    return
+                }
+
+                setTimeout(
+                    () => $el.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'start' }),
+                    100,
+                )
+            }
+         }"
         x-on:open-form-section.window="if ($event.detail.id == $el.id) isCollapsed = false"
         x-on:collapse-form-section.window="if ($event.detail.id == $el.id) isCollapsed = true"
         x-on:toggle-form-section.window="if ($event.detail.id == $el.id) isCollapsed = ! isCollapsed"
         x-on:expand-concealing-component.window="
             if ($event.detail.id === $el.id) {
                 isCollapsed = false
-                
+
                 setTimeout(() => $el.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'start' }), 100)
+            } else {
+               isCollapsed = !containsErrors ?? isCollapsed
             }
         "
     @endif
@@ -26,18 +49,7 @@
         ])
         @if ($isCollapsible())
             x-bind:class="{ 'rounded-b-xl': isCollapsed }"
-            x-on:click="
-                isCollapsed = ! isCollapsed
-                
-                if (isCollapsed) {
-                    return
-                }
-                
-                setTimeout(
-                    () => $el.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'start' }),
-                    100,
-                )
-            "
+            x-on:click="toggle()"
         @endif
     >
         <div
@@ -58,7 +70,7 @@
         </div>
 
         @if ($isCollapsible())
-            <button x-on:click.stop="isCollapsed = ! isCollapsed"
+            <button x-on:click.stop="toggle()"
                 x-bind:class="{
                     '-rotate-180': !isCollapsed,
                 }" type="button"

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -69,10 +69,12 @@
                 {{ $getExtraInputAttributeBag()->class([
                     'block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600 disabled:opacity-70',
                     'dark:bg-gray-700 dark:text-white dark:focus:border-primary-600' => config('forms.dark_mode'),
-                    'border-gray-300' => ! $errors->has($getStatePath()),
-                    'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
-                    'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),
                 ]) }}
+                x-bind:class="{
+                    'border-gray-300': ! (@js($getStatePath()) in validationErrors),
+                    'dark:border-gray-600': ! (@js($getStatePath()) in validationErrors) && @js(config('forms.dark_mode')),
+                    'border-danger-600 ring-danger-600': (@js($getStatePath()) in validationErrors),
+                }"
             />
         </div>
 

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -71,9 +71,9 @@
                     'dark:bg-gray-700 dark:text-white dark:focus:border-primary-600' => config('forms.dark_mode'),
                 ]) }}
                 x-bind:class="{
-                    'border-gray-300': ! (@js($getStatePath()) in validationErrors),
-                    'dark:border-gray-600': ! (@js($getStatePath()) in validationErrors) && @js(config('forms.dark_mode')),
-                    'border-danger-600 ring-danger-600': (@js($getStatePath()) in validationErrors),
+                    'border-gray-300': ! (@js($getStatePath()) in $wire.__instance.serverMemo.errors),
+                    'dark:border-gray-600': ! (@js($getStatePath()) in $wire.__instance.serverMemo.errors) && @js(config('forms.dark_mode')),
+                    'border-danger-600 ring-danger-600': (@js($getStatePath()) in $wire.__instance.serverMemo.errors),
                 }"
             />
         </div>


### PR DESCRIPTION
- Border colors will react to validation errors, even if the field has the wire:ignore attribute applied.
- Sections that are collapsed will expand if they contain fields with validation errors.
--------

Compatible w LW3
`$wire.__instance.serverMemo.errors` is the same as `$wire.errors` in LW3 (maybe).
Src: https://github.com/livewire/livewire/pull/5054 Thank you @zepfietje 

If it will be implemented in LW3, we can do a simple search'n'replace.

(This PR does not have any conflict with the notification plugin. It replaces the previous PR #3069)