### PR TITLE
Automatically detect button and link tag

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -23,7 +23,6 @@
             <div class="space-x-2 rtl:space-x-reverse" x-data="{}">
                 <x-forms::link
                     x-on:click="$dispatch('builder-collapse', '{{ $getStatePath() }}')"
-                    tag="button"
                     size="sm"
                 >
                     {{ __('forms::components.builder.buttons.collapse_all.label') }}
@@ -31,7 +30,6 @@
 
                 <x-forms::link
                     x-on:click="$dispatch('builder-expand', '{{ $getStatePath() }}')"
-                    tag="button"
                     size="sm"
                 >
                     {{ __('forms::components.builder.buttons.expand_all.label') }}

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -198,7 +198,6 @@
                 <x-forms::button
                     :wire:click="'dispatchFormEvent(\'repeater::createItem\', \'' . $getStatePath() . '\')'"
                     size="sm"
-                    type="button"
                 >
                     {{ $getCreateItemButtonLabel() }}
                 </x-forms::button>

--- a/packages/support/resources/views/components/button.blade.php
+++ b/packages/support/resources/views/components/button.blade.php
@@ -8,7 +8,7 @@
     'keyBindings' => null,
     'outlined' => false,
     'size' => 'md',
-    'tag' => 'button',
+    'tag' => $attributes->get('href') ? 'a' : 'button',
     'tooltip' => null,
     'type' => 'button',
     'labelSrOnly' => false,

--- a/packages/support/resources/views/components/link.blade.php
+++ b/packages/support/resources/views/components/link.blade.php
@@ -6,7 +6,7 @@
     'iconPosition' => 'before',
     'keyBindings' => null,
     'size' => 'md',
-    'tag' => 'a',
+    'tag' => $attributes->get('href') ? 'a' : 'button',
     'tooltip' => null,
     'type' => 'button',
 ])

--- a/packages/tables/resources/views/components/filters/index.blade.php
+++ b/packages/tables/resources/views/components/filters/index.blade.php
@@ -12,7 +12,6 @@
         <x-tables::link
             wire:click="resetTableFiltersForm"
             color="danger"
-            tag="button"
             size="sm"
         >
             {{ __('tables::table.filters.buttons.reset.label') }}


### PR DESCRIPTION
This is especially useful when using the Filament button and link outside of Filament admin in your own project.

You no longer need to pass the `tag` attribute as it will automatically detect if an `href` has been passed and uses a button or link HTML tag accordingly.