### PR TITLE
Add forceSaveRelationships method

### DIFF
--- a/packages/forms/docs/02-getting-started.md
+++ b/packages/forms/docs/02-getting-started.md
@@ -517,28 +517,18 @@ class CreatePost extends Component implements Forms\Contracts\HasForms
 }
 ```
 
-#### Force saving relationships
+### Saving relationships when the field is hidden
 
-By default, relationships will only be saved if the field is visible. For example, if you have a `Repeater` field that is only visible on a certain condition. When the repeater is hidden, the relationships will not be saved.
+By default, relationships will only be saved if the field is visible. For example, if you have a `Repeater` field that is only visible on a certain condition, the relationships will not be saved when it is hidden.
 
-This might cause unexpected behaviour if you still want to modify the relationship, even when the field is hidden. For example, you might want to delete remaining records.
-
-To force relationships to be saved, you may call the `forceSaveRelationships()` method on the form:
+This might cause unexpected behaviour if you still want to save the relationship, even when the field is hidden. To force relationships to be saved, you may call the `saveRelationshipsWhenHidden()` method on the form component:
 
 ```php
-Repeater::make('products')
-    ->saveRelationshipsUsing(function (array $state, Model $record, Repeater $component) {
-        $record->products()->delete();
-        
-        if ($component->isHidden()) {
-            return;
-        }
-        
-        foreach ($state ?? [] as $product) {
-            $record->products()->create($product);
-        }
-    })
-    ->forceSaveRelationships();
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+
+SpatieMediaLibraryFileUpload::make('attachments')
+    ->visible(fn (Closure $get): bool => $get('has_attachments'))
+    ->saveRelationshipsWhenHidden();
 ```
 
 ## Using multiple forms

--- a/packages/forms/docs/02-getting-started.md
+++ b/packages/forms/docs/02-getting-started.md
@@ -538,7 +538,7 @@ Repeater::make('products')
             $record->products()->create($product);
         }
     })
-    ->forceSaveRelationships(true);
+    ->forceSaveRelationships();
 ```
 
 ## Using multiple forms

--- a/packages/forms/docs/02-getting-started.md
+++ b/packages/forms/docs/02-getting-started.md
@@ -527,8 +527,12 @@ To force relationships to be saved, you may call the `forceSaveRelationships()` 
 
 ```php
 Repeater::make('products')
-    ->saveRelationshipsUsing(function (array $state, Model $record) {
+    ->saveRelationshipsUsing(function (array $state, Model $record, Repeater $component) {
         $record->products()->delete();
+        
+        if ($component->isHidden()) {
+            return;
+        }
         
         foreach ($state ?? [] as $product) {
             $record->products()->create($product);

--- a/packages/forms/docs/02-getting-started.md
+++ b/packages/forms/docs/02-getting-started.md
@@ -517,6 +517,26 @@ class CreatePost extends Component implements Forms\Contracts\HasForms
 }
 ```
 
+#### Force saving relationships
+
+By default, relationships will only be saved if the field is visible. For example, if you have a `Repeater` field that is only visible on a certain condition. When the repeater is hidden, the relationships will not be saved.
+
+This might cause unexpected behaviour if you still want to modify the relationship, even when the field is hidden. For example, you might want to delete remaining records.
+
+To force relationships to be saved, you may call the `forceSaveRelationships()` method on the form:
+
+```php
+Repeater::make('products')
+    ->saveRelationshipsUsing(function (array $state, Model $record) {
+        $record->products()->delete();
+        
+        foreach ($state ?? [] as $product) {
+            $record->products()->create($product);
+        }
+    })
+    ->forceSaveRelationships(true);
+```
+
 ## Using multiple forms
 
 By default, the `InteractsWithForms` trait only handles one form per Livewire component. To change this, you can override the `getForms()` method to return more than one form, each with a unique name:

--- a/packages/forms/src/Components/Concerns/BelongsToModel.php
+++ b/packages/forms/src/Components/Concerns/BelongsToModel.php
@@ -75,7 +75,7 @@ trait BelongsToModel
         return $this;
     }
 
-    public function forceSaveRelationships(null|bool|Closure $callback): static
+    public function forceSaveRelationships(null|bool|Closure $callback = true): static
     {
         $this->forceSaveRelationships = $callback;
 

--- a/packages/forms/src/Components/Concerns/BelongsToModel.php
+++ b/packages/forms/src/Components/Concerns/BelongsToModel.php
@@ -13,7 +13,7 @@ trait BelongsToModel
 
     protected ?Closure $saveRelationshipsUsing = null;
 
-    protected bool|Closure|null $forceSaveRelationships = null;
+    protected bool | Closure $shouldSaveRelationshipsWhenHidden = false;
 
     public function model(Model | string | Closure | null $model = null): static
     {
@@ -30,13 +30,7 @@ trait BelongsToModel
             return;
         }
 
-        if ($this->shouldForceSaveRelationships()) {
-            $this->evaluate($callback);
-
-            return;
-        }
-
-        if ($this->isHidden()) {
+        if ((! $this->shouldSaveRelationshipsWhenHidden()) && $this->isHidden()) {
             return;
         }
 
@@ -75,16 +69,16 @@ trait BelongsToModel
         return $this;
     }
 
-    public function forceSaveRelationships(null|bool|Closure $callback = true): static
+    public function saveRelationshipsWhenHidden(bool | Closure $condition = true): static
     {
-        $this->forceSaveRelationships = $callback;
+        $this->shouldSaveRelationshipsWhenHidden = $condition;
 
         return $this;
     }
 
-    public function shouldForceSaveRelationships(): bool
+    public function shouldSaveRelationshipsWhenHidden(): bool
     {
-        return $this->evaluate($this->forceSaveRelationships) ?? false;
+        return (bool) $this->evaluate($this->shouldSaveRelationshipsWhenHidden);
     }
 
     public function loadStateFromRelationshipsUsing(?Closure $callback): static

--- a/packages/forms/src/Components/Concerns/BelongsToModel.php
+++ b/packages/forms/src/Components/Concerns/BelongsToModel.php
@@ -13,6 +13,8 @@ trait BelongsToModel
 
     protected ?Closure $saveRelationshipsUsing = null;
 
+    protected bool|Closure|null $forceSaveRelationships = null;
+
     public function model(Model | string | Closure | null $model = null): static
     {
         $this->model = $model;
@@ -25,6 +27,16 @@ trait BelongsToModel
         $callback = $this->saveRelationshipsUsing;
 
         if (! $callback) {
+            return;
+        }
+
+        if ($this->shouldForceSaveRelationships()) {
+            $this->evaluate($callback);
+
+            return;
+        }
+
+        if ($this->isHidden()) {
             return;
         }
 
@@ -61,6 +73,18 @@ trait BelongsToModel
         $this->saveRelationshipsUsing = $callback;
 
         return $this;
+    }
+
+    public function forceSaveRelationships(null|bool|Closure $callback): static
+    {
+        $this->forceSaveRelationships = $callback;
+
+        return $this;
+    }
+
+    public function shouldForceSaveRelationships(): bool
+    {
+        return $this->evaluate($this->forceSaveRelationships) ?? false;
     }
 
     public function loadStateFromRelationshipsUsing(?Closure $callback): static

--- a/packages/forms/src/Concerns/BelongsToModel.php
+++ b/packages/forms/src/Concerns/BelongsToModel.php
@@ -18,7 +18,7 @@ trait BelongsToModel
     public function saveRelationships(): void
     {
         foreach ($this->getComponents(withHidden: true) as $component) {
-            foreach ($component->getChildComponentContainers() as $container) {
+            foreach ($component->getChildComponentContainers(withHidden: true) as $container) {
                 $container->saveRelationships();
             }
 

--- a/packages/forms/src/Concerns/BelongsToModel.php
+++ b/packages/forms/src/Concerns/BelongsToModel.php
@@ -17,7 +17,7 @@ trait BelongsToModel
 
     public function saveRelationships(): void
     {
-        foreach ($this->getComponents() as $component) {
+        foreach ($this->getComponents(withHidden: true) as $component) {
             foreach ($component->getChildComponentContainers() as $container) {
                 $container->saveRelationships();
             }

--- a/tests/src/Forms/StateTest.php
+++ b/tests/src/Forms/StateTest.php
@@ -482,7 +482,7 @@ test('visible fields can save to relationships', function () {
                     return $fieldVisible;
                 }),
         ])
-        ->model(tap(new User(), fn(User $user) => $user->exists = true));
+        ->model(tap(new User(), fn (User $user) => $user->exists = true));
 
     $componentContainer
         ->saveRelationships();
@@ -523,7 +523,7 @@ test('invisible fields can force save to relationships', function () {
                     return $forceSaveRelationships;
                 }),
         ])
-        ->model(tap(new User(), fn(User $user) => $user->exists = true));
+        ->model(tap(new User(), fn (User $user) => $user->exists = true));
 
     $componentContainer
         ->saveRelationships();
@@ -545,4 +545,3 @@ test('invisible fields can force save to relationships', function () {
     expect($nrOfRelationshipsSaved)
         ->toBe(2);
 });
-

--- a/tests/src/Forms/StateTest.php
+++ b/tests/src/Forms/StateTest.php
@@ -519,7 +519,7 @@ test('invisible fields can force save to relationships', function () {
             ( new Field(Str::random()) )
                 ->saveRelationshipsUsing($saveRelationshipsUsing)
                 ->visible(false)
-                ->forceSaveRelationships(function () use (&$forceSaveRelationships) {
+                ->saveRelationshipsWhenHidden(function () use (&$forceSaveRelationships) {
                     return $forceSaveRelationships;
                 }),
         ])

--- a/tests/src/Forms/StateTest.php
+++ b/tests/src/Forms/StateTest.php
@@ -2,8 +2,10 @@
 
 use Filament\Forms\ComponentContainer;
 use Filament\Forms\Components\Component;
+use Filament\Forms\Components\Field;
 use Filament\Forms\Components\Placeholder;
 use Filament\Tests\Forms\Fixtures\Livewire;
+use Filament\Tests\Models\User;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Str;
 
@@ -462,3 +464,85 @@ test('parent sibling state can be retrieved absolutely from another component', 
     expect($placeholder)
         ->getContent()->toBe($state);
 });
+
+test('visible fields can save to relationships', function () {
+    $nrOfRelationshipsSaved = 0;
+    $fieldVisible = true;
+
+    $saveRelationshipsUsing = function () use (&$nrOfRelationshipsSaved) {
+        $nrOfRelationshipsSaved++;
+    };
+
+    $componentContainer = ComponentContainer::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            ( new Field(Str::random()) )
+                ->saveRelationshipsUsing($saveRelationshipsUsing)
+                ->visible(function () use (&$fieldVisible) {
+                    return $fieldVisible;
+                }),
+        ])
+        ->model(tap(new User(), fn(User $user) => $user->exists = true));
+
+    $componentContainer
+        ->saveRelationships();
+
+    expect($nrOfRelationshipsSaved)
+        ->toBe(1);
+
+    $componentContainer
+        ->saveRelationships();
+
+    expect($nrOfRelationshipsSaved)
+        ->toBe(2);
+
+    $fieldVisible = false;
+
+    $componentContainer
+        ->saveRelationships();
+
+    expect($nrOfRelationshipsSaved)
+        ->toBe(2);
+});
+
+test('invisible fields can force save to relationships', function () {
+    $nrOfRelationshipsSaved = 0;
+    $forceSaveRelationships = true;
+
+    $saveRelationshipsUsing = function () use (&$nrOfRelationshipsSaved) {
+        $nrOfRelationshipsSaved++;
+    };
+
+    $componentContainer = ComponentContainer::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            ( new Field(Str::random()) )
+                ->saveRelationshipsUsing($saveRelationshipsUsing)
+                ->visible(false)
+                ->forceSaveRelationships(function () use (&$forceSaveRelationships) {
+                    return $forceSaveRelationships;
+                }),
+        ])
+        ->model(tap(new User(), fn(User $user) => $user->exists = true));
+
+    $componentContainer
+        ->saveRelationships();
+
+    expect($nrOfRelationshipsSaved)
+        ->toBe(1);
+
+    $componentContainer
+        ->saveRelationships();
+
+    expect($nrOfRelationshipsSaved)
+        ->toBe(2);
+
+    $forceSaveRelationships = false;
+
+    $componentContainer
+        ->saveRelationships();
+
+    expect($nrOfRelationshipsSaved)
+        ->toBe(2);
+});
+


### PR DESCRIPTION
Today I encountered a situation where a `Repeater` component was conditionally visible. The `Repeater` component represented a relationship to the main Eloquent model.

The main Eloquent model also had a certain `type` (enum), set as the value of a `Radio` field. Only in 1 of the enum cases should we have any records on the relationship. For the other 3 values, it is totally useless to want those records, because they aren't useful.

However, I noticed that when the `Repeater` component wasn't visible, the `saveRelationshipsUsing()` method wasn't been called. In that situation, I didn't have the option to delete the old remnants of the relation.

This PR adds a `forceSaveRelationships()` method that allows to always call the callback for saving relationships.