### PR TITLE
fix: `multiFieldComparisonRule` handle spaces in $statePaths

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -298,6 +298,7 @@ trait CanBeValidated
                 if ($containerStatePath) {
                     $statePaths = array_map(function ($statePath) use ($containerStatePath) {
                         $statePath = trim($statePath);
+
                         return "{$containerStatePath}.{$statePath}";
                     }, $statePaths);
                 }

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -296,7 +296,10 @@ trait CanBeValidated
                 $containerStatePath = $component->getContainer()->getStatePath();
 
                 if ($containerStatePath) {
-                    $statePaths = array_map(fn ($statePath) => "{$containerStatePath}.{$statePath}", $statePaths);
+                    $statePaths = array_map(function ($statePath) use ($containerStatePath) {
+                        $statePath = trim($statePath);
+                        return "{$containerStatePath}.{$statePath}";
+                    }, $statePaths);
                 }
             }
 


### PR DESCRIPTION
Fixes a small issue in https://github.com/filamentphp/filament/pull/3682
```php
//previously didn't work as intended because of space after ,
Field::make('name')->requiredWith('field, another_field') 
```