### PR TITLE
fixes issue with casting to string for non-incrementing primary keys

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -134,7 +134,7 @@
         selectAllRecords: async function () {
             this.isLoading = true
 
-            this.selectedRecords = (await $wire.getAllTableRecordKeys()).map((key) => key.toString())
+            this.selectedRecords = $wire.getAllTableRecordKeys()
 
             this.isLoading = false
         },

--- a/packages/tables/src/Concerns/CanSelectRecords.php
+++ b/packages/tables/src/Concerns/CanSelectRecords.php
@@ -21,7 +21,10 @@ trait CanSelectRecords
     {
         $query = $this->getFilteredTableQuery();
 
-        return $query->pluck($query->getModel()->getQualifiedKeyName())->toArray();
+        return $query
+            ->pluck($query->getModel()->getQualifiedKeyName())
+            ->transform(fn ($key) => (string) $key)
+            ->toArray();
     }
 
     public function getAllTableRecordsCount(): int

--- a/packages/tables/src/Concerns/CanSelectRecords.php
+++ b/packages/tables/src/Concerns/CanSelectRecords.php
@@ -24,7 +24,7 @@ trait CanSelectRecords
         return $query
             ->pluck($query->getModel()->getQualifiedKeyName())
             ->map(fn ($key): string => (string) $key)
-            ->toArray();
+            ->all();
     }
 
     public function getAllTableRecordsCount(): int

--- a/packages/tables/src/Concerns/CanSelectRecords.php
+++ b/packages/tables/src/Concerns/CanSelectRecords.php
@@ -23,7 +23,7 @@ trait CanSelectRecords
 
         return $query
             ->pluck($query->getModel()->getQualifiedKeyName())
-            ->transform(fn ($key) => (string) $key)
+            ->map(fn ($key): string => (string) $key)
             ->toArray();
     }
 


### PR DESCRIPTION
This PR transforms the primary key being plucked from the table query and casts it to a string type. For some non-incrementing primary keys (i.e snowflake), selecting all records was exhibiting unexpected behavior.

This fixes the issue with all records not being selected when using a non-incrementing primary key.