### PR TITLE
Allow Hint Color Specification for Fields

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -117,7 +117,7 @@ RichEditor::make('content')
     ->hintIcon('heroicon-s-translate')
 ```
 
-Hints may have a `color()`. The default is a light gray, but you may use `primary`, `secondary`, `success`, `warning`, or `danger`:
+Hints may have a `color()`. By default it's gray, but you may use `primary`, `success`, `warning`, or `danger`:
 
 ```php
 use Filament\Forms\Components\RichEditor;

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -117,6 +117,16 @@ RichEditor::make('content')
     ->hintIcon('heroicon-s-translate')
 ```
 
+Hints may have a `color()`. The default is a light gray, but you may use `primary`, `secondary`, `success`, `warning`, or `danger`:
+
+```php
+use Filament\Forms\Components\RichEditor;
+
+RichEditor::make('content')
+    ->hint('Translatable')
+    ->hintColor('primary')
+```
+
 ### Custom attributes
 
 The HTML attributes of the field's wrapper can be customized by passing an array of `extraAttributes()`:
@@ -1866,6 +1876,7 @@ Using [Livewire's entangle](https://laravel-livewire.com/docs/alpine-js#sharing-
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"
@@ -1885,6 +1896,7 @@ Or, you may bind the value to a Livewire property using [`wire:model`](https://l
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"
@@ -1927,6 +1939,7 @@ The `$getStatePath()` closure may be used by the view to retrieve the Livewire p
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -5,6 +5,7 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -5,6 +5,7 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"

--- a/packages/forms/resources/views/components/checkbox.blade.php
+++ b/packages/forms/resources/views/components/checkbox.blade.php
@@ -5,6 +5,7 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"

--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -13,6 +13,7 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -5,6 +5,7 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"

--- a/packages/forms/resources/views/components/field-wrapper/hint.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/hint.blade.php
@@ -1,41 +1,33 @@
 @props([
-    'icon' => null,
     'color' => null,
+    'icon' => null,
 ])
 
-<div {{ $attributes->class(
-    array_merge(
-        [
-            'filament-forms-field-wrapper-hint flex space-x-2 rtl:space-x-reverse',
+<div {{ $attributes->class([
+    'filament-forms-field-wrapper-hint flex space-x-2 rtl:space-x-reverse',
+    match ($color) {
+        'danger' => [
+            'text-danger-500',
+            'dark:text-danger-300' => config('tables.dark_mode'),
         ],
-        match ($color) {
-            'danger' => [
-                'text-danger-700',
-                'dark:text-danger-500' => config('tables.dark_mode'),
-            ],
-            'secondary' => [
-                'text-gray-700',
-                'dark:text-gray-500' => config('tables.dark_mode'),
-            ],
-            'success' => [
-                'text-success-700',
-                'dark:text-success-500' => config('tables.dark_mode'),
-            ],
-            'warning' => [
-                'text-warning-700',
-                'dark:text-warning-500' => config('filament.dark_mode'),
-            ],
-            'primary' => [
-                'text-primary-700',
-                'dark:text-primary-500' => config('tables.dark_mode'),
-            ],
-            null => [
-                'text-gray-500',
-                'dark:text-gray-300' => config('tables.dark_mode'),
-            ],
-        },
-    )
-) }}>
+        'success' => [
+            'text-success-500',
+            'dark:text-success-300' => config('tables.dark_mode'),
+        ],
+        'warning' => [
+            'text-warning-500',
+            'dark:text-warning-300' => config('filament.dark_mode'),
+        ],
+        'primary' => [
+            'text-primary-500',
+            'dark:text-primary-300' => config('tables.dark_mode'),
+        ],
+        default => [
+            'text-gray-500',
+            'dark:text-gray-300' => config('tables.dark_mode'),
+        ],
+    },
+]) }}>
     @if ($slot->isNotEmpty())
         <span class="text-xs leading-tight">
             {{ $slot }}

--- a/packages/forms/resources/views/components/field-wrapper/hint.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/hint.blade.php
@@ -1,11 +1,41 @@
 @props([
     'icon' => null,
+    'color' => null,
 ])
 
-<div {{ $attributes->class([
-    'filament-forms-field-wrapper-hint flex space-x-2 rtl:space-x-reverse text-gray-500',
-    'dark:text-gray-300' => config('forms.dark_mode'),
-]) }}>
+<div {{ $attributes->class(
+    array_merge(
+        [
+            'filament-forms-field-wrapper-hint flex space-x-2 rtl:space-x-reverse',
+        ],
+        match ($color) {
+            'danger' => [
+                'text-danger-700',
+                'dark:text-danger-500' => config('tables.dark_mode'),
+            ],
+            'secondary' => [
+                'text-gray-700',
+                'dark:text-gray-500' => config('tables.dark_mode'),
+            ],
+            'success' => [
+                'text-success-700',
+                'dark:text-success-500' => config('tables.dark_mode'),
+            ],
+            'warning' => [
+                'text-warning-700',
+                'dark:text-warning-500' => config('filament.dark_mode'),
+            ],
+            'primary' => [
+                'text-primary-700',
+                'dark:text-primary-500' => config('tables.dark_mode'),
+            ],
+            null => [
+                'text-gray-500',
+                'dark:text-gray-300' => config('tables.dark_mode'),
+            ],
+        },
+    )
+) }}>
     @if ($slot->isNotEmpty())
         <span class="text-xs leading-tight">
             {{ $slot }}

--- a/packages/forms/resources/views/components/field-wrapper/index.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/index.blade.php
@@ -6,6 +6,7 @@
     'labelSuffix' => null,
     'helperText' => null,
     'hint' => null,
+    'hintColor' => null,
     'hintIcon' => null,
     'required' => false,
     'statePath',
@@ -38,7 +39,7 @@
                 @endif
 
                 @if ($hint || $hintIcon)
-                    <x-forms::field-wrapper.hint :icon="$hintIcon">
+                    <x-forms::field-wrapper.hint :color="$hintColor" :icon="$hintIcon">
                         {{ filled($hint) ? ($hint instanceof \Illuminate\Support\HtmlString ? $hint : \Illuminate\Support\Str::of($hint)->markdown()->sanitizeHtml()->toHtmlString()) : null }}
                     </x-forms::field-wrapper.hint>
                 @endif

--- a/packages/forms/resources/views/components/field-wrapper/inline.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/inline.blade.php
@@ -6,6 +6,7 @@
     'labelSuffix' => null,
     'helperText' => null,
     'hint' => null,
+    'hintColor' => null,
     'hintIcon' => null,
     'required' => false,
     'statePath',
@@ -38,7 +39,7 @@
                 @endif
 
                 @if ($hint || $hintIcon)
-                    <x-forms::field-wrapper.hint :icon="$hintIcon">
+                    <x-forms::field-wrapper.hint :color="$hintColor" :icon="$hintIcon">
                         {{ filled($hint) ? ($hint instanceof \Illuminate\Support\HtmlString ? $hint : \Illuminate\Support\Str::of($hint)->markdown()->sanitizeHtml()->toHtmlString()) : null }}
                     </x-forms::field-wrapper.hint>
                 @endif

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -5,6 +5,7 @@
     :label-sr-only="$isAvatar() || $isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"

--- a/packages/forms/resources/views/components/key-value.blade.php
+++ b/packages/forms/resources/views/components/key-value.blade.php
@@ -5,6 +5,7 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -5,6 +5,7 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"

--- a/packages/forms/resources/views/components/placeholder.blade.php
+++ b/packages/forms/resources/views/components/placeholder.blade.php
@@ -5,6 +5,7 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :state-path="$getStatePath()"
 >

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -5,6 +5,7 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -5,6 +5,7 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -5,6 +5,7 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -13,6 +13,7 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -5,6 +5,7 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -15,6 +15,7 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -5,6 +5,7 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -5,6 +5,7 @@
     :label-sr-only="$isLabelHidden()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
+    :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"

--- a/packages/forms/src/Components/Concerns/HasHint.php
+++ b/packages/forms/src/Components/Concerns/HasHint.php
@@ -9,11 +9,20 @@ trait HasHint
 {
     protected string | HtmlString | Closure | null $hint = null;
 
+    protected string | Closure | null $hintColor = null;
+
     protected string | Closure | null $hintIcon = null;
 
     public function hint(string | HtmlString | Closure | null $hint): static
     {
         $this->hint = $hint;
+
+        return $this;
+    }
+
+    public function hintColor(string | Closure | null $hintColor): static
+    {
+        $this->hintColor = $hintColor;
 
         return $this;
     }
@@ -28,6 +37,11 @@ trait HasHint
     public function getHint(): string | HtmlString | null
     {
         return $this->evaluate($this->hint);
+    }
+
+    public function getHintColor(): ?string
+    {
+        return $this->evaluate($this->hintColor);
     }
 
     public function getHintIcon(): ?string


### PR DESCRIPTION
This PR allows developers to provide a color for a field hint, like this:

```php
use Filament\Forms\Components\RichEditor;

RichEditor::make('content')
    ->hint('Translatable')
    ->hintColor('primary')
```