### PR TITLE
Style the scrollbar in the side menu

### DIFF
--- a/packages/admin/resources/css/app.css
+++ b/packages/admin/resources/css/app.css
@@ -49,3 +49,23 @@
         top: -1px;
     }
 }
+
+@layer utilities {
+
+    /* Scroll thumb styles */
+    .filament-sidebar-nav::-webkit-scrollbar {
+        width: .2rem;
+    }
+    .filament-sidebar-nav::-webkit-scrollbar-thumb {
+        background-color: transparent;
+        border-radius: 1rem;
+    }
+    .filament-sidebar-nav:hover::-webkit-scrollbar-thumb {
+        background-color: theme('colors.gray.300');
+    }
+    /* Scroll track styles (Background) */
+    .filament-sidebar-nav::-webkit-scrollbar-track {
+        background: transparent;
+        border-radius: 0;
+    }
+}

--- a/packages/admin/resources/css/app.css
+++ b/packages/admin/resources/css/app.css
@@ -54,16 +54,16 @@
     .filament-sidebar-nav::-webkit-scrollbar {
         width: 0.2rem;
     }
-    
+
     .filament-sidebar-nav::-webkit-scrollbar-thumb {
         background-color: transparent;
         border-radius: 1rem;
     }
-    
+
     .filament-sidebar-nav:hover::-webkit-scrollbar-thumb {
         background-color: theme('colors.gray.300');
     }
-    
+
     .filament-sidebar-nav::-webkit-scrollbar-track {
         background: transparent;
         border-radius: 0;

--- a/packages/admin/resources/css/app.css
+++ b/packages/admin/resources/css/app.css
@@ -51,10 +51,9 @@
 }
 
 @layer utilities {
-
     /* Scroll thumb styles */
     .filament-sidebar-nav::-webkit-scrollbar {
-        width: .2rem;
+        width: 0.2rem;
     }
     .filament-sidebar-nav::-webkit-scrollbar-thumb {
         background-color: transparent;

--- a/packages/admin/resources/css/app.css
+++ b/packages/admin/resources/css/app.css
@@ -51,18 +51,19 @@
 }
 
 @layer utilities {
-    /* Scroll thumb styles */
     .filament-sidebar-nav::-webkit-scrollbar {
         width: 0.2rem;
     }
+    
     .filament-sidebar-nav::-webkit-scrollbar-thumb {
         background-color: transparent;
         border-radius: 1rem;
     }
+    
     .filament-sidebar-nav:hover::-webkit-scrollbar-thumb {
         background-color: theme('colors.gray.300');
     }
-    /* Scroll track styles (Background) */
+    
     .filament-sidebar-nav::-webkit-scrollbar-track {
         background: transparent;
         border-radius: 0;


### PR DESCRIPTION
A simple style to improve the look of the side menu with a scrollbar.

NOTE: the scrollbar appears only on the sidebar hover

![image](https://user-images.githubusercontent.com/7275012/187546815-f39e089f-0625-4950-bb0b-e5300a66cd2c.png)
![image](https://user-images.githubusercontent.com/7275012/187546871-930bff54-ca01-4a8a-b216-9b040a4dff6c.png)
