### PR TITLE
Document missing supported badge colour

### DIFF
--- a/packages/tables/docs/03-columns/06-badge.md
+++ b/packages/tables/docs/03-columns/06-badge.md
@@ -21,13 +21,14 @@ Badges may have a color. It may be either `primary`, `secondary`, `success`, `wa
 
 ```php
 use Filament\Tables\Columns\BadgeColumn;
-
+ 
 BadgeColumn::make('status')
     ->colors([
         'primary',
-        'danger' => 'draft',
+        'secondary' => 'draft',
         'warning' => 'reviewing',
         'success' => 'published',
+        'danger' => 'rejected',
     ])
 ```
 

--- a/packages/tables/docs/03-columns/06-badge.md
+++ b/packages/tables/docs/03-columns/06-badge.md
@@ -21,7 +21,7 @@ Badges may have a color. It may be either `primary`, `secondary`, `success`, `wa
 
 ```php
 use Filament\Tables\Columns\BadgeColumn;
- 
+
 BadgeColumn::make('status')
     ->colors([
         'primary',
@@ -40,9 +40,10 @@ use Filament\Tables\Columns\BadgeColumn;
 BadgeColumn::make('status')
     ->colors([
         'primary',
-        'danger' => static fn ($state): bool => $state === 'draft',
+        'secondary' => static fn ($state): bool => $state === 'draft',
         'warning' => static fn ($state): bool => $state === 'reviewing',
         'success' => static fn ($state): bool => $state === 'published',
+        'danger' => static fn ($state): bool => $state === 'rejected',
     ])
 ```
 

--- a/packages/tables/docs/03-columns/06-badge.md
+++ b/packages/tables/docs/03-columns/06-badge.md
@@ -17,7 +17,7 @@ BadgeColumn::make('status')
 
 ## Customizing the color
 
-Badges may have a color. It may be either `primary`, `success`, `warning` or `danger`:
+Badges may have a color. It may be either `primary`, `secondary`, `success`, `warning` or `danger`:
 
 ```php
 use Filament\Tables\Columns\BadgeColumn;


### PR DESCRIPTION
The colour `secondary` is supported by the badge column, this PR updates it to match the writing style of other documentation pages, for example the [text column page](https://filamentphp.com/docs/2.x/tables/columns/text#customizing-the-color).

If it's of interest, I'd be happy to add a commit to the PR that also updates the example to the following (or something else) to showcase the colour in action.

```php
use Filament\Tables\Columns\BadgeColumn;
 
BadgeColumn::make('status')
    ->colors([
        'primary',
        'secondary' => 'draft',
        'warning' => 'reviewing',
        'success' => 'published',
        'danger' => 'rejected',
    ])
```