### PR TITLE
fix: table 'select all records' broken

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -134,7 +134,7 @@
         selectAllRecords: async function () {
             this.isLoading = true
 
-            this.selectedRecords = $wire.getAllTableRecordKeys()
+            this.selectedRecords = await $wire.getAllTableRecordKeys()
 
             this.isLoading = false
         },


### PR DESCRIPTION
`await` was removed causing the function to not wait the Promise, then `this.selectedRecords` is being replaced by an unfinished Promise instead of an array

video of the error:
https://discord.com/channels/883083792112300104/883083792653381695/1014526276238839908

PR that introduced this:
https://github.com/filamentphp/filament/pull/3763