### PR TITLE
Fix: Resource generation apply `maxLength` only on  `TextInput` & `Textarea`

### DIFF
--- a/packages/admin/src/Commands/Concerns/CanGenerateResources.php
+++ b/packages/admin/src/Commands/Concerns/CanGenerateResources.php
@@ -57,7 +57,9 @@ trait CanGenerateResources
                 if (Str::of($column->getName())->contains(['phone', 'tel'])) {
                     $componentData['tel'] = [];
                 }
+            }
 
+            if (in_array($type, [Forms\Components\TextInput::class, Forms\Components\Textarea::class])) {
                 if ($length = $column->getLength()) {
                     $componentData['maxLength'] = [$length];
                 }

--- a/packages/admin/src/Commands/Concerns/CanGenerateResources.php
+++ b/packages/admin/src/Commands/Concerns/CanGenerateResources.php
@@ -57,14 +57,14 @@ trait CanGenerateResources
                 if (Str::of($column->getName())->contains(['phone', 'tel'])) {
                     $componentData['tel'] = [];
                 }
+
+                if ($length = $column->getLength()) {
+                    $componentData['maxLength'] = [$length];
+                }
             }
 
             if ($column->getNotnull()) {
                 $componentData['required'] = [];
-            }
-
-            if ($length = $column->getLength()) {
-                $componentData['maxLength'] = [$length];
             }
 
             $components[$column->getName()] = $componentData;

--- a/packages/admin/src/Commands/Concerns/CanGenerateResources.php
+++ b/packages/admin/src/Commands/Concerns/CanGenerateResources.php
@@ -59,10 +59,8 @@ trait CanGenerateResources
                 }
             }
 
-            if (in_array($type, [Forms\Components\TextInput::class, Forms\Components\Textarea::class])) {
-                if ($length = $column->getLength()) {
-                    $componentData['maxLength'] = [$length];
-                }
+            if (in_array($type, [Forms\Components\TextInput::class, Forms\Components\Textarea::class]) && ($length = $column->getLength())) {
+                $componentData['maxLength'] = [$length];
             }
 
             if ($column->getNotnull()) {

--- a/packages/admin/src/Commands/Concerns/CanGenerateResources.php
+++ b/packages/admin/src/Commands/Concerns/CanGenerateResources.php
@@ -59,12 +59,12 @@ trait CanGenerateResources
                 }
             }
 
-            if (in_array($type, [Forms\Components\TextInput::class, Forms\Components\Textarea::class]) && ($length = $column->getLength())) {
-                $componentData['maxLength'] = [$length];
-            }
-
             if ($column->getNotnull()) {
                 $componentData['required'] = [];
+            }
+
+            if (in_array($type, [Forms\Components\TextInput::class, Forms\Components\Textarea::class]) && ($length = $column->getLength())) {
+                $componentData['maxLength'] = [$length];
             }
 
             $components[$column->getName()] = $componentData;


### PR DESCRIPTION
fixes https://github.com/filamentphp/filament/issues/3807