### PR TITLE
Swap filter trigger and column toggle icons position

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -288,18 +288,18 @@
                             </div>
                         @endif
 
-                        @if ($isColumnToggleFormVisible)
-                            <x-tables::toggleable
-                                :form="$getColumnToggleForm()"
-                                :width="$getColumnToggleFormWidth()"
-                                class="shrink-0"
-                            />
-                        @endif
-
                         @if ($hasFiltersPopover)
                             <x-tables::filters.popover
                                 :form="$getFiltersForm()"
                                 :width="$getFiltersFormWidth()"
+                                class="shrink-0"
+                            />
+                        @endif
+
+                        @if ($isColumnToggleFormVisible)
+                            <x-tables::toggleable
+                                :form="$getColumnToggleForm()"
+                                :width="$getColumnToggleFormWidth()"
                                 class="shrink-0"
                             />
                         @endif


### PR DESCRIPTION
The placement of column toggle icon should not between search and filter since their functionalities are not similar. I propose this layout to make it more sense in term of functionality.

Before:
![image](https://user-images.githubusercontent.com/26832856/186586095-531d56d4-24ba-45ea-9e6e-683b586fa856.png)

After:
![image](https://user-images.githubusercontent.com/26832856/186585981-05c65a3c-ad55-43e0-85f7-32ee78e2cd38.png)

What do you think guys?