### PR TITLE
Adds 'translateLabel()' method to HasLabel concerns

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -49,6 +49,17 @@ use Filament\Forms\Components\TextInput;
 TextInput::make('name')->label(__('fields.name'))
 ```
 
+Optionally, you can have the label automatically translated by using the `translateLabel()` method:
+
+```php
+use Filament\Forms\Components\TextInput;
+
+TextInput::make('name')->translateLabel()
+
+// This is equivalent to
+// TextInput::make('name')->label(__('name'))
+```
+
 ### Setting an ID
 
 In the same way as labels, field IDs are also automatically determined based on their names. To override a field ID, use the `id()` method:

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -54,10 +54,7 @@ Optionally, you can have the label automatically translated by using the `transl
 ```php
 use Filament\Forms\Components\TextInput;
 
-TextInput::make('name')->translateLabel()
-
-// This is equivalent to
-// TextInput::make('name')->label(__('name'))
+TextInput::make('name')->translateLabel() // Equivalent to `label(__('Name'))`
 ```
 
 ### Setting an ID

--- a/packages/forms/src/Components/Concerns/HasLabel.php
+++ b/packages/forms/src/Components/Concerns/HasLabel.php
@@ -11,6 +11,8 @@ trait HasLabel
 
     protected string | Htmlable | Closure | null $label = null;
 
+    protected bool $shouldTranslateLabel = false;
+
     public function disableLabel(bool | Closure $condition = true): static
     {
         $this->isLabelHidden = $condition;
@@ -25,9 +27,20 @@ trait HasLabel
         return $this;
     }
 
+    public function translateLabel(bool $shouldTranslateLabel = true): static
+    {
+        $this->shouldTranslateLabel = $shouldTranslateLabel;
+
+        return $this;
+    }
+
     public function getLabel(): string | Htmlable | null
     {
-        return $this->evaluate($this->label);
+        $label = $this->evaluate($this->label);
+
+        return is_string($label) && $this->shouldTranslateLabel
+            ? __($label)
+            : $label;
     }
 
     public function isLabelHidden(): bool

--- a/packages/support/src/Actions/Concerns/HasLabel.php
+++ b/packages/support/src/Actions/Concerns/HasLabel.php
@@ -12,6 +12,8 @@ trait HasLabel
 
     protected bool | Closure $isLabelHidden = false;
 
+    protected bool $shouldTranslateLabel = false;
+
     public function disableLabel(bool | Closure $condition = true): static
     {
         $this->isLabelHidden = $condition;
@@ -26,13 +28,24 @@ trait HasLabel
         return $this;
     }
 
+    public function translateLabel(bool $shouldTranslateLabel = true): static
+    {
+        $this->shouldTranslateLabel = $shouldTranslateLabel;
+
+        return $this;
+    }
+
     public function getLabel(): string | Htmlable | null
     {
-        return $this->evaluate($this->label) ?? (string) Str::of($this->getName())
+        $label = $this->evaluate($this->label) ?? (string) Str::of($this->getName())
             ->before('.')
             ->kebab()
             ->replace(['-', '_'], ' ')
             ->ucfirst();
+
+        return is_string($label) && $this->shouldTranslateLabel
+            ? __($label)
+            : $label;
     }
 
     public function isLabelHidden(): bool

--- a/packages/tables/docs/03-columns.md
+++ b/packages/tables/docs/03-columns.md
@@ -49,6 +49,17 @@ use Filament\Tables\Columns\TextColumn;
 TextColumn::make('title')->label('Post title')
 ```
 
+Optionally, you can have the label automatically translated by using the `translateLabel()` method:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('title')->translateLabel()
+
+// This is equivalent to
+// TextColumn::make('title')->label(__('title'))
+```
+
 ### Sorting
 
 Columns may be sortable, by clicking on the column label. To make a column sortable, you must use the `sortable()` method:

--- a/packages/tables/docs/03-columns.md
+++ b/packages/tables/docs/03-columns.md
@@ -54,10 +54,7 @@ Optionally, you can have the label automatically translated by using the `transl
 ```php
 use Filament\Tables\Columns\TextColumn;
 
-TextColumn::make('title')->translateLabel()
-
-// This is equivalent to
-// TextColumn::make('title')->label(__('title'))
+TextColumn::make('title')->translateLabel() // Equivalent to `label(__('Title'))`
 ```
 
 ### Sorting

--- a/packages/tables/docs/04-filters.md
+++ b/packages/tables/docs/04-filters.md
@@ -55,10 +55,7 @@ Optionally, you can have the label automatically translated by using the `transl
 ```php
 use Filament\Tables\Filters\Filter;
 
-Filter::make('is_featured')->translateLabel()
-
-// This is equivalent to
-// Filter::make('is_featured')->label(_('is_featured'))
+Filter::make('is_featured')->translateLabel() // Equivalent to `label(__('Is featured'))`
 ```
 
 ### Using a toggle button instead of a checkbox

--- a/packages/tables/docs/04-filters.md
+++ b/packages/tables/docs/04-filters.md
@@ -49,6 +49,18 @@ use Filament\Tables\Filters\Filter;
 Filter::make('is_featured')->label('Featured')
 ```
 
+
+Optionally, you can have the label automatically translated by using the `translateLabel()` method:
+
+```php
+use Filament\Tables\Filters\Filter;
+
+Filter::make('is_featured')->translateLabel()
+
+// This is equivalent to
+// Filter::make('is_featured')->label(_('is_featured'))
+```
+
 ### Using a toggle button instead of a checkbox
 
 By default, filters use a checkbox to control the filter. Instead, you may switch to using a toggle button, using the `toggle()` method:

--- a/packages/tables/docs/05-actions.md
+++ b/packages/tables/docs/05-actions.md
@@ -112,7 +112,7 @@ use App\Models\Post;
 use Filament\Tables\Actions\Action;
 
 Action::make('edit')
-    ->translateLabel() // equivalent to ->label(__('edit'))
+    ->translateLabel() // equivalent to ->label(__('Edit'))
     ->url(fn (Post $record): string => route('posts.edit', $record))
 ```
 

--- a/packages/tables/docs/05-actions.md
+++ b/packages/tables/docs/05-actions.md
@@ -105,6 +105,17 @@ Action::make('edit')
     ->url(fn (Post $record): string => route('posts.edit', $record))
 ```
 
+Optionally, you can have the label automatically translated by using the `translateLabel()` method:
+
+```php
+use App\Models\Post;
+use Filament\Tables\Actions\Action;
+
+Action::make('edit')
+    ->translateLabel() // equivalent to ->label(__('edit'))
+    ->url(fn (Post $record): string => route('posts.edit', $record))
+```
+
 ## Setting a color
 
 Actions may have a color to indicate their significance. It may be either `primary`, `secondary`, `success`, `warning` or `danger`:

--- a/packages/tables/docs/05-actions.md
+++ b/packages/tables/docs/05-actions.md
@@ -112,7 +112,7 @@ use App\Models\Post;
 use Filament\Tables\Actions\Action;
 
 Action::make('edit')
-    ->translateLabel() // equivalent to ->label(__('Edit'))
+    ->translateLabel() // Equivalent to `label(__('Edit'))`
     ->url(fn (Post $record): string => route('posts.edit', $record))
 ```
 

--- a/packages/tables/src/Columns/Concerns/HasLabel.php
+++ b/packages/tables/src/Columns/Concerns/HasLabel.php
@@ -33,8 +33,6 @@ trait HasLabel
             ->replace(['-', '_'], ' ')
             ->ucfirst();
 
-        return $this->shouldTranslateLabel
-            ? __($label)
-            : $label;
+        return $this->shouldTranslateLabel ? __($label) : $label;
     }
 }

--- a/packages/tables/src/Columns/Concerns/HasLabel.php
+++ b/packages/tables/src/Columns/Concerns/HasLabel.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 trait HasLabel
 {
     protected string | Closure | null $label = null;
+    protected bool $shouldTranslateLabel = false;
 
     public function label(string | Closure | null $label): static
     {
@@ -16,13 +17,24 @@ trait HasLabel
         return $this;
     }
 
+    public function translateLabel(bool $shouldTranslateLabel = true): static
+    {
+        $this->shouldTranslateLabel = $shouldTranslateLabel;
+
+        return $this;
+    }
+
     public function getLabel(): string
     {
-        return $this->evaluate($this->label) ?? (string) Str::of($this->getName())
+        $label = $this->evaluate($this->label) ?? (string) Str::of($this->getName())
             ->beforeLast('.')
             ->afterLast('.')
             ->kebab()
             ->replace(['-', '_'], ' ')
             ->ucfirst();
+
+        return $this->shouldTranslateLabel
+            ? __($label)
+            : $label;
     }
 }

--- a/packages/tables/src/Filters/Concerns/HasLabel.php
+++ b/packages/tables/src/Filters/Concerns/HasLabel.php
@@ -9,6 +9,8 @@ trait HasLabel
 {
     protected string | Closure | null $label = null;
 
+    protected bool $shouldTranslateLabel = false;
+
     public function label(string | Closure | null $label): static
     {
         $this->label = $label;
@@ -16,12 +18,23 @@ trait HasLabel
         return $this;
     }
 
+    public function translateLabel(bool $shouldTranslateLabel = true): static
+    {
+        $this->shouldTranslateLabel = $shouldTranslateLabel;
+
+        return $this;
+    }
+
     public function getLabel(): string
     {
-        return $this->evaluate($this->label) ?? (string) Str::of($this->getName())
+        $label = $this->evaluate($this->label) ?? (string) Str::of($this->getName())
             ->before('.')
             ->kebab()
             ->replace(['-', '_'], ' ')
             ->ucfirst();
+
+        return $this->shouldTranslateLabel
+            ? __($label)
+            : $label;
     }
 }

--- a/packages/tables/src/Filters/Concerns/HasLabel.php
+++ b/packages/tables/src/Filters/Concerns/HasLabel.php
@@ -33,8 +33,6 @@ trait HasLabel
             ->replace(['-', '_'], ' ')
             ->ucfirst();
 
-        return $this->shouldTranslateLabel
-            ? __($label)
-            : $label;
+        return $this->shouldTranslateLabel ? __($label) : $label;
     }
 }


### PR DESCRIPTION
Hi.

I find myself using ->label() in a lot o places to simply translate the name of a component.
This is simply a UX nicety to have cleaner code.

Adds a new method `translateLabel(bool)`  to the several HasLabel concerns:
Form components, Actions, Columns and Filters

This allows the developer to replace something like:

```php
TextColumn::make('name')->label(__('name'))
```

with

```php
TextColumn::make('name')->translateLabel()
```