### PR TITLE
Adding reset and deselect records on individual search

### DIFF
--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -45,6 +45,13 @@ trait CanSearchRecords
         $this->resetPage();
     }
 
+    public function updatedTableColumnSearchQueries(): void
+    {
+        $this->deselectAllTableRecords();
+
+        $this->resetPage();
+    }
+    
     protected function applySearchToTableQuery(Builder $query): Builder
     {
         $this->applyColumnSearchToTableQuery($query);


### PR DESCRIPTION
Hi,

I propose this PR in order to add the same behavior that the global search when doing a search action.

I was on the sixth page of a table, then I made an indivudiual search and no records were appearing, because the new number of page was below one.