### PR TITLE
fix: Remove filters via the indicator icons

### DIFF
--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -97,6 +97,10 @@ namespace Livewire\Testing {
 
         public function resetTableFilters(): static {}
 
+        public function removeTableFilter(string $filter, ?string $field = null): static {}
+
+        public function removeTableFilters(): static {}
+
         public function assertCanSeeTableRecords(array | Collection $records, bool $inOrder = false): static {}
 
         public function assertCanNotSeeTableRecords(array | Collection $records): static {}

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -84,7 +84,7 @@ trait HasFilters
 
         foreach ($fields as $field) {
             $field->state(
-                is_array($field->getState()) ? [] : null,
+                is_array($field->getState()) ? [] : $field->getDefaultState(),
             );
         }
 
@@ -95,7 +95,7 @@ trait HasFilters
     {
         foreach ($this->getTableFiltersForm()->getFlatFields(withAbsolutePathKeys: true) as $field) {
             $field->state(
-                is_array($field->getState()) ? [] : null,
+                is_array($field->getState()) ? [] : $field->getDefaultState(),
             );
         }
 

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -83,9 +83,13 @@ trait HasFilters
         }
 
         foreach ($fields as $field) {
-            $field->state(
-                is_array($field->getState()) ? [] : $field->getDefaultState(),
-            );
+            $state = $field->getState();
+
+            $field->state(match (true) {
+                is_array($state) => [],
+                $state === true => false,
+                default => null,
+            });
         }
 
         $this->updatedTableFilters();
@@ -94,9 +98,13 @@ trait HasFilters
     public function removeTableFilters(): void
     {
         foreach ($this->getTableFiltersForm()->getFlatFields(withAbsolutePathKeys: true) as $field) {
-            $field->state(
-                is_array($field->getState()) ? [] : $field->getDefaultState(),
-            );
+            $state = $field->getState();
+
+            $field->state(match (true) {
+                is_array($state) => [],
+                $state === true => false,
+                default => null,
+            });
         }
 
         $this->updatedTableFilters();

--- a/packages/tables/src/Filters/Concerns/HasFormSchema.php
+++ b/packages/tables/src/Filters/Concerns/HasFormSchema.php
@@ -3,6 +3,7 @@
 namespace Filament\Tables\Filters\Concerns;
 
 use Closure;
+use Filament\Forms\Components\Field;
 
 trait HasFormSchema
 {
@@ -17,6 +18,23 @@ trait HasFormSchema
 
     public function getFormSchema(): array
     {
-        return $this->evaluate($this->formSchema) ?? [];
+        $schema = $this->evaluate($this->formSchema);
+
+        if ($schema !== null) {
+            return $schema;
+        }
+
+        $field = $this->getFormField();
+
+        if ($field === null) {
+            return [];
+        }
+
+        return [$field];
+    }
+
+    protected function getFormField(): ?Field
+    {
+        return null;
     }
 }

--- a/packages/tables/src/Filters/Filter.php
+++ b/packages/tables/src/Filters/Filter.php
@@ -13,6 +13,8 @@ class Filter extends BaseFilter
     {
         parent::setUp();
 
+        $this->checkbox();
+
         $this->indicateUsing(function (array $state): array {
             if (! ($state['isActive'] ?? false)) {
                 return [];
@@ -26,6 +28,8 @@ class Filter extends BaseFilter
     {
         $this->formComponent(Toggle::class);
 
+        $this->default(state: false);
+
         return $this;
     }
 
@@ -33,12 +37,16 @@ class Filter extends BaseFilter
     {
         $this->formComponent(Checkbox::class);
 
+        $this->default(state:false);
+
         return $this;
     }
 
     public function formComponent(string $component): static
     {
         $this->formComponent = $component;
+
+        $this->default(null);
 
         return $this;
     }

--- a/packages/tables/src/Filters/Filter.php
+++ b/packages/tables/src/Filters/Filter.php
@@ -3,6 +3,9 @@
 namespace Filament\Tables\Filters;
 
 use Filament\Forms\Components\Checkbox;
+use Filament\Forms\Components\Field;
+use Filament\Forms\Components\MultiSelect;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Toggle;
 
 class Filter extends BaseFilter
@@ -12,8 +15,6 @@ class Filter extends BaseFilter
     protected function setUp(): void
     {
         parent::setUp();
-
-        $this->checkbox();
 
         $this->indicateUsing(function (array $state): array {
             if (! ($state['isActive'] ?? false)) {
@@ -28,16 +29,12 @@ class Filter extends BaseFilter
     {
         $this->formComponent(Toggle::class);
 
-        $this->default(state: false);
-
         return $this;
     }
 
     public function checkbox(): static
     {
         $this->formComponent(Checkbox::class);
-
-        $this->default(state: false);
 
         return $this;
     }
@@ -46,18 +43,19 @@ class Filter extends BaseFilter
     {
         $this->formComponent = $component;
 
-        $this->default(state: null);
-
         return $this;
     }
 
-    public function getFormSchema(): array
+    protected function getFormField(): Field
     {
-        return $this->evaluate($this->formSchema) ?? [
-            $this->formComponent::make('isActive')
-                ->label($this->getLabel())
-                ->default($this->getDefaultState())
-                ->columnSpan($this->getColumnSpan()),
-        ];
+        $field = $this->formComponent::make('isActive')
+            ->label($this->getLabel())
+            ->columnSpan($this->getColumnSpan());
+
+        if (filled($defaultState = $this->getDefaultState())) {
+            $field->default($defaultState);
+        }
+
+        return $field;
     }
 }

--- a/packages/tables/src/Filters/Filter.php
+++ b/packages/tables/src/Filters/Filter.php
@@ -4,8 +4,6 @@ namespace Filament\Tables\Filters;
 
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\Field;
-use Filament\Forms\Components\MultiSelect;
-use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Toggle;
 
 class Filter extends BaseFilter

--- a/packages/tables/src/Filters/Filter.php
+++ b/packages/tables/src/Filters/Filter.php
@@ -37,7 +37,7 @@ class Filter extends BaseFilter
     {
         $this->formComponent(Checkbox::class);
 
-        $this->default(state:false);
+        $this->default(state: false);
 
         return $this;
     }
@@ -46,7 +46,7 @@ class Filter extends BaseFilter
     {
         $this->formComponent = $component;
 
-        $this->default(null);
+        $this->default(state: null);
 
         return $this;
     }

--- a/packages/tables/src/Filters/MultiSelectFilter.php
+++ b/packages/tables/src/Filters/MultiSelectFilter.php
@@ -3,7 +3,9 @@
 namespace Filament\Tables\Filters;
 
 use Closure;
+use Filament\Forms\Components\Field;
 use Filament\Forms\Components\MultiSelect;
+use Filament\Forms\Components\Select;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 
@@ -89,15 +91,19 @@ class MultiSelectFilter extends BaseFilter
         return $this->evaluate($this->column) ?? $this->getName();
     }
 
-    public function getFormSchema(): array
+    protected function getFormField(): Field
     {
-        return $this->formSchema ?? [
-            MultiSelect::make('values')
-                ->label($this->getLabel())
-                ->options($this->getOptions())
-                ->placeholder($this->getPlaceholder())
-                ->default($this->getDefaultState())
-                ->columnSpan($this->getColumnSpan()),
-        ];
+        $field = MultiSelect::make('values')
+            ->label($this->getLabel())
+            ->options($this->getOptions())
+            ->placeholder($this->getPlaceholder())
+            ->default($this->getDefaultState())
+            ->columnSpan($this->getColumnSpan());
+
+        if (filled($defaultState = $this->getDefaultState())) {
+            $field->default($defaultState);
+        }
+
+        return $field;
     }
 }

--- a/packages/tables/src/Filters/MultiSelectFilter.php
+++ b/packages/tables/src/Filters/MultiSelectFilter.php
@@ -5,7 +5,6 @@ namespace Filament\Tables\Filters;
 use Closure;
 use Filament\Forms\Components\Field;
 use Filament\Forms\Components\MultiSelect;
-use Filament\Forms\Components\Select;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 

--- a/packages/tables/src/Filters/MultiSelectFilter.php
+++ b/packages/tables/src/Filters/MultiSelectFilter.php
@@ -5,6 +5,7 @@ namespace Filament\Tables\Filters;
 use Closure;
 use Filament\Forms\Components\Field;
 use Filament\Forms\Components\MultiSelect;
+use Filament\Forms\Components\Select;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 
@@ -90,7 +91,7 @@ class MultiSelectFilter extends BaseFilter
         return $this->evaluate($this->column) ?? $this->getName();
     }
 
-    protected function getFormField(): Field
+    protected function getFormField(): Select
     {
         $field = MultiSelect::make('values')
             ->label($this->getLabel())

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -3,6 +3,7 @@
 namespace Filament\Tables\Filters;
 
 use Closure;
+use Filament\Forms\Components\Field;
 use Filament\Forms\Components\Select;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -90,22 +91,28 @@ class SelectFilter extends BaseFilter
         return $this->evaluate($this->column) ?? $this->getName();
     }
 
-    public function getFormSchema(): array
+    protected function getFormField(): Field
     {
-        return $this->formSchema ?? [
-            $this->getFormSelectComponent(),
-        ];
+        return $this->getFormSelectComponent();
     }
 
+    /**
+     * @deprecated Overwrite `getFormField()` instead.
+     */
     protected function getFormSelectComponent(): Select
     {
-        return Select::make('value')
+        $field = Select::make('value')
             ->label($this->getLabel())
             ->options($this->getOptions())
             ->placeholder($this->getPlaceholder())
-            ->default($this->getDefaultState())
             ->searchable($this->isSearchable())
             ->columnSpan($this->getColumnSpan());
+
+        if (filled($defaultState = $this->getDefaultState())) {
+            $field->default($defaultState);
+        }
+
+        return $field;
     }
 
     public function isSearchable(): bool

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -91,7 +91,7 @@ class SelectFilter extends BaseFilter
         return $this->evaluate($this->column) ?? $this->getName();
     }
 
-    protected function getFormField(): Field
+    protected function getFormField(): Select
     {
         return $this->getFormSelectComponent();
     }

--- a/packages/tables/src/Filters/TernaryFilter.php
+++ b/packages/tables/src/Filters/TernaryFilter.php
@@ -57,9 +57,9 @@ class TernaryFilter extends SelectFilter
         return $this->falseLabel;
     }
 
-    protected function getFormSelectComponent(): Select
+    protected function getFormField(): Select
     {
-        return parent::getFormSelectComponent()
+        return parent::getFormField()
             ->boolean(
                 trueLabel: $this->getTrueLabel(),
                 falseLabel: $this->getFalseLabel(),

--- a/packages/tables/src/Testing/TestsFilters.php
+++ b/packages/tables/src/Testing/TestsFilters.php
@@ -66,6 +66,24 @@ class TestsFilters
         };
     }
 
+    public function removeTableFilter(): Closure
+    {
+        return function (string $filter, ?string $field = null): static {
+            $this->call('removeTableFilter', $filter, $field);
+
+            return $this;
+        };
+    }
+
+    public function removeTableFilters(): Closure
+    {
+        return function (): static {
+            $this->call('removeTableFilters');
+
+            return $this;
+        };
+    }
+
     public function assertTableFilterExists(): Closure
     {
         return function (string $name): static {

--- a/tests/src/Tables/FilterTest.php
+++ b/tests/src/Tables/FilterTest.php
@@ -61,3 +61,29 @@ it('can persist filters in the user\'s session', function () {
     livewire(PostsTable::class)
         ->assertCanSeeTableRecords($unpublishedPosts);
 });
+
+it('can remove a filter', function() {
+    $posts = Post::factory()->count(10)->create();
+
+    $unpublishedPosts = $posts->where('is_published', false);
+
+    livewire(PostsTable::class)
+        ->assertCanSeeTableRecords($posts)
+        ->filterTable('is_published')
+        ->assertCanNotSeeTableRecords($unpublishedPosts)
+        ->removeTableFilter(filter: 'is_published')
+        ->assertCanSeeTableRecords($posts);
+});
+
+it('can remove all table filters', function() {
+    $posts = Post::factory()->count(10)->create();
+
+    $unpublishedPosts = $posts->where('is_published', false);
+
+    livewire(PostsTable::class)
+        ->assertCanSeeTableRecords($posts)
+        ->filterTable('is_published')
+        ->assertCanNotSeeTableRecords($unpublishedPosts)
+        ->removeTableFilters()
+        ->assertCanSeeTableRecords($posts);
+});

--- a/tests/src/Tables/FilterTest.php
+++ b/tests/src/Tables/FilterTest.php
@@ -29,18 +29,6 @@ it('can filter records by relationship', function () {
         ->assertCanNotSeeTableRecords($posts->where('author_id', '!=', $author->getKey()));
 });
 
-it('can reset filters', function () {
-    $posts = Post::factory()->count(10)->create();
-
-    $unpublishedPosts = $posts->where('is_published', false);
-
-    livewire(PostsTable::class)
-        ->filterTable('is_published')
-        ->assertCanNotSeeTableRecords($unpublishedPosts)
-        ->resetTableFilters()
-        ->assertCanSeeTableRecords($unpublishedPosts);
-});
-
 it('can persist filters in the user\'s session', function () {
     $posts = Post::factory()->count(10)->create();
 
@@ -62,6 +50,18 @@ it('can persist filters in the user\'s session', function () {
         ->assertCanSeeTableRecords($unpublishedPosts);
 });
 
+it('can reset filters', function () {
+    $posts = Post::factory()->count(10)->create();
+
+    $unpublishedPosts = $posts->where('is_published', false);
+
+    livewire(PostsTable::class)
+        ->filterTable('is_published')
+        ->assertCanNotSeeTableRecords($unpublishedPosts)
+        ->resetTableFilters()
+        ->assertCanSeeTableRecords($unpublishedPosts);
+});
+
 it('can remove a filter', function () {
     $posts = Post::factory()->count(10)->create();
 
@@ -71,7 +71,7 @@ it('can remove a filter', function () {
         ->assertCanSeeTableRecords($posts)
         ->filterTable('is_published')
         ->assertCanNotSeeTableRecords($unpublishedPosts)
-        ->removeTableFilter(filter: 'is_published')
+        ->removeTableFilter('is_published')
         ->assertCanSeeTableRecords($posts);
 });
 

--- a/tests/src/Tables/FilterTest.php
+++ b/tests/src/Tables/FilterTest.php
@@ -62,7 +62,7 @@ it('can persist filters in the user\'s session', function () {
         ->assertCanSeeTableRecords($unpublishedPosts);
 });
 
-it('can remove a filter', function() {
+it('can remove a filter', function () {
     $posts = Post::factory()->count(10)->create();
 
     $unpublishedPosts = $posts->where('is_published', false);
@@ -75,7 +75,7 @@ it('can remove a filter', function() {
         ->assertCanSeeTableRecords($posts);
 });
 
-it('can remove all table filters', function() {
+it('can remove all table filters', function () {
     $posts = Post::factory()->count(10)->create();
 
     $unpublishedPosts = $posts->where('is_published', false);


### PR DESCRIPTION
This fixes #3794.

The details bug are in that issue but essentially if you have a `Filament\Tables\Filters\Filter` added to a form, apply the filter, and then remove it either by clicking the icon in the filter indicator or the 'x' icon in the filter indicator row, the table does not update until the page is refreshed.

This fixes the issue by first making sure that the Filter sets a default state of false when it's using a Checkbox or Toggle component. Then when removing the filter it sets the state of the filter to the default state of the field.

I've added tests showing this fixes the issue and all other tests are passing. However I'm not sure if this breaks other filter types or filters with custom forms. I don't think it should since it only sets the default state to false for Checkbox and Toggle components and it should be null for all other components.