### PR TITLE
feature: Add some form testing helpers

### DIFF
--- a/packages/forms/.stubs.php
+++ b/packages/forms/.stubs.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Livewire\Testing {
+
+    class TestableLivewire {
+        public function assertFormExists(string $name = 'form'): static {}
+
+        public function assertFormFieldExists(string $fieldName, string $formName = 'form'): static {}
+
+        public function assertFormFieldIsDisabled(string $fieldName, string $formName = 'form'): static {}
+
+        public function assertFormFieldIsEnabled(string $fieldName, string $formName = 'form'): static {}
+
+        public function assertFormFieldIsHidden(string $fieldName, string $formName = 'form'): static {}
+
+        public function assertFormFieldIsVisible(string $fieldName, string $formName = 'form'): static {}
+    }
+
+}

--- a/packages/forms/docs/07-testing.md
+++ b/packages/forms/docs/07-testing.md
@@ -4,11 +4,11 @@ title: Testing
 
 All examples in this guide will be written using [Pest](https://pestphp.com). However, you can easily adapt this to a PHPUnit.
 
-Since the form builder works on Livewire components, you can use the [Livewire testing helpers](https://laravel-livewire.com/docs/testing). However, we have custom testing helpers that you can use for forms:
+Since the form builder works on Livewire components, you can use the [Livewire testing helpers](https://laravel-livewire.com/docs/testing). However, we have custom testing helpers that you can use with forms:
 
-## Forms
+## Form existance
 
-To check that a Livewire component has a form, use `assertFormExists`:
+To check that a Livewire component has a form, use `assertFormExists()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -19,11 +19,11 @@ it('has a form', function () {
 });
 ```
 
-> Note that if you have multiple forms on a Livewire component, you can pass the name of a specific form like `assertFormExists('fooForm')`.
+> Note that if you have multiple forms on a Livewire component, you can pass the name of a specific form like `assertFormExists('createPostForm')`.
 
 ## Fields
 
-To ensure that a form has a given field pass the field name to `assertFormFieldExists`:
+To ensure that a form has a given field pass the field name to `assertFormFieldExists()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -34,11 +34,11 @@ it('has a title field', function () {
 });
 ```
 
-> Note that if you have multiple forms on a Livewire component, you can specify which form you want to check for the existence of the field like `assertFormFieldExists('title', 'fooForm')`.
+> Note that if you have multiple forms on a Livewire component, you can specify which form you want to check for the existence of the field like `assertFormFieldExists('title', 'createPostForm')`.
 
-### Visibility
+### Hidden fields
 
-To ensure that a field is visible pass the name to `assertFormFieldIsVisible`:
+To ensure that a field is visible pass the name to `assertFormFieldIsVisible()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -49,7 +49,7 @@ test('title is visible', function () {
 });
 ```
 
-Or to ensure that a field is hidden you can pass the name to `assertFormFieldIsHidden`:
+Or to ensure that a field is hidden you can pass the name to `assertFormFieldIsHidden()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -60,11 +60,11 @@ test('title is hidden', function () {
 });
 ```
 
-> Note that for both `assertFormFieldIsHidden` and `assertFormFieldIsVisible` you can pass the name of a specific form the field belongs to as the second argument like `assertFormFieldIsHidden('title', 'fooForm')`.
+> Note that for both `assertFormFieldIsHidden()` and `assertFormFieldIsVisible()` you can pass the name of a specific form the field belongs to as the second argument like `assertFormFieldIsHidden('title', 'createPostForm')`.
 
-### Enabled State
+### Disabled fields
 
-To ensure that a field is enabled pass the name to `assertFormFieldIsEnabled`:
+To ensure that a field is enabled pass the name to `assertFormFieldIsEnabled()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -75,7 +75,7 @@ test('title is enabled', function () {
 });
 ```
 
-Or to ensure that a field is disabled you can pass the name to `assertFormFieldIsDisabled`:
+Or to ensure that a field is disabled you can pass the name to `assertFormFieldIsDisabled()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -86,4 +86,4 @@ test('title is disabled', function () {
 });
 ```
 
-> Note that for both `assertFormFieldIsEnabled` and `assertFormFieldIsDisabled` you can pass the name of a specific form the field belongs to as the second argument like `assertFormFieldIsEnabled('title', 'fooForm')`.
+> Note that for both `assertFormFieldIsEnabled()` and `assertFormFieldIsDisabled()` you can pass the name of a specific form the field belongs to as the second argument like `assertFormFieldIsEnabled('title', 'createPostForm')`.

--- a/packages/forms/docs/07-testing.md
+++ b/packages/forms/docs/07-testing.md
@@ -56,7 +56,7 @@ use function Pest\Livewire\livewire;
 
 test('title is hidden', function () {
     livewire(CreatePost::class)
-        ->assertFormFieldIsVisible('title');
+        ->assertFormFieldIsHidden('title');
 });
 ```
 

--- a/packages/forms/docs/07-testing.md
+++ b/packages/forms/docs/07-testing.md
@@ -1,0 +1,89 @@
+---
+title: Testing
+---
+
+All examples in this guide will be written using [Pest](https://pestphp.com). However, you can easily adapt this to a PHPUnit.
+
+Since the form builder works on Livewire components, you can use the [Livewire testing helpers](https://laravel-livewire.com/docs/testing). However, we have custom testing helpers that you can use for forms:
+
+## Forms
+
+To check that a Livewire component has a form, use `assertFormExists`:
+
+```php
+use function Pest\Livewire\livewire;
+
+it('has a form', function () {
+    livewire(CreatePost::class)
+        ->assertFormExists();
+});
+```
+
+> Note that if you have multiple forms on a Livewire component, you can pass the name of a specific form like `assertFormExists('fooForm')`.
+
+## Fields
+
+To ensure that a form has a given field pass the field name to `assertFormFieldExists`:
+
+```php
+use function Pest\Livewire\livewire;
+
+it('has a title field', function () {
+    livewire(CreatePost::class)
+        ->assertFormFieldExists('title');
+});
+```
+
+> Note that if you have multiple forms on a Livewire component, you can specify which form you want to check for the existence of the field like `assertFormFieldExists('title', 'fooForm')`.
+
+### Visibility
+
+To ensure that a field is visible pass the name to `assertFormFieldIsVisible`:
+
+```php
+use function Pest\Livewire\livewire;
+
+test('title is visible', function () {
+    livewire(CreatePost::class)
+        ->assertFormFieldIsVisible('title');
+});
+```
+
+Or to ensure that a field is hidden you can pass the name to `assertFormFieldIsHidden`:
+
+```php
+use function Pest\Livewire\livewire;
+
+test('title is hidden', function () {
+    livewire(CreatePost::class)
+        ->assertFormFieldIsVisible('title');
+});
+```
+
+> Note that for both `assertFormFieldIsHidden` and `assertFormFieldIsVisible` you can pass the name of a specific form the field belongs to as the second argument like `assertFormFieldIsHidden('title', 'fooForm')`.
+
+### Enabled State
+
+To ensure that a field is enabled pass the name to `assertFormFieldIsEnabled`:
+
+```php
+use function Pest\Livewire\livewire;
+
+test('title is enabled', function () {
+    livewire(CreatePost::class)
+        ->assertFormFieldIsEnabled('title');
+});
+```
+
+Or to ensure that a field is disabled you can pass the name to `assertFormFieldIsDisabled`:
+
+```php
+use function Pest\Livewire\livewire;
+
+test('title is disabled', function () {
+    livewire(CreatePost::class)
+        ->assertFormFieldIsDisabled('title');
+});
+```
+
+> Note that for both `assertFormFieldIsEnabled` and `assertFormFieldIsDisabled` you can pass the name of a specific form the field belongs to as the second argument like `assertFormFieldIsEnabled('title', 'fooForm')`.

--- a/packages/forms/src/FormsServiceProvider.php
+++ b/packages/forms/src/FormsServiceProvider.php
@@ -3,10 +3,9 @@
 namespace Filament\Forms;
 
 use Filament\Forms\Testing\TestsForms;
+use Livewire\Testing\TestableLivewire;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
-use Livewire\Testing\TestableLivewire;
-
 
 class FormsServiceProvider extends PackageServiceProvider
 {

--- a/packages/forms/src/FormsServiceProvider.php
+++ b/packages/forms/src/FormsServiceProvider.php
@@ -2,8 +2,11 @@
 
 namespace Filament\Forms;
 
+use Filament\Forms\Testing\TestsForms;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Livewire\Testing\TestableLivewire;
+
 
 class FormsServiceProvider extends PackageServiceProvider
 {
@@ -38,5 +41,10 @@ class FormsServiceProvider extends PackageServiceProvider
         }
 
         return array_merge($commands, $aliases);
+    }
+
+    public function packageBooted(): void
+    {
+        TestableLivewire::mixin(new TestsForms());
     }
 }

--- a/packages/forms/src/Testing/TestsForms.php
+++ b/packages/forms/src/Testing/TestsForms.php
@@ -151,7 +151,7 @@ class TestsForms
             Assert::assertArrayHasKey(
                 $fieldName,
                 $fields,
-                "Failed asserting that a field with the name [{$fieldName}] is hidden on the form named [{$formName}] on the [{$livewireClass}] component."
+                "Failed asserting that a field with the name [{$fieldName}] is visible on the form named [{$formName}] on the [{$livewireClass}] component."
             );
 
             return $this;

--- a/packages/forms/src/Testing/TestsForms.php
+++ b/packages/forms/src/Testing/TestsForms.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Filament\Forms\Testing;
+
+use Closure;
+use Filament\Forms\ComponentContainer;
+use Filament\Forms\Components\Field;
+use Filament\Forms\Contracts\HasForms;
+use Illuminate\Testing\Assert;
+use Livewire\Testing\TestableLivewire;
+
+/**
+ * @method HasForms instance()
+ *
+ * @mixin TestableLivewire
+ */
+class TestsForms
+{
+    public function assertFormExists(): Closure
+    {
+        return function (string $name = 'form'): static {
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            /** @var ComponentContainer $form */
+            $form = $livewire->$name;
+
+            Assert::assertInstanceOf(
+                ComponentContainer::class,
+                $form,
+                "Failed asserting that a form with the name [{$name}] exists on the [{$livewireClass}] component."
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertFormFieldExists(): Closure
+    {
+        return function (string $fieldName, string $formName = 'form'): static {
+            /** @phpstan-ignore-next-line  */
+            $this->assertFormExists($formName);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            /** @var ComponentContainer $form */
+            $form = $livewire->$formName;
+
+            /** @var ?Field $field */
+            $field = data_get($form->getFlatFields(true), $fieldName, null);
+
+            Assert::assertInstanceOf(
+                Field::class,
+                $field,
+                "Failed asserting that a field with the name [{$fieldName}] exists on the form with the name [${formName}] on the [{$livewireClass}] component."
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertFormFieldIsDisabled(): Closure
+    {
+        return function (string $fieldName, string $formName = 'form'): static {
+            /** @phpstan-ignore-next-line  */
+            $this->assertFormFieldExists($fieldName, $formName);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            /** @var ComponentContainer $form */
+            $form = $livewire->$formName;
+
+            /** @var Field $field */
+            $field = $form->getFlatFields(true)[$fieldName];
+
+            Assert::assertTrue(
+                $field->isDisabled(),
+                "Failed asserting that a field with the name [{$fieldName}] is disabled on the form named [{$formName}] on the [{$livewireClass}] component."
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertFormFieldIsEnabled(): Closure
+    {
+        return function (string $fieldName, string $formName = 'form'): static {
+            /** @phpstan-ignore-next-line  */
+            $this->assertFormFieldExists($fieldName, $formName);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            /** @var ComponentContainer $form */
+            $form = $livewire->$formName;
+
+            /** @var Field $field */
+            $field = $form->getFlatFields(true)[$fieldName];
+
+            Assert::assertFalse(
+                $field->isDisabled(),
+                "Failed asserting that a field with the name [{$fieldName}] is enabled on the form named [{$formName}] on the [{$livewireClass}] component."
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertFormFieldIsHidden(): Closure
+    {
+        return function (string $fieldName, string $formName = 'form'): static {
+            /** @phpstan-ignore-next-line  */
+            $this->assertFormFieldExists($fieldName, $formName);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            /** @var ComponentContainer $form */
+            $form = $livewire->$formName;
+
+            $fields = $form->getFlatFields();
+
+            Assert::assertArrayNotHasKey(
+                $fieldName,
+                $fields,
+                "Failed asserting that a field with the name [{$fieldName}] is hidden on the form named [{$formName}] on the [{$livewireClass}] component."
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertFormFieldIsVisible(): Closure
+    {
+        return function (string $fieldName, string $formName = 'form'): static {
+            /** @phpstan-ignore-next-line  */
+            $this->assertFormFieldExists($fieldName, $formName);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            /** @var ComponentContainer $form */
+            $form = $livewire->$formName;
+
+            $fields = $form->getFlatFields(true);
+
+            $fields = $form->getFlatFields();
+
+            Assert::assertArrayHasKey(
+                $fieldName,
+                $fields,
+                "Failed asserting that a field with the name [{$fieldName}] is hidden on the form named [{$formName}] on the [{$livewireClass}] component."
+            );
+
+            return $this;
+        };
+    }
+}

--- a/packages/forms/src/Testing/TestsForms.php
+++ b/packages/forms/src/Testing/TestsForms.php
@@ -48,7 +48,7 @@ class TestsForms
             $form = $livewire->$formName;
 
             /** @var ?Field $field */
-            $field = data_get($form->getFlatFields(true), $fieldName, null);
+            $field = data_get($form->getFlatFields(withHidden: true), $fieldName, null);
 
             Assert::assertInstanceOf(
                 Field::class,
@@ -73,7 +73,7 @@ class TestsForms
             $form = $livewire->$formName;
 
             /** @var Field $field */
-            $field = $form->getFlatFields(true)[$fieldName];
+            $field = $form->getFlatFields(withHidden: true)[$fieldName];
 
             Assert::assertTrue(
                 $field->isDisabled(),
@@ -97,7 +97,7 @@ class TestsForms
             $form = $livewire->$formName;
 
             /** @var Field $field */
-            $field = $form->getFlatFields(true)[$fieldName];
+            $field = $form->getFlatFields(withHidden: true)[$fieldName];
 
             Assert::assertFalse(
                 $field->isDisabled(),
@@ -120,7 +120,7 @@ class TestsForms
             /** @var ComponentContainer $form */
             $form = $livewire->$formName;
 
-            $fields = $form->getFlatFields();
+            $fields = $form->getFlatFields(withHidden: false);
 
             Assert::assertArrayNotHasKey(
                 $fieldName,
@@ -144,9 +144,7 @@ class TestsForms
             /** @var ComponentContainer $form */
             $form = $livewire->$formName;
 
-            $fields = $form->getFlatFields(true);
-
-            $fields = $form->getFlatFields();
+            $fields = $form->getFlatFields(withHidden: false);
 
             Assert::assertArrayHasKey(
                 $fieldName,

--- a/tests/src/Forms/FormsTest.php
+++ b/tests/src/Forms/FormsTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use Filament\Forms\Components\Actions\Action;
+use Filament\Forms\Components\TextInput;
+use Filament\Tests\Forms\Fixtures\Livewire;
+use Filament\Tests\TestCase;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Str;
+use function Pest\Livewire\livewire;
+
+uses(TestCase::class);
+
+it('has a form with the default name \'form\'', function() {
+    livewire(TestComponentWithForm::class)
+        ->assertFormExists();
+})->only();
+
+it('can have forms with non-default names', function() {
+    livewire(TestComponentWithMultipleForms::class)
+        ->assertFormExists('fooForm')
+        ->assertFormExists('barForm');
+})->only();
+
+it('has fields', function() {
+    livewire(TestComponentWithForm::class)
+        ->assertFormFieldExists('title');
+})->only();
+
+it('has fields on multiple forms', function() {
+    livewire(TestComponentWithMultipleForms::class)
+        ->assertFormFieldExists('title', 'fooForm')
+        ->assertFormFieldExists('title', 'barForm');
+})->only();
+
+it('can have disabled fields', function() {
+    livewire(TestComponentWithForm::class)
+        ->assertFormFieldIsDisabled('disabled');
+})->only();
+
+it('can have disabled fields on multiple forms', function() {
+    livewire(TestComponentWithMultipleForms::class)
+        ->assertFormFieldIsDisabled('disabled', 'fooForm')
+        ->assertFormFieldIsDisabled('disabled', 'barForm');
+})->only();
+
+it('can have enabled fields', function() {
+    livewire(TestComponentWithForm::class)
+        ->assertFormFieldIsEnabled('enabled');
+})->only();
+
+it('can have enabled fields on multiple forms', function() {
+    livewire(TestComponentWithMultipleForms::class)
+        ->assertFormFieldIsEnabled('enabled', 'fooForm')
+        ->assertFormFieldIsEnabled('enabled', 'barForm');
+})->only();
+
+it('can have hidden fields', function() {
+    livewire(TestComponentWithForm::class)
+        ->assertFormFieldIsHidden('hidden');
+})->only();
+
+it('can have hidden fields on multiple forms', function() {
+    livewire(TestComponentWithMultipleForms::class)
+        ->assertFormFieldIsHidden('hidden', 'fooForm')
+        ->assertFormFieldIsHidden('hidden', 'barForm');
+})->only();
+
+it('can have visible fields', function() {
+    livewire(TestComponentWithForm::class)
+        ->assertFormFieldIsVisible('visible');
+})->only();
+
+it('can have visible fields on multiple forms', function() {
+    livewire(TestComponentWithMultipleForms::class)
+        ->assertFormFieldIsVisible('visible', 'fooForm')
+        ->assertFormFieldIsVisible('visible', 'barForm');
+})->only();
+
+class TestComponentWithForm extends Livewire
+{
+    public function getFormSchema(): array
+    {
+        return [
+            TextInput::make('title'),
+
+            TextInput::make('disabled')
+                ->disabled(),
+
+            TextInput::make('enabled'),
+
+            TextInput::make('hidden')
+                ->hidden(),
+
+            TextInput::make('visible'),
+        ];
+    }
+
+    public function render(): View
+    {
+        return view('forms.fixtures.form');
+    }
+}
+
+class TestComponentWithMultipleForms extends Livewire
+{
+    protected function getForms(): array
+    {
+        return [
+            'fooForm' => $this->makeForm()
+                ->schema($this->getSchemaForForms()),
+
+            'barForm' => $this->makeForm()
+                ->schema($this->getSchemaForForms()),
+        ];
+    }
+
+    private function getSchemaForForms(): array
+    {
+        return [
+            TextInput::make('title'),
+
+            TextInput::make('disabled')
+                ->disabled(),
+
+            TextInput::make('enabled'),
+
+            TextInput::make('hidden')
+                ->hidden(),
+
+            TextInput::make('visible'),
+        ];
+    }
+
+    public function render(): View
+    {
+        return view('forms.fixtures.form');
+    }
+}

--- a/tests/src/Forms/FormsTest.php
+++ b/tests/src/Forms/FormsTest.php
@@ -1,76 +1,74 @@
 <?php
 
-use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\TextInput;
 use Filament\Tests\Forms\Fixtures\Livewire;
 use Filament\Tests\TestCase;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Str;
 use function Pest\Livewire\livewire;
 
 uses(TestCase::class);
 
-it('has a form with the default name \'form\'', function() {
+it('has a form with the default name \'form\'', function () {
     livewire(TestComponentWithForm::class)
         ->assertFormExists();
 })->only();
 
-it('can have forms with non-default names', function() {
+it('can have forms with non-default names', function () {
     livewire(TestComponentWithMultipleForms::class)
         ->assertFormExists('fooForm')
         ->assertFormExists('barForm');
 })->only();
 
-it('has fields', function() {
+it('has fields', function () {
     livewire(TestComponentWithForm::class)
         ->assertFormFieldExists('title');
 })->only();
 
-it('has fields on multiple forms', function() {
+it('has fields on multiple forms', function () {
     livewire(TestComponentWithMultipleForms::class)
         ->assertFormFieldExists('title', 'fooForm')
         ->assertFormFieldExists('title', 'barForm');
 })->only();
 
-it('can have disabled fields', function() {
+it('can have disabled fields', function () {
     livewire(TestComponentWithForm::class)
         ->assertFormFieldIsDisabled('disabled');
 })->only();
 
-it('can have disabled fields on multiple forms', function() {
+it('can have disabled fields on multiple forms', function () {
     livewire(TestComponentWithMultipleForms::class)
         ->assertFormFieldIsDisabled('disabled', 'fooForm')
         ->assertFormFieldIsDisabled('disabled', 'barForm');
 })->only();
 
-it('can have enabled fields', function() {
+it('can have enabled fields', function () {
     livewire(TestComponentWithForm::class)
         ->assertFormFieldIsEnabled('enabled');
 })->only();
 
-it('can have enabled fields on multiple forms', function() {
+it('can have enabled fields on multiple forms', function () {
     livewire(TestComponentWithMultipleForms::class)
         ->assertFormFieldIsEnabled('enabled', 'fooForm')
         ->assertFormFieldIsEnabled('enabled', 'barForm');
 })->only();
 
-it('can have hidden fields', function() {
+it('can have hidden fields', function () {
     livewire(TestComponentWithForm::class)
         ->assertFormFieldIsHidden('hidden');
 })->only();
 
-it('can have hidden fields on multiple forms', function() {
+it('can have hidden fields on multiple forms', function () {
     livewire(TestComponentWithMultipleForms::class)
         ->assertFormFieldIsHidden('hidden', 'fooForm')
         ->assertFormFieldIsHidden('hidden', 'barForm');
 })->only();
 
-it('can have visible fields', function() {
+it('can have visible fields', function () {
     livewire(TestComponentWithForm::class)
         ->assertFormFieldIsVisible('visible');
 })->only();
 
-it('can have visible fields on multiple forms', function() {
+it('can have visible fields on multiple forms', function () {
     livewire(TestComponentWithMultipleForms::class)
         ->assertFormFieldIsVisible('visible', 'fooForm')
         ->assertFormFieldIsVisible('visible', 'barForm');

--- a/tests/src/Forms/FormsTest.php
+++ b/tests/src/Forms/FormsTest.php
@@ -11,68 +11,68 @@ uses(TestCase::class);
 it('has a form with the default name \'form\'', function () {
     livewire(TestComponentWithForm::class)
         ->assertFormExists();
-})->only();
+});
 
 it('can have forms with non-default names', function () {
     livewire(TestComponentWithMultipleForms::class)
         ->assertFormExists('fooForm')
         ->assertFormExists('barForm');
-})->only();
+});
 
 it('has fields', function () {
     livewire(TestComponentWithForm::class)
         ->assertFormFieldExists('title');
-})->only();
+});
 
 it('has fields on multiple forms', function () {
     livewire(TestComponentWithMultipleForms::class)
         ->assertFormFieldExists('title', 'fooForm')
         ->assertFormFieldExists('title', 'barForm');
-})->only();
+});
 
 it('can have disabled fields', function () {
     livewire(TestComponentWithForm::class)
         ->assertFormFieldIsDisabled('disabled');
-})->only();
+});
 
 it('can have disabled fields on multiple forms', function () {
     livewire(TestComponentWithMultipleForms::class)
         ->assertFormFieldIsDisabled('disabled', 'fooForm')
         ->assertFormFieldIsDisabled('disabled', 'barForm');
-})->only();
+});
 
 it('can have enabled fields', function () {
     livewire(TestComponentWithForm::class)
         ->assertFormFieldIsEnabled('enabled');
-})->only();
+});
 
 it('can have enabled fields on multiple forms', function () {
     livewire(TestComponentWithMultipleForms::class)
         ->assertFormFieldIsEnabled('enabled', 'fooForm')
         ->assertFormFieldIsEnabled('enabled', 'barForm');
-})->only();
+});
 
 it('can have hidden fields', function () {
     livewire(TestComponentWithForm::class)
         ->assertFormFieldIsHidden('hidden');
-})->only();
+});
 
 it('can have hidden fields on multiple forms', function () {
     livewire(TestComponentWithMultipleForms::class)
         ->assertFormFieldIsHidden('hidden', 'fooForm')
         ->assertFormFieldIsHidden('hidden', 'barForm');
-})->only();
+});
 
 it('can have visible fields', function () {
     livewire(TestComponentWithForm::class)
         ->assertFormFieldIsVisible('visible');
-})->only();
+});
 
 it('can have visible fields on multiple forms', function () {
     livewire(TestComponentWithMultipleForms::class)
         ->assertFormFieldIsVisible('visible', 'fooForm')
         ->assertFormFieldIsVisible('visible', 'barForm');
-})->only();
+});
 
 class TestComponentWithForm extends Livewire
 {


### PR DESCRIPTION
The new table and action testing helpers are great. The current project I'm working on has some interactive forms with disabled/enabled fields and hidden/visible fields depending on who is logged in or the state of other fields on the form. I wanted an easy way to test them so I took inspiration from the table testing helpers and I added the following helpers:

- assertFormExists: I haven't used this outside of use in the other testing helpers
- assertFormFieldExists: I haven't used this outside of use in the other testing helpers
- assertFormFieldIsDisabled
- assertFormFieldIsEnabled:
- assertFormFieldIsHidden
- assertFormFieldIsVisible

You can look at tests/src/Forms/FormsTest.php to see examples of how these helpers can be used. I also added some documentation showing simple use cases of how they work.

Regarding tests, I wasn't sure of the best place to add them so I put them all in FormsTest.php. Most of the helpers are actually about form fields, but they didn't seem to fit in the FieldTest.php file. I can move them around though if needed.

Let me know if there are any changes needed or if this would be better off as a plugin.