### PR TITLE
fix: Tables empty state max width

### DIFF
--- a/packages/tables/resources/views/components/empty-state/index.blade.php
+++ b/packages/tables/resources/views/components/empty-state/index.blade.php
@@ -27,7 +27,7 @@
         />
     </div>
 
-    <div class="max-w-xs space-y-1">
+    <div class="max-w-md space-y-1">
         <x-tables::empty-state.heading>
             {{ $heading }}
         </x-tables::empty-state.heading>


### PR DESCRIPTION
This PR updates the tables empty state max width to a more sensible value.