### PR TITLE
Document using `wire:model` in view fields

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -1912,13 +1912,13 @@ Using [Livewire's entangle](https://laravel-livewire.com/docs/2.x/alpine-js#shar
     :required="$isRequired()"
     :state-path="$getStatePath()"
 >
-    <div x-data="{ state: $wire.entangle('{{ $getStatePath() }}') }">
+    <div x-data="{ state: $wire.entangle('{{ $getStatePath() }}').defer }">
         <!-- Interact with the `state` property in Alpine.js -->
     </div>
 </x-forms::field-wrapper>
 ```
 
-You may bind the value to a Livewire property using [`wire:model`](https://laravel-livewire.com/docs/properties#data-binding):
+Or, you may bind the value to a Livewire property using [`wire:model`](https://laravel-livewire.com/docs/properties#data-binding):
 
 ```
 <x-forms::field-wrapper
@@ -1931,7 +1931,7 @@ You may bind the value to a Livewire property using [`wire:model`](https://larav
     :required="$isRequired()"
     :state-path="$getStatePath()"
 >
-    <input wire:model="{{ $getStatePath() }}" />
+    <input wire:model.defer="{{ $getStatePath() }}" />
 </x-forms::field-wrapper>
 ```
 
@@ -1973,7 +1973,7 @@ The `$getStatePath()` closure may be used by the view to retrieve the Livewire p
     :required="$isRequired()"
     :state-path="$getStatePath()"
 >
-    <div x-data="{ state: $wire.entangle('{{ $getStatePath() }}') }">
+    <div x-data="{ state: $wire.entangle('{{ $getStatePath() }}').defer }">
         <!-- Interact with the `state` property in Alpine.js -->
     </div>
 </x-forms::field-wrapper>

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -1899,6 +1899,8 @@ Inside your view, you may interact with the state of the form component using Li
 
 The `$getStatePath()` closure may be used by the view to retrieve the Livewire property path of the field. You could use this to [`wire:model`](https://laravel-livewire.com/docs/properties#data-binding) a value, or [`$wire.entangle`](https://laravel-livewire.com/docs/alpine-js) it with Alpine.js:
 
+Using [Livewire's entangle](https://laravel-livewire.com/docs/2.x/alpine-js#sharing-state) allows sharing state with Alpine.js:
+
 ```blade
 <x-forms::field-wrapper
     :id="$getId()"
@@ -1913,6 +1915,23 @@ The `$getStatePath()` closure may be used by the view to retrieve the Livewire p
     <div x-data="{ state: $wire.entangle('{{ $getStatePath() }}') }">
         <!-- Interact with the `state` property in Alpine.js -->
     </div>
+</x-forms::field-wrapper>
+```
+
+You can also bind with [`wire:model`](https://laravel-livewire.com/docs/properties#data-binding) :
+
+```
+<x-forms::field-wrapper
+    :id="$getId()"
+    :label="$getLabel()"
+    :label-sr-only="$isLabelHidden()"
+    :helper-text="$getHelperText()"
+    :hint="$getHint()"
+    :hint-icon="$getHintIcon()"
+    :required="$isRequired()"
+    :state-path="$getStatePath()"
+>
+    <input wire:model="{{ $getStatePath() }}" />
 </x-forms::field-wrapper>
 ```
 

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -1918,7 +1918,7 @@ Using [Livewire's entangle](https://laravel-livewire.com/docs/2.x/alpine-js#shar
 </x-forms::field-wrapper>
 ```
 
-You can also bind with [`wire:model`](https://laravel-livewire.com/docs/properties#data-binding) :
+You may bind the value to a Livewire property using [`wire:model`](https://laravel-livewire.com/docs/properties#data-binding):
 
 ```
 <x-forms::field-wrapper

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -1897,7 +1897,7 @@ ViewField::make('notifications')->view('filament.forms.components.range-slider')
 
 Inside your view, you may interact with the state of the form component using Livewire and Alpine.js.
 
-The `$getStatePath()` closure may be used by the view to retrieve the Livewire property path of the field. You could use this to [`wire:model`](https://laravel-livewire.com/docs/properties#data-binding) a value, or [`$wire.entangle`](https://laravel-livewire.com/docs/alpine-js) it with Alpine.js:
+The `$getStatePath()` closure may be used by the view to retrieve the Livewire property path of the field. You could use this to [`wire:model`](https://laravel-livewire.com/docs/properties#data-binding) a value, or [`$wire.entangle`](https://laravel-livewire.com/docs/alpine-js) it with Alpine.js.
 
 Using [Livewire's entangle](https://laravel-livewire.com/docs/2.x/alpine-js#sharing-state) allows sharing state with Alpine.js:
 


### PR DESCRIPTION
I wasn't sure how to use `wire:model` today in a view field and wasn't sure how that would work. I wanted to document how this works for others.

