### PR TITLE
chore: Add translation bot

### DIFF
--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -1,0 +1,32 @@
+name: translation-update
+
+on:
+  pull_request:
+    branches:
+      - 2.x
+    types:
+      - closed
+
+jobs:
+  translation_update:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v31
+        with:
+          files: |
+            packages/**/resources/lang/en/**
+
+      - name: Notify on Discord
+        if: steps.changed-files.outputs.any_changed == 'true'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        uses: Ilshidur/action-discord@0.3.2
+        with:
+          args: '<@&1026513157142872185> PR [#${{ github.event.number }}](${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.number }}/files) introduced translation changes.'

--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Notify on Discord
         if: steps.changed-files.outputs.any_changed == 'true'
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: ${{ secrets.TRANSLATION_BOT_DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@0.3.2
         with:
           args: '<@&1026513157142872185> PR [#${{ github.event.number }}](${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.number }}/files) introduced translation changes.'


### PR DESCRIPTION
This PR adds a GitHub Action that checks lang files for updates and sends a Discord notification to all translation managers.

Tested in https://github.com/pxlrbt/fil-test

**TODO:** You need to set `DISCORD_WEBHOOK` as a repo secret and use the webhook URL from Discord.