### PR TITLE
🐛 Check if there are indeed no actions before checking resource pages

### DIFF
--- a/packages/admin/src/Resources/Pages/ListRecords.php
+++ b/packages/admin/src/Resources/Pages/ListRecords.php
@@ -414,6 +414,10 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
                 return $url;
             }
 
+            if (count($this->getCachedTableActions()) !== 0) {
+                return null;
+            }
+
             $resource = static::getResource();
 
             foreach (['view', 'edit'] as $action) {


### PR DESCRIPTION
This aims to add empty checks for table actions before falling back to checking the resources pages on `ListRecord::getTableRecordUrlUsing()` that was implemented on [this commit](https://github.com/filamentphp/filament/commit/d9cc6d23f9d7328e9c704f66a940478d1dd340d0)

Given the following table setup:
```php
public static function table(Table $table): Table
{
    return $table
        ->columns([
            ...
        ])
        ->actions([
            Tables\Actions\EditAction::make()
                ->visible(fn (Admin $record): bool => Auth::user()->can('update', $record))
        ]);
}
```

Since I have a `visible()` in my `EditAction`, when the closure returns `false` it treats as if there were no actions for the table.

Now on the resource pages fallback, it checks for a `view` and `edit` policy. But `edit` is not a standard ability for a policy, but instead we have `update`. Thus it still allows the clicking of the row to open the edit page for the resource. And upon opening it just shows a 403 error.

To remedy this, we can check if there are indeed no actions set before checking for the resource pages.

You may also want see my [other PR](https://github.com/filamentphp/filament/pull/4054) that solves the same issue