### PR TITLE
Support non-streamed downloads

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/09-export.md
+++ b/packages/actions/docs/07-prebuilt-actions/09-export.md
@@ -691,3 +691,8 @@ public function view(User $user, Export $export): bool
     return $export->user()->is($user);
 }
 ```
+
+## Streamed downloads
+
+Some hosting environments do not support streamed downloads. If you encounter issues with downloading files, you can disable streamed downloads by setting the `filament.supports_stream_downloads` config variable to `false`.
+It is possible to define the location of the temporary file used for generating downloads by setting the `filament.temp_directory` config variable to the desired path.

--- a/packages/actions/src/Exports/Downloaders/CsvDownloader.php
+++ b/packages/actions/src/Exports/Downloaders/CsvDownloader.php
@@ -24,7 +24,7 @@ class CsvDownloader implements Downloader
             return $disk->download($filePath);
         }
 
-        if (!config('filament.supports_stream_downloads', true)) {
+        if (! config('filament.supports_stream_downloads', true)) {
             return $this->handleNonStreamedDownload($disk, $directory, $fileName, $filePath);
         }
 
@@ -35,7 +35,7 @@ class CsvDownloader implements Downloader
     {
         $tempPath = $this->getTempFilePath($fileName);
 
-        $this->writeCsvContent($disk, $directory, function($content) use ($tempPath) {
+        $this->writeCsvContent($disk, $directory, function ($content) use ($tempPath) {
             file_put_contents($tempPath, $content, FILE_APPEND);
         });
 
@@ -48,7 +48,7 @@ class CsvDownloader implements Downloader
     private function handleStreamedDownload($disk, $directory, $fileName): StreamedResponse
     {
         return response()->streamDownload(function () use ($disk, $directory) {
-            $this->writeCsvContent($disk, $directory, function($content) {
+            $this->writeCsvContent($disk, $directory, function ($content) {
                 echo $content;
                 flush();
             });
@@ -70,7 +70,7 @@ class CsvDownloader implements Downloader
 
     private function shouldProcessFile($file): bool
     {
-        return !str($file)->endsWith('headers.csv') && str($file)->endsWith('.csv');
+        return ! str($file)->endsWith('headers.csv') && str($file)->endsWith('.csv');
     }
 
     private function getTempFilePath($fileName): string

--- a/packages/actions/src/Exports/Downloaders/CsvDownloader.php
+++ b/packages/actions/src/Exports/Downloaders/CsvDownloader.php
@@ -17,26 +17,64 @@ class CsvDownloader implements Downloader
             abort(404);
         }
 
+        $fileName = "{$export->file_name}.csv";
+        $filePath = $directory . DIRECTORY_SEPARATOR . $fileName;
+
+        if ($disk->exists($filePath)) {
+            return $disk->download($filePath);
+        }
+
+        if (!config('filament.supports_stream_downloads', true)) {
+            return $this->handleNonStreamedDownload($disk, $directory, $fileName, $filePath);
+        }
+
+        return $this->handleStreamedDownload($disk, $directory, $fileName);
+    }
+
+    private function handleNonStreamedDownload($disk, $directory, $fileName, $filePath): StreamedResponse
+    {
+        $tempPath = $this->getTempFilePath($fileName);
+
+        $this->writeCsvContent($disk, $directory, function($content) use ($tempPath) {
+            file_put_contents($tempPath, $content, FILE_APPEND);
+        });
+
+        $disk->put($filePath, file_get_contents($tempPath));
+        unlink($tempPath);
+
+        return $disk->download($filePath);
+    }
+
+    private function handleStreamedDownload($disk, $directory, $fileName): StreamedResponse
+    {
         return response()->streamDownload(function () use ($disk, $directory) {
-            echo $disk->get($directory . DIRECTORY_SEPARATOR . 'headers.csv');
-
-            flush();
-
-            foreach ($disk->files($directory) as $file) {
-                if (str($file)->endsWith('headers.csv')) {
-                    continue;
-                }
-
-                if (! str($file)->endsWith('.csv')) {
-                    continue;
-                }
-
-                echo $disk->get($file);
-
+            $this->writeCsvContent($disk, $directory, function($content) {
+                echo $content;
                 flush();
-            }
-        }, "{$export->file_name}.csv", [
+            });
+        }, $fileName, [
             'Content-Type' => 'text/csv',
         ]);
+    }
+
+    private function writeCsvContent($disk, $directory, callable $outputCallback): void
+    {
+        $outputCallback($disk->get($directory . DIRECTORY_SEPARATOR . 'headers.csv'));
+
+        foreach ($disk->files($directory) as $file) {
+            if ($this->shouldProcessFile($file)) {
+                $outputCallback($disk->get($file));
+            }
+        }
+    }
+
+    private function shouldProcessFile($file): bool
+    {
+        return !str($file)->endsWith('headers.csv') && str($file)->endsWith('.csv');
+    }
+
+    private function getTempFilePath($fileName): string
+    {
+        return config('filament.temp_directory', storage_path('/tmp')) . DIRECTORY_SEPARATOR . $fileName;
     }
 }

--- a/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
+++ b/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
@@ -31,7 +31,7 @@ class XlsxDownloader implements Downloader
         $writer = app(Writer::class);
         $csvDelimiter = $export->exporter::getCsvDelimiter();
 
-        if (!config('filament.supports_stream_downloads', true)) {
+        if (! config('filament.supports_stream_downloads', true)) {
             return $this->handleNonStreamedDownload($disk, $directory, $fileName, $filePath, $writer, $csvDelimiter);
         }
 
@@ -69,7 +69,7 @@ class XlsxDownloader implements Downloader
         $this->writeRowsFromFile($writer, $disk, $directory . DIRECTORY_SEPARATOR . 'headers.csv', $csvDelimiter);
 
         foreach ($disk->files($directory) as $file) {
-            if (!$this->shouldProcessFile($file)) {
+            if (! $this->shouldProcessFile($file)) {
                 continue;
             }
             $this->writeRowsFromFile($writer, $disk, $file, $csvDelimiter);
@@ -89,7 +89,7 @@ class XlsxDownloader implements Downloader
 
     private function shouldProcessFile($file): bool
     {
-        return !str($file)->endsWith('headers.csv') && str($file)->endsWith('.csv');
+        return ! str($file)->endsWith('headers.csv') && str($file)->endsWith('.csv');
     }
 
     private function getTempFilePath($fileName): string

--- a/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
+++ b/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
@@ -22,45 +22,78 @@ class XlsxDownloader implements Downloader
         }
 
         $fileName = $export->file_name . '.xlsx';
+        $filePath = $directory . DIRECTORY_SEPARATOR . $fileName;
 
-        if ($disk->exists($filePath = $directory . DIRECTORY_SEPARATOR . $fileName)) {
+        if ($disk->exists($filePath)) {
             return $disk->download($filePath);
         }
 
         $writer = app(Writer::class);
-
         $csvDelimiter = $export->exporter::getCsvDelimiter();
 
-        $writeRowsFromFile = function (string $file) use ($csvDelimiter, $disk, $writer) {
-            $csvReader = CsvReader::createFromStream($disk->readStream($file));
-            $csvReader->setDelimiter($csvDelimiter);
-            $csvResults = Statement::create()->process($csvReader);
+        if (!config('filament.supports_stream_downloads', true)) {
+            return $this->handleNonStreamedDownload($disk, $directory, $fileName, $filePath, $writer, $csvDelimiter);
+        }
 
-            foreach ($csvResults->getRecords() as $row) {
-                $writer->addRow(Row::fromValues($row));
-            }
-        };
+        return $this->handleStreamedDownload($disk, $directory, $fileName, $writer, $csvDelimiter);
+    }
 
-        return response()->streamDownload(function () use ($disk, $directory, $fileName, $writer, $writeRowsFromFile) {
+    private function handleNonStreamedDownload($disk, $directory, $fileName, $filePath, $writer, $csvDelimiter): StreamedResponse
+    {
+        $tempPath = $this->getTempFilePath($fileName);
+        $writer->openToFile($tempPath);
+
+        $this->writeRowsToWriter($writer, $disk, $directory, $csvDelimiter);
+
+        $writer->close();
+
+        $disk->put($filePath, file_get_contents($tempPath));
+        unlink($tempPath);
+
+        return $disk->download($filePath);
+    }
+
+    private function handleStreamedDownload($disk, $directory, $fileName, $writer, $csvDelimiter): StreamedResponse
+    {
+        return response()->streamDownload(function () use ($disk, $directory, $fileName, $writer, $csvDelimiter) {
             $writer->openToBrowser($fileName);
-
-            $writeRowsFromFile($directory . DIRECTORY_SEPARATOR . 'headers.csv');
-
-            foreach ($disk->files($directory) as $file) {
-                if (str($file)->endsWith('headers.csv')) {
-                    continue;
-                }
-
-                if (! str($file)->endsWith('.csv')) {
-                    continue;
-                }
-
-                $writeRowsFromFile($file);
-            }
-
+            $this->writeRowsToWriter($writer, $disk, $directory, $csvDelimiter);
             $writer->close();
         }, $fileName, [
             'Content-Type' => 'application/vnd.ms-excel',
         ]);
+    }
+
+    private function writeRowsToWriter($writer, $disk, $directory, $csvDelimiter): void
+    {
+        $this->writeRowsFromFile($writer, $disk, $directory . DIRECTORY_SEPARATOR . 'headers.csv', $csvDelimiter);
+
+        foreach ($disk->files($directory) as $file) {
+            if (!$this->shouldProcessFile($file)) {
+                continue;
+            }
+            $this->writeRowsFromFile($writer, $disk, $file, $csvDelimiter);
+        }
+    }
+
+    private function writeRowsFromFile($writer, $disk, $file, $csvDelimiter): void
+    {
+        $csvReader = CsvReader::createFromStream($disk->readStream($file));
+        $csvReader->setDelimiter($csvDelimiter);
+        $csvResults = Statement::create()->process($csvReader);
+
+        foreach ($csvResults->getRecords() as $row) {
+            $writer->addRow(Row::fromValues($row));
+        }
+    }
+
+    private function shouldProcessFile($file): bool
+    {
+        return !str($file)->endsWith('headers.csv') && str($file)->endsWith('.csv');
+    }
+
+    private function getTempFilePath($fileName): string
+    {
+        return config('filament.temp_directory', storage_path('/tmp')) . DIRECTORY_SEPARATOR . $fileName;
     }
 }

--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -86,4 +86,17 @@ return [
 
     'livewire_loading_delay' => 'default',
 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Supports Stream Downloads
+    |--------------------------------------------------------------------------
+    |
+    | Some hosting environments (Like Vapor/Bref) don't support streaming.
+    |
+    | Setting this to 'false' makes sure a file is first written to disk before being downloaded
+    */
+
+    'supports_stream_downloads' => true,
+    'temp_directory' => storage_path('tmp'),
 ];

--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -86,7 +86,6 @@ return [
 
     'livewire_loading_delay' => 'default',
 
-
     /*
     |--------------------------------------------------------------------------
     | Supports Stream Downloads


### PR DESCRIPTION
## Description

Some hosting environments do not support streamed downloads (mainly environments running on lambda like Laravel Vapor or Bref). This makes the export functionality not work because the downloaders assume we can do a streamed download. 

This PR adds a config to enable/disable streamed downloads. When disabled, the downloader will write the contents to one file and uploads it to the disk (so we don't have to re-do the generation on multiple downloads).  

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
