### PR TITLE
Make global search case insensitive for translatable json fields

### DIFF
--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -402,12 +402,14 @@ class Resource
 
             $query->when(
                 method_exists($model, 'isTranslatableAttribute') && $model->isTranslatableAttribute($searchAttribute),
-                function (Builder $query) use ($searchAttribute, $searchOperator, $searchQuery, $whereClause, $databaseConnection): Builder {
+                function (Builder $query) use ($databaseConnection, $searchAttribute, $searchOperator, $searchQuery, $whereClause): Builder {
                     $activeLocale = app()->getLocale();
+                    
                     $searchColumn = match ($databaseConnection->getDriverName()) {
                         'pgsql' => "{$searchAttribute}->>'{$activeLocale}'",
                         default => "json_extract({$searchAttribute}, \"$.{$activeLocale}\")",
                     };
+                    
                     return $query->{"{$whereClause}Raw"}(
                         "lower({$searchColumn}) {$searchOperator} ?",
                         "%{$searchQuery}%",

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -428,7 +428,7 @@ class Resource
                         $searchOperator,
                         "%{$searchQuery}%",
                     ),
-                )
+                ),
             );
 
             $isFirst = false;

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -395,22 +395,38 @@ class Resource
             default => 'like',
         };
 
+        $model = $query->getModel();
+
         foreach ($searchAttributes as $searchAttribute) {
             $whereClause = $isFirst ? 'where' : 'orWhere';
 
             $query->when(
-                Str::of($searchAttribute)->contains('.'),
-                fn ($query) => $query->{"{$whereClause}Relation"}(
-                    (string) Str::of($searchAttribute)->beforeLast('.'),
-                    (string) Str::of($searchAttribute)->afterLast('.'),
-                    $searchOperator,
-                    "%{$searchQuery}%",
-                ),
-                fn ($query) => $query->{$whereClause}(
-                    $searchAttribute,
-                    $searchOperator,
-                    "%{$searchQuery}%",
-                ),
+                method_exists($model, 'isTranslatableAttribute') && $model->isTranslatableAttribute($searchAttribute),
+                function (Builder $query) use ($searchAttribute, $searchOperator, $searchQuery, $whereClause, $databaseConnection): Builder {
+                    $activeLocale = app()->getLocale();
+                    $searchColumn = match ($databaseConnection->getDriverName()) {
+                        'pgsql' => "{$searchAttribute}->>'{$activeLocale}'",
+                        default => "json_extract({$searchAttribute}, \"$.{$activeLocale}\")",
+                    };
+                    return $query->{"{$whereClause}Raw"}(
+                        "lower({$searchColumn}) {$searchOperator} ?",
+                        "%{$searchQuery}%",
+                    );
+                },
+                fn (Builder $query): Builder => $query->when(
+                    Str::of($searchAttribute)->contains('.'),
+                    fn ($query) => $query->{"{$whereClause}Relation"}(
+                        (string) Str::of($searchAttribute)->beforeLast('.'),
+                        (string) Str::of($searchAttribute)->afterLast('.'),
+                        $searchOperator,
+                        "%{$searchQuery}%",
+                    ),
+                    fn ($query) => $query->{$whereClause}(
+                        $searchAttribute,
+                        $searchOperator,
+                        "%{$searchQuery}%",
+                    ),
+                )
             );
 
             $isFirst = false;


### PR DESCRIPTION
Made global search case insensitive for translated fields saved in json. Applied the same approach as in `\Filament\Tables\Columns\Concerns\InteractsWithTableQuery`. Ideally, some code could be shared, but I don't know where to put it given the files that belong to different packages. 