### PR TITLE
Support allow use 'above', 'below' description for TextColumn at the same time

### DIFF
--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -1,5 +1,6 @@
 @php
-    $description = $getDescription();
+    $descriptionAbove = $getDescriptionAbove();
+    $descriptionBelow = $getDescriptionBelow();
     $descriptionPosition = $getDescriptionPosition();
 @endphp
 
@@ -10,17 +11,17 @@
         'whitespace-normal' => $canWrap(),
     ]) }}
 >
-    @if (filled($description) && $descriptionPosition === 'above')
+    @if (filled($descriptionAbove) && (filled($descriptionPosition) ? $descriptionPosition === 'above' : true))
         <span class="block text-sm text-gray-400">
-            {{ $description instanceof \Illuminate\Support\HtmlString ? $description : \Illuminate\Support\Str::of($description)->markdown()->sanitizeHtml()->toHtmlString() }}
+            {{ $descriptionAbove instanceof \Illuminate\Support\HtmlString ? $descriptionAbove : \Illuminate\Support\Str::of($descriptionAbove)->markdown()->sanitizeHtml()->toHtmlString() }}
         </span>
     @endif
 
     {{ $getFormattedState() }}
 
-    @if (filled($description) && $descriptionPosition === 'below')
+    @if (filled($descriptionBelow) && (filled($descriptionPosition) ? $descriptionPosition === 'below' : true))
         <span class="block text-sm text-gray-400">
-            {{ $description instanceof \Illuminate\Support\HtmlString ? $description : \Illuminate\Support\Str::of($description)->markdown()->sanitizeHtml()->toHtmlString() }}
+            {{ $descriptionBelow instanceof \Illuminate\Support\HtmlString ? $descriptionBelow : \Illuminate\Support\Str::of($descriptionBelow)->markdown()->sanitizeHtml()->toHtmlString() }}
         </span>
     @endif
 </div>

--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -1,7 +1,6 @@
 @php
     $descriptionAbove = $getDescriptionAbove();
     $descriptionBelow = $getDescriptionBelow();
-    $descriptionPosition = $getDescriptionPosition();
 @endphp
 
 <div
@@ -11,7 +10,7 @@
         'whitespace-normal' => $canWrap(),
     ]) }}
 >
-    @if (filled($descriptionAbove) && (filled($descriptionPosition) ? $descriptionPosition === 'above' : true))
+    @if (filled($descriptionAbove))
         <span class="block text-sm text-gray-400">
             {{ $descriptionAbove instanceof \Illuminate\Support\HtmlString ? $descriptionAbove : \Illuminate\Support\Str::of($descriptionAbove)->markdown()->sanitizeHtml()->toHtmlString() }}
         </span>
@@ -19,7 +18,7 @@
 
     {{ $getFormattedState() }}
 
-    @if (filled($descriptionBelow) && (filled($descriptionPosition) ? $descriptionPosition === 'below' : true))
+    @if (filled($descriptionBelow))
         <span class="block text-sm text-gray-400">
             {{ $descriptionBelow instanceof \Illuminate\Support\HtmlString ? $descriptionBelow : \Illuminate\Support\Str::of($descriptionBelow)->markdown()->sanitizeHtml()->toHtmlString() }}
         </span>

--- a/packages/tables/src/Columns/Concerns/HasDescription.php
+++ b/packages/tables/src/Columns/Concerns/HasDescription.php
@@ -11,8 +11,6 @@ trait HasDescription
 
     protected string | HtmlString | Closure | null $descriptionBelow = null;
 
-    protected string | Closure | null $descriptionPosition = null;
-
     public function description(string | HtmlString | Closure | null $description, string | Closure | null $position = 'below'): static
     {
         if ($position == 'above') {

--- a/packages/tables/src/Columns/Concerns/HasDescription.php
+++ b/packages/tables/src/Columns/Concerns/HasDescription.php
@@ -7,18 +7,40 @@ use Illuminate\Support\HtmlString;
 
 trait HasDescription
 {
-    protected string | HtmlString | Closure | null $description = null;
+    protected string | HtmlString | Closure | null $descriptionAbove = null;
+
+    protected string | HtmlString | Closure | null $descriptionBelow = null;
 
     protected string | Closure | null $descriptionPosition = null;
 
     public function description(string | HtmlString | Closure | null $description, string | Closure | null $position = 'below'): static
     {
-        $this->description = $description;
-        $this->descriptionPosition($position);
+        if ($position == 'above') {
+            $this->descriptionAbove($description);
+        } else {
+            $this->descriptionBelow($description);
+        }
 
         return $this;
     }
 
+    public function descriptionAbove(string | HtmlString | Closure | null $descriptionAbove): static
+    {
+        $this->descriptionAbove = $descriptionAbove;
+
+        return $this;
+    }
+
+    public function descriptionBelow(string | HtmlString | Closure | null $descriptionBelow): static
+    {
+        $this->descriptionBelow = $descriptionBelow;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated use descriptionAbove() or descriptionBelow()
+     */
     public function descriptionPosition(string | Closure | null $position): static
     {
         $this->descriptionPosition = $position;
@@ -26,13 +48,33 @@ trait HasDescription
         return $this;
     }
 
+    /**
+     * @deprecated use getDescriptionAbove() or getDescriptionBelow()
+     */
     public function getDescription(): string | HtmlString | null
     {
-        return $this->evaluate($this->description);
+        if ($this->descriptionPosition == 'above') {
+            return $this->getDescriptionAbove();
+        } else {
+            return $this->getDescriptionBelow();
+        }
     }
 
-    public function getDescriptionPosition(): string
+    public function getDescriptionAbove(): string | HtmlString | null
     {
-        return $this->evaluate($this->descriptionPosition) ?? 'below';
+        return $this->evaluate($this->descriptionAbove);
+    }
+
+    public function getDescriptionBelow(): string | HtmlString | null
+    {
+        return $this->evaluate($this->descriptionBelow);
+    }
+
+    /**
+     * @deprecated use direct getDescriptionAbove() or getDescriptionBelow()
+     */
+    public function getDescriptionPosition(): ?string
+    {
+        return $this->evaluate($this->descriptionPosition);
     }
 }

--- a/packages/tables/src/Columns/Concerns/HasDescription.php
+++ b/packages/tables/src/Columns/Concerns/HasDescription.php
@@ -16,48 +16,12 @@ trait HasDescription
     public function description(string | HtmlString | Closure | null $description, string | Closure | null $position = 'below'): static
     {
         if ($position == 'above') {
-            $this->descriptionAbove($description);
+            $this->descriptionAbove = $description;
         } else {
-            $this->descriptionBelow($description);
+            $this->descriptionBelow = $description;
         }
 
         return $this;
-    }
-
-    public function descriptionAbove(string | HtmlString | Closure | null $descriptionAbove): static
-    {
-        $this->descriptionAbove = $descriptionAbove;
-
-        return $this;
-    }
-
-    public function descriptionBelow(string | HtmlString | Closure | null $descriptionBelow): static
-    {
-        $this->descriptionBelow = $descriptionBelow;
-
-        return $this;
-    }
-
-    /**
-     * @deprecated use descriptionAbove() or descriptionBelow()
-     */
-    public function descriptionPosition(string | Closure | null $position): static
-    {
-        $this->descriptionPosition = $position;
-
-        return $this;
-    }
-
-    /**
-     * @deprecated use getDescriptionAbove() or getDescriptionBelow()
-     */
-    public function getDescription(): string | HtmlString | null
-    {
-        if ($this->descriptionPosition == 'above') {
-            return $this->getDescriptionAbove();
-        } else {
-            return $this->getDescriptionBelow();
-        }
     }
 
     public function getDescriptionAbove(): string | HtmlString | null
@@ -68,13 +32,5 @@ trait HasDescription
     public function getDescriptionBelow(): string | HtmlString | null
     {
         return $this->evaluate($this->descriptionBelow);
-    }
-
-    /**
-     * @deprecated use direct getDescriptionAbove() or getDescriptionBelow()
-     */
-    public function getDescriptionPosition(): ?string
-    {
-        return $this->evaluate($this->descriptionPosition);
     }
 }


### PR DESCRIPTION
Some time we need to use description on above TextColumn and below at the same time,

so that I added :

```
 ->descriptionAbove('Above description')
 ->descriptionBelow('Below description'))
```
