### PR TITLE
fix: Prevent hidden builder fields from breaking repeaters

### DIFF
--- a/packages/schemas/src/Components/Concerns/HasState.php
+++ b/packages/schemas/src/Components/Concerns/HasState.php
@@ -381,11 +381,17 @@ trait HasState
         $container = $this->getContainer();
 
         while ($parentComponent = $container->getParentComponent()) {
+            $parentContainer = $parentComponent->getContainer();
+
             if ($parentComponent->hasStatePath()) {
                 break;
             }
 
-            $container = $parentComponent->getContainer();
+            if ($parentContainer->getStatePath() !== $container->getStatePath()) {
+                break;
+            }
+
+            $container = $parentContainer;
         }
 
         foreach ($container->getFlatComponents(withActions: false, withHidden: true) as $component) {

--- a/tests/src/Forms/Components/BuilderTest.php
+++ b/tests/src/Forms/Components/BuilderTest.php
@@ -278,6 +278,13 @@ it('can access correct block state from `extraItemActions()`', function (): void
     $undoBuilderFake();
 });
 
+it('can save a builder block containing a repeater and hidden field', function (): void {
+    livewire(TestComponentWithBuilderRepeaterAndHiddenField::class)
+        ->assertSuccessful()
+        ->call('save')
+        ->assertHasNoFormErrors();
+});
+
 class TestComponentWithActionInBuilder extends Livewire
 {
     public function mount(): void
@@ -339,6 +346,47 @@ class TestComponentWithExtraItemActionInBuilder extends Livewire
                     ]),
             ])
             ->statePath('data');
+    }
+}
+
+class TestComponentWithBuilderRepeaterAndHiddenField extends Livewire
+{
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->components([
+                Builder::make('builder')
+                    ->blocks([
+                        Builder\Block::make('services')
+                            ->schema([
+                                Repeater::make('items')
+                                    ->schema([
+                                        TextInput::make('service')
+                                            ->required(),
+                                    ]),
+                                TextInput::make('hidden')
+                                    ->visible(false),
+                            ]),
+                    ])
+                    ->default([
+                        [
+                            'type' => 'services',
+                            'data' => [
+                                'items' => [
+                                    [
+                                        'service' => 'Service 1',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
     }
 }
 


### PR DESCRIPTION

## Description
### Fixes: #19672 

   Hidden builder fields could walk out of the current runtime container scope while resolving shared state paths, which broke nested repeater child schema resolution on save.

  This keeps that lookup within the current container state scope.

## Visual changes

### Before

https://github.com/user-attachments/assets/1f6cb0aa-7f12-4f5e-bc78-dd71ee84b46a




### After

https://github.com/user-attachments/assets/cf371024-117c-485b-8142-1dc97aacb6a7






## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
