### PR TITLE
fix: pass item argument when calling query builder actions

### DIFF
--- a/packages/query-builder/src/Constraints/Constraint.php
+++ b/packages/query-builder/src/Constraints/Constraint.php
@@ -142,14 +142,14 @@ class Constraint extends Component
                                     ->color('gray')
                                     ->iconButton()
                                     ->size(Size::Small)
-                                    ->action($builder->getAction($cloneActionName)->arguments(['item' => (string) str($component->getContainer()->getStatePath(isAbsolute: false))->beforeLast('.data')])->getLivewireClickHandler()),
+                                    ->action($builder->getAction($cloneActionName)(['item' => (string) str($component->getContainer()->getStatePath(isAbsolute: false))->beforeLast('.data')])->getLivewireClickHandler()),
                                 Action::make($deleteActionName = $builder->getDeleteActionName())
                                     ->label(__('filament-forms::components.builder.actions.delete.label'))
                                     ->icon(FilamentIcon::resolve(FormsIconAlias::COMPONENTS_BUILDER_ACTIONS_DELETE) ?? Heroicon::Trash)
                                     ->color('danger')
                                     ->iconButton()
                                     ->size(Size::Small)
-                                    ->action($builder->getAction($deleteActionName)->arguments(['item' => (string) str($component->getContainer()->getStatePath(isAbsolute: false))->beforeLast('.data')])->getLivewireClickHandler()),
+                                    ->action($builder->getAction($deleteActionName)(['item' => (string) str($component->getContainer()->getStatePath(isAbsolute: false))->beforeLast('.data')])->getLivewireClickHandler()),
                             ])->grow(false),
                         ];
                     })->gridContainer(),

--- a/packages/query-builder/src/Forms/Components/RuleBuilder.php
+++ b/packages/query-builder/src/Forms/Components/RuleBuilder.php
@@ -68,7 +68,7 @@ class RuleBuilder extends Builder
                                                             ->color('danger')
                                                             ->iconButton()
                                                             ->size(Size::Small)
-                                                            ->action($repeater->getAction($deleteActionName)->arguments(['item' => (string) str($component->getContainer()->getParentComponent()->getContainer()->getStatePath(isAbsolute: false))->beforeLast('.data')])->getLivewireClickHandler())
+                                                            ->action($repeater->getAction($deleteActionName)(['item' => (string) str($component->getContainer()->getParentComponent()->getContainer()->getStatePath(isAbsolute: false))->beforeLast('.data')])->getLivewireClickHandler())
                                                             ->visible(fn (Get $get): bool => blank($get('rules')) && (count($repeater->getRawState()) > 2)),
                                                     ];
                                                 })->grow(false),
@@ -94,14 +94,14 @@ class RuleBuilder extends Builder
                                             ->color('gray')
                                             ->iconButton()
                                             ->size(Size::Small)
-                                            ->action($builder->getAction($cloneActionName)->arguments(['item' => (string) str($component->getContainer()->getStatePath(isAbsolute: false))->beforeLast('.data')])->getLivewireClickHandler()),
+                                            ->action($builder->getAction($cloneActionName)(['item' => (string) str($component->getContainer()->getStatePath(isAbsolute: false))->beforeLast('.data')])->getLivewireClickHandler()),
                                         Action::make($deleteActionName = $builder->getDeleteActionName())
                                             ->label(__('filament-forms::components.builder.actions.delete.label'))
                                             ->icon(FilamentIcon::resolve(FormsIconAlias::COMPONENTS_BUILDER_ACTIONS_DELETE) ?? Heroicon::Trash)
                                             ->color('danger')
                                             ->iconButton()
                                             ->size(Size::Small)
-                                            ->action($builder->getAction($deleteActionName)->arguments(['item' => (string) str($component->getContainer()->getStatePath(isAbsolute: false))->beforeLast('.data')])->getLivewireClickHandler()),
+                                            ->action($builder->getAction($deleteActionName)(['item' => (string) str($component->getContainer()->getStatePath(isAbsolute: false))->beforeLast('.data')])->getLivewireClickHandler()),
                                     ])->grow(false),
                                 ];
                             }),

--- a/tests/src/Fixtures/Pages/QueryBuilderTableTest.php
+++ b/tests/src/Fixtures/Pages/QueryBuilderTableTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Pages;
+
+use BackedEnum;
+use Filament\Pages\Page;
+use Filament\QueryBuilder\Constraints\TextConstraint;
+use Filament\Schemas\Components\EmbeddedTable;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Filters\QueryBuilder;
+use Filament\Tables\Table;
+use Filament\Tests\Fixtures\Models\Post;
+
+class QueryBuilderTableTest extends Page implements HasTable
+{
+    use Tables\Concerns\InteractsWithTable;
+
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedFunnel;
+
+    protected static ?int $navigationSort = 8;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(Post::query())
+            ->columns([
+                Tables\Columns\TextColumn::make('title'),
+                Tables\Columns\TextColumn::make('content'),
+            ])
+            ->filters([
+                QueryBuilder::make('query_builder')
+                    ->constraints([
+                        TextConstraint::make('title'),
+                        TextConstraint::make('content'),
+                    ]),
+            ]);
+    }
+
+    public function content(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                EmbeddedTable::make(),
+            ]);
+    }
+}

--- a/tests/src/Fixtures/Providers/AdminPanelProvider.php
+++ b/tests/src/Fixtures/Providers/AdminPanelProvider.php
@@ -24,6 +24,7 @@ use Filament\Tests\Fixtures\Pages\AutofocusWizardBrowserTest;
 use Filament\Tests\Fixtures\Pages\BuilderTest;
 use Filament\Tests\Fixtures\Pages\CalloutBrowserTest;
 use Filament\Tests\Fixtures\Pages\KeyValueTest;
+use Filament\Tests\Fixtures\Pages\QueryBuilderTableTest;
 use Filament\Tests\Fixtures\Pages\RepeaterTest;
 use Filament\Tests\Fixtures\Pages\SelectTest;
 use Filament\Tests\Fixtures\Pages\Settings;
@@ -82,6 +83,7 @@ class AdminPanelProvider extends PanelProvider
                 BuilderTest::class,
                 CalloutBrowserTest::class,
                 KeyValueTest::class,
+                QueryBuilderTableTest::class,
                 RepeaterTest::class,
                 SelectTest::class,
                 Settings::class,

--- a/tests/src/Tables/Filters/QueryBuilderTest.php
+++ b/tests/src/Tables/Filters/QueryBuilderTest.php
@@ -3944,3 +3944,19 @@ it('can filter records using datetime constraint with is before operator with `c
         ->assertCanSeeTableRecords($veryOldPosts)
         ->assertCanNotSeeTableRecords($recentPosts);
 });
+
+it('can delete a rule in the query builder filter in the browser', function (): void {
+    $this->actingAs(User::factory()->create());
+
+    visit('/query-builder-table-test')
+        ->assertSee('Query Builder Table Test')
+        ->click('button[title="Filter"]')
+        ->assertSee('Add rule')
+        ->click('text=Add rule')
+        ->assertSee('Title')
+        ->click('.fi-dropdown-list-item >> text=Title')
+        ->assertPresent('.fi-fo-builder-item')
+        ->click('.fi-fo-builder-item button[title="Delete"]')
+        ->assertNotPresent('.fi-fo-builder-item')
+        ->assertNoSmoke();
+});

--- a/tests/src/Tables/Filters/QueryBuilderTest.php
+++ b/tests/src/Tables/Filters/QueryBuilderTest.php
@@ -6,6 +6,7 @@ use Filament\Tests\Fixtures\Models\Post;
 use Filament\Tests\Fixtures\Models\Team;
 use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\Tables\TestCase;
+use Illuminate\Support\Facades\Artisan;
 
 use function Filament\Tests\livewire;
 
@@ -3946,6 +3947,8 @@ it('can filter records using datetime constraint with is before operator with `c
 });
 
 it('can delete a rule in the query builder filter in the browser', function (): void {
+    Artisan::call('filament:assets');
+
     $this->actingAs(User::factory()->create());
 
     visit('/query-builder-table-test')


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

### Fixes #19469.

  QueryBuilder was using the wrong action argument path when building item action click handlers, so the `item` argument was missing for delete and clone actions.

  This regression was introduced by #19395, which changed action click handlers to use invocation-time arguments without updating these QueryBuilder call sites.

  This PR fixes the QueryBuilder call sites and adds browser coverage for rule deletion.

  There may still be room to make the distinction between definition-time and invocation-time arguments clearer, but that is outside the scope of this PR.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
