### PR TITLE
Conditionally render footer in empty-state component

### DIFF
--- a/packages/support/resources/views/components/empty-state.blade.php
+++ b/packages/support/resources/views/components/empty-state.blade.php
@@ -21,6 +21,7 @@
     }
 
     $hasDescription = filled((string) $description);
+    $hasFooter = filled((string) $footer);
     $hasIcon = filled($icon);
 @endphp
 
@@ -59,9 +60,11 @@
                 </p>
             @endif
 
-            <footer class="fi-empty-state-footer">
-                {{ $footer }}
-            </footer>
+            @if ($hasFooter)
+                <footer class="fi-empty-state-footer">
+                    {{ $footer }}
+                </footer>
+            @endif
         </div>
     </div>
 </section>


### PR DESCRIPTION
Automatically hide the footer if it is not used in the component. This removes unnecessary padding during rendering.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The current version of the component renders the footer regardless, creating additional padding, which isn't very visually appealing. The solution is to hide the footer if it's not being used, similar to the description.

## Visual changes

### Before

<img width="1129" height="239" alt="Before" src="https://github.com/user-attachments/assets/8130a658-eac6-43b5-8545-c8dc0464a9c0" />

### After

<img width="1114" height="214" alt="After" src="https://github.com/user-attachments/assets/6b4744bd-eaac-4a27-8457-2c44c3eae16b" />

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
