### PR TITLE
fix: Ternary filter default indicator

### DIFF
--- a/packages/tables/src/Filters/TernaryFilter.php
+++ b/packages/tables/src/Filters/TernaryFilter.php
@@ -16,6 +16,8 @@ class TernaryFilter extends SelectFilter
     {
         parent::setUp();
 
+        $this->trueLabel(__('forms::components.select.boolean.true'));
+        $this->falseLabel(__('forms::components.select.boolean.false'));
         $this->placeholder('-');
 
         $this->boolean();


### PR DESCRIPTION
Bug report: https://discord.com/channels/883083792112300104/883085291722788964/1016070446183108679

Not sure if we need a separate translation key for the ternary filter labels instead of defaulting to the boolean select component. This also happens currently, since the labels are just `null` by default. That's why I used these values to fix the indicator issue.