### PR TITLE
change whitespace to nowrap instead of normal

### DIFF
--- a/packages/tables/resources/views/columns/badge-column.blade.php
+++ b/packages/tables/resources/views/columns/badge-column.blade.php
@@ -26,7 +26,7 @@
 ]) }}>
     @if (filled($state))
         <div @class([
-            'inline-flex items-center justify-center space-x-1 rtl:space-x-reverse min-h-6 px-2 py-0.5 text-sm font-medium tracking-tight rounded-xl whitespace-normal',
+            'inline-flex items-center justify-center space-x-1 rtl:space-x-reverse min-h-6 px-2 py-0.5 text-sm font-medium tracking-tight rounded-xl whitespace-nowrap',
             $stateColor => $stateColor,
         ])>
             @if ($stateIcon && $iconPosition === 'before')


### PR DESCRIPTION
This PR is a fix for BadgeColumn as it did not look good when the the text of  BadgeColumn have multi word and there is many column in table like this
![badgeColumnIssue](https://user-images.githubusercontent.com/77433449/186988627-024b9b60-3ff8-42b6-86ba-0f6abdab5e86.PNG)
it should be like this
![badgeColumn](https://user-images.githubusercontent.com/77433449/186988865-fd9e5324-b770-4446-8180-dbbd8b2a0a95.PNG)
 