### PR TITLE
fix: button overflow

### DIFF
--- a/packages/support/resources/views/components/dropdown/index.blade.php
+++ b/packages/support/resources/views/components/dropdown/index.blade.php
@@ -39,7 +39,7 @@
             wire:key="{{ $attributes->get('wire:key') }}.panel"
         @endif
         @class([
-            'filament-dropdown-panel absolute z-10 w-full rounded-lg bg-white shadow-lg ring-1 ring-black/5 transition',
+            'filament-dropdown-panel absolute z-10 w-full rounded-lg bg-white shadow-lg overflow-hidden ring-1 ring-black/5 transition',
             'dark:bg-gray-800 dark:ring-white/10' => $darkMode,
             match ($width) {
                 'xs' => 'max-w-xs',


### PR DESCRIPTION
Dropdown have a rounded borders, and buttons inside will overflow

### Before
![Before](https://i.imgur.com/ZWpkA8v.png)

### After
![After](https://i.imgur.com/03TvnSF.png)