### PR TITLE
fix: prevent duplicate action mounting from double-click

### DIFF
--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -595,6 +595,12 @@ trait InteractsWithActions
             throw new ActionNotResolvableException('Failed to resolve table action for Livewire component without the [' . HasTable::class . '] trait.');
         }
 
+        if (count($parentActions)) {
+            $parentAction = Arr::last($parentActions);
+
+            return $parentAction->getModalAction($action['name']) ?? throw new ActionNotResolvableException("Action [{$action['name']}] was not found for action [{$parentAction->getName()}].");
+        }
+
         if ($action['context']['bulk'] ?? false) {
             $resolvedAction = $this->getTable()->getBulkAction($action['name']);
         }


### PR DESCRIPTION

## Description

### Fixes: #19483

`resolveTableAction()` doesn't check `$parentActions` like `resolveAction()` does,
so duplicate table actions from double-clicks always resolve successfully instead
of failing and being cleaned up by `unmountAction()`.



## Visual changes


### Before


https://github.com/user-attachments/assets/913e83fe-1aee-474a-9774-8b503a509304




### After


https://github.com/user-attachments/assets/62903ffd-3568-43d0-ae01-6b4336c7ee70





## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
