### PR TITLE
[2.x] Make `Builder` blocks cloneable

### DIFF
--- a/packages/forms/resources/lang/en/components.php
+++ b/packages/forms/resources/lang/en/components.php
@@ -8,6 +8,10 @@ return [
 
         'buttons' => [
 
+            'clone_item' => [
+                'label' => 'Clone',
+            ],
+
             'create_item' => [
                 'label' => 'Add to :label',
             ],

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -147,7 +147,7 @@
                                     @if ($isCloneable)
                                         <li>
                                             <button
-                                                title="{{ __('forms::components.repeater.buttons.clone_item.label') }}"
+                                                title="{{ __('forms::components.builder.buttons.clone_item.label') }}"
                                                 wire:click="dispatchFormEvent('builder::cloneItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
                                                 type="button"
                                                 @class([
@@ -156,7 +156,7 @@
                                                 ])
                                             >
                                                 <span class="sr-only">
-                                                    {{ __('forms::components.repeater.buttons.clone_item.label') }}
+                                                    {{ __('forms::components.builder.buttons.clone_item.label') }}
                                                 </span>
 
                                                 <x-heroicon-s-duplicate class="w-4 h-4"/>

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -12,6 +12,7 @@
     @php
         $containers = $getChildComponentContainers();
 
+        $isCloneable = $isCloneable();
         $isCollapsible = $isCollapsible();
         $isItemCreationDisabled = $isItemCreationDisabled();
         $isItemDeletionDisabled = $isItemDeletionDisabled();
@@ -90,7 +91,7 @@
                             'dark:bg-gray-800 dark:border-gray-600' => config('forms.dark_mode'),
                         ])
                     >
-                        @if ((! $isItemMovementDisabled) || $hasBlockLabels || (! $isItemDeletionDisabled) || $isCollapsible)
+                        @if ((! $isItemMovementDisabled) || $hasBlockLabels || (! $isItemDeletionDisabled) || $isCollapsible || $isCloneable)
                             <header @class([
                                 'flex items-center h-10 overflow-hidden border-b bg-gray-50 rounded-t-xl',
                                 'dark:bg-gray-800 dark:border-gray-700' => config('forms.dark_mode'),
@@ -144,7 +145,7 @@
                                     'flex divide-x rtl:divide-x-reverse',
                                     'dark:divide-gray-700' => config('forms.dark_mode'),
                                 ])>
-                                    @if ($isCloneable())
+                                    @if ($isCloneable)
                                         <li>
                                             <button
                                                 title="{{ __('forms::components.builder.buttons.clone_item.label') }}"

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -144,7 +144,7 @@
                                     'flex divide-x rtl:divide-x-reverse',
                                     'dark:divide-gray-700' => config('forms.dark_mode'),
                                 ])>
-                                    @if ($isCloneable)
+                                    @if ($isCloneable())
                                         <li>
                                             <button
                                                 title="{{ __('forms::components.builder.buttons.clone_item.label') }}"
@@ -162,7 +162,7 @@
                                                 <x-heroicon-s-duplicate class="w-4 h-4"/>
                                             </button>
                                         </li>
-                                    @endunless
+                                    @endif
 
                                     @unless ($isItemDeletionDisabled)
                                         <li>

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -144,6 +144,26 @@
                                     'flex divide-x rtl:divide-x-reverse',
                                     'dark:divide-gray-700' => config('forms.dark_mode'),
                                 ])>
+                                    @if ($isCloneable)
+                                        <li>
+                                            <button
+                                                title="{{ __('forms::components.repeater.buttons.clone_item.label') }}"
+                                                wire:click="dispatchFormEvent('builder::cloneItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                type="button"
+                                                @class([
+                                                    'flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-300',
+                                                    'dark:text-gray-400 dark:border-gray-700 dark:hover:text-gray-500' => config('forms.dark_mode'),
+                                                ])
+                                            >
+                                                <span class="sr-only">
+                                                    {{ __('forms::components.repeater.buttons.clone_item.label') }}
+                                                </span>
+
+                                                <x-heroicon-s-duplicate class="w-4 h-4"/>
+                                            </button>
+                                        </li>
+                                    @endunless
+
                                     @unless ($isItemDeletionDisabled)
                                         <li>
                                             <button

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -14,6 +14,7 @@ class Builder extends Field implements Contracts\CanConcealComponents
 {
     use Concerns\CanBeCollapsed;
     use Concerns\CanLimitItemsLength;
+    use Concerns\CanBeCloned;
 
     protected string $view = 'forms::components.builder';
 

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -108,6 +108,24 @@ class Builder extends Field implements Contracts\CanConcealComponents
                     data_set($livewire, $statePath, $items);
                 },
             ],
+            'builder::cloneItem' => [
+                function (Builder $component, string $statePath, string $uuidToDuplicate): void {
+                    if ($statePath !== $component->getStatePath()) {
+                        return;
+                    }
+
+                    $newUuid = (string) Str::uuid();
+
+                    $livewire = $component->getLivewire();
+                    data_set(
+                        $livewire,
+                        "{$statePath}.{$newUuid}",
+                        data_get($livewire, "{$statePath}.{$uuidToDuplicate}"),
+                    );
+
+                    $component->collapsed(false, shouldMakeComponentCollapsible: false);
+                },
+            ],
             'builder::moveItemDown' => [
                 function (Builder $component, string $statePath, string $uuidToMoveDown): void {
                     if ($component->isItemMovementDisabled()) {

--- a/packages/forms/src/Components/Concerns/CanBeCloned.php
+++ b/packages/forms/src/Components/Concerns/CanBeCloned.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Filament\Forms\Components\Concerns;
+
+use Closure;
+
+trait CanBeCloned
+{
+    protected bool | Closure $isCloneable = false;
+
+    public function cloneable(bool | Closure $condition = true): static
+    {
+        $this->isCloneable = $condition;
+
+        return $this;
+    }
+
+    public function isCloneable(): bool
+    {
+        return $this->evaluate($this->isCloneable) && (! $this->isDisabled());
+    }
+}

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -17,6 +17,7 @@ class Repeater extends Field implements Contracts\CanConcealComponents
     use Concerns\CanBeCollapsed;
     use Concerns\CanLimitItemsLength;
     use Concerns\HasContainerGridLayout;
+    use Concerns\CanBeCloned;
 
     protected string $view = 'forms::components.repeater';
 
@@ -29,8 +30,6 @@ class Repeater extends Field implements Contracts\CanConcealComponents
     protected bool | Closure $isItemMovementDisabled = false;
 
     protected bool | Closure $isInset = false;
-
-    protected bool | Closure $isCloneable = false;
 
     protected ?Collection $cachedExistingRecords = null;
 
@@ -216,13 +215,6 @@ class Repeater extends Field implements Contracts\CanConcealComponents
         return $this;
     }
 
-    public function cloneable(bool | Closure $condition = true): static
-    {
-        $this->isCloneable = $condition;
-
-        return $this;
-    }
-
     public function disableItemMovement(bool | Closure $condition = true): static
     {
         $this->isItemMovementDisabled = $condition;
@@ -275,11 +267,6 @@ class Repeater extends Field implements Contracts\CanConcealComponents
     public function isItemDeletionDisabled(): bool
     {
         return $this->evaluate($this->isItemDeletionDisabled) || $this->isDisabled();
-    }
-
-    public function isCloneable(): bool
-    {
-        return $this->evaluate($this->isCloneable) && (! $this->isDisabled());
     }
 
     public function isInset(): bool


### PR DESCRIPTION
Closes #4071.

Logic is identical to `Repeater`. Have extracted and abstracted methods into `CanBeCloned` trait to reduce duplication.