### PR TITLE
Merge extra attributes in layout components

### DIFF
--- a/packages/tables/resources/views/columns/layout/panel.blade.php
+++ b/packages/tables/resources/views/columns/layout/panel.blade.php
@@ -1,7 +1,9 @@
-<div @class([
-    'px-4 py-3 bg-gray-100 rounded-lg',
-    'dark:bg-gray-900' => config('forms.dark_mode'),
-])>
+<div
+    {{ $attributes->merge($getExtraAttributes())->class([
+        'px-4 py-3 bg-gray-100 rounded-lg',
+        'dark:bg-gray-900' => config('forms.dark_mode'),
+    ]) }}
+>
     <x-tables::columns.layout
         :components="$getComponents()"
         :record="$getRecord()"

--- a/packages/tables/resources/views/columns/layout/panel.blade.php
+++ b/packages/tables/resources/views/columns/layout/panel.blade.php
@@ -1,8 +1,10 @@
 <div
-    {{ $attributes->merge($getExtraAttributes())->class([
-        'px-4 py-3 bg-gray-100 rounded-lg',
-        'dark:bg-gray-900' => config('forms.dark_mode'),
-    ]) }}
+    {{ $attributes
+        ->merge($getExtraAttributes())
+        ->class([
+            'px-4 py-3 bg-gray-100 rounded-lg',
+            'dark:bg-gray-900' => config('forms.dark_mode'),
+        ]) }}
 >
     <x-tables::columns.layout
         :components="$getComponents()"

--- a/packages/tables/resources/views/columns/layout/panel.blade.php
+++ b/packages/tables/resources/views/columns/layout/panel.blade.php
@@ -1,10 +1,12 @@
 <div
-    {{ $attributes
-        ->merge($getExtraAttributes())
-        ->class([
-            'px-4 py-3 bg-gray-100 rounded-lg',
-            'dark:bg-gray-900' => config('forms.dark_mode'),
-        ]) }}
+    {{
+        $attributes
+            ->merge($getExtraAttributes())
+            ->class([
+                'px-4 py-3 bg-gray-100 rounded-lg',
+                'dark:bg-gray-900' => config('forms.dark_mode'),
+            ])
+    }}
 >
     <x-tables::columns.layout
         :components="$getComponents()"

--- a/packages/tables/resources/views/columns/layout/split.blade.php
+++ b/packages/tables/resources/views/columns/layout/split.blade.php
@@ -1,15 +1,17 @@
 <div
-    {{ $attributes->merge($getExtraAttributes())->class([
-        'flex',
-        match ($getFromBreakpoint()) {
-            'sm' => 'flex-col gap-1 sm:gap-3 sm:items-center sm:flex-row',
-            'md' => 'flex-col gap-1 md:gap-3 md:items-center md:flex-row',
-            'lg' => 'flex-col gap-1 lg:gap-3 lg:items-center lg:flex-row',
-            'xl' => 'flex-col gap-1 xl:gap-3 xl:items-center xl:flex-row',
-            '2xl' => 'flex-col gap-1 2xl:gap-3 2xl:items-center 2xl:flex-row',
-            default => 'gap-3 items-center',
-        },
-    ]) }}
+    {{ $attributes
+        ->merge($getExtraAttributes())
+        ->class([
+            'flex',
+            match ($getFromBreakpoint()) {
+                'sm' => 'flex-col gap-1 sm:gap-3 sm:items-center sm:flex-row',
+                'md' => 'flex-col gap-1 md:gap-3 md:items-center md:flex-row',
+                'lg' => 'flex-col gap-1 lg:gap-3 lg:items-center lg:flex-row',
+                'xl' => 'flex-col gap-1 xl:gap-3 xl:items-center xl:flex-row',
+                '2xl' => 'flex-col gap-1 2xl:gap-3 2xl:items-center 2xl:flex-row',
+                default => 'gap-3 items-center',
+            },
+        ]) }}
 >
     <x-tables::columns.layout
         :components="$getComponents()"

--- a/packages/tables/resources/views/columns/layout/split.blade.php
+++ b/packages/tables/resources/views/columns/layout/split.blade.php
@@ -1,17 +1,19 @@
 <div
-    {{ $attributes
-        ->merge($getExtraAttributes())
-        ->class([
-            'flex',
-            match ($getFromBreakpoint()) {
-                'sm' => 'flex-col gap-1 sm:gap-3 sm:items-center sm:flex-row',
-                'md' => 'flex-col gap-1 md:gap-3 md:items-center md:flex-row',
-                'lg' => 'flex-col gap-1 lg:gap-3 lg:items-center lg:flex-row',
-                'xl' => 'flex-col gap-1 xl:gap-3 xl:items-center xl:flex-row',
-                '2xl' => 'flex-col gap-1 2xl:gap-3 2xl:items-center 2xl:flex-row',
-                default => 'gap-3 items-center',
-            },
-        ]) }}
+    {{
+        $attributes
+            ->merge($getExtraAttributes())
+            ->class([
+                'flex',
+                match ($getFromBreakpoint()) {
+                    'sm' => 'flex-col gap-1 sm:gap-3 sm:items-center sm:flex-row',
+                    'md' => 'flex-col gap-1 md:gap-3 md:items-center md:flex-row',
+                    'lg' => 'flex-col gap-1 lg:gap-3 lg:items-center lg:flex-row',
+                    'xl' => 'flex-col gap-1 xl:gap-3 xl:items-center xl:flex-row',
+                    '2xl' => 'flex-col gap-1 2xl:gap-3 2xl:items-center 2xl:flex-row',
+                    default => 'gap-3 items-center',
+                },
+            ])
+    }}
 >
     <x-tables::columns.layout
         :components="$getComponents()"

--- a/packages/tables/resources/views/columns/layout/split.blade.php
+++ b/packages/tables/resources/views/columns/layout/split.blade.php
@@ -1,14 +1,16 @@
-<div @class([
-    'flex',
-    match ($getFromBreakpoint()) {
-        'sm' => 'flex-col gap-1 sm:gap-3 sm:items-center sm:flex-row',
-        'md' => 'flex-col gap-1 md:gap-3 md:items-center md:flex-row',
-        'lg' => 'flex-col gap-1 lg:gap-3 lg:items-center lg:flex-row',
-        'xl' => 'flex-col gap-1 xl:gap-3 xl:items-center xl:flex-row',
-        '2xl' => 'flex-col gap-1 2xl:gap-3 2xl:items-center 2xl:flex-row',
-        default => 'gap-3 items-center',
-    },
-])>
+<div
+    {{ $attributes->merge($getExtraAttributes())->class([
+        'flex',
+        match ($getFromBreakpoint()) {
+            'sm' => 'flex-col gap-1 sm:gap-3 sm:items-center sm:flex-row',
+            'md' => 'flex-col gap-1 md:gap-3 md:items-center md:flex-row',
+            'lg' => 'flex-col gap-1 lg:gap-3 lg:items-center lg:flex-row',
+            'xl' => 'flex-col gap-1 xl:gap-3 xl:items-center xl:flex-row',
+            '2xl' => 'flex-col gap-1 2xl:gap-3 2xl:items-center 2xl:flex-row',
+            default => 'gap-3 items-center',
+        },
+    ]) }}
+>
     <x-tables::columns.layout
         :components="$getComponents()"
         :record="$getRecord()"

--- a/packages/tables/resources/views/columns/layout/stack.blade.php
+++ b/packages/tables/resources/views/columns/layout/stack.blade.php
@@ -1,20 +1,22 @@
 <div
-    {{ $attributes
-        ->merge($getExtraAttributes())
-        ->class([
-            'flex flex-col',
-            match ($getAlignment()) {
-                'center' => 'items-center',
-                'right' => 'items-end',
-                default => 'items-start',
-            },
-            match ($getSpace()) {
-                1 => 'space-y-1',
-                2 => 'space-y-2',
-                3 => 'space-y-3',
-                default => null,
-            },
-        ]) }}
+    {{
+        $attributes
+            ->merge($getExtraAttributes())
+            ->class([
+                'flex flex-col',
+                match ($getAlignment()) {
+                    'center' => 'items-center',
+                    'right' => 'items-end',
+                    default => 'items-start',
+                },
+                match ($getSpace()) {
+                    1 => 'space-y-1',
+                    2 => 'space-y-2',
+                    3 => 'space-y-3',
+                    default => null,
+                },
+            ])
+    }}
 >
     <x-tables::columns.layout
         :components="$getComponents()"

--- a/packages/tables/resources/views/columns/layout/stack.blade.php
+++ b/packages/tables/resources/views/columns/layout/stack.blade.php
@@ -1,18 +1,20 @@
 <div
-    {{ $attributes->merge($getExtraAttributes())->class([
-        'flex flex-col',
-        match ($getAlignment()) {
-            'center' => 'items-center',
-            'right' => 'items-end',
-            default => 'items-start',
-        },
-        match ($getSpace()) {
-            1 => 'space-y-1',
-            2 => 'space-y-2',
-            3 => 'space-y-3',
-            default => null,
-        },
-    ]) }}
+    {{ $attributes
+        ->merge($getExtraAttributes())
+        ->class([
+            'flex flex-col',
+            match ($getAlignment()) {
+                'center' => 'items-center',
+                'right' => 'items-end',
+                default => 'items-start',
+            },
+            match ($getSpace()) {
+                1 => 'space-y-1',
+                2 => 'space-y-2',
+                3 => 'space-y-3',
+                default => null,
+            },
+        ]) }}
 >
     <x-tables::columns.layout
         :components="$getComponents()"

--- a/packages/tables/resources/views/columns/layout/stack.blade.php
+++ b/packages/tables/resources/views/columns/layout/stack.blade.php
@@ -1,17 +1,19 @@
-<div @class([
-    'flex flex-col',
-    match ($getAlignment()) {
-        'center' => 'items-center',
-        'right' => 'items-end',
-        default => 'items-start',
-    },
-    match ($getSpace()) {
-        1 => 'space-y-1',
-        2 => 'space-y-2',
-        3 => 'space-y-3',
-        default => null,
-    },
-])>
+<div
+    {{ $attributes->merge($getExtraAttributes())->class([
+        'flex flex-col',
+        match ($getAlignment()) {
+            'center' => 'items-center',
+            'right' => 'items-end',
+            default => 'items-start',
+        },
+        match ($getSpace()) {
+            1 => 'space-y-1',
+            2 => 'space-y-2',
+            3 => 'space-y-3',
+            default => null,
+        },
+    ]) }}
+>
     <x-tables::columns.layout
         :components="$getComponents()"
         :record="$getRecord()"


### PR DESCRIPTION
This will allow to define extra attributes on the new layout components, e.g. increase the spacing within the stack:

```php
Tables\Columns\Layout\Split::make([
    Tables\Columns\Layout\Stack::make([
        // ...
    ])
    ->alignCenter()
    ->extraAttributes([
        'class' => 'space-y-2',
    ]),
]),
```

Edit: Just saw the `getSpace()` afterwards - lol. But even though, this might be useful :) 