### PR TITLE
Document recordSelectOptionsQuery() method

### DIFF
--- a/packages/admin/docs/02-resources/01-getting-started.md
+++ b/packages/admin/docs/02-resources/01-getting-started.md
@@ -569,6 +569,14 @@ public function creating(Post $post): void
 }
 ```
 
+Additionally, you may want to apply a scope to the models available for attaching in a relation manager:
+
+```php
+use Filament\Tables\Actions\AttachAction;
+
+AttachAction::make()->recordSelectOptionsQuery(fn ($query) => $query->whereBelongsTo(auth()->user())
+```
+
 ### `stancl/tenancy`
 
 To set up [`stancl/tenancy`](https://tenancyforlaravel.com/docs) to work with Filament, you just need to add the `InitializeTenancyByDomain::class` middleware to [Livewire](https://tenancyforlaravel.com/docs/v3/integrations/livewire) and the [Filament config file](../installation#publishing-configuration):

--- a/packages/admin/docs/02-resources/01-getting-started.md
+++ b/packages/admin/docs/02-resources/01-getting-started.md
@@ -569,7 +569,7 @@ public function creating(Post $post): void
 }
 ```
 
-Additionally, you may want to apply a scope to the models available for attaching in a relation manager:
+Additionally, you may want to apply a scope to the models available to the following relation manager Actions: `AttachAction`, `DetachAction`, `AssociateAction` or `DissociateAction`.
 
 ```php
 use Filament\Tables\Actions\AttachAction;

--- a/packages/admin/docs/02-resources/01-getting-started.md
+++ b/packages/admin/docs/02-resources/01-getting-started.md
@@ -569,7 +569,7 @@ public function creating(Post $post): void
 }
 ```
 
-Additionally, you may want to apply a database scope to the options available in the [relation manager](relation-managers) `AttachAction` or `AssociateAction`:
+Additionally, you may want to scope the options available in the [relation manager](relation-managers) `AttachAction` or `AssociateAction`:
 
 ```php
 use Filament\Tables\Actions\AttachAction;

--- a/packages/admin/docs/02-resources/01-getting-started.md
+++ b/packages/admin/docs/02-resources/01-getting-started.md
@@ -569,7 +569,7 @@ public function creating(Post $post): void
 }
 ```
 
-Additionally, you may want to apply a database scope to the models available to the `AttachAction` or `AssociateAction` relation manager Actions.
+Additionally, you may want to apply a database scope to the options available in the [relation manager](relation-managers) `AttachAction` or `AssociateAction`:
 
 ```php
 use Filament\Tables\Actions\AttachAction;

--- a/packages/admin/docs/02-resources/01-getting-started.md
+++ b/packages/admin/docs/02-resources/01-getting-started.md
@@ -569,7 +569,7 @@ public function creating(Post $post): void
 }
 ```
 
-Additionally, you may want to apply a scope to the models available to the following relation manager Actions: `AttachAction`, `DetachAction`, `AssociateAction` or `DissociateAction`.
+Additionally, you may want to apply a database scope to the models available to the `AttachAction` or `AssociateAction` relation manager Actions.
 
 ```php
 use Filament\Tables\Actions\AttachAction;

--- a/packages/admin/docs/02-resources/01-getting-started.md
+++ b/packages/admin/docs/02-resources/01-getting-started.md
@@ -573,8 +573,10 @@ Additionally, you may want to apply a scope to the models available for attachin
 
 ```php
 use Filament\Tables\Actions\AttachAction;
+use Illuminate\Database\Eloquent\Builder;
 
-AttachAction::make()->recordSelectOptionsQuery(fn ($query) => $query->whereBelongsTo(auth()->user())
+AttachAction::make()
+    ->recordSelectOptionsQuery(fn (Builder $query) => $query->whereBelongsTo(auth()->user())
 ```
 
 ### `stancl/tenancy`

--- a/packages/admin/docs/02-resources/06-relation-managers.md
+++ b/packages/admin/docs/02-resources/06-relation-managers.md
@@ -395,6 +395,16 @@ In this example, `$action->getRecordSelect()` outputs the select field to pick t
 
 Please ensure that any pivot attributes are listed in the `withPivot()` method of the relationship *and* inverse relationship.
 
+### Scoping attachable models
+
+You may want to apply a scope to the models available for attaching in a relation manager:
+
+```php
+use Filament\Tables\Actions\AttachAction;
+
+AttachAction::make()->recordSelectOptionsQuery(fn ($query) => $query->whereBelongsTo(auth()->user())
+```
+
 ### Handling duplicates
 
 By default, you will not be allowed to attach a record more than once. This is because you must also set up a primary `id` column on the pivot table for this feature to work.

--- a/packages/admin/docs/02-resources/06-relation-managers.md
+++ b/packages/admin/docs/02-resources/06-relation-managers.md
@@ -397,7 +397,7 @@ Please ensure that any pivot attributes are listed in the `withPivot()` method o
 
 ### Scoping available models
 
-You may want to apply a scope to the models available to `AttachAction` or `DetachAction`:
+You may want to apply a database scope to the models available to `AttachAction`:
 
 ```php
 use Filament\Tables\Actions\AttachAction;
@@ -468,7 +468,7 @@ AssociateAction::make()->preloadRecordSelect()
 
 ### Scoping available models
 
-You may want to apply a scope to the models available to `AssociateAction` or `DissociateAction`:
+You may want to apply a database scope to the models available to `AssociateAction`:
 
 ```php
 use Filament\Tables\Actions\AssociateAction;

--- a/packages/admin/docs/02-resources/06-relation-managers.md
+++ b/packages/admin/docs/02-resources/06-relation-managers.md
@@ -401,8 +401,10 @@ You may want to apply a scope to the models available for attaching in a relatio
 
 ```php
 use Filament\Tables\Actions\AttachAction;
+use Illuminate\Database\Eloquent\Builder;
 
-AttachAction::make()->recordSelectOptionsQuery(fn ($query) => $query->whereBelongsTo(auth()->user())
+AttachAction::make()
+    ->recordSelectOptionsQuery(fn (Builder $query) => $query->whereBelongsTo(auth()->user())
 ```
 
 ### Handling duplicates

--- a/packages/admin/docs/02-resources/06-relation-managers.md
+++ b/packages/admin/docs/02-resources/06-relation-managers.md
@@ -395,9 +395,9 @@ In this example, `$action->getRecordSelect()` outputs the select field to pick t
 
 Please ensure that any pivot attributes are listed in the `withPivot()` method of the relationship *and* inverse relationship.
 
-### Scoping attachable models
+### Scoping available models
 
-You may want to apply a scope to the models available for attaching in a relation manager:
+You may want to apply a scope to the models available to `AttachAction` or `DetachAction`:
 
 ```php
 use Filament\Tables\Actions\AttachAction;
@@ -464,6 +464,18 @@ By default, as you search for a record to associate, options will load from the 
 use Filament\Tables\Actions\AssociateAction;
 
 AssociateAction::make()->preloadRecordSelect()
+```
+
+### Scoping available models
+
+You may want to apply a scope to the models available to `AssociateAction` or `DissociateAction`:
+
+```php
+use Filament\Tables\Actions\AssociateAction;
+use Illuminate\Database\Eloquent\Builder;
+
+AssociateAction::make()
+    ->recordSelectOptionsQuery(fn (Builder $query) => $query->whereBelongsTo(auth()->user())
 ```
 
 ## Viewing records

--- a/packages/admin/docs/02-resources/06-relation-managers.md
+++ b/packages/admin/docs/02-resources/06-relation-managers.md
@@ -395,9 +395,9 @@ In this example, `$action->getRecordSelect()` outputs the select field to pick t
 
 Please ensure that any pivot attributes are listed in the `withPivot()` method of the relationship *and* inverse relationship.
 
-### Scoping available models
+### Scoping the options
 
-You may want to apply a database scope to the models available to `AttachAction`:
+You may want to scope the options available to `AttachAction`:
 
 ```php
 use Filament\Tables\Actions\AttachAction;
@@ -466,9 +466,9 @@ use Filament\Tables\Actions\AssociateAction;
 AssociateAction::make()->preloadRecordSelect()
 ```
 
-### Scoping available models
+### Scoping the options
 
-You may want to apply a database scope to the models available to `AssociateAction`:
+You may want to scope the options available to `AssociateAction`:
 
 ```php
 use Filament\Tables\Actions\AssociateAction;


### PR DESCRIPTION
This PR adds documentation for the `Document recordSelectOptionsQuery()` method, which was added in #3588 