### PR TITLE
Fix `mountTableBulkAction()` deprecated replacement

### DIFF
--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -171,7 +171,7 @@ namespace Livewire\Features\SupportTesting {
         public function assertHasNoTableActionErrors(array $keys = []): static {}
 
         /**
-         * @deprecated Use `mountBulkAction()` instead.
+         * @deprecated Use `selectTableRecords()` and `mountAction()` instead.
          */
         public function mountTableBulkAction(string $name, array | Collection $records): static {}
 


### PR DESCRIPTION

## Description

### Fixes #19563

Fix `mountTableBulkAction()` deprecation description referencing non-existent `mountBulkAction()` 

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
