### PR TITLE
Fix: changed from array_merge to array_replace to avoid reindexing in…

### DIFF
--- a/packages/admin/resources/views/components/resources/relation-managers/index.blade.php
+++ b/packages/admin/resources/views/components/resources/relation-managers/index.blade.php
@@ -15,7 +15,7 @@
                     $tabs = $managers;
 
                     if ($form) {
-                        $tabs = array_merge([null => null], $tabs);
+                        $tabs = array_replace[null => null], $tabs);
                     }
                 @endphp
 

--- a/packages/admin/resources/views/components/resources/relation-managers/index.blade.php
+++ b/packages/admin/resources/views/components/resources/relation-managers/index.blade.php
@@ -15,7 +15,7 @@
                     $tabs = $managers;
 
                     if ($form) {
-                        $tabs = array_replace[null => null], $tabs);
+                        $tabs = array_replace([null => null], $tabs);
                     }
                 @endphp
 


### PR DESCRIPTION
When using the new `hasCombinedRelationManagerTabsWithForm()` method, RM keys would get reindex by the use of array_merge() and if an RM is hidden due to canViewForRecord(), the keys would be wrong and cause an error of `Undefined array key 3` (or whatever RM is hidden) when selected.