### PR TITLE
fix: evaluate Closures passed to getIcon()

### DIFF
--- a/packages/tables/src/Columns/Concerns/HasIcon.php
+++ b/packages/tables/src/Columns/Concerns/HasIcon.php
@@ -26,7 +26,7 @@ trait HasIcon
 
     public function getIcon(): ?string
     {
-        return $this->icon;
+        return $this->evaluate($this->icon);
     }
 
     public function getIconPosition(): string


### PR DESCRIPTION
This method wasn't wrapped in `$this->evaluate()`,
so a Closure passed to TextColumn wasn't correctly handled.

This fails before this PR:
```php
TextColumn->icon(fn() => 'heroicon-o-check')
```