### PR TITLE
Fix/IconButton method missing in GlobalSearch Action

### DIFF
--- a/packages/admin/src/GlobalSearch/Actions/Action.php
+++ b/packages/admin/src/GlobalSearch/Actions/Action.php
@@ -28,4 +28,11 @@ class Action extends BaseAction
 
         return $this;
     }
+
+    public function iconButton(): static
+    {
+        $this->view('filament::global-search.actions.icon-button-action');
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Added iconButton method GlobalSearch/Actions/Action , as the view file exist.