### PR TITLE
Fix getFlatComponents doesn't return all hidden components

### DIFF
--- a/packages/forms/src/Concerns/HasComponents.php
+++ b/packages/forms/src/Concerns/HasComponents.php
@@ -43,7 +43,7 @@ trait HasComponents
                         $component,
                         array_map(
                             fn (ComponentContainer $container): array => $container->getFlatComponents($withHidden),
-                            $component->getChildComponentContainers(),
+                            $component->getChildComponentContainers($withHidden),
                         ),
                     ];
                 }

--- a/tests/src/Forms/ComponentContainerTest.php
+++ b/tests/src/Forms/ComponentContainerTest.php
@@ -98,6 +98,27 @@ it('can return a flat array of components', function () {
         ]);
 });
 
+it('can return a flat array of components including hidden components', function () {
+    $container = ComponentContainer::make(Livewire::make())
+        ->components([
+            $fieldset = Fieldset::make(Str::random())
+                ->hidden(true)
+                ->schema([
+                    $field = TextInput::make(Str::random()),
+                ]),
+            $section = Section::make(Str::random()),
+        ]);
+
+    expect($container)
+        ->getFlatComponents(true)
+        ->toHaveCount(3)
+        ->toMatchArray([
+            $fieldset,
+            $field,
+            $section,
+        ]);
+});
+
 it('can return a flat array of fields', function () {
     $container = ComponentContainer::make(Livewire::make())
         ->components([
@@ -110,6 +131,25 @@ it('can return a flat array of fields', function () {
 
     expect($container)
         ->getFlatFields()
+        ->toHaveCount(1)
+        ->toMatchArray([
+            $name => $field,
+        ]);
+});
+
+it('can return a flat array of fields including hidden fields', function () {
+    $container = ComponentContainer::make(Livewire::make())
+        ->components([
+            Fieldset::make(Str::random())
+                ->hidden(true)
+                ->schema([
+                    $field = TextInput::make($name = Str::random()),
+                ]),
+            $section = Section::make(Str::random()),
+        ]);
+
+    expect($container)
+        ->getFlatFields(true)
         ->toHaveCount(1)
         ->toMatchArray([
             $name => $field,

--- a/tests/src/Forms/ComponentContainerTest.php
+++ b/tests/src/Forms/ComponentContainerTest.php
@@ -102,7 +102,7 @@ it('can return a flat array of components including hidden components', function
     $container = ComponentContainer::make(Livewire::make())
         ->components([
             $fieldset = Fieldset::make(Str::random())
-                ->hidden(true)
+                ->hidden()
                 ->schema([
                     $field = TextInput::make(Str::random()),
                 ]),
@@ -110,7 +110,7 @@ it('can return a flat array of components including hidden components', function
         ]);
 
     expect($container)
-        ->getFlatComponents(true)
+        ->getFlatComponents(withHidden: true)
         ->toHaveCount(3)
         ->toMatchArray([
             $fieldset,
@@ -141,7 +141,7 @@ it('can return a flat array of fields including hidden fields', function () {
     $container = ComponentContainer::make(Livewire::make())
         ->components([
             Fieldset::make(Str::random())
-                ->hidden(true)
+                ->hidden()
                 ->schema([
                     $field = TextInput::make($name = Str::random()),
                 ]),
@@ -149,7 +149,7 @@ it('can return a flat array of fields including hidden fields', function () {
         ]);
 
     expect($container)
-        ->getFlatFields(true)
+        ->getFlatFields(withHidden: true)
         ->toHaveCount(1)
         ->toMatchArray([
             $name => $field,


### PR DESCRIPTION
I'm working on adding some form testing helpers and ran into what looks like a bug to me when implementing an `assertFormFieldExists` helper. 

The helper gets the form from the Livewire instance. Then to check for the existence of the field it calls`$form->getFlatFields(true)` to get all of the fields on the form including hidden fields. However when testing a form with a container like a Section or Fieldset that is hidden, the child components of that container are not returned.

I tracked this down to the `getFlatComponents` method not including `$withHidden` when calling `$component->getChildContainers()`. `getChildContainers` calls `hasChildComponentContainer` and if `$withHidden` is not passed in it will return false. 

This PR fixes that. I don't think this should break anything. Everything on my project is still working. All of the tests are passing and I've added a couple of extra tests that verify the fix. But I'm still trying to get familiar with the internals of Filament so I'm not sure if there are any side effects I'm not aware of.