### PR TITLE
Make rows default sortable by multiple columns

### DIFF
--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -74,6 +74,15 @@ trait CanSortRecords
         }
 
         if ($columnName === $this->getDefaultTableSortColumn()) {
+            if(\Str::contains($columnName, ',')) {
+                $columnNames = explode(',', $columnName);
+                foreach($columnNames as $columnName) {
+                    $direction = \Str::after($columnName, '-');
+                    $columnName = \Str::before($columnName, '-');
+                    $query->orderBy($columnName, $direction);
+                }
+                return $query;
+            }
             return $query->orderBy($columnName, $direction);
         }
 


### PR DESCRIPTION
For example:
```php
return $table
            ->columns([
                TextColumn::make('title')
                          ->label('Title'),

                BadgeColumn::make('is_active')
                           ->label('Status')
                           ->enum([
                               0 => 'Inactive',
                               1 => 'Active',
                           ])
                           ->colors([
                               'success',
                               'danger' => 0,
                           ])->sortable(),

                TextColumn::make('created_at')
                          ->label('Created at')
                          ->sortable()
                          ->dateTime('d/m/Y H:i'),
            ])
            ->actions([
                Tables\Actions\ViewAction::make(),
            ])->defaultSort('is_active-desc,created_at-asc');
```

This shows the active records first, ordered by creation date and then shows the inactive records ordered by creation date.