### PR TITLE
fix: Use JS select when `allowHtml()` is enabled

### DIFF
--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -12,7 +12,7 @@
     $isRequired = $isRequired();
     $isConcealed = $isConcealed();
     $isHtmlAllowed = $isHtmlAllowed();
-    $isNative = (! ($isSearchable || $isMultiple) && $isNative());
+    $isNative = (! ($isSearchable || $isMultiple || $isHtmlAllowed) && $isNative());
     $isPrefixInline = $isPrefixInline();
     $isSuffixInline = $isSuffixInline();
     $key = $getKey();


### PR DESCRIPTION

## Description
### Fixes: #19669

Native <option> elements cannot render HTML. Add $isHtmlAllowed to the native select guard so allowHtml() automatically uses the JS select.


## Visual changes

### Before
<img width="1378" height="484" alt="image" src="https://github.com/user-attachments/assets/9d272815-9bb2-4f21-a00e-d4f778c20939" />


### After
<img width="1218" height="548" alt="image" src="https://github.com/user-attachments/assets/bb2f328e-40e3-47d1-add3-a82420a155a9" />



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
