### PR TITLE
Add missing Spanish translations

### DIFF
--- a/packages/forms/resources/lang/es/components.php
+++ b/packages/forms/resources/lang/es/components.php
@@ -6,7 +6,12 @@ return [
 
         'collapsed' => 'Contenido contraido',
 
+
         'buttons' => [
+
+            'clone_item' => [
+                'label' => 'Clonar',
+            ],
 
             'create_item' => [
                 'label' => 'Añadir a :label',
@@ -211,6 +216,8 @@ return [
         ],
 
         'loading_message' => 'Cargando...',
+
+        'max_items_message' => 'Solo :count pueden ser seleccionados.',
 
         'no_search_results_message' => 'No se encontraron coincidencias con su búsqueda.',
 

--- a/packages/support/resources/lang/es/actions/replicate.php
+++ b/packages/support/resources/lang/es/actions/replicate.php
@@ -4,7 +4,21 @@ return [
 
     'single' => [
 
-        'label' => 'Repetir',
+        'label' => 'Replicar',
+
+        'modal' => [
+
+            'heading' => 'Replicar :label',
+
+            'actions' => [
+
+                'replicate' => [
+                    'label' => 'Replicar',
+                ],
+
+            ],
+
+        ],
 
         'messages' => [
             'replicated' => 'Registro replicado',

--- a/packages/tables/resources/lang/es/table.php
+++ b/packages/tables/resources/lang/es/table.php
@@ -156,4 +156,27 @@ return [
 
     ],
 
+    'sorting' => [
+
+        'fields' => [
+
+            'column' => [
+                'label' => 'Ordenar por',
+            ],
+
+            'direction' => [
+
+                'label' => 'Dirección de orden',
+
+                'options' => [
+                    'asc' => 'Ascendente',
+                    'desc' => 'Descendente',
+                ],
+
+            ],
+
+        ],
+
+    ],
+
 ];


### PR DESCRIPTION
Added missing ES translations in following files:

- `forms/components.php`
- `tables/table.php`
- `support/actions/replicate.php`