### PR TITLE
Currency formatting default to config value

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -114,11 +114,15 @@ trait CanFormatState
         return $this;
     }
 
-    public function money(string | Closure $currency = 'usd', bool $shouldConvert = false): static
+    public function money(string | Closure | null $currency = null, bool $shouldConvert = false): static
     {
         $this->formatStateUsing(static function (Column $column, $state) use ($currency, $shouldConvert): ?string {
             if (blank($state)) {
                 return null;
+            }
+            
+            if (blank($currency)) {
+                $currency = config('money.default_currency') ?? 'usd';
             }
 
             return (new Money\Money(


### PR DESCRIPTION
Since `akaunting/laravel-money` supports the default currency being set in the key `default_currency` from the config file `config/money.php`, Filament should honour this when formatting state with the `money()` table helper.

This will keep the old behaviour of defaulting to 'usd' if the config key `default_currency` is not set.