### PR TITLE
Fix collapsible section header click handling

### DIFF
--- a/packages/support/resources/views/components/section/index.blade.php
+++ b/packages/support/resources/views/components/section/index.blade.php
@@ -69,7 +69,7 @@
     @if ($hasHeader)
         <header
             @if ($collapsible)
-                x-on:click="isCollapsed = ! isCollapsed"
+                x-on:click="if (! $event.target.closest('.fi-section-header-after-ctn')) isCollapsed = ! isCollapsed"
             @endif
             class="fi-section-header"
         >
@@ -95,7 +95,7 @@
             @endif
 
             @if (! is_slot_empty($afterHeader))
-                <div x-on:click.stop class="fi-section-header-after-ctn">
+                <div class="fi-section-header-after-ctn">
                     {{ $afterHeader }}
                 </div>
             @endif


### PR DESCRIPTION

## Description

### Fixes: #19618 

This PR removes `x-on:click.stop `from `fi-section-header-after-ctn`.

  Based on my analysis, that handler was originally there to stop clicks inside the header after content from toggling a collapsible section, but it also stopped the click event
  from bubbling, which is what dropdowns rely on to close other open panels. This change keeps the original collapse behavior by making the section header click handler ignore
  clicks coming from `fi-section-header-after-ctn` instead.

## Visual changes


### Before



https://github.com/user-attachments/assets/31cf4030-c41e-49c2-a61b-8376f1bd9535



### After


https://github.com/user-attachments/assets/b3939f85-0f30-49bf-9e01-80e30d908a03



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
