### PR TITLE
Filter hidden modal actions

### DIFF
--- a/packages/support/src/Actions/Concerns/CanOpenModal.php
+++ b/packages/support/src/Actions/Concerns/CanOpenModal.php
@@ -117,7 +117,9 @@ trait CanOpenModal
         }
 
         if ($this->modalActions !== null) {
-            return $this->evaluate($this->modalActions);
+            return $this->filterModalActions(
+                $this->evaluate($this->modalActions)
+            );
         }
 
         $actions = array_merge(
@@ -130,7 +132,12 @@ trait CanOpenModal
             $actions = array_reverse($actions);
         }
 
-        return $actions;
+        return $this->filterModalActions($actions);
+    }
+
+    protected function filterModalActions(array $actions): array
+    {
+        return array_filter($actions, fn (ModalAction $action): bool => ! $action->isHidden());
     }
 
     public function getModalSubmitAction(): ModalAction

--- a/packages/support/src/Actions/Concerns/CanOpenModal.php
+++ b/packages/support/src/Actions/Concerns/CanOpenModal.php
@@ -117,8 +117,8 @@ trait CanOpenModal
         }
 
         if ($this->modalActions !== null) {
-            return $this->filterModalActions(
-                $this->evaluate($this->modalActions)
+            return $this->filterHiddenModalActions(
+                $this->evaluate($this->modalActions),
             );
         }
 
@@ -132,12 +132,15 @@ trait CanOpenModal
             $actions = array_reverse($actions);
         }
 
-        return $this->filterModalActions($actions);
+        return $this->filterHiddenModalActions($actions);
     }
 
-    protected function filterModalActions(array $actions): array
+    protected function filterHiddenModalActions(array $actions): array
     {
-        return array_filter($actions, fn (ModalAction $action): bool => ! $action->isHidden());
+        return array_filter(
+            $actions,
+            fn (ModalAction $action): bool => ! $action->isHidden(),
+        );
     }
 
     public function getModalSubmitAction(): ModalAction

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -880,17 +880,10 @@
                     {{ $getMountedActionForm() }}
                 @endif
 
-                @php
-                    $modalActions = array_filter(
-                        $action->getModalActions(),
-                        fn (\Filament\Support\Actions\Modal\Actions\Action $action): bool => ! $action->isHidden(),
-                    );
-                @endphp
-
-                @if (count($modalActions))
+                @if (count($action->getModalActions()))
                     <x-slot name="footer">
                         <x-tables::modal.actions :full-width="$action->isModalCentered()">
-                            @foreach ($modalActions as $modalAction)
+                            @foreach ($action->getModalActions() as $modalAction)
                                 {{ $modalAction }}
                             @endforeach
                         </x-tables::modal.actions>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -880,10 +880,17 @@
                     {{ $getMountedActionForm() }}
                 @endif
 
-                @if (count($action->getModalActions()))
+                @php
+                    $modalActions = array_filter(
+                        $action->getModalActions(),
+                        fn (\Filament\Support\Actions\Modal\Actions\Action $action): bool => ! $action->isHidden(),
+                    );
+                @endphp
+
+                @if (count($modalActions))
                     <x-slot name="footer">
                         <x-tables::modal.actions :full-width="$action->isModalCentered()">
-                            @foreach ($action->getModalActions() as $modalAction)
+                            @foreach ($modalActions as $modalAction)
                                 {{ $modalAction }}
                             @endforeach
                         </x-tables::modal.actions>


### PR DESCRIPTION
With this one I am not 100% sure if it's the correct approach.
I noticed that table `modalActions()` are not respecting the hidden-status of an action, my current example is list of sent emails that have a resend option, depending on their status.

```php
Tables\Actions\Action::make('view')
    ->color('secondary')
    ->label('View')
    ->icon('heroicon-o-eye')
    ->action('resend')
    ->modalContent(fn (MailSend $record) => view('filament.modals.mail-send-modal', ['record' => $record]))
    ->modalActions(fn (MailSend $record): array => [
        Pages\Actions\Action::makeModalAction('submit')
            ->authorize($record->canBeResent())
            ->color('danger')
            ->label('Resend')
            ->submit(),
        Pages\Actions\Action::makeModalAction('cancel')
            ->color('secondary')
            ->label('Close')
            ->cancel()
    ]),
```

`authorize()` should hide the resend option but it doesn't :) 
The thing I am note sure with is the typing of the `array_filter´ callback. Maybe you can take over please :) Thanks!