### PR TITLE
Absolute option possible for Resource::getUrl()

### DIFF
--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -95,9 +95,9 @@ class Page extends Component implements Forms\Contracts\HasForms, RendersFormCom
             ->slug();
     }
 
-    public static function getUrl(array $parameters = [], bool $absolute = true): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true): string
     {
-        return route(static::getRouteName(), $parameters, $absolute);
+        return route(static::getRouteName(), $parameters, $isAbsolute);
     }
 
     public function render(): View

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -368,11 +368,11 @@ class Resource
             ->implode('/');
     }
 
-    public static function getUrl($name = 'index', $params = [], $absolute = true): string
+    public static function getUrl($name = 'index', $params = [], $isAbsolute = true): string
     {
         $routeBaseName = static::getRouteBaseName();
 
-        return route("{$routeBaseName}.{$name}", $params, $absolute);
+        return route("{$routeBaseName}.{$name}", $params, $isAbsolute);
     }
 
     public static function hasPage($page): bool

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -368,11 +368,11 @@ class Resource
             ->implode('/');
     }
 
-    public static function getUrl($name = 'index', $params = []): string
+    public static function getUrl($name = 'index', $params = [], $absolute = true): string
     {
         $routeBaseName = static::getRouteBaseName();
 
-        return route("{$routeBaseName}.{$name}", $params);
+        return route("{$routeBaseName}.{$name}", $params, $absolute);
     }
 
     public static function hasPage($page): bool


### PR DESCRIPTION
Adds the possibility to set the $absolute parameter to false when retrieving a resource url.