### PR TITLE
Docs: Document Action size() Method

### DIFF
--- a/packages/admin/docs/03-pages/02-actions.md
+++ b/packages/admin/docs/03-pages/02-actions.md
@@ -67,6 +67,19 @@ protected function getActions(): array
 }
 ```
 
+Buttons may have a `size()`. The default is `md`, but you may also use `sm` or `lg`:
+
+```php
+use Filament\Pages\Actions\Action;
+
+protected function getActions(): array
+{
+    return [
+        Action::make('settings')->size('lg'),
+    ];
+}
+```
+
 Buttons may also have an `icon()`, which is the name of any Blade component. By default, the [Blade Heroicons](https://github.com/blade-ui-kit/blade-heroicons) package is installed, so you may use the name of any [Heroicon](https://heroicons.com) out of the box. However, you may create your own custom icon components or install an alternative library if you wish.
 
 ```php

--- a/packages/tables/docs/05-actions.md
+++ b/packages/tables/docs/05-actions.md
@@ -130,6 +130,17 @@ BulkAction::make('delete')
     ->color('danger')
 ```
 
+## Setting a size
+
+The default size for table actions is `sm` but you may also change it to either `md` or `lg`:
+
+```php
+use Filament\Tables\Actions\Action;
+
+Action::make('delete')
+    ->size('lg')
+```
+
 ## Setting an icon
 
 Bulk actions and some single actions may also render a Blade icon component to indicate their purpose:


### PR DESCRIPTION
This documents the current possible sizes of `sm`, `md` and `lg`. These docs would need to be updated if #4346 gets merged (seems like this will probably be in v3 though).