### PR TITLE
Allow filterTable testing helper to accept array of data

### DIFF
--- a/packages/tables/src/Testing/TestsFilters.php
+++ b/packages/tables/src/Testing/TestsFilters.php
@@ -47,7 +47,7 @@ class TestsFilters
                 )];
             } elseif ($filter instanceof SelectFilter) {
                 $data = ['value' => $data instanceof Model ? $data->getKey() : $data];
-            } else {
+            } elseif (! is_array($data)) {
                 $data = ['isActive' => $data === true || $data === null];
             }
 


### PR DESCRIPTION
Currently when using the `filterTable()` testing helper, a series of conditional checks happen to ensure data is being passed to the various filter types correctly, transforming it as necessary. This PR allows data of type `array` to pass through the checks without being transformed into data for a simple boolean filter, meaning custom filter forms can be tested, such as:

```php
livewire(QuoteResource\Pages\ListQuotes::class)
    ->filterTable('date_range', [
        'start_date' => today()->subDay(),
        'end_date' => today()->addDay(),
    ])
    // ...
```