### PR TITLE
Feature/export action file type

### DIFF
--- a/packages/actions/database/migrations/create_exports_table.php
+++ b/packages/actions/database/migrations/create_exports_table.php
@@ -19,6 +19,7 @@ return new class() extends Migration
             $table->string('exporter');
             $table->unsignedInteger('processed_rows')->default(0);
             $table->unsignedInteger('total_rows');
+            $table->string('writer_type')->nullable();
             $table->unsignedInteger('successful_rows')->default(0);
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->timestamps();

--- a/packages/actions/docs/07-prebuilt-actions/09-export.md
+++ b/packages/actions/docs/07-prebuilt-actions/09-export.md
@@ -522,3 +522,14 @@ public function getJobTags(): array
 ```
 
 If you'd like to customize the tags that are applied to jobs of a certain exporter, you may override this method in your exporter class.
+
+### Customizing the writer type
+
+By default, the export system will export the `xlsx` and `csv` file. If you want to download only the `XLSX` or `CSV` file. That functionality is defined in the `getWriterType` method on the  exporter class:
+
+```php
+public function getWriterType(): ?string
+{
+    return null;   
+}
+```

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -53,6 +53,8 @@ trait CanExportRecords
 
     protected string | Closure | null $fileName = null;
 
+    protected string | Closure | null $writerType = null;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -148,6 +150,9 @@ trait CanExportRecords
             $export->save();
 
             $export->file_name = $action->getFileName($export) ?? $exporter->getFileName($export);
+            $export->save();
+
+            $export->writer_type = $action->getWriterType() ?? $exporter->getWriterType();
             $export->save();
 
             $query->withoutEagerLoads();
@@ -330,5 +335,17 @@ trait CanExportRecords
         return $this->evaluate($this->fileName, [
             'export' => $export,
         ]);
+    }
+
+    public function writerType(string | Closure | null $writerType): static
+    {
+        $this->writerType = $writerType;
+
+        return $this;
+    }
+
+    public function getWriterType(): ?string
+    {
+        return $this->evaluate($this->writerType);
     }
 }

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -152,4 +152,9 @@ abstract class Exporter
     {
         return ',';
     }
+
+    public function getWriterType(): ?string
+    {
+        return null;
+    }
 }

--- a/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
+++ b/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
@@ -120,6 +120,10 @@ class PrepareCsvExport implements ShouldQueue
 
     public function getExportCsvJob(): string
     {
+        if ($this->export->writer_type === 'XLSX') {
+            return CreateXlsxFile::class;
+        }
+
         return ExportCsv::class;
     }
 }

--- a/packages/actions/src/Exports/Models/Export.php
+++ b/packages/actions/src/Exports/Models/Export.php
@@ -97,7 +97,7 @@ class Export extends Model
         return 'filament_exports' . DIRECTORY_SEPARATOR . $this->getKey();
     }
 
-    public function getWriterType()
+    public function getWriterType(): ?string
     {
         return null;
     }

--- a/packages/actions/src/Exports/Models/Export.php
+++ b/packages/actions/src/Exports/Models/Export.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Facades\Storage;
  * @property class-string<Exporter> $exporter
  * @property int $processed_rows
  * @property int $total_rows
+ * @property string $writer_type
  * @property int $successful_rows
  * @property-read Authenticatable $user
  */
@@ -94,5 +95,10 @@ class Export extends Model
     public function getFileDirectory(): string
     {
         return 'filament_exports' . DIRECTORY_SEPARATOR . $this->getKey();
+    }
+
+    public function getWriterType()
+    {
+        return null;
     }
 }


### PR DESCRIPTION
## Description

Allow the exporter to export only the `csv` or `xlsx` file.

## Code style

- [X] `composer cs` command has been run.

## Testing

- [ ] Changes have been tested.

## Documentation

- [X] Documentation is up-to-date.
