### PR TITLE
Fix TagsInput Php 8.1 #4229

### DIFF
--- a/packages/forms/src/Components/TagsInput.php
+++ b/packages/forms/src/Components/TagsInput.php
@@ -35,7 +35,7 @@ class TagsInput extends Field
                 return;
             }
 
-            $state = explode($separator, $state);
+            $state = explode($separator, $state ?? '');
 
             if (count($state) === 1 && blank($state[0])) {
                 $state = [];


### PR DESCRIPTION
explode(): Passing null to parameter ($string) of type string is deprecated