### PR TITLE
add pivot property to a record when a relationship is present

### DIFF
--- a/packages/tables/src/Concerns/CanSelectRecords.php
+++ b/packages/tables/src/Concerns/CanSelectRecords.php
@@ -51,9 +51,9 @@ trait CanSelectRecords
         $pivotClass = $relationship->getPivotClass();
         $pivotKeyName = app($pivotClass)->getKeyName();
 
-        return $this->selectPivotDataInQuery(
+        return $this->hydratePivotRelation($this->selectPivotDataInQuery(
             $relationship->wherePivotIn($pivotKeyName, $this->selectedTableRecords),
-        )->get();
+        )->get());
     }
 
     public function isTableSelectionEnabled(): bool

--- a/packages/tables/src/Concerns/CanSelectRecords.php
+++ b/packages/tables/src/Concerns/CanSelectRecords.php
@@ -51,7 +51,7 @@ trait CanSelectRecords
         $pivotClass = $relationship->getPivotClass();
         $pivotKeyName = app($pivotClass)->getKeyName();
 
-        return $this->hydratePivotRelation($this->selectPivotDataInQuery(
+        return $this->hydratePivotRelationForTableRecords($this->selectPivotDataInQuery(
             $relationship->wherePivotIn($pivotKeyName, $this->selectedTableRecords),
         )->get());
     }

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -41,7 +41,7 @@ trait HasRecords
         return $query;
     }
 
-    protected function hydratePivotRelation(Collection | Paginator $records): Collection | Paginator
+    protected function hydratePivotRelationForTableRecords(Collection | Paginator $records): Collection | Paginator
     {
         if ($this instanceof HasRelationshipTable && $this->getRelationship() instanceof BelongsToMany && ! $this->allowsDuplicates()) {
             invade($this->getRelationship())->hydratePivotRelation($records->all());
@@ -64,10 +64,10 @@ trait HasRecords
             (! $this->isTablePaginationEnabled()) ||
             ($this->isTableReordering() && (! $this->isTablePaginationEnabledWhileReordering()))
         ) {
-            return $this->records = $this->hydratePivotRelation($query->get());
+            return $this->records = $this->hydratePivotRelationForTableRecords($query->get());
         }
 
-        return $this->records = $this->hydratePivotRelation($this->paginateTableQuery($query));
+        return $this->records = $this->hydratePivotRelationForTableRecords($this->paginateTableQuery($query));
     }
 
     protected function resolveTableRecord(?string $key): ?Model

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -92,6 +92,8 @@ trait HasRecords
 
         $record = $this->selectPivotDataInQuery($query)->first();
 
+        invade($relationship)->hydratePivotRelation([$record]);
+
         return $record?->setRawAttributes($record->getRawOriginal());
     }
 

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -4,6 +4,8 @@ namespace Filament\Tables\Concerns;
 
 use function Filament\locale_has_pluralization;
 use function Filament\Support\get_model_label;
+use function Livewire\invade;
+
 use Filament\Tables\Contracts\HasRelationshipTable;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Builder;

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -41,7 +41,7 @@ trait HasRecords
 
     protected function hydratePivotRelation(Collection | Paginator $records): Collection | Paginator
     {
-        if (($this instanceof HasRelationshipTable && $this->getRelationship() instanceof BelongsToMany) && ! $this->allowsDuplicates()) {
+        if ($this instanceof HasRelationshipTable && $this->getRelationship() instanceof BelongsToMany && ! $this->allowsDuplicates()) {
             invade($this->getRelationship())->hydratePivotRelation($records->all());
         }
 

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -41,7 +41,7 @@ trait HasRecords
 
     protected function hydratePivotRelation(Collection | Paginator $records): Collection | Paginator
     {
-        if (($this instanceof HasRelationshipTable && $this->getRelationship() instanceof BelongsToMany)) {
+        if (($this instanceof HasRelationshipTable && $this->getRelationship() instanceof BelongsToMany) && ! $this->allowsDuplicates()) {
             invade($this->getRelationship())->hydratePivotRelation($records->all());
         }
 

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -39,6 +39,15 @@ trait HasRecords
         return $query;
     }
 
+    protected function hydratePivotRelation(Collection | Paginator $records): Collection | Paginator
+    {
+        if (($this instanceof HasRelationshipTable && $this->getRelationship() instanceof BelongsToMany)) {
+            invade($this->getRelationship())->hydratePivotRelation($records->all());
+        }
+
+        return $records;
+    }
+
     public function getTableRecords(): Collection | Paginator
     {
         if ($this->records) {
@@ -53,10 +62,10 @@ trait HasRecords
             (! $this->isTablePaginationEnabled()) ||
             ($this->isTableReordering() && (! $this->isTablePaginationEnabledWhileReordering()))
         ) {
-            return $this->records = $query->get();
+            return $this->records = $this->hydratePivotRelation($query->get());
         }
 
-        return $this->records = $this->paginateTableQuery($query);
+        return $this->records = $this->hydratePivotRelation($this->paginateTableQuery($query));
     }
 
     protected function resolveTableRecord(?string $key): ?Model

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -2,6 +2,8 @@
 
 namespace Filament\Tables\Concerns;
 
+use function Livewire\invade;
+
 use Exception;
 use Filament\Forms;
 use Filament\Tables\Contracts\HasRelationshipTable;

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -175,10 +175,13 @@ trait InteractsWithTable
         /** @var BelongsToMany $relationship */
         $relationship = $this->getRelationship();
 
-        $query->select(
-            $relationship->getTable() . '.*',
-            $query->getModel()->getTable() . '.*',
-        );
+        $query->select(array_merge(
+            invade($relationship)->aliasedPivotColumns(),
+            [
+                $relationship->getTable() . '.*',
+                $query->getModel()->getTable() . '.*',
+            ]
+        ));
 
         return $query;
     }


### PR DESCRIPTION
At this moment, filament gets all pivot data and all model data. When keys overlap (eg. created_at on the pivot table and on the model table), data from the model takes precedence. In order to access this data more easily, I tried to recreate the `pivot` property as laravel also uses it when a `BelongsToMany` relation is set.

I am not sure if the implementation is complete. Also, a mention in the docs needs to be added.

```php
<?php

namespace App\Filament\Resources\PostResource\RelationManagers;

use App\Models\Post;
use Filament\Resources\RelationManagers\RelationManager;
use Filament\Resources\Table;
use Filament\Tables\Columns\TextColumn;

class PostUserRelationManager extends RelationManager
{
    protected static string $relationship = 'users';
    //...

    public static function table(Table $table): Table
    {
        return $table
            ->columns([
                TextColumn::make('created_at')
                    ->getStateUsing(fn (Post $record) => $record->pivot?->created_at) // before this fix, this returns null
                    ->dateTime('d-m-Y H:i'),
            ]);
    }
    //...
}
```