### PR TITLE
Add support for the before method in policy

### DIFF
--- a/packages/admin/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/admin/src/Resources/RelationManagers/RelationManager.php
@@ -232,12 +232,21 @@ class RelationManager extends Component implements Tables\Contracts\HasRelations
     protected function can(string $action, ?Model $record = null): bool
     {
         $policy = Gate::getPolicyFor($model = $this->getRelatedModel());
+        $user = Filament::auth()->user();
 
-        if ($policy === null || (! method_exists($policy, $action))) {
+        if ($policy === null) {
             return true;
         }
 
-        return Gate::forUser(Filament::auth()->user())->check($action, $record ?? $model);
+        if (method_exists($policy, 'before') && is_bool($response = $policy->before($user, $action))) {
+            return $response;
+        }
+
+        if (! method_exists($policy, $action)) {
+            return true;
+        }
+
+        return Gate::forUser($user)->check($action, $record ?? $model);
     }
 
     public static function canViewForRecord(Model $ownerRecord): bool
@@ -245,13 +254,22 @@ class RelationManager extends Component implements Tables\Contracts\HasRelations
         $model = $ownerRecord->{static::getRelationshipName()}()->getQuery()->getModel()::class;
 
         $policy = Gate::getPolicyFor($model);
+        $user = Filament::auth()->user();
         $action = 'viewAny';
 
-        if ($policy === null || (! method_exists($policy, $action))) {
+        if ($policy === null) {
             return true;
         }
 
-        return Gate::forUser(Filament::auth()->user())->check($action, $model);
+        if (method_exists($policy, 'before') && is_bool($response = $policy->before($user, $action))) {
+            return $response;
+        }
+
+        if (! method_exists($policy, $action)) {
+            return true;
+        }
+
+        return Gate::forUser($user)->check($action, $model);
     }
 
     public static function form(Form $form): Form

--- a/packages/admin/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/admin/src/Resources/RelationManagers/RelationManager.php
@@ -238,7 +238,10 @@ class RelationManager extends Component implements Tables\Contracts\HasRelations
             return true;
         }
 
-        if (method_exists($policy, 'before') && is_bool($response = $policy->before($user, $action))) {
+        if (
+            method_exists($policy, 'before') &&
+            is_bool($response = $policy->before($user, $action))
+        ) {
             return $response;
         }
 
@@ -261,7 +264,10 @@ class RelationManager extends Component implements Tables\Contracts\HasRelations
             return true;
         }
 
-        if (method_exists($policy, 'before') && is_bool($response = $policy->before($user, $action))) {
+        if (
+            method_exists($policy, 'before') &&
+            is_bool($response = $policy->before($user, $action))
+        ) {
             return $response;
         }
 

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -107,12 +107,21 @@ class Resource
     public static function can(string $action, ?Model $record = null): bool
     {
         $policy = Gate::getPolicyFor($model = static::getModel());
+        $user = Filament::auth()->user();
 
-        if ($policy === null || (! method_exists($policy, $action))) {
+        if ($policy === null) {
             return true;
         }
 
-        return Gate::forUser(Filament::auth()->user())->check($action, $record ?? $model);
+        if (method_exists($policy, 'before') && is_bool($policy->before($user, $action))) {
+            return $policy->before($user, $action);
+        }
+
+        if (!method_exists($policy, $action)) {
+            return true;
+        }
+
+        return Gate::forUser($user)->check($action, $record ?? $model);
     }
 
     public static function canViewAny(): bool

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -117,7 +117,7 @@ class Resource
             return $policy->before($user, $action);
         }
 
-        if (!method_exists($policy, $action)) {
+        if (! method_exists($policy, $action)) {
             return true;
         }
 

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -113,7 +113,10 @@ class Resource
             return true;
         }
 
-        if (method_exists($policy, 'before') && is_bool($response = $policy->before($user, $action))) {
+        if (
+            method_exists($policy, 'before') &&
+            is_bool($response = $policy->before($user, $action))
+        ) {
             return $response;
         }
 

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -113,8 +113,8 @@ class Resource
             return true;
         }
 
-        if (method_exists($policy, 'before') && is_bool($policy->before($user, $action))) {
-            return $policy->before($user, $action);
+        if (method_exists($policy, 'before') && is_bool($response = $policy->before($user, $action))) {
+            return $response;
         }
 
         if (! method_exists($policy, $action)) {


### PR DESCRIPTION
Currently there is no support for the `before` in policy method because checking if a method exists returns false.