### PR TITLE
 fix: support grouped toolbar buttons in rich editor toolbar checks and modifications

### DIFF
--- a/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
+++ b/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
@@ -135,7 +135,11 @@ trait InteractsWithToolbarButtons
 
         foreach ($buttons as $button) {
             if (is_object($button)) {
-                $modified[] = $button;
+                $button = $this->filterDisabledToolbarButtonsFromItem($button, $buttonsToDisable);
+
+                if ($button !== null) {
+                    $modified[] = $button;
+                }
 
                 continue;
             }
@@ -145,7 +149,11 @@ trait InteractsWithToolbarButtons
 
                 foreach ($button as $item) {
                     if (is_object($item)) {
-                        $filteredGroup[] = $item;
+                        $item = $this->filterDisabledToolbarButtonsFromItem($item, $buttonsToDisable);
+
+                        if ($item !== null) {
+                            $filteredGroup[] = $item;
+                        }
 
                         continue;
                     }
@@ -168,6 +176,14 @@ trait InteractsWithToolbarButtons
         }
 
         return $modified;
+    }
+
+    /**
+     * @param  array<string>  $buttonsToDisable
+     */
+    protected function filterDisabledToolbarButtonsFromItem(object $item, array $buttonsToDisable): ?object
+    {
+        return $item;
     }
 
     /**
@@ -196,7 +212,7 @@ trait InteractsWithToolbarButtons
                         continue;
                     }
 
-                    if ($this->hasToolbarButtonInArray($modified, $item) || in_array($item, $filteredGroup)) {
+                    if ($this->hasToolbarButtonInButtons($modified, $item) || in_array($item, $filteredGroup)) {
                         continue;
                     }
 
@@ -210,7 +226,7 @@ trait InteractsWithToolbarButtons
                 continue;
             }
 
-            if ($this->hasToolbarButtonInArray($modified, $button)) {
+            if ($this->hasToolbarButtonInButtons($modified, $button)) {
                 continue;
             }
 
@@ -223,11 +239,11 @@ trait InteractsWithToolbarButtons
     /**
      * @param  array<int, string | object | array<int, string | object>>  $buttons
      */
-    protected function hasToolbarButtonInArray(array $buttons, string $button): bool
+    protected function hasToolbarButtonInButtons(array $buttons, string $button): bool
     {
         foreach ($buttons as $item) {
             if (is_array($item)) {
-                if ($this->hasToolbarButtonInArray($item, $button)) {
+                if ($this->hasToolbarButtonInButtons($item, $button)) {
                     return true;
                 }
 
@@ -238,7 +254,7 @@ trait InteractsWithToolbarButtons
                 return true;
             }
 
-            if (is_object($item) && $this->isToolbarButtonInObject($item, $button)) {
+            if (is_object($item) && $this->hasToolbarButtonInItem($item, $button)) {
                 return true;
             }
         }
@@ -246,7 +262,7 @@ trait InteractsWithToolbarButtons
         return false;
     }
 
-    protected function isToolbarButtonInObject(object $item, string $button): bool
+    protected function hasToolbarButtonInItem(object $item, string $button): bool
     {
         return false;
     }
@@ -273,12 +289,11 @@ trait InteractsWithToolbarButtons
     public function hasToolbarButton(string | array $button): bool
     {
         $buttonsToCheck = is_array($button) ? $button : [$button];
+        $toolbarButtons = $this->getToolbarButtons();
 
-        foreach ($this->getToolbarButtons() as $buttonGroup) {
-            foreach ($buttonGroup as $item) {
-                if (is_string($item) && in_array($item, $buttonsToCheck)) {
-                    return true;
-                }
+        foreach ($buttonsToCheck as $buttonToCheck) {
+            if ($this->hasToolbarButtonInButtons($toolbarButtons, $buttonToCheck)) {
+                return true;
             }
         }
 

--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -828,13 +828,37 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
         return $modifications;
     }
 
-    protected function isToolbarButtonInObject(object $item, string $button): bool
+    protected function hasToolbarButtonInItem(object $item, string $button): bool
     {
         if ($item instanceof ToolbarButtonGroup) {
             return in_array($button, $item->getButtons());
         }
 
         return false;
+    }
+
+    /**
+     * @param  array<string>  $buttonsToDisable
+     */
+    protected function filterDisabledToolbarButtonsFromItem(object $item, array $buttonsToDisable): ?object
+    {
+        if (! ($item instanceof ToolbarButtonGroup)) {
+            return $item;
+        }
+
+        $buttons = array_values(array_filter(
+            $item->getButtons(),
+            static fn (string $button): bool => ! in_array($button, $buttonsToDisable),
+        ));
+
+        if (blank($buttons)) {
+            return null;
+        }
+
+        $item = clone $item;
+        $item->buttons($buttons);
+
+        return $item;
     }
 
     /**

--- a/tests/src/Forms/Components/RichEditorTest.php
+++ b/tests/src/Forms/Components/RichEditorTest.php
@@ -4,6 +4,7 @@ use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\RichEditor\Plugins\Contracts\HasFileAttachmentProvider;
 use Filament\Forms\Components\RichEditor\RichContentCustomBlock;
 use Filament\Forms\Components\RichEditor\RichContentRenderer;
+use Filament\Forms\Components\RichEditor\ToolbarButtonGroup;
 use Filament\Schemas\Schema;
 use Filament\Tests\Fixtures\Forms\RichEditor\PluginWithFileAttachmentProvider;
 use Filament\Tests\Fixtures\Livewire\Livewire;
@@ -282,6 +283,29 @@ describe('toolbar buttons', function (): void {
             ->toThrow(LogicException::class, 'You cannot use the `enableToolbarButtons()` method when the toolbar buttons are dynamically returned from a function.');
     });
 
+    test('can disable grouped toolbar buttons using `disableToolbarButtons()`', function (): void {
+        $richEditor = Schema::make(Livewire::make())
+            ->statePath('data')
+            ->components([
+                RichEditor::make('content')
+                    ->toolbarButtons([
+                        [ToolbarButtonGroup::make('Heading', ['h1', 'h2'])],
+                        ['undo', 'redo'],
+                    ]),
+            ])
+            ->getComponents()[0];
+
+        $richEditor->disableToolbarButtons(['h1']);
+
+        $headingButtonGroup = $richEditor->getToolbarButtons()[0][0];
+
+        expect($headingButtonGroup)->toBeInstanceOf(ToolbarButtonGroup::class);
+
+        expect($headingButtonGroup->getButtons())->toEqual(['h2'])
+            ->and($richEditor->hasToolbarButton('h1'))->toBeFalse()
+            ->and($richEditor->hasToolbarButton('h2'))->toBeTrue();
+    });
+
 });
 
 describe('file attachments', function (): void {
@@ -454,6 +478,29 @@ describe('plugins', function (): void {
             ->and($buttons[0])->toEqual(['bold', 'highlight'])
             ->and($buttons[1])->toEqual(['undo', 'redo'])
             ->and($highlightButtons)->toHaveCount(1);
+    });
+
+    test('plugin implementing `HasToolbarButtons` does not duplicate toolbar buttons already returned by `ToolbarButtonGroup` in `toolbarButtons()`', function (): void {
+        $buttons = Schema::make(Livewire::make())
+            ->statePath('data')
+            ->components([
+                RichEditor::make('content')
+                    ->toolbarButtons([
+                        ['bold', 'italic'],
+                        [ToolbarButtonGroup::make('Formatting', ['highlight', 'underline'])],
+                        ['undo', 'redo'],
+                    ])
+                    ->plugins([new TestRichContentPlugin(enabledButtons: ['highlight'])]),
+            ])
+            ->getComponents()[0]
+            ->getToolbarButtons();
+
+        $highlightButtonGroup = $buttons[1][0];
+
+        expect($buttons)->toHaveCount(3)
+            ->and($highlightButtonGroup)->toBeInstanceOf(ToolbarButtonGroup::class)
+            ->and($highlightButtonGroup->getButtons())->toEqual(['highlight', 'underline'])
+            ->and($buttons[2])->toEqual(['undo', 'redo']);
     });
 
     test('plugin implementing `HasToolbarButtons` does not duplicate toolbar buttons already enabled by user `enableToolbarButtons()`', function (): void {


### PR DESCRIPTION

## Description
### Follow-up to: #19666

  #19666 fixed duplicate plugin-enabled buttons, but `ToolbarButtonGroup` items were still ignored by `disableToolbarButtons()` and `hasToolbarButton()`.

  This follow-up makes grouped buttons participate in the same lookup and filtering paths as string buttons, and removes empty groups after disabling.

  Also renames the internal helper methods to better match their behavior.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
