### PR TITLE
fix: close user menu panel after clicking Profile link

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasUserMenu.php
+++ b/packages/panels/src/Panel/Concerns/HasUserMenu.php
@@ -62,7 +62,7 @@ trait HasUserMenu
             ->label(($page ? $page::getLabel() : null) ?? Filament::getUserName(Filament::auth()->user()))
             ->icon(FilamentIcon::resolve(PanelsIconAlias::USER_MENU_PROFILE_ITEM) ?? Heroicon::UserCircle)
             ->url(Filament::getProfileUrl())
-            ->alpineClickHandler('close()')
+            ->close()
             ->sort(-1);
 
         if ($item instanceof MenuItem) {

--- a/packages/panels/src/Panel/Concerns/HasUserMenu.php
+++ b/packages/panels/src/Panel/Concerns/HasUserMenu.php
@@ -62,6 +62,7 @@ trait HasUserMenu
             ->label(($page ? $page::getLabel() : null) ?? Filament::getUserName(Filament::auth()->user()))
             ->icon(FilamentIcon::resolve(PanelsIconAlias::USER_MENU_PROFILE_ITEM) ?? Heroicon::UserCircle)
             ->url(Filament::getProfileUrl())
+            ->alpineClickHandler('close()')
             ->sort(-1);
 
         if ($item instanceof MenuItem) {


### PR DESCRIPTION
Fixes #19779

The user menu dropdown was not closing when navigating to the Profile page. Added @click handler to close the dropdown on link click.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
