### PR TITLE
Fix dashboard route silently dropped on domain panels

### DIFF
--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -140,8 +140,6 @@ Route::name('filament.')
                                             $routes($panel);
                                         }
 
-                                        Route::get('/', RedirectToHomeController::class)->name('home');
-
                                         Route::name('tenant.')->group(function () use ($panel): void {
                                             if ($panel->hasTenantBilling()) {
                                                 Route::get($panel->getTenantBillingRouteSlug(), $panel->getTenantBillingProvider()->getRouteAction())
@@ -175,6 +173,12 @@ Route::name('filament.')
                                             $configuration->resource::registerRoutes($panel, configuration: $configuration);
 
                                             Filament::setCurrentResourceConfigurationKey(null);
+                                        }
+
+                                        if (! collect($panel->getPages())->contains(
+                                            static fn (string $page): bool => blank($page::getCluster()) && $page::getRoutePath($panel) === '/',
+                                        )) {
+                                            Route::get('/', RedirectToHomeController::class)->name('home');
                                         }
                                     });
 

--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -175,9 +175,11 @@ Route::name('filament.')
                                             Filament::setCurrentResourceConfigurationKey(null);
                                         }
 
-                                        if (! collect($panel->getPages())->contains(
-                                            static fn (string $page): bool => blank($page::getCluster()) && $page::getRoutePath($panel) === '/',
-                                        )) {
+                                        $rootUri = trim(Route::getLastGroupPrefix(), '/') ?: '/';
+                                        $groupStack = Route::getGroupStack();
+                                        $rootKey = (end($groupStack)['domain'] ?? '') . $rootUri;
+
+                                        if (! isset(Route::getRoutes()->getRoutesByMethod()['GET'][$rootKey])) {
                                             Route::get('/', RedirectToHomeController::class)->name('home');
                                         }
                                     });

--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -183,12 +183,6 @@ trait HasRoutes
             return route($homeRouteName, $tenant ? ['tenant' => $tenant] : []);
         }
 
-        foreach ($this->getPages() as $page) {
-            if (((! $hasTenancy) || $tenant) && blank($page::getCluster()) && $page::getRoutePath($this) === '/' && Route::has($pageRouteName = $page::getRouteName($this))) {
-                return route($pageRouteName, $tenant ? ['tenant' => $tenant] : []);
-            }
-        }
-
         if ($tenant) {
             $tenantSlugAttribute = $this->getTenantSlugAttribute();
             $tenantRoutePrefix = $this->getTenantRoutePrefix() ?? '';

--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -183,6 +183,12 @@ trait HasRoutes
             return route($homeRouteName, $tenant ? ['tenant' => $tenant] : []);
         }
 
+        foreach ($this->getPages() as $page) {
+            if (((! $hasTenancy) || $tenant) && blank($page::getCluster()) && $page::getRoutePath($this) === '/' && Route::has($pageRouteName = $page::getRouteName($this))) {
+                return route($pageRouteName, $tenant ? ['tenant' => $tenant] : []);
+            }
+        }
+
         if ($tenant) {
             $tenantSlugAttribute = $this->getTenantSlugAttribute();
             $tenantRoutePrefix = $this->getTenantRoutePrefix() ?? '';

--- a/tests/src/Panels/Routes/SingleAndMultiDomainTest.php
+++ b/tests/src/Panels/Routes/SingleAndMultiDomainTest.php
@@ -34,3 +34,8 @@ it('panels with multiple domains should use the domain in names of all routes', 
     $route = Route::getRoutes()->getByName($routeName);
     expect($route)->not->toBeEmpty();
 });
+
+it('does not register the home route when a page already owns the root path', function (): void {
+    expect(Route::getRoutes()->getByName('filament.single-domain.home'))->toBeNull();
+    expect(Route::getRoutes()->getByName('filament.single-domain.pages.dashboard'))->not->toBeNull();
+});

--- a/tests/src/Panels/Routes/SingleAndMultiDomainTest.php
+++ b/tests/src/Panels/Routes/SingleAndMultiDomainTest.php
@@ -39,3 +39,7 @@ it('does not register the home route when a page already owns the root path', fu
     expect(Route::getRoutes()->getByName('filament.single-domain.home'))->toBeNull();
     expect(Route::getRoutes()->getByName('filament.single-domain.pages.dashboard'))->not->toBeNull();
 });
+
+it('preserves the dashboard route when registered on a panel without a domain', function (): void {
+    expect(Route::getRoutes()->getByName('filament.admin.pages.dashboard'))->not->toBeNull();
+});


### PR DESCRIPTION

## Description

### Fixes: #19549 

Laravel 13 changed route registration to keep the first match instead of the last. On domain panels, the home redirect gets registered before page routes, so Dashboard's / route
   just disappears.                                                                                                                                                                
                                                                                                                                                                                   
  Fix: don't register home when there's already a page at /, and let Panel::getUrl() fall back to the root page route.                                                             
                                                                                                                                                                                   
  Side effect: filament.{panel}.home won't exist anymore if a page owns /. Shouldn't matter, docs only expose Panel::getUrl().




## Visual changes


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
