### PR TITLE
fix: Tables empty state description wrap

### DIFF
--- a/packages/tables/resources/views/components/empty-state/description.blade.php
+++ b/packages/tables/resources/views/components/empty-state/description.blade.php
@@ -1,5 +1,5 @@
 <p {{ $attributes->class([
-    'filament-tables-empty-state-description text-sm font-medium text-gray-500',
+    'filament-tables-empty-state-description whitespace-normal text-sm font-medium text-gray-500',
     'dark:text-gray-400' => config('tables.dark_mode'),
 ]) }}>
     {{ $slot }}


### PR DESCRIPTION
Currently, the tables empty state description does not wrap and thus overflows the container for long descriptions.