### PR TITLE
Fixed empty check on filter indication

### DIFF
--- a/packages/tables/src/Filters/MultiSelectFilter.php
+++ b/packages/tables/src/Filters/MultiSelectFilter.php
@@ -24,7 +24,7 @@ class MultiSelectFilter extends BaseFilter
         $this->placeholder(__('tables::table.filters.multi_select.placeholder'));
 
         $this->indicateUsing(function (array $state): array {
-            if (! ($state['values'] ?? false)) {
+            if (blank($state['value'] ?? null)) {
                 return [];
             }
 

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -25,7 +25,7 @@ class SelectFilter extends BaseFilter
         $this->placeholder(__('tables::table.filters.select.placeholder'));
 
         $this->indicateUsing(function (array $state): array {
-            if (! ($state['value'] ?? false)) {
+            if (blank($state['value'] ?? null)) {
                 return [];
             }
 


### PR DESCRIPTION
Not really sure if it is a bug, but I noticed that if you have a select filter with:

```php
SelectFilter::make('active')
    ->options([
        '1' => 'Yes',
        '0' => 'No',
    ]),
```

And you select 'No' it does not show up in the filter indications because of the '0' value.