### PR TITLE
fix: Cloak bulk actions trigger

### DIFF
--- a/packages/tables/resources/views/components/bulk-actions/trigger.blade.php
+++ b/packages/tables/resources/views/components/bulk-actions/trigger.blade.php
@@ -1,5 +1,6 @@
 <x-tables::icon-button
     icon="heroicon-o-dots-vertical"
     :label="__('tables::table.buttons.open_actions.label')"
+    x-cloak
     {{ $attributes->class(['filament-tables-bulk-actions-trigger']) }}
 />


### PR DESCRIPTION
This PR prevents the bulk actions trigger from briefly appearing on page load.