### PR TITLE
Chore: Replace Model with Authenticatable

### DIFF
--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -12,6 +12,7 @@ use Filament\Models\Contracts\HasName;
 use Filament\Navigation\NavigationGroup;
 use Filament\Navigation\UserMenuItem;
 use Filament\Notifications\Notification;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
@@ -368,7 +369,7 @@ class FilamentManager
         return $firstItem->getUrl();
     }
 
-    public function getUserAvatarUrl(Model $user): string
+    public function getUserAvatarUrl(Authenticatable $user): string
     {
         $avatar = null;
 
@@ -385,7 +386,7 @@ class FilamentManager
         return app($provider)->get($user);
     }
 
-    public function getUserName(Model $user): string
+    public function getUserName(Authenticatable $user): string
     {
         if ($user instanceof HasName) {
             return $user->getFilamentName();

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -369,7 +369,7 @@ class FilamentManager
         return $firstItem->getUrl();
     }
 
-    public function getUserAvatarUrl(Authenticatable $user): string
+    public function getUserAvatarUrl(Model|Authenticatable $user): string
     {
         $avatar = null;
 
@@ -386,7 +386,7 @@ class FilamentManager
         return app($provider)->get($user);
     }
 
-    public function getUserName(Authenticatable $user): string
+    public function getUserName(Model|Authenticatable $user): string
     {
         if ($user instanceof HasName) {
             return $user->getFilamentName();

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -369,7 +369,7 @@ class FilamentManager
         return $firstItem->getUrl();
     }
 
-    public function getUserAvatarUrl(Model|Authenticatable $user): string
+    public function getUserAvatarUrl(Model | Authenticatable $user): string
     {
         $avatar = null;
 
@@ -386,7 +386,7 @@ class FilamentManager
         return app($provider)->get($user);
     }
 
-    public function getUserName(Model|Authenticatable $user): string
+    public function getUserName(Model | Authenticatable $user): string
     {
         if ($user instanceof HasName) {
             return $user->getFilamentName();


### PR DESCRIPTION
### Package

filament/filament

### Package Version

v2.15.29

### Laravel Version

v9.26.1

### Livewire Version

_No response_

### PHP Version

PHP 8.1

### Problem description

Today, i've tried Filament for the first time. So far so good!
We actually have an centralized system for user management. That means that all colleagues of our company are allowed to login with their own 'internal login'. 

It's easy to create an custom UserProvider in Laravel and use it  in Filament. The problem is that this is an API connection and not an database table perse. In the `FilamentManager` and specifically `getUserName` and `getUserAvatarUrl` an instance of `Illuminate\Database\Eloquent\Model` is expected. In this case I've created my own User model, and it's not an instance of Model because it's not saved locally but elsewhere. 

For now i've fixed it by manually removing the typehint in the function itself, but that's not a solution.

App\Models\User doesn't have to be an Model. It could be something else right?

### Expected behavior

I'd expect that FilamentManager doesn't bind itself to instances of Model (Eloquent)

### Steps to reproduce


```php
<?php

namespace Wearejust\FillamentAuth;

use Filament\Models\Contracts\FilamentUser;
use Filament\Models\Contracts\HasAvatar;
use Filament\Models\Contracts\HasName;
use Illuminate\Auth\GenericUser;

class User extends GenericUser implements FilamentUser, HasAvatar, HasName
{
    public function canAccessFilament(): bool
    {
        return true;
    }

    public function getFilamentAvatarUrl(): ?string
    {
        return sprintf('https://www.gravatar.com/avatar/%s', md5($this->id));
    }

    public function getFilamentName(): string
    {
        return trim(vsprintf('%s %s %s', [
            $this->attributes['first_name'],
            $this->attributes['prefix'],
            $this->attributes['last_name'],
        ]));
    }
}
```

```php
<?php

namespace Wearejust\FillamentAuth;

use Illuminate\Contracts\Auth\Authenticatable;
use Illuminate\Contracts\Auth\UserProvider as UserProviderInterface;

class UserProvider implements UserProviderInterface
{
    public function retrieveById($identifier)
    {
        if ($output = $this->getUserByEmail($identifier)) {
            return new User($output['user']);
        }

        return false;
    }

    public function retrieveByToken($identifier, $token)
    {
        return false;
    }

    public function updateRememberToken(Authenticatable $user, $token)
    {
        return false;
    }

    public function retrieveByCredentials(array $credentials)
    {
        $email = $credentials['email'];
        $password = $credentials['password'];

        $output = $this->getUserByEmail($email);

        if ($output['status'] === 'error') {
            return false;
        }

        if (password_verify($password, $output['user']['password'])) {
            $output['user']['id'] = $output['user']['email'];

            return new User($output['user']);
        }

        return false;
    }

    public function validateCredentials(Authenticatable $user, array $credentials)
    {
        return password_verify($credentials['password'], $user->getAuthPassword());
    }

    private function getUserByEmail(string $email): array
    {
        // ... do some logic to get user
        return $output;
    }
}
```

### Reproduction repository

Is this really needed for this?

### Relevant log output

_No response_