### PR TITLE
Feature: configurable select search debounce

### DIFF
--- a/packages/forms/resources/js/components/select.js
+++ b/packages/forms/resources/js/components/select.js
@@ -22,6 +22,7 @@ export default (Alpine) => {
             options,
             optionsLimit,
             placeholder,
+            searchDebounce,
             searchingMessage,
             searchPrompt,
             state,
@@ -133,7 +134,7 @@ export default (Alpine) => {
                                 })
 
                                 this.isSearching = false
-                            }, 1000),
+                            }, searchDebounce),
                         )
                     }
 

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -91,6 +91,7 @@
                         options: @js($getOptionsForJs()),
                         optionsLimit: @js($getOptionsLimit()),
                         placeholder: @js($getPlaceholder()),
+                        searchDebounce: @js($getSearchDebounce()),
                         searchingMessage: @js($getSearchingMessage()),
                         searchPrompt: @js($getSearchPrompt()),
                         state: $wire.{{ $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')') }},

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -60,6 +60,8 @@ class Select extends Field
 
     protected string | Htmlable | Closure | null $noSearchResultsMessage = null;
 
+    protected int | Closure $searchDebounce = 1000;
+
     protected string | Closure | null $searchingMessage = null;
 
     protected string | Htmlable | Closure | null $searchPrompt = null;
@@ -317,6 +319,13 @@ class Select extends Field
         return $this;
     }
 
+    public function searchDebounce(int | Closure $debounce): static
+    {
+        $this->searchDebounce = $debounce;
+
+        return $this;
+    }
+
     public function searchingMessage(string | Closure | null $message): static
     {
         $this->searchingMessage = $message;
@@ -376,6 +385,11 @@ class Select extends Field
     public function getMaxItemsMessage(): string
     {
         return $this->evaluate($this->maxItemsMessage);
+    }
+
+    public function getSearchDebounce(): int
+    {
+        return $this->evaluate($this->searchDebounce);
     }
 
     public function getSearchingMessage(): string


### PR DESCRIPTION
I felt like a debounce of 1000ms, for search, is a bit too long.
This PR adds `->searchDebounce()`

I am having some trouble building assets on my local machine. So please rebuild assets.