### PR TITLE
Fix casing inconsistency between resource titles

### DIFF
--- a/packages/admin/src/Resources/Pages/CreateRecord.php
+++ b/packages/admin/src/Resources/Pages/CreateRecord.php
@@ -7,6 +7,7 @@ use Filament\Notifications\Notification;
 use Filament\Pages\Actions\Action;
 use Filament\Pages\Contracts\HasFormActions;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 /**
  * @property ComponentContainer $form
@@ -157,7 +158,7 @@ class CreateRecord extends Page implements HasFormActions
         }
 
         return __('filament::resources/pages/create-record.title', [
-            'label' => static::getResource()::getModelLabel(),
+            'label' => Str::headline(static::getResource()::getModelLabel()),
         ]);
     }
 


### PR DESCRIPTION
## Abstract
The automatic title generated for resource pages seems to be inconsistent. On the view and edit pages, the resource name is in Title Case, but on create, it's in lower case. This PR fixes that.

### Cause of bug
This bug is caused due to the `getTitle()` method on create pages not using the `Str::headline()` helper that the other pages use.

The create page uses the following in [CreateRecord.php#L160](https://github.com/filamentphp/filament/blob/2.x/packages/admin/src/Resources/Pages/CreateRecord.php#L160)
```php
'label' => static::getResource()::getModelLabel(),
```

While the others use the following (through the InteractsWithRecord trait)
```php
return Str::headline($resource::getModelLabel());
```

I think that the create record should also use the Str::headline() method to be visually consistent, which incidentally is exactly what this PR changes.

## Screenshots

### Before
![hyde-cloud test_app_hyde_blade-pages_create](https://user-images.githubusercontent.com/95144705/188480774-1b0dc8a2-7286-4325-ba03-ddef13b0d9b0.png)

### After

![hyde-cloud test_app_hyde_blade-pages_create (1)](https://user-images.githubusercontent.com/95144705/188480820-9dae45b2-ffff-40bb-9805-2d3953ace6c2.png)

### Edit/View pages for comparison
![hyde-cloud test_app_hyde_blade-pages_404_edit (1)](https://user-images.githubusercontent.com/95144705/188481043-d54949ed-1c7c-409e-8a0c-a9627bed290b.png)

![hyde-cloud test_app_hyde_blade-pages_404](https://user-images.githubusercontent.com/95144705/188480963-96ba98aa-b966-41f0-932c-a8bb5cbc3159.png)
