### PR TITLE
Fixed bulk-select/deselect not working after reorder toggled.

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -489,9 +489,12 @@
                                 $getRecordClasses($record),
                             ))"
                         >
-                            @if ($isReordering)
-                                <x-tables::reorder.cell />
-                            @else
+                            <x-tables::reorder.cell
+                                x-cloak
+                                :x-bind:class="json_encode(['hidden' => !$isReordering])"
+                            />
+
+                            @if (! $isReordering)
                                 @if (count($actions) && $actionsPosition === Position::BeforeCells)
                                     <x-tables::actions-cell
                                         :actions="$actions"


### PR DESCRIPTION
Select / deselect all functionality (both the select-all checkbox and the select / deselect links) breaks after a table reorder has been toggled. This appears to be due to conditionally switching out the reorder cell & checkbox cell. This fix inserts the reorder cell unconditionally and then conditionally hides it with Tailwind.