### PR TITLE
Visual tidyup of table header during reorder when no heading / description set

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -15,6 +15,7 @@
     $header = $getHeader();
     $headerActions = $getHeaderActions();
     $heading = $getHeading();
+    $description = $getDescription();
     $isReorderable = $isReorderable();
     $isReordering = $isReordering();
     $isColumnSearchVisible = $isSearchableByColumn();
@@ -239,15 +240,18 @@
         >
             @if ($header)
                 {{ $header }}
-            @elseif ($heading || $headerActions)
-                <div class="px-2 pt-2">
+            @elseif ($heading || $description || $headerActions)
+                <div @class([
+                    'px-2 pt-2',
+                    'hidden' => ! $heading && ! $description && $isReordering,
+                ])>
                     <x-tables::header :actions="$isReordering ? [] : $headerActions" class="mb-2">
                         <x-slot name="heading">
                             {{ $heading }}
                         </x-slot>
 
                         <x-slot name="description">
-                            {{ $getDescription() }}
+                            {{ $description }}
                         </x-slot>
                     </x-tables::header>
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -240,10 +240,10 @@
         >
             @if ($header)
                 {{ $header }}
-            @elseif ($heading || $description || $headerActions)
+            @elseif ($heading || $headerActions)
                 <div @class([
                     'px-2 pt-2',
-                    'hidden' => ! $heading && ! $description && $isReordering,
+                    'hidden' => ! $heading && $isReordering,
                 ])>
                     <x-tables::header :actions="$isReordering ? [] : $headerActions" class="mb-2">
                         <x-slot name="heading">


### PR DESCRIPTION
As discussed in #3851 this will now hide the whole table header (including grey border) when reordering a table with no heading or description set.