### PR TITLE
Argument for signed/unsigned in money mask

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -411,14 +411,13 @@ use Filament\Forms\Components\TextInput;
 TextInput::make('cost')->mask(fn (TextInput\Mask $mask) => $mask->money('$', ',', 2))
 ```
 
-You can also control whether the number is signed or not. While the default is to allow both negative and positive numbers, the following code would only allow positive numbers:
+You can also control whether the number is signed or not. While the default is to allow both negative and positive numbers, `isSigned: false` allows only positive numbers:
 
 ```php
 use Filament\Forms\Components\TextInput;
 
-TextInput::make('cost')->mask(fn (TextInput\Mask $mask) => $mask->money('$', ',', 2, false))
+TextInput::make('cost')->mask(fn (TextInput\Mask $mask) => $mask->money('$', ',', 2, isSigned: false))
 ```
-
 
 ### Datalists
 

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -411,6 +411,15 @@ use Filament\Forms\Components\TextInput;
 TextInput::make('cost')->mask(fn (TextInput\Mask $mask) => $mask->money('$', ',', 2))
 ```
 
+You can also control whether the number is signed or not. While the default is to allow both negative and positive numbers, the following code would only allow positive numbers:
+
+```php
+use Filament\Forms\Components\TextInput;
+
+TextInput::make('cost')->mask(fn (TextInput\Mask $mask) => $mask->money('$', ',', 2, false))
+```
+
+
 ### Datalists
 
 You may specify [datalist](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist) options for a text input using the `datalist()` method:

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -408,7 +408,7 @@ There is also a `money()` method that is able to define easier formatting for cu
 ```php
 use Filament\Forms\Components\TextInput;
 
-TextInput::make('cost')->mask(fn (TextInput\Mask $mask) => $mask->money('$', ',', 2))
+TextInput::make('cost')->mask(fn (TextInput\Mask $mask) => $mask->money(prefix: '$', thousandsSeparator: ',', decimalPlaces: 2))
 ```
 
 You can also control whether the number is signed or not. While the default is to allow both negative and positive numbers, `isSigned: false` allows only positive numbers:
@@ -416,7 +416,7 @@ You can also control whether the number is signed or not. While the default is t
 ```php
 use Filament\Forms\Components\TextInput;
 
-TextInput::make('cost')->mask(fn (TextInput\Mask $mask) => $mask->money('$', ',', 2, isSigned: false))
+TextInput::make('cost')->mask(fn (TextInput\Mask $mask) => $mask->money(prefix: '$', thousandsSeparator: ',', decimalPlaces: 2, isSigned: false))
 ```
 
 ### Datalists

--- a/packages/forms/src/Components/TextInput/Mask.php
+++ b/packages/forms/src/Components/TextInput/Mask.php
@@ -141,7 +141,7 @@ class Mask implements Jsonable
         return $this;
     }
 
-    public function money(string $prefix = '$', string $thousandsSeparator = ',', int $decimalPlaces = 2, bool $signed = true): static
+    public function money(string $prefix = '$', string $thousandsSeparator = ',', int $decimalPlaces = 2, bool $isSigned = true): static
     {
         $this
             ->patternBlocks([
@@ -149,7 +149,7 @@ class Mask implements Jsonable
                     ->numeric()
                     ->thousandsSeparator($thousandsSeparator)
                     ->decimalPlaces($decimalPlaces)
-                    ->signed($signed)
+                    ->signed($isSigned)
                     ->padFractionalZeros()
                     ->normalizeZeros(false),
             ])

--- a/packages/forms/src/Components/TextInput/Mask.php
+++ b/packages/forms/src/Components/TextInput/Mask.php
@@ -141,7 +141,7 @@ class Mask implements Jsonable
         return $this;
     }
 
-    public function money(string $prefix = '$', string $thousandsSeparator = ',', int $decimalPlaces = 2): static
+    public function money(string $prefix = '$', string $thousandsSeparator = ',', int $decimalPlaces = 2, bool $signed = true): static
     {
         $this
             ->patternBlocks([
@@ -149,6 +149,7 @@ class Mask implements Jsonable
                     ->numeric()
                     ->thousandsSeparator($thousandsSeparator)
                     ->decimalPlaces($decimalPlaces)
+                    ->signed($signed)
                     ->padFractionalZeros()
                     ->normalizeZeros(false),
             ])


### PR DESCRIPTION
Currently the money mask allows both negative and positive numbers, which isn't always the desired behavior. This PR allows you to specify whether the mask should allow signed or unsigned numbers.