### PR TITLE
Feature: Page SelectOption default selection

### DIFF
--- a/packages/admin/resources/views/pages/actions/select-action.blade.php
+++ b/packages/admin/resources/views/pages/actions/select-action.blade.php
@@ -16,9 +16,15 @@
         @endif
 
         @foreach ($getOptions() as $value => $label)
-            <option value="{{ $value }}">
-                {{ $label }}
-            </option>
+            @if(($selected = $getSelected()) !== null)
+              @if($selected == $value)
+                <option value="{{ $value }}" selected>{{ $label }}</option>
+              @else
+                <option value="{{ $value }}">{{ $label }}</option>
+              @endif
+            @else
+              <option value="{{ $value }}">{{ $label }}</option>
+            @endif
         @endforeach
     </select>
 </div>

--- a/packages/admin/src/Pages/Actions/SelectAction.php
+++ b/packages/admin/src/Pages/Actions/SelectAction.php
@@ -12,6 +12,7 @@ class SelectAction extends Action
     protected array | Arrayable | Closure $options = [];
 
     protected ?string $placeholder = null;
+    protected $selected = null;
 
     protected function setUp(): void
     {
@@ -34,6 +35,13 @@ class SelectAction extends Action
         return $this;
     }
 
+    public function selected($selected): static
+    {
+        $this->selected = $selected;
+
+        return $this;
+    }
+
     public function getOptions(): array
     {
         $options = $this->evaluate($this->options);
@@ -48,5 +56,10 @@ class SelectAction extends Action
     public function getPlaceholder(): ?string
     {
         return $this->placeholder;
+    }
+
+    public function getSelected()
+    {
+        return $this->selected;
     }
 }


### PR DESCRIPTION
This PR will allow setting the default selected option for the `SelectAction` under Page Actions.

I had a problem where when I refresh the page, the default option I wanted it to show is not selected, making it confusing to my users on what is the selected default option, because my table is showing a different data.