### PR TITLE
fix: prevent duplicate toolbar buttons when rich editor plugin enables already-present buttons

### DIFF
--- a/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
+++ b/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
@@ -87,7 +87,8 @@ trait InteractsWithToolbarButtons
             $buttons = match ($modification['type']) {
                 'disableAll' => [],
                 'disable' => $this->applyDisableToolbarButtonsModification($buttons, $modification['buttons']),
-                'enable' => [...$buttons, ...$modification['buttons']],
+                // 'enable' => [...$buttons, ...$modification['buttons']],
+                'enable' => $this->applyEnableToolbarButtonsModification($buttons, $modification['buttons']),
                 default => throw new Exception('Unknown toolbar buttons modification type: [' . $modification['type'] . '].'),
             };
         }
@@ -168,6 +169,84 @@ trait InteractsWithToolbarButtons
         }
 
         return $modified;
+    }
+
+    /**
+     * @param  array<int, string | object | array<int, string | object>>  $buttons
+     * @param  array<int, string | object | array<int, string | object>>  $buttonsToEnable
+     * @return array<int, string | object | array<int, string | object>>
+     */
+    protected function applyEnableToolbarButtonsModification(array $buttons, array $buttonsToEnable): array
+    {
+        $modified = $buttons;
+
+        foreach ($buttonsToEnable as $button) {
+            if (is_object($button)) {
+                $modified[] = $button;
+
+                continue;
+            }
+
+            if (is_array($button)) {
+                $filteredGroup = [];
+
+                foreach ($button as $item) {
+                    if (is_object($item)) {
+                        $filteredGroup[] = $item;
+
+                        continue;
+                    }
+
+                    if ($this->hasToolbarButtonInArray($modified, $item) || in_array($item, $filteredGroup, true)) {
+                        continue;
+                    }
+
+                    $filteredGroup[] = $item;
+                }
+
+                if (filled($filteredGroup)) {
+                    $modified[] = $filteredGroup;
+                }
+
+                continue;
+            }
+
+            if ($this->hasToolbarButtonInArray($modified, $button)) {
+                continue;
+            }
+
+            $modified[] = $button;
+        }
+
+        return $modified;
+    }
+
+    /**
+     * @param  array<int, string | object | array<int, string | object>>  $buttons
+     */
+    protected function hasToolbarButtonInArray(array $buttons, string $button): bool
+    {
+        foreach ($buttons as $item) {
+            if (is_object($item)) {
+                continue;
+            }
+
+            if (is_array($item)) {
+                foreach ($item as $groupedItem) {
+                    if (is_string($groupedItem) && ($groupedItem === $button)) {
+                        return true;
+                    }
+                }
+
+                continue;
+            }
+
+            if ($item === $button) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
+++ b/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
@@ -196,7 +196,7 @@ trait InteractsWithToolbarButtons
                         continue;
                     }
 
-                    if ($this->hasToolbarButtonInArray($modified, $item) || in_array($item, $filteredGroup, true)) {
+                    if ($this->hasToolbarButtonInArray($modified, $item) || in_array($item, $filteredGroup)) {
                         continue;
                     }
 
@@ -226,25 +226,28 @@ trait InteractsWithToolbarButtons
     protected function hasToolbarButtonInArray(array $buttons, string $button): bool
     {
         foreach ($buttons as $item) {
-            if (is_object($item)) {
-                continue;
-            }
-
             if (is_array($item)) {
-                foreach ($item as $groupedItem) {
-                    if (is_string($groupedItem) && ($groupedItem === $button)) {
-                        return true;
-                    }
+                if ($this->hasToolbarButtonInArray($item, $button)) {
+                    return true;
                 }
 
                 continue;
             }
 
-            if ($item === $button) {
+            if (is_string($item) && ($item === $button)) {
+                return true;
+            }
+
+            if (is_object($item) && $this->isToolbarButtonInObject($item, $button)) {
                 return true;
             }
         }
 
+        return false;
+    }
+
+    protected function isToolbarButtonInObject(object $item, string $button): bool
+    {
         return false;
     }
 

--- a/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
+++ b/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
@@ -87,7 +87,6 @@ trait InteractsWithToolbarButtons
             $buttons = match ($modification['type']) {
                 'disableAll' => [],
                 'disable' => $this->applyDisableToolbarButtonsModification($buttons, $modification['buttons']),
-                // 'enable' => [...$buttons, ...$modification['buttons']],
                 'enable' => $this->applyEnableToolbarButtonsModification($buttons, $modification['buttons']),
                 default => throw new Exception('Unknown toolbar buttons modification type: [' . $modification['type'] . '].'),
             };

--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -820,6 +820,15 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
         return $modifications;
     }
 
+    protected function isToolbarButtonInObject(object $item, string $button): bool
+    {
+        if ($item instanceof ToolbarButtonGroup) {
+            return in_array($button, $item->getButtons());
+        }
+
+        return false;
+    }
+
     /**
      * @return array<string | array<string>>
      */

--- a/tests/src/Forms/Components/RichEditorTest.php
+++ b/tests/src/Forms/Components/RichEditorTest.php
@@ -432,6 +432,48 @@ describe('plugins', function (): void {
             ->toContain('bold');
     });
 
+    test('plugin implementing `HasToolbarButtons` does not duplicate toolbar buttons already returned by `toolbarButtons()`', function (): void {
+        $buttons = Schema::make(Livewire::make())
+            ->statePath('data')
+            ->components([
+                RichEditor::make('content')
+                    ->toolbarButtons([
+                        ['bold', 'highlight'],
+                        ['undo', 'redo'],
+                    ])
+                    ->plugins([new TestRichContentPlugin(enabledButtons: ['highlight'])]),
+            ])
+            ->getComponents()[0]
+            ->getToolbarButtons();
+
+        $flatButtons = array_merge(...$buttons);
+        $highlightButtons = array_values(array_filter($flatButtons, fn (mixed $button): bool => $button === 'highlight'));
+
+        expect($buttons)
+            ->toHaveCount(2)
+            ->and($buttons[0])->toEqual(['bold', 'highlight'])
+            ->and($buttons[1])->toEqual(['undo', 'redo'])
+            ->and($highlightButtons)->toHaveCount(1);
+    });
+
+    test('plugin implementing `HasToolbarButtons` does not duplicate toolbar buttons already enabled by user `enableToolbarButtons()`', function (): void {
+        $schema = Schema::make(Livewire::make())
+            ->statePath('data')
+            ->components([
+                RichEditor::make('content')
+                    ->plugins([new TestRichContentPlugin(enabledButtons: ['highlight'])]),
+            ]);
+
+        $richEditor = $schema->getComponents()[0];
+        $richEditor->enableToolbarButtons(['highlight']);
+
+        $flatButtons = array_merge(...$richEditor->getToolbarButtons());
+        $highlightButtons = array_values(array_filter($flatButtons, fn (mixed $button): bool => $button === 'highlight'));
+
+        expect($highlightButtons)
+            ->toHaveCount(1);
+    });
+
     test('plugin implementing `HasToolbarButtons` can disable toolbar buttons', function (): void {
         $richEditor = Schema::make(Livewire::make())
             ->statePath('data')


### PR DESCRIPTION

## Description
### Fixes: #19659 

`enableToolbarButtons()` was appending buttons via `[...$buttons, ...$modification['buttons']]` without checking for duplicates.

Added `applyEnableToolbarButtonsModification()` (similar to `applyDisableToolbarButtonsModification()`) to skip buttons that already exist in the toolbar.


## Visual changes


### Before

<img width="1282" height="289" alt="image" src="https://github.com/user-attachments/assets/55584d77-4854-4382-9fff-b05c48b786eb" />




### After

<img width="1279" height="305" alt="image" src="https://github.com/user-attachments/assets/d57c3314-ef59-49cf-8329-940abda8f6fe" />



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
