### PR TITLE
Feat: multi field based validations

### DIFF
--- a/packages/forms/docs/05-validation.md
+++ b/packages/forms/docs/05-validation.md
@@ -163,7 +163,7 @@ Field::make('name')->required()
 
 ### Required With
 
-The field value must not be empty _only if_ any of the other specified fields are not empty. [See the Laravel documentation](https://laravel.com/docs/9.x/validation#rule-required-with)
+The field value must not be empty _only if_ any of the other specified fields are not empty. [See the Laravel documentation](https://laravel.com/docs/validation#rule-required-with)
 
 ```php
 Field::make('name')->requiredWith('field,another_field')
@@ -171,7 +171,7 @@ Field::make('name')->requiredWith('field,another_field')
 
 ### Required With All
 
-The field value must not be empty _only if_ all of the other specified fields are not empty. [See the Laravel documentation](https://laravel.com/docs/9.x/validation#rule-required-with-all)
+The field value must not be empty _only if_ all of the other specified fields are not empty. [See the Laravel documentation](https://laravel.com/docs/validation#rule-required-with-all)
 
 ```php
 Field::make('name')->requiredWithAll('field,another_field')
@@ -179,7 +179,7 @@ Field::make('name')->requiredWithAll('field,another_field')
 
 ### Required Without
 
-The field value must not be empty _only when_ any of the other specified fields are empty. [See the Laravel documentation](https://laravel.com/docs/9.x/validation#rule-required-without)
+The field value must not be empty _only when_ any of the other specified fields are empty. [See the Laravel documentation](https://laravel.com/docs/validation#rule-required-without)
 
 ```php
 Field::make('name')->requiredWithout('field,another_field')
@@ -187,7 +187,7 @@ Field::make('name')->requiredWithout('field,another_field')
 
 ### Required Without All
 
-The field value must not be empty _only when_ all of the other specified fields are empty. [See the Laravel documentation](https://laravel.com/docs/9.x/validation#rule-required-without-all)
+The field value must not be empty _only when_ all of the other specified fields are empty. [See the Laravel documentation](https://laravel.com/docs/validation#rule-required-without-all)
 
 ```php
 Field::make('name')->requiredWithoutAll('field,another_field')

--- a/packages/forms/docs/05-validation.md
+++ b/packages/forms/docs/05-validation.md
@@ -161,6 +161,38 @@ The field value must not be empty. [See the Laravel documentation](https://larav
 Field::make('name')->required()
 ```
 
+### Required With
+
+The field value must not be empty _only if_ any of the other specified fields are not empty. [See the Laravel documentation](https://laravel.com/docs/9.x/validation#rule-required-with)
+
+```php
+Field::make('name')->requiredWith('field,another_field')
+```
+
+### Required With All
+
+The field value must not be empty _only if_ all of the other specified fields are not empty. [See the Laravel documentation](https://laravel.com/docs/9.x/validation#rule-required-with-all)
+
+```php
+Field::make('name')->requiredWithAll('field,another_field')
+```
+
+### Required Without
+
+The field value must not be empty _only when_ any of the other specified fields are empty. [See the Laravel documentation](https://laravel.com/docs/9.x/validation#rule-required-without)
+
+```php
+Field::make('name')->requiredWithout('field,another_field')
+```
+
+### Required Without All
+
+The field value must not be empty _only when_ all of the other specified fields are empty. [See the Laravel documentation](https://laravel.com/docs/9.x/validation#rule-required-without-all)
+
+```php
+Field::make('name')->requiredWithoutAll('field,another_field')
+```
+
 ### Same
 
 The field value must be the same as another. [See the Laravel documentation](https://laravel.com/docs/validation#rule-same)

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -290,7 +290,7 @@ trait CanBeValidated
 
             if (! $isStatePathAbsolute) {
                 if (is_string($statePaths)) {
-                    $statePaths = explode(",", $statePaths);
+                    $statePaths = explode(',', $statePaths);
                 }
 
                 $containerStatePath = $component->getContainer()->getStatePath();
@@ -301,7 +301,7 @@ trait CanBeValidated
             }
 
             if (is_array($statePaths)) {
-                $statePaths = join(",", $statePaths);
+                $statePaths = implode(',', $statePaths);
             }
 
             return "{$rule}:{$statePaths}";

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -262,4 +262,31 @@ trait CanBeValidated
 
         return $this;
     }
+
+    public function multiFieldComparisonRule(string $rule, array | string | Closure $statePaths, bool $isStatePathAbsolute = false): static
+    {
+        $this->rule(static function (Field $component) use ($isStatePathAbsolute, $rule, $statePaths): string {
+            $statePaths = $component->evaluate($statePaths);
+
+            if (! $isStatePathAbsolute) {
+                if (is_string($statePaths)) {
+                    $statePaths = explode(",", $statePaths);
+                }
+
+                $containerStatePath = $component->getContainer()->getStatePath();
+
+                if ($containerStatePath) {
+                    $statePaths = array_map(fn ($statePath) => "{$containerStatePath}.{$statePath}", $statePaths);
+                }
+            }
+
+            if (is_array($statePaths)) {
+                $statePaths = join(",", $statePaths);
+            }
+
+            return "{$rule}:{$statePaths}";
+        }, fn (Field $component): bool => (bool) $component->evaluate($statePaths));
+
+        return $this;
+    }
 }

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -59,6 +59,11 @@ trait CanBeValidated
         return $this->multiFieldComparisonRule('required_with', $statePaths, $isStatePathAbsolute);
     }
 
+    public function requiredWithAll(string | array | Closure $statePaths, bool $isStatePathAbsolute = false): static
+    {
+        return $this->multiFieldComparisonRule('required_with_all', $statePaths, $isStatePathAbsolute);
+    }
+
     public function requiredWithout(string | array | Closure $statePaths, bool $isStatePathAbsolute = false): static
     {
         return $this->multiFieldComparisonRule('required_without', $statePaths, $isStatePathAbsolute);

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -54,6 +54,11 @@ trait CanBeValidated
         return $this;
     }
 
+    public function requiredWith(string | array | Closure $statePaths, bool $isStatePathAbsolute = false): static
+    {
+        return $this->multiFieldComparisonRule('required_with', $statePaths, $isStatePathAbsolute);
+    }
+
     public function regex(string | Closure | null $pattern): static
     {
         $this->regexPattern = $pattern;

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -59,6 +59,11 @@ trait CanBeValidated
         return $this->multiFieldComparisonRule('required_with', $statePaths, $isStatePathAbsolute);
     }
 
+    public function requiredWithout(string | array | Closure $statePaths, bool $isStatePathAbsolute = false): static
+    {
+        return $this->multiFieldComparisonRule('required_without', $statePaths, $isStatePathAbsolute);
+    }
+
     public function regex(string | Closure | null $pattern): static
     {
         $this->regexPattern = $pattern;

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -69,6 +69,11 @@ trait CanBeValidated
         return $this->multiFieldComparisonRule('required_without', $statePaths, $isStatePathAbsolute);
     }
 
+    public function requiredWithoutAll(string | array | Closure $statePaths, bool $isStatePathAbsolute = false): static
+    {
+        return $this->multiFieldComparisonRule('required_without_all', $statePaths, $isStatePathAbsolute);
+    }
+
     public function regex(string | Closure | null $pattern): static
     {
         $this->regexPattern = $pattern;

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -225,7 +225,7 @@ trait CanBeValidated
         return (bool) $this->evaluate($this->isRequired);
     }
 
-    protected function dateComparisonRule(string $rule, string | Closure $date, bool $isStatePathAbsolute = false): static
+    public function dateComparisonRule(string $rule, string | Closure $date, bool $isStatePathAbsolute = false): static
     {
         $this->rule(static function (Field $component) use ($date, $isStatePathAbsolute, $rule): string {
             $date = $component->evaluate($date);
@@ -244,7 +244,7 @@ trait CanBeValidated
         return $this;
     }
 
-    protected function fieldComparisonRule(string $rule, string | Closure $statePath, bool $isStatePathAbsolute = false): static
+    public function fieldComparisonRule(string $rule, string | Closure $statePath, bool $isStatePathAbsolute = false): static
     {
         $this->rule(static function (Field $component) use ($isStatePathAbsolute, $rule, $statePath): string {
             $statePath = $component->evaluate($statePath);


### PR DESCRIPTION
#### Adds the following validation rules:
- `requiredWith()`
- `requiredWithAll()`
- `requiredWithout()`
- `requiredWithoutAll()`
- `multiFieldComparisonRule()`

#### Changed the following `protected` methods to `public`:
- `dateComparisonRule()`
- `fieldComparisionRule()`

### Syntax
```php
->requiredWith(['another_field', 'someother_field']) //array
```
```php
->requiredWith('another_field, someother_field') //string
```
```php
->requiredWith(fn () => ['another_field']) //closure
```


ref: https://github.com/filamentphp/filament/discussions/2585 & https://github.com/filamentphp/filament/discussions/2639#discussioncomment-3477505