### PR TITLE
fix: SPA progress bar uses panel primary color

### DIFF
--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -82,6 +82,10 @@
                 --collapsed-sidebar-width: {{ filament()->getCollapsedSidebarWidth() }};
                 --default-theme-mode: {{ filament()->getDefaultThemeMode()->value }};
             }
+
+            html.fi {
+                --livewire-progress-bar-color: var(--primary-500);
+            }
         </style>
 
         @stack('styles')


### PR DESCRIPTION

## Description

Fixes #19471

Sets `--livewire-progress-bar-color` to the panel's primary color via inline style.

Considered adding `spaProgressBarColor()` for customization but decided to keep it
minimal for now -- can always add later if there's demand.

## Visual changes

### Before


https://github.com/user-attachments/assets/f25a7c91-162c-4cfc-ac9f-1f2ba8e1dba8




### After

https://github.com/user-attachments/assets/fc64736d-252b-4f7e-b73b-7c061fba43d8




## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
