### PR TITLE
Table : unset empty value of tableColumnSearchQueries

### DIFF
--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -37,17 +37,6 @@ trait CanSearchRecords
 
         return false;
     }
-
-    public function hasSearchApplied(): bool
-    {
-        if (! empty($this->tableSearchQuery) 
-            || ! empty($this->tableColumnSearchQueries)) 
-        {
-            return true;
-        }
-
-        return false;
-    }
     
     public function updatedTableSearchQuery(): void
     {
@@ -58,7 +47,7 @@ trait CanSearchRecords
 
     public function updatedTableColumnSearchQueries($value, $key): void
     {
-        if (empty($value)) {
+        if (blank($value)) {
             unset($this->tableColumnSearchQueries[$key]);
         }
         

--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -38,6 +38,17 @@ trait CanSearchRecords
         return false;
     }
 
+    public function hasSearchApplied(): bool
+    {
+        if (! empty($this->tableSearchQuery) 
+            || ! empty($this->tableColumnSearchQueries)) 
+        {
+            return true;
+        }
+
+        return false;
+    }
+    
     public function updatedTableSearchQuery(): void
     {
         $this->deselectAllTableRecords();
@@ -45,8 +56,12 @@ trait CanSearchRecords
         $this->resetPage();
     }
 
-    public function updatedTableColumnSearchQueries(): void
+    public function updatedTableColumnSearchQueries($value, $key): void
     {
+        if (empty($value)) {
+            unset($this->tableColumnSearchQueries[$key]);
+        }
+        
         $this->deselectAllTableRecords();
 
         $this->resetPage();


### PR DESCRIPTION
I added the unsetting of the key of the `$tableColumnSearchQueries` because it was still in even when value was empty, meaning no search was done.

I also added a method that returns if any search is applied on the table.

I need it because I dynamically change the pagination mode based on it.

I got tables with 1 million of records or more.

I don't want pagination when no search is done (execution query for the count is over 30secs). But as soon as a search is done, I can display the pagination.

```php
class ArticleEntrepotListe extends Component implements Tables\Contracts\HasTable
{
    use Tables\Concerns\InteractsWithTable;

    use Tables\Concerns\InteractsWithTable {
        paginateTableQuery as protected parentPaginateTableQuery;
    }

    protected function paginateTableQuery(Builder $query): Paginator
    {
        if ($this->hasSearchApplied()) {
            return $this->parentPaginateTableQuery($query);
        }

        return $query->simplePaginate($this->getTableRecordsPerPage() == -1 ? $query->count() : $this->getTableRecordsPerPage());
    }
```