### PR TITLE
fix: toggle component icons not respecting on/off colors

### DIFF
--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -69,7 +69,7 @@
                                         'primary' => 'text-primary-500',
                                         'success' => 'text-success-500',
                                         'warning' => 'text-warning-500',
-                                        default => 'text-gray-400'
+                                        default => 'text-gray-400',
                                     },
                                 ])"
                             />
@@ -95,7 +95,7 @@
                                         'secondary' => 'text-gray-400',
                                         'success' => 'text-success-500',
                                         'warning' => 'text-warning-500',
-                                        default => 'text-primary-500'
+                                        default => 'text-primary-500',
                                     },
                                 ])"
                             />

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -64,13 +64,13 @@
                                 :component="$getOffIcon()"
                                 @class([
                                     'h-3 w-3',
-                                    match($getOffColor()) {
+                                    match ($getOffColor()) {
                                         'danger' => 'text-danger-500',
                                         'primary' => 'text-primary-500',
                                         'success' => 'text-success-500',
                                         'warning' => 'text-warning-500',
                                         default => 'text-gray-400'
-                                    }
+                                    },
                                 ])
                             />
                         @endif
@@ -90,13 +90,13 @@
                                 x-cloak
                                 @class([
                                     'h-3 w-3',
-                                    match($getOnColor()) {
+                                    match ($getOnColor()) {
                                         'danger' => 'text-danger-500',
                                         'secondary' => 'text-gray-400',
                                         'success' => 'text-success-500',
                                         'warning' => 'text-warning-500',
                                         default => 'text-primary-500'
-                                    }
+                                    },
                                 ])
                             />
                         @endif

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -62,7 +62,7 @@
                         @if ($hasOffIcon())
                             <x-dynamic-component
                                 :component="$getOffIcon()"
-                                @class([
+                                :class="\Illuminate\Support\Arr::toCssClasses([
                                     'h-3 w-3',
                                     match ($getOffColor()) {
                                         'danger' => 'text-danger-500',
@@ -71,7 +71,7 @@
                                         'warning' => 'text-warning-500',
                                         default => 'text-gray-400'
                                     },
-                                ])
+                                ])"
                             />
                         @endif
                     </span>
@@ -88,7 +88,7 @@
                             <x-dynamic-component
                                 :component="$getOnIcon()"
                                 x-cloak
-                                @class([
+                                :class="\Illuminate\Support\Arr::toCssClasses([
                                     'h-3 w-3',
                                     match ($getOnColor()) {
                                         'danger' => 'text-danger-500',
@@ -97,7 +97,7 @@
                                         'warning' => 'text-warning-500',
                                         default => 'text-primary-500'
                                     },
-                                ])
+                                ])"
                             />
                         @endif
                     </span>

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -60,7 +60,19 @@
                         }"
                     >
                         @if ($hasOffIcon())
-                            <x-dynamic-component :component="$getOffIcon()" class="h-3 w-3 text-gray-400" />
+                            <x-dynamic-component
+                                :component="$getOffIcon()"
+                                @class([
+                                    'h-3 w-3',
+                                    match($getOffColor()) {
+                                        'danger' => 'text-danger-500',
+                                        'primary' => 'text-primary-500',
+                                        'success' => 'text-success-500',
+                                        'warning' => 'text-warning-500',
+                                        default => 'text-gray-400'
+                                    }
+                                ])
+                            />
                         @endif
                     </span>
 
@@ -73,7 +85,20 @@
                         }"
                     >
                         @if ($hasOnIcon())
-                            <x-dynamic-component :component="$getOnIcon()" x-cloak class="h-3 w-3 text-primary-600" />
+                            <x-dynamic-component
+                                :component="$getOnIcon()"
+                                x-cloak
+                                @class([
+                                    'h-3 w-3',
+                                    match($getOnColor()) {
+                                        'danger' => 'text-danger-500',
+                                        'secondary' => 'text-gray-400',
+                                        'success' => 'text-success-500',
+                                        'warning' => 'text-warning-500',
+                                        default => 'text-primary-500'
+                                    }
+                                ])
+                            />
                         @endif
                     </span>
                 </span>

--- a/packages/tables/resources/views/columns/toggle-column.blade.php
+++ b/packages/tables/resources/views/columns/toggle-column.blade.php
@@ -56,17 +56,17 @@
                 @if ($hasOffIcon())
                     <x-dynamic-component
                     :component="$getOffIcon()"
-                            @class([
-                                'h-3 w-3',
-                                match($getOffColor()) {
-                                    'danger' => 'text-danger-500',
-                                    'primary' => 'text-primary-500',
-                                    'success' => 'text-success-500',
-                                    'warning' => 'text-warning-500',
-                                    default => 'text-gray-400'
-                                }
-                            ])
-                        />
+                    :class="\Illuminate\Support\Arr::toCssClasses([
+                        'h-3 w-3',
+                        match ($getOffColor()) {
+                            'danger' => 'text-danger-500',
+                            'primary' => 'text-primary-500',
+                            'success' => 'text-success-500',
+                            'warning' => 'text-warning-500',
+                            default => 'text-gray-400',
+                        },
+                    ])"
+                />
                 @endif
             </span>
 
@@ -82,16 +82,16 @@
                     <x-dynamic-component
                         :component="$getOnIcon()"
                         x-cloak
-                        @class([
+                        :class="\Illuminate\Support\Arr::toCssClasses([
                             'h-3 w-3',
-                            match($getOnColor()) {
+                            match ($getOnColor()) {
                                 'danger' => 'text-danger-500',
                                 'secondary' => 'text-gray-400',
                                 'success' => 'text-success-500',
                                 'warning' => 'text-warning-500',
-                                default => 'text-primary-500'
-                            }
-                        ])
+                                default => 'text-primary-500',
+                            },
+                        ])"
                     />
                 @endif
             </span>

--- a/packages/tables/resources/views/columns/toggle-column.blade.php
+++ b/packages/tables/resources/views/columns/toggle-column.blade.php
@@ -54,7 +54,19 @@
                 }"
             >
                 @if ($hasOffIcon())
-                    <x-dynamic-component :component="$getOffIcon()" class="h-3 w-3 text-gray-400" />
+                    <x-dynamic-component
+                    :component="$getOffIcon()"
+                            @class([
+                                'h-3 w-3',
+                                match($getOffColor()) {
+                                    'danger' => 'text-danger-500',
+                                    'primary' => 'text-primary-500',
+                                    'success' => 'text-success-500',
+                                    'warning' => 'text-warning-500',
+                                    default => 'text-gray-400'
+                                }
+                            ])
+                        />
                 @endif
             </span>
 
@@ -67,7 +79,20 @@
                 }"
             >
                 @if ($hasOnIcon())
-                    <x-dynamic-component :component="$getOnIcon()" x-cloak class="h-3 w-3 text-primary-600" />
+                    <x-dynamic-component
+                        :component="$getOnIcon()"
+                        x-cloak
+                        @class([
+                            'h-3 w-3',
+                            match($getOnColor()) {
+                                'danger' => 'text-danger-500',
+                                'secondary' => 'text-gray-400',
+                                'success' => 'text-success-500',
+                                'warning' => 'text-warning-500',
+                                default => 'text-primary-500'
+                            }
+                        ])
+                    />
                 @endif
             </span>
         </span>


### PR DESCRIPTION
This fixes an issue where the colors of the on/off icons of the `Forms\Components\Toggle` and `Tables\Columns\ToggleColumn` don't respect the colors provided in the `onColor()` and `offColor()` methods.