### PR TITLE
Fix CSS class on edit page

### DIFF
--- a/packages/admin/resources/views/resources/pages/edit-record.blade.php
+++ b/packages/admin/resources/views/resources/pages/edit-record.blade.php
@@ -1,7 +1,7 @@
 <x-filament::page
     :widget-data="['record' => $record]"
     :class="\Illuminate\Support\Arr::toCssClasses([
-        'filament-resources-create-record-page',
+        'filament-resources-edit-record-page',
         'filament-resources-' . str_replace('/', '-', $this->getResource()::getSlug()),
         'filament-resources-record-' . $record->getKey(),
     ])"


### PR DESCRIPTION
The edit page currently has the create class.
I've checked the list and view pages as well, those seem to be correct.