### PR TITLE
fix: using record key instead of routeKey

### DIFF
--- a/packages/admin/src/Resources/Pages/EditRecord.php
+++ b/packages/admin/src/Resources/Pages/EditRecord.php
@@ -72,7 +72,7 @@ class EditRecord extends Page implements HasFormActions
 
     public function save(bool $shouldRedirect = true): void
     {
-        $this->authorizeAccess($this->getRecord()->getKey());
+        $this->authorizeAccess($this->getRecord()->{$this->getRecord()->getRouteKeyName()});
 
         $this->callHook('beforeValidate');
 

--- a/packages/admin/src/Resources/Pages/EditRecord.php
+++ b/packages/admin/src/Resources/Pages/EditRecord.php
@@ -38,16 +38,16 @@ class EditRecord extends Page implements HasFormActions
 
     public function mount($record): void
     {
-        $this->authorizeAccess($record);
+        $this->record = $this->resolveRecord($record);
+
+        $this->authorizeAccess();
 
         $this->fillForm();
     }
 
-    protected function authorizeAccess($record): void
+    protected function authorizeAccess(): void
     {
         static::authorizeResourceAccess();
-
-        $this->record = $this->resolveRecord($record);
 
         abort_unless(static::getResource()::canEdit($this->getRecord()), 403);
     }
@@ -72,7 +72,7 @@ class EditRecord extends Page implements HasFormActions
 
     public function save(bool $shouldRedirect = true): void
     {
-        $this->authorizeAccess($this->getRecord()->{$this->getRecord()->getRouteKeyName()});
+        $this->authorizeAccess();
 
         $this->callHook('beforeValidate');
 


### PR DESCRIPTION
PR #3733 introduced authorization into record create and edit actions.

While create seems fine, it broke the edit action because its not using the `routeKeyName`, so that leaves to a 404 while resolving the record.


on mount, it authorizes the `$record` wich is the "id" (in some cases uuid) from the record in the route
```php
    public function mount($record): void
    {
        $this->authorizeAccess($record); // record is the routeKey (in some cases the uuid)

        $this->fillForm();
    }
```

that passes since it resolves the records using its uuid (in my case)

on save, it authorizes again, but using the record key (primaryKey), wich leads to a 404, since its using the model id instead of the `routeKey` (uuid)

```php
public function save(bool $shouldRedirect = true): void
    {
        $this->authorizeAccess($this->getRecord()->getKey());
        ...
```

this PR fixes that behavior using the `routeKey` wich in my case is the uuid, but in other cases will default to the model id.