### PR TITLE
Fixed broken table header layout while reordering when table has header actions.

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -239,8 +239,10 @@
         >
             @if ($header)
                 {{ $header }}
-            @elseif ($heading || ($headerActions && (! $isReordering)))
-                <div class="px-2 pt-2">
+            @elseif ($heading || $headerActions)
+                <div class="px-2 pt-2" x-bind:class="{
+                    'hidden': @js($isReordering)
+                }">
                     <x-tables::header :actions="$isReordering ? [] : $headerActions" class="mb-2">
                         <x-slot name="heading">
                             {{ $heading }}

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -240,9 +240,10 @@
             @if ($header)
                 {{ $header }}
             @elseif ($heading || $headerActions)
-                <div class="px-2 pt-2" x-bind:class="{
-                    'hidden': @js($isReordering)
-                }">
+                <div @class([
+                    'px-2 pt-2',
+                    'hidden' => $isReordering,
+                ])>
                     <x-tables::header :actions="$isReordering ? [] : $headerActions" class="mb-2">
                         <x-slot name="heading">
                             {{ $heading }}


### PR DESCRIPTION
When a table defines both `getTableHeaderActions()` and `getTableReorderColumn()`, clicking the reorder icon to trigger reordering breaks the layout when the header is hidden. When the search bar is visible (which I'm sure is true for most use cases) it drops down under the reorder icon and some padding is also lost. This fix simply hides the header div via Tailwind instead of removing it from the DOM, which resolves the issue.