### PR TITLE
Notifications: support mass send

### DIFF
--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -18,6 +18,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\DatabaseNotification as DatabaseNotificationModel;
 use Illuminate\Notifications\Messages\BroadcastMessage;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 class Notification extends ViewComponent implements Arrayable
@@ -92,18 +93,36 @@ class Notification extends ViewComponent implements Arrayable
         return $this;
     }
 
-    public function broadcast(Model | Authenticatable $user): static
+    public function broadcast(Model | Authenticatable | Collection | array $users): static
     {
-        /** @phpstan-ignore-next-line */
-        $user->notify($this->toBroadcast());
+        if (
+            $users instanceof Model ||
+            $users instanceof Authenticatable
+        ) {
+            $users = collect([$users]);
+        }
+
+        foreach ($users as $user) {
+            /** @phpstan-ignore-next-line */
+            $user->notify($this->toBroadcast());
+        }
 
         return $this;
     }
 
-    public function sendToDatabase(Model | Authenticatable $user): static
+    public function sendToDatabase(Model | Authenticatable | Collection | array $users): static
     {
-        /** @phpstan-ignore-next-line */
-        $user->notify($this->toDatabase());
+        if (
+            $users instanceof Model ||
+            $users instanceof Authenticatable
+        ) {
+            $users = collect([$users]);
+        }
+
+        foreach ($users as $user) {
+            /** @phpstan-ignore-next-line */
+            $user->notify($this->toDatabase());
+        }
 
         return $this;
     }

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -103,7 +103,6 @@ class Notification extends ViewComponent implements Arrayable
         }
 
         foreach ($users as $user) {
-            /** @phpstan-ignore-next-line */
             $user->notify($this->toBroadcast());
         }
 
@@ -120,7 +119,6 @@ class Notification extends ViewComponent implements Arrayable
         }
 
         foreach ($users as $user) {
-            /** @phpstan-ignore-next-line */
             $user->notify($this->toDatabase());
         }
 

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -95,11 +95,8 @@ class Notification extends ViewComponent implements Arrayable
 
     public function broadcast(Model | Authenticatable | Collection | array $users): static
     {
-        if (
-            $users instanceof Model ||
-            $users instanceof Authenticatable
-        ) {
-            $users = collect([$users]);
+        if (! is_iterable($users)) {
+            $users = [$users];
         }
 
         foreach ($users as $user) {
@@ -111,11 +108,8 @@ class Notification extends ViewComponent implements Arrayable
 
     public function sendToDatabase(Model | Authenticatable | Collection | array $users): static
     {
-        if (
-            $users instanceof Model ||
-            $users instanceof Authenticatable
-        ) {
-            $users = collect([$users]);
+        if (! is_iterable($users)) {
+            $users = [$users];
         }
 
         foreach ($users as $user) {


### PR DESCRIPTION
Reference: #3964

I modified `sendToDatabase()` and `broadcast()` to support mass notifications. Tested with database, but I don't use broadcast at the moment, so a quick glance would be appreciated.

The issue is, `Collection | array` bypasses PHP's type hint and can fail if one of collected objects don't implement the `notify()` method. What's the Filament way to handle this?