### PR TITLE
fix(tables): preserve addSelect() subqueries when resolving BelongsToMany records

### DIFF
--- a/packages/tables/src/Table/Concerns/HasQuery.php
+++ b/packages/tables/src/Table/Concerns/HasQuery.php
@@ -127,7 +127,7 @@ trait HasQuery
             ];
         }
 
-        $query->select($columns);
+        $query->addSelect($columns);
 
         return $query;
     }

--- a/tests/src/Fixtures/Resources/Tickets/RelationManagers/DepartmentsWithModifiedQueryRelationManager.php
+++ b/tests/src/Fixtures/Resources/Tickets/RelationManagers/DepartmentsWithModifiedQueryRelationManager.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Resources\Tickets\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
+
+class DepartmentsWithModifiedQueryRelationManager extends RelationManager
+{
+    protected static string $relationship = 'departments';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->modifyQueryUsing(fn (Builder $query): Builder => $query->addSelect([
+                DB::raw("'preserved' as virtual_label"),
+            ]))
+            ->columns([
+                TextColumn::make('virtual_label'),
+            ]);
+    }
+}

--- a/tests/src/Fixtures/Resources/Tickets/RelationManagers/DepartmentsWithPivotAndModifiedQueryRelationManager.php
+++ b/tests/src/Fixtures/Resources/Tickets/RelationManagers/DepartmentsWithPivotAndModifiedQueryRelationManager.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Resources\Tickets\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
+
+class DepartmentsWithPivotAndModifiedQueryRelationManager extends RelationManager
+{
+    protected static string $relationship = 'departments';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->modifyQueryUsing(fn (Builder $query): Builder => $query->addSelect([
+                DB::raw("'preserved' as virtual_label"),
+            ]))
+            ->columns([
+                TextColumn::make('name'),
+                TextColumn::make('quantity'),
+                TextColumn::make('pivot.price'),
+                TextColumn::make('virtual_label'),
+            ]);
+    }
+}

--- a/tests/src/Panels/Resources/RelationManagerTest.php
+++ b/tests/src/Panels/Resources/RelationManagerTest.php
@@ -22,6 +22,7 @@ use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsRelati
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithAttachTableSelectRelationManager;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithDeferredBadgeRelationManager;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithMixedSummaryRelationManager;
+use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithModifiedQueryRelationManager;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithPivotSummaryRelationManager;
 use Filament\Tests\Panels\Resources\TestCase;
 use Illuminate\Auth\Access\Response;
@@ -358,6 +359,18 @@ it('can summarize pivot columns in a `BelongsToMany` `RelationManager`', functio
         ->assertSuccessful()
         ->assertTableColumnSummarySet('quantity', 'quantity_sum', 60)    // 10 + 20 + 30
         ->assertTableColumnSummarySet('pivot.price', 'price_sum', 6000); // 1000 + 2000 + 3000
+});
+
+it('preserves `modifyQueryUsing()` `addSelect()` subqueries when resolving a `BelongsToMany` record', function (): void {
+    $ticket = Ticket::factory()->create();
+    $department = Department::factory()->create();
+    $ticket->departments()->attach($department);
+
+    livewire(DepartmentsWithModifiedQueryRelationManager::class, [
+        'ownerRecord' => $ticket,
+        'pageClass' => EditTicket::class,
+    ])
+        ->assertTableColumnStateSet('virtual_label', 'preserved', $department->getKey());
 });
 
 it('can summarize both pivot and non-pivot columns in a `BelongsToMany` `RelationManager`', function (): void {

--- a/tests/src/Panels/Resources/RelationManagerTest.php
+++ b/tests/src/Panels/Resources/RelationManagerTest.php
@@ -23,6 +23,7 @@ use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithAt
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithDeferredBadgeRelationManager;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithMixedSummaryRelationManager;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithModifiedQueryRelationManager;
+use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithPivotAndModifiedQueryRelationManager;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithPivotSummaryRelationManager;
 use Filament\Tests\Panels\Resources\TestCase;
 use Illuminate\Auth\Access\Response;
@@ -371,6 +372,54 @@ it('preserves `modifyQueryUsing()` `addSelect()` subqueries when resolving a `Be
         'pageClass' => EditTicket::class,
     ])
         ->assertTableColumnStateSet('virtual_label', 'preserved', $department->getKey());
+});
+
+it('still resolves pivot columns on a single `BelongsToMany` record', function (): void {
+    $ticket = Ticket::factory()->create();
+    $department = Department::factory()->create();
+    $ticket->departments()->attach($department, ['quantity' => 42, 'price' => 1234]);
+
+    livewire(DepartmentsWithPivotSummaryRelationManager::class, [
+        'ownerRecord' => $ticket,
+        'pageClass' => EditTicket::class,
+    ])
+        ->assertTableColumnStateSet('quantity', 42, $department->getKey())
+        ->assertTableColumnStateSet('pivot.price', 1234, $department->getKey());
+});
+
+it('resolves pivot columns alongside `modifyQueryUsing()` virtual columns on a single `BelongsToMany` record', function (): void {
+    $ticket = Ticket::factory()->create();
+    $department = Department::factory()->create(['name' => 'Engineering']);
+    $ticket->departments()->attach($department, ['quantity' => 7, 'price' => 99]);
+
+    livewire(DepartmentsWithPivotAndModifiedQueryRelationManager::class, [
+        'ownerRecord' => $ticket,
+        'pageClass' => EditTicket::class,
+    ])
+        ->assertTableColumnStateSet('name', 'Engineering', $department->getKey())
+        ->assertTableColumnStateSet('quantity', 7, $department->getKey())
+        ->assertTableColumnStateSet('pivot.price', 99, $department->getKey())
+        ->assertTableColumnStateSet('virtual_label', 'preserved', $department->getKey());
+});
+
+it('resolves pivot columns and `modifyQueryUsing()` virtual columns across multiple `BelongsToMany` records', function (): void {
+    $ticket = Ticket::factory()->create();
+    $departments = Department::factory()->count(2)->create();
+    $ticket->departments()->attach($departments[0], ['quantity' => 10, 'price' => 100]);
+    $ticket->departments()->attach($departments[1], ['quantity' => 20, 'price' => 200]);
+
+    livewire(DepartmentsWithPivotAndModifiedQueryRelationManager::class, [
+        'ownerRecord' => $ticket,
+        'pageClass' => EditTicket::class,
+    ])
+        ->assertSuccessful()
+        ->assertCanSeeTableRecords($departments)
+        ->assertTableColumnStateSet('quantity', 10, $departments[0]->getKey())
+        ->assertTableColumnStateSet('quantity', 20, $departments[1]->getKey())
+        ->assertTableColumnStateSet('pivot.price', 100, $departments[0]->getKey())
+        ->assertTableColumnStateSet('pivot.price', 200, $departments[1]->getKey())
+        ->assertTableColumnStateSet('virtual_label', 'preserved', $departments[0]->getKey())
+        ->assertTableColumnStateSet('virtual_label', 'preserved', $departments[1]->getKey());
 });
 
 it('can summarize both pivot and non-pivot columns in a `BelongsToMany` `RelationManager`', function (): void {


### PR DESCRIPTION
## Description

When resolving a single record for a `BelongsToMany` relationship table — e.g. `assertTableColumnStateSet()`, edit/view action records, or anything routing through `resolveTableRecord()` — virtual columns added by user scopes via `modifyQueryUsing(fn ($query) => $query->addSelect([...]))` are silently dropped. `getStateUsing()` callbacks reading those virtual attributes return `null`.

The table rendering path (`getTableRecords()`) is unaffected, which makes this easy to miss: columns display correctly when listing, but the same column is `null` when reading state for a single record.

This mostly caused issues with `assertTableColumnStateSet` during tests.

## Root cause

In `resolveTableRecord()` (`packages/tables/src/Concerns/HasRecords.php:215-227`) the order of operations is:

1. `$relationship->getQuery()` — raw relationship query
2. `$table->applyQueryScopes(...)` — runs user `modifyQueryUsing()` callbacks, including any `addSelect()` subqueries
3. `$table->selectPivotDataInQuery($query)` — called `$query->select([...])`, which **replaces** the column list and wipes step 2's `addSelect`

The list path goes through `getQuery() → getRelationshipQuery()`, where `selectPivotDataInQuery()` runs *first* (HasQuery.php:101) and `applyQueryScopes()` runs *after* — so the bug never surfaces there.

## Fix

Change `$query->select($columns)` → `$query->addSelect($columns)` in `selectPivotDataInQuery()` at `packages/tables/src/Table/Concerns/HasQuery.php:130`.

Why this is safe:
- Eloquent's `Builder::addSelect()` initialises `$query->columns` from `null` when no prior `select()` was made, so callers that previously had no columns set end up with the exact same column list as before — `select()` and `addSelect()` produce identical SQL on a fresh query.
- Callers that *did* add columns earlier (the bug case) now have those columns preserved alongside the pivot/base selections.
- The method already explicitly includes `$query->getModel()->getTable() . '.*'` in `$columns`, so base-table columns are always selected.

The alternative — reordering operations in `resolveTableRecord()` — only patches one call site and leaves the same hazard for future callers (e.g. `HasBulkActions::getSelectedTableRecordsQuery()` at line 341). The one-line `addSelect` change addresses the root cause.

## Test

Added a regression test in `tests/src/Panels/Resources/RelationManagerTest.php` backed by a new fixture `DepartmentsWithModifiedQueryRelationManager` that:

- Calls `->modifyQueryUsing(fn ($query) => $query->addSelect([DB::raw("'preserved' as virtual_label")]))`
- Exposes the virtual column via a `TextColumn`
- Asserts `assertTableColumnStateSet('virtual_label', 'preserved', $department->getKey())`

Verified the test **fails** on the pre-fix code (reads `null`) and **passes** with the fix.

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
