### PR TITLE
fix Type Error on return type

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -716,7 +716,7 @@ class Select extends Field
         return parent::getLabel();
     }
 
-    public function getRelationship(): BelongsTo | BelongsToMany | null | \Znck\Eloquent\Relations\BelongsToThrough
+    public function getRelationship(): BelongsTo | BelongsToMany | \Znck\Eloquent\Relations\BelongsToThrough | null
     {
         $name = $this->getRelationshipName();
 

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -716,7 +716,7 @@ class Select extends Field
         return parent::getLabel();
     }
 
-    public function getRelationship(): BelongsTo | BelongsToMany | null
+    public function getRelationship(): BelongsTo | BelongsToMany | null | \Znck\Eloquent\Relations\BelongsToThrough
     {
         $name = $this->getRelationshipName();
 


### PR DESCRIPTION
Filament\Forms\Components\Select::getRelationship(): Return value must be of type Illuminate\Database\Eloquent\Relations\BelongsTo|Illuminate\Database\Eloquent\Relations\BelongsToMany|null, Znck\Eloquent\Relations\BelongsToThrough returned