### PR TITLE
Change sidebar active item background color

### DIFF
--- a/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
@@ -33,7 +33,7 @@
             'flex items-center justify-center gap-3 px-3 py-2 rounded-lg font-medium transition',
             'hover:bg-gray-500/5 focus:bg-gray-500/5' => ! $active,
             'dark:text-gray-300 dark:hover:bg-gray-700' => (! $active) && config('filament.dark_mode'),
-            'bg-primary-500 text-white' => $active,
+            'bg-primary-600 text-white' => $active,
         ])
     >
         <x-dynamic-component :component="$icon" class="h-5 w-5 shrink-0" />


### PR DESCRIPTION
Change active item background color from `bg-primary-500` to `bg-primary-600` to enhance white text visibility especially for filament default theme, and bring color consistency with primary buttons. This applies for both light and dark mode.

Before:
![image](https://user-images.githubusercontent.com/26832856/187084039-74e0020c-fa8b-498f-96ee-7872f3dc8427.png)

After:
![image](https://user-images.githubusercontent.com/26832856/187084063-19979f95-2c2f-4799-936d-471aa0e8b851.png)

Current primary button:
![image](https://user-images.githubusercontent.com/26832856/187084098-f1044ed9-40e8-43c6-9fac-8c63a7636a8e.png)

**Note:** I know this change is subjective & debatable, so discussions or rejections are totally welcome ✌️