### PR TITLE
✨ Add notifications in card layout

### DIFF
--- a/packages/admin/resources/views/components/layouts/card.blade.php
+++ b/packages/admin/resources/views/components/layouts/card.blade.php
@@ -46,5 +46,5 @@
         </div>
     </div>
     
-    @livewire('filament.core.notifications')
+    @livewire('notifications')
 </x-filament::layouts.base>

--- a/packages/admin/resources/views/components/layouts/card.blade.php
+++ b/packages/admin/resources/views/components/layouts/card.blade.php
@@ -45,4 +45,6 @@
             </div>
         </div>
     </div>
+    
+    @livewire('filament.core.notifications')
 </x-filament::layouts.base>


### PR DESCRIPTION
This PR aim to add the notification component to the card layout.

I believe that is particularly useful like for example, I'm creating a custom card page for request password reset. After successfully sending the email and redirecting back to the login page, I can just use the notifications to say that the password reset link has been sent to the user's email.