### PR TITLE
support debounce on masked text-input

### DIFF
--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -47,7 +47,8 @@
                     })"
                     type="text"
                     wire:ignore
-                    @if ($isLazy() || $getDebounce()) x-on:blur="$wire.$refresh" @endif
+                    {!! $isLazy() ? "x-on:blur=\"\$wire.\$refresh\"" : null !!}
+                    {!! $isDebounced() ? "x-on:input.debounce.{$getDebounce()}=\"\$wire.\$refresh\"" : null !!}
                     {{ $getExtraAlpineAttributeBag() }}
                 @endunless
                 dusk="filament.forms.{{ $getStatePath() }}"

--- a/packages/forms/src/Concerns/HasStateBindingModifiers.php
+++ b/packages/forms/src/Concerns/HasStateBindingModifiers.php
@@ -76,6 +76,11 @@ trait HasStateBindingModifiers
         return in_array('lazy', $this->getStateBindingModifiers());
     }
 
+    public function isDebounced(): bool
+    {
+        return in_array('debounce', $this->getStateBindingModifiers());
+    }
+
     public function getDebounce(): string | int | null
     {
         return $this->debounce;


### PR DESCRIPTION
- Add support for: `TextInput(...)->mask(...)->debounce() `
- Changes code format in text-input to match the code style in the rest of the component.
- Adds `$isDebounced()` getter (Because `$isLazy()` exists)

Now, both `lazy` and `debounce` modifiers can be used on a masked `TextInput`.