### PR TITLE
Add handling for array item data in RepeatableEntry and update state …

### DIFF
--- a/packages/infolists/src/Components/Concerns/HasState.php
+++ b/packages/infolists/src/Components/Concerns/HasState.php
@@ -69,7 +69,7 @@ trait HasState
 
             $state = $containerState instanceof Model ?
                 $this->getStateFromRecord($containerState) :
-                data_get($containerState, $this->getStatePath());
+                data_get($containerState, $this->getStatePath(false));
         }
 
         if (is_string($state) && ($separator = $this->getSeparator())) {

--- a/packages/infolists/src/Components/Concerns/HasState.php
+++ b/packages/infolists/src/Components/Concerns/HasState.php
@@ -69,7 +69,7 @@ trait HasState
 
             $state = $containerState instanceof Model ?
                 $this->getStateFromRecord($containerState) :
-                data_get($containerState, $this->getStatePath(false));
+                data_get($containerState, $this->getStatePath(isAbsolute: false));
         }
 
         if (is_string($state) && ($separator = $this->getSeparator())) {

--- a/packages/infolists/src/Components/RepeatableEntry.php
+++ b/packages/infolists/src/Components/RepeatableEntry.php
@@ -36,6 +36,8 @@ class RepeatableEntry extends Entry
 
             if ($itemData instanceof Model) {
                 $container->record($itemData);
+            } elseif (is_array($itemData)) {
+                $container->state($itemData);
             }
 
             $containers[$itemKey] = $container;


### PR DESCRIPTION
Fixes issue with `RepeatableEntry` not correctly handling array data in nested contexts, and improves state path resolution in `HasState` trait. more information here : https://github.com/filamentphp/filament/issues/18807

**Problem:**
1. When `RepeatableEntry` contains array data (not Model instances), child components couldn't access state because `getChildComponentContainers()` only handled Model instances via `record()` method.
2. `HasState::getState()` always used absolute paths, which broke nested structures where relative paths are needed.


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
