### PR TITLE
Fix "Malformed UTF-8 characters, possibly incorrectly encoded" error …

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -7,6 +7,7 @@ use Filament\Forms\Components\Field;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Unique;
+use Illuminate\Support\Str;
 
 trait CanBeValidated
 {
@@ -204,7 +205,7 @@ trait CanBeValidated
 
     public function getValidationAttribute(): string
     {
-        return $this->evaluate($this->validationAttribute) ?? lcfirst($this->getLabel());
+        return $this->evaluate($this->validationAttribute) ?? Str::lcfirst($this->getLabel());
     }
 
     public function getValidationRules(): array


### PR DESCRIPTION
If the value of the label property of a form field is set in an encoding other than English, the error "**Malformed UTF-8 characters, possibly incorrectly encoded**" occurs.
These changes resolve the reported error.
An example of reproducing the problem:
`    
public static function form(Form $form): Form
    {
        return $form
            ->schema([
                Forms\Components\TextInput::make('name')
                    ->label('Наименование права')
                    ->required()
                    ->maxLength(255)
                    ->unique(),
                Forms\Components\TextInput::make('description')->label('Описание права')
            ]);
    }
`
