### PR TITLE
Improve translateLabel() coverage

### DIFF
--- a/packages/forms/src/Components/Field.php
+++ b/packages/forms/src/Components/Field.php
@@ -36,10 +36,14 @@ class Field extends Component implements Contracts\HasValidationRules
 
     public function getLabel(): string | Htmlable | null
     {
-        return parent::getLabel() ?? (string) Str::of($this->getName())
+        $label = parent::getLabel() ?? (string) Str::of($this->getName())
             ->afterLast('.')
             ->kebab()
             ->replace(['-', '_'], ' ')
             ->ucfirst();
+
+        return is_string($label) && $this->shouldTranslateLabel
+            ? __($label)
+            : $label;
     }
 }

--- a/packages/support/src/Actions/ActionGroup.php
+++ b/packages/support/src/Actions/ActionGroup.php
@@ -35,7 +35,9 @@ class ActionGroup extends ViewComponent
 
     public function getLabel(): ?string
     {
-        return $this->evaluate($this->label);
+        $label = $this->evaluate($this->label);
+
+        return $this->shouldTranslateLabel ? __($label) : $label;
     }
 
     public function getActions(): array


### PR DESCRIPTION
Some Components override `getLabel()` from the `HasLabels` trait.
This extends the `translateLabel() `to cover this case.

If I'm missing other places where the `getLabel()` is overridden, let me know and i'll extend the coverage to those as well