### PR TITLE
Fix code example to match text body in the documentation

### DIFF
--- a/packages/tables/docs/03-columns/06-badge.md
+++ b/packages/tables/docs/03-columns/06-badge.md
@@ -53,7 +53,7 @@ Or dynamically calculate the color based on the `$record` and / or `$state`:
 use Filament\Tables\Columns\BadgeColumn;
 
 BadgeColumn::make('status')
-    ->icon(static function ($state): string {
+    ->color(static function ($state): string {
         if ($state === 'published') {
             return 'success';
         }


### PR DESCRIPTION
Since the text reads "Or dynamically calculate the **color**" I assume the example is meant to show this.

I confirmed the updated example works.