### PR TITLE
fix: close color picker panel on focus out when open

### DIFF
--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -57,6 +57,7 @@
                         state: $wire.$entangle('{{ $statePath }}'),
                     })"
             x-on:keydown.esc="isOpen() && $event.stopPropagation()"
+            x-on:focusout="if (isOpen() && ! $el.contains($event.relatedTarget)) $refs.panel.close()"
             {{ $getExtraAlpineAttributeBag()->class(['fi-input-wrp-content']) }}
         >
             <input


### PR DESCRIPTION

## Description
### Fixes: #19459



## Visual changes


### Before


https://github.com/user-attachments/assets/282b27a4-6680-4010-bf8b-0b70df5c909a




### After


https://github.com/user-attachments/assets/a2745de3-ba12-42da-a620-60fc1d6c3df8






## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
