### PR TITLE
fix rounded borders for dropdown panel

### DIFF
--- a/packages/support/resources/views/components/dropdown/index.blade.php
+++ b/packages/support/resources/views/components/dropdown/index.blade.php
@@ -39,7 +39,7 @@
             wire:key="{{ $attributes->get('wire:key') }}.panel"
         @endif
         @class([
-            'filament-dropdown-panel absolute z-10 w-full rounded-lg bg-white shadow-lg ring-1 ring-black/5 transition',
+            'filament-dropdown-panel absolute z-10 w-full rounded-lg bg-white shadow-lg ring-1 ring-black/5 transition overflow-hidden',
             'dark:bg-gray-800 dark:ring-white/10' => $darkMode,
             match ($width) {
                 'xs' => 'max-w-xs',


### PR DESCRIPTION
`overflow-hidden` was removed causing the items background to overflow the panel

before:
<img width="291" alt="image" src="https://user-images.githubusercontent.com/14329460/187709201-eb30dcb2-261f-4249-88e5-9eaa5ecd7ff0.png">

after:
<img width="296" alt="image" src="https://user-images.githubusercontent.com/14329460/187709288-f182ae05-d1fe-46dc-a1c5-e488ae284df3.png">
