### PR TITLE
Support Turbo navigation

### DIFF
--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -27,6 +27,7 @@
                 x-transition:enter-start="opacity-0"
                 x-transition:enter-end="opacity-100"
             @endif
+            data-turbo="false"
         >
             <x-filament::brand />
         </a>
@@ -39,6 +40,7 @@
                 x-transition:enter="lg:transition delay-100"
                 x-transition:enter-start="opacity-0"
                 x-transition:enter-end="opacity-100"
+                data-turbo="false"
             >
                 <x-filament::brand-icon />
             </a>


### PR DESCRIPTION
Please consider adding support for us who use hotwire Turbo.
This change has absolutely no impact for non Turbo users, but it is very important if you do.
The data attribute forces a full page reload when clicking on the navigation brand links.
(Which in most cases leads to a part of the application outside of the Filament Admin panel.)

It would be great, not having to override this file for only these lines.