### PR TITLE
Fix: wrap more methods in evaluate()

### DIFF
--- a/packages/tables/src/Columns/Concerns/HasColor.php
+++ b/packages/tables/src/Columns/Concerns/HasColor.php
@@ -17,6 +17,6 @@ trait HasColor
 
     public function getColor(): ?string
     {
-        return $this->color;
+        return $this->evaluate($this->color);
     }
 }

--- a/packages/tables/src/Columns/Concerns/HasSize.php
+++ b/packages/tables/src/Columns/Concerns/HasSize.php
@@ -17,6 +17,6 @@ trait HasSize
 
     public function getSize(): ?string
     {
-        return $this->size;
+        return $this->evaluate($this->size);
     }
 }

--- a/packages/tables/src/Columns/Concerns/HasWeight.php
+++ b/packages/tables/src/Columns/Concerns/HasWeight.php
@@ -17,6 +17,6 @@ trait HasWeight
 
     public function getWeight(): ?string
     {
-        return $this->weight;
+        return $this->evaluate($this->weight);
     }
 }


### PR DESCRIPTION
I found late that `getColor()` also wasn't evaluated.

In order to avoid making more duplicate PRs, I checked other traits that accept Closures but don't evaluate them as well.
- HasColor
- HasSize
- HasWeight