### PR TITLE
Adding menu item override code + sample config.

### DIFF
--- a/packages/admin/config/filament.php
+++ b/packages/admin/config/filament.php
@@ -201,6 +201,21 @@ return [
             'should_show_logo' => true,
         ],
         'max_content_width' => null,
+        /*
+         * Through these settings, you can override the following (empty string values have no effect)
+         * 1) The menu group the item is placed under
+         * 2) The icon used for the menu item
+         * 3) Hide the menu item by setting "display" to false
+         * NOTE: for a multilingual site, you will need multiple entries per menu item as
+         * array key is the label of the menu item (which will change for different locales)
+         */
+        'menuItemsOverride' => [
+            'Profile' => [
+                'group'   => '',
+                'icon'    => '',
+                'display' => true,
+            ]
+        ],
         'notifications' => [
             'vertical_alignment' => 'top',
             'alignment' => 'right',

--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -9,6 +9,8 @@ use Filament\Http\Livewire\Concerns\CanNotify;
 use Filament\Navigation\NavigationItem;
 use Filament\Tables\Contracts\RendersFormComponentActionModal;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
@@ -45,6 +47,12 @@ class Page extends Component implements Forms\Contracts\HasForms, RendersFormCom
 
     public static function registerNavigationItems(): void
     {
+        $menuOverrideItem = self::getNavigationOverrideConfig();
+        $doDisplay = $menuOverrideItem['display'] ?? true;
+        if (!$doDisplay) {
+            return;
+        }
+
         if (! static::shouldRegisterNavigation()) {
             return;
         }
@@ -113,11 +121,23 @@ class Page extends Component implements Forms\Contracts\HasForms, RendersFormCom
 
     protected static function getNavigationGroup(): ?string
     {
+        $menuOverrideItem = self::getNavigationOverrideConfig();
+        $group = $menuOverrideItem['group'] ?? null;
+        if ($group) {
+            return $group;
+        }
+
         return static::$navigationGroup;
     }
 
     protected static function getNavigationIcon(): string
     {
+        $menuOverrideItem = self::getNavigationOverrideConfig();
+        $icon = $menuOverrideItem['icon'] ?? null;
+        if ($icon) {
+            return $icon;
+        }
+
         return static::$navigationIcon ?? 'heroicon-o-document-text';
     }
 
@@ -127,6 +147,13 @@ class Page extends Component implements Forms\Contracts\HasForms, RendersFormCom
             ->kebab()
             ->replace('-', ' ')
             ->title();
+    }
+
+    private static function getNavigationOverrideConfig(): array
+    {
+        $menuLabel = static::getNavigationLabel();
+
+        return (array)Config::get("filament.layout.menuItemsOverride.$menuLabel");
     }
 
     protected static function getNavigationBadge(): ?string


### PR DESCRIPTION
This patch allows you to override/change menu item properties through the filament.php config file. 

The rationale for this change is that currently, it is difficult to change these properties because: 
1) Some plugins define these in a translation file
2) Some plugins simply hardcode these in code
Either way, you have to change the plugin's code or translation file to change these options. 

This way, you can override this behavior from the central filament config file without having to touch plugin code. For me, this is a useful addition, I hope you find it useful as well.  