### PR TITLE
security: Introduce `Str::sanitizeUrl()` helper method

### DIFF
--- a/docs/09-advanced/06-security.md
+++ b/docs/09-advanced/06-security.md
@@ -65,18 +65,55 @@ Do not rely solely on Filament's built-in policy checks. Treat them as a helpful
 
 Many Filament configuration methods accept closures that can return dynamic values. Methods like `url()`, `icon()`, `html()`, and others are designed to be flexible, allowing developers to build rich, dynamic interfaces. However, when the values passed to these methods originate from user input or untrusted database content, it is your responsibility to validate and sanitize them appropriately.
 
-For example, the `url()` method on columns, entries, and actions renders an `<a href="...">` tag with whatever value you provide. If you pass a URL sourced from user input without validation, a malicious value like `javascript:alert(document.cookie)` could be rendered as a clickable link, leading to XSS. Always validate that URLs use a safe scheme such as `http` or `https` before passing them to Filament:
+For example, the `url()` method on columns, entries, and actions renders an `<a href="...">` tag with whatever value you provide. If you pass a URL sourced from user input without validation, a malicious value like `javascript:alert(document.cookie)` could be rendered as a clickable link, leading to XSS. Always validate that URLs use a safe scheme such as `http` or `https` before passing them to Filament.
+
+Filament ships a `Str::sanitizeUrl()` helper that returns the URL when it is schemeless (relative) or uses the `http`/`https` scheme, and returns `null` for anything else. It also normalizes obfuscation tricks such as leading whitespace, embedded control characters (`\t`, `\n`, `\r`, NUL bytes), and mixed-case schemes before checking — so values like `"\tJaVa\nScRiPt:alert(1)"` are rejected, and even on a safe URL the return value has those bytes stripped so they cannot reach the rendered HTML:
 
 ```php
 use Filament\Tables\Columns\TextColumn;
+use Illuminate\Support\Str;
 
 TextColumn::make('website')
+    ->url(fn (string $state): ?string => Str::sanitizeUrl($state))
+```
+
+You can call the helper anywhere a URL is being passed to a Filament configuration method (`url()`, `image()`, `icon()` when given a URL, `openUrlInNewTab()` callbacks, and so on). Internally Filament already runs every file URL it emits from components like `FileUpload` and `SpatieMediaLibraryFileUpload` through this helper.
+
+If you need to allow additional schemes — for example `mailto:` or `tel:` — pass them in as the second argument. The default allowlist is replaced by what you pass, so include `http` and `https` if you still want them:
+
+```php
+TextColumn::make('contact')
+    ->url(fn (string $state): ?string => Str::sanitizeUrl(
+        $state,
+        allowedSchemes: ['http', 'https', 'mailto', 'tel'],
+    ))
+```
+
+`Str::sanitizeUrl()` is a scheme allowlist designed to prevent XSS from dangerous URL schemes. It does not:
+
+- check that the host belongs to a domain you control (open-redirect protection),
+- check that the URL is safe for the server to fetch (SSRF protection),
+- decode percent-encoded or HTML-entity-encoded payloads (the browser's URL parser doesn't either, so this is intentional, but it means callers that decode the value before rendering need their own check on the decoded form),
+- validate that an `http(s)` URL is reachable or trusted in any other way.
+
+If you need any of those guarantees, layer your own check on top of the helper's return value.
+
+If you need a stricter allowlist (for example, only your own domains), wrap the helper:
+
+```php
+TextColumn::make('website')
     ->url(function (string $state): ?string {
-        if (! str_starts_with($state, 'http://') && ! str_starts_with($state, 'https://')) {
+        $sanitized = Str::sanitizeUrl($state);
+
+        if (blank($sanitized)) {
             return null;
         }
 
-        return $state;
+        $host = parse_url($sanitized, PHP_URL_HOST);
+
+        return in_array($host, ['example.com', 'cdn.example.com'], true)
+            ? $sanitized
+            : null;
     })
 ```
 

--- a/packages/actions/docs/01-overview.md
+++ b/packages/actions/docs/01-overview.md
@@ -55,7 +55,7 @@ Action::make('edit')
 <UtilityInjection set="actions" version="4.x">As well as allowing a static value, the `url()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 <Aside variant="danger">
-    If you are passing user-controlled data to the `url()` method, you should validate that the URL does not use a dangerous scheme such as `javascript:` or `data:`. Failing to do so could expose your application to XSS attacks.
+    If you are passing user-controlled data to the `url()` method, you should validate that the URL does not use a dangerous scheme such as `javascript:` or `data:`. Failing to do so could expose your application to XSS attacks. The simplest way to guard against this is to wrap the value in Filament's [`Str::sanitizeUrl()`](../advanced/security#validating-user-input) helper, which returns `null` for any URL that does not use `http`/`https` (or a relative path).
 </Aside>
 
 The entire look of the action's trigger button and the modal is customizable using fluent PHP methods. We provide a sensible and consistent styling for the UI, but all of this is customizable with CSS.

--- a/packages/forms/docs/10-rich-editor.md
+++ b/packages/forms/docs/10-rich-editor.md
@@ -939,6 +939,20 @@ RichContentRenderer::make($record->content)
     ->toHtml()
 ```
 
+<Aside variant="tip">
+    The string returned from the `url()` closure is rendered directly into the `href` attribute of an `<a>` tag, so if any part of the URL is built from user input you should make sure it cannot resolve to a scheme like `javascript:` or `data:` that the browser would execute. The simplest way to guarantee this is to wrap the return value in Filament's [`Str::sanitizeUrl()`](../../advanced/security#validating-user-input) helper, which only allows `http`/`https` and relative URLs:
+
+    ```php
+    use Illuminate\Support\Str;
+
+    ->url(fn (string $id, string $label): ?string => Str::sanitizeUrl(
+        route('users.show', $id),
+    ))
+    ```
+
+    If you intentionally want to allow a `javascript:` URL (for example, to wire a mention to an Alpine.js handler), skip the helper and return the raw value — just make sure none of the components of that URL come from untrusted user input.
+</Aside>
+
 ## Registering rich content attributes
 
 There are elements of the rich editor configuration that apply to both the editor and the renderer. For example, if you are using [private images](#using-private-images-in-the-editor), [custom blocks](#using-custom-blocks), [merge tags](#using-merge-tags), [mentions](#using-mentions), or [plugins](#extending-the-rich-editor), you need to ensure that the same configuration is used in both places. To do this, Filament provides you with a way to register rich content attributes that can be used in both the editor and the renderer. If a plugin implements `HasFileAttachmentProvider`, the file attachment provider is automatically resolved from the plugin, so you do not need to call `fileAttachmentProvider()` on the attribute or on the renderer.

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -202,7 +202,7 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
             'name' => ($this->isMultiple() ? ($storedFileNames[$file] ?? null) : $storedFileNames) ?? basename($file),
             'size' => $shouldFetchFileInformation ? $storage->size($file) : 0,
             'type' => $shouldFetchFileInformation ? $storage->mimeType($file) : null,
-            'url' => $url,
+            'url' => Str::sanitizeUrl($url),
         ];
     }
 
@@ -927,11 +927,15 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
                 continue;
             }
 
+            if (array_key_exists('url', $urls[$fileKey])) {
+                $urls[$fileKey]['url'] = Str::sanitizeUrl($urls[$fileKey]['url']);
+            }
+
             if ($openableFileUrlCallback) {
-                $openableUrl = $this->evaluate($openableFileUrlCallback, [
+                $openableUrl = Str::sanitizeUrl($this->evaluate($openableFileUrlCallback, [
                     'file' => $file,
                     'storedFileNames' => $storedFileNames,
-                ]);
+                ]));
 
                 if ($openableUrl !== null) {
                     $urls[$fileKey]['openableUrl'] = $openableUrl;
@@ -939,10 +943,10 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
             }
 
             if ($downloadableFileUrlCallback) {
-                $downloadableUrl = $this->evaluate($downloadableFileUrlCallback, [
+                $downloadableUrl = Str::sanitizeUrl($this->evaluate($downloadableFileUrlCallback, [
                     'file' => $file,
                     'storedFileNames' => $storedFileNames,
-                ]);
+                ]));
 
                 if ($downloadableUrl !== null) {
                     $urls[$fileKey]['downloadableUrl'] = $downloadableUrl;

--- a/packages/infolists/docs/01-overview.md
+++ b/packages/infolists/docs/01-overview.md
@@ -209,7 +209,7 @@ TextEntry::make('title')
 <UtilityInjection set="infolistEntries" version="4.x">As well as allowing a static value, the `openUrlInNewTab()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 <Aside variant="danger">
-    If you are passing user-controlled data to the `url()` method, you should validate that the URL does not use a dangerous scheme such as `javascript:` or `data:`. Failing to do so could expose your application to XSS attacks.
+    If you are passing user-controlled data to the `url()` method, you should validate that the URL does not use a dangerous scheme such as `javascript:` or `data:`. Failing to do so could expose your application to XSS attacks. The simplest way to guard against this is to wrap the value in Filament's [`Str::sanitizeUrl()`](../advanced/security#validating-user-input) helper, which returns `null` for any URL that does not use `http`/`https` (or a relative path).
 </Aside>
 
 ## Hiding an entry

--- a/packages/notifications/docs/01-overview.md
+++ b/packages/notifications/docs/01-overview.md
@@ -308,7 +308,7 @@ new FilamentNotification()
 ```
 
 <Aside variant="danger">
-    If you are passing user-controlled data to the `url()` method, you should validate that the URL does not use a dangerous scheme such as `javascript:` or `data:`. Failing to do so could expose your application to XSS attacks.
+    If you are passing user-controlled data to the `url()` method, you should validate that the URL does not use a dangerous scheme such as `javascript:` or `data:`. Failing to do so could expose your application to XSS attacks. The simplest way to guard against this is to wrap the value in Filament's [`Str::sanitizeUrl()`](../advanced/security#validating-user-input) helper, which returns `null` for any URL that does not use `http`/`https` (or a relative path).
 </Aside>
 
 ### Dispatching Livewire events from notification actions

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -6,6 +6,7 @@ use Closure;
 use Filament\Support\Concerns\HasMediaFilter;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use League\Flysystem\UnableToCheckFileExistence;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Spatie\MediaLibrary\HasMedia;
@@ -112,7 +113,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
                 'name' => $media?->getAttributeValue('name') ?? $media?->getAttributeValue('file_name'),
                 'size' => $media?->getAttributeValue('size'),
                 'type' => $media?->getAttributeValue('mime_type'),
-                'url' => $url,
+                'url' => Str::sanitizeUrl($url),
             ];
         });
 

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -322,6 +322,35 @@ class SupportServiceProvider extends PackageServiceProvider
             return new Stringable(Str::sanitizeHtml($this->value));
         });
 
+        Str::macro('sanitizeUrl', function (?string $url, array $allowedSchemes = ['http', 'https']): ?string {
+            if (blank($url)) {
+                return null;
+            }
+
+            // Reject whitespace and control characters instead of stripping
+            // them: browsers ignore those bytes when parsing URLs, so an
+            // input like "\tjavascript:..." would resolve to a scheme the
+            // visible string does not suggest.
+            if (preg_match('/[\s\x00-\x1F\x7F]/', $url)) {
+                return null;
+            }
+
+            if (preg_match('#^([a-z][a-z0-9+\-.]*):#i', $url, $matches)) {
+                $allowedSchemes = array_map(strtolower(...), $allowedSchemes);
+
+                if (! in_array(strtolower($matches[1]), $allowedSchemes, strict: true)) {
+                    return null;
+                }
+            }
+
+            return $url;
+        });
+
+        Stringable::macro('sanitizeUrl', function (array $allowedSchemes = ['http', 'https']): Stringable {
+            /** @phpstan-ignore-next-line */
+            return new Stringable(Str::sanitizeUrl($this->value, $allowedSchemes));
+        });
+
         Str::macro('ucwords', function (string $value): string {
             return implode(' ', array_map(
                 [Str::class, 'ucfirst'],

--- a/packages/tables/docs/02-columns/01-overview.md
+++ b/packages/tables/docs/02-columns/01-overview.md
@@ -576,7 +576,7 @@ TextColumn::make('title')
 ```
 
 <Aside variant="danger">
-    If you are passing user-controlled data to the `url()` method, you should validate that the URL does not use a dangerous scheme such as `javascript:` or `data:`. Failing to do so could expose your application to XSS attacks.
+    If you are passing user-controlled data to the `url()` method, you should validate that the URL does not use a dangerous scheme such as `javascript:` or `data:`. Failing to do so could expose your application to XSS attacks. The simplest way to guard against this is to wrap the value in Filament's [`Str::sanitizeUrl()`](../../advanced/security#validating-user-input) helper, which returns `null` for any URL that does not use `http`/`https` (or a relative path).
 </Aside>
 
 ### Triggering actions

--- a/tests/src/Support/UrlSanitizerTest.php
+++ b/tests/src/Support/UrlSanitizerTest.php
@@ -1,0 +1,299 @@
+<?php
+
+use Filament\Tests\TestCase;
+use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
+
+uses(TestCase::class);
+
+it('returns `null` for `null` input', function (): void {
+    expect(Str::sanitizeUrl(null))->toBeNull();
+});
+
+it('returns `null` for an empty string', function (): void {
+    expect(Str::sanitizeUrl(''))->toBeNull();
+});
+
+it('returns `null` for a whitespace-only string', function (): void {
+    expect(Str::sanitizeUrl('   '))->toBeNull();
+});
+
+it('allows absolute `http` URLs', function (): void {
+    expect(Str::sanitizeUrl('http://example.com/file.pdf'))
+        ->toBe('http://example.com/file.pdf');
+});
+
+it('allows absolute `https` URLs', function (): void {
+    expect(Str::sanitizeUrl('https://example.com/file.pdf'))
+        ->toBe('https://example.com/file.pdf');
+});
+
+it('allows `https` URLs with query strings and fragments', function (): void {
+    expect(Str::sanitizeUrl('https://example.com/path?foo=bar&baz=1#section'))
+        ->toBe('https://example.com/path?foo=bar&baz=1#section');
+});
+
+it('allows `https` URLs with ports and userinfo', function (): void {
+    expect(Str::sanitizeUrl('https://user:pass@example.com:8443/file.pdf'))
+        ->toBe('https://user:pass@example.com:8443/file.pdf');
+});
+
+it('allows mixed-case `HTTP`/`HTTPS` schemes', function (): void {
+    expect(Str::sanitizeUrl('HTTP://example.com'))->toBe('HTTP://example.com')
+        ->and(Str::sanitizeUrl('HtTpS://example.com'))->toBe('HtTpS://example.com');
+});
+
+it('allows root-relative URLs', function (): void {
+    expect(Str::sanitizeUrl('/storage/files/abc.pdf'))
+        ->toBe('/storage/files/abc.pdf');
+});
+
+it('allows path-relative URLs', function (): void {
+    expect(Str::sanitizeUrl('files/abc.pdf'))->toBe('files/abc.pdf');
+});
+
+it('allows protocol-relative URLs', function (): void {
+    expect(Str::sanitizeUrl('//cdn.example.com/file.pdf'))
+        ->toBe('//cdn.example.com/file.pdf');
+});
+
+it('allows query-only and fragment-only URLs', function (): void {
+    expect(Str::sanitizeUrl('?download=1'))->toBe('?download=1')
+        ->and(Str::sanitizeUrl('#section'))->toBe('#section');
+});
+
+it('allows URLs whose path contains a `:`', function (): void {
+    expect(Str::sanitizeUrl('/files/folder:name/abc.pdf'))
+        ->toBe('/files/folder:name/abc.pdf');
+});
+
+it('allows http URLs whose userinfo looks like a dangerous scheme', function (): void {
+    expect(Str::sanitizeUrl('http://javascript:alert(1)@example.com'))
+        ->toBe('http://javascript:alert(1)@example.com');
+});
+
+it('rejects plain `javascript:` URLs', function (): void {
+    expect(Str::sanitizeUrl('javascript:alert(1)'))->toBeNull();
+});
+
+it('rejects plain `data:` URLs', function (): void {
+    expect(Str::sanitizeUrl('data:text/html,<script>alert(1)</script>'))
+        ->toBeNull();
+});
+
+it('rejects `data:` image URLs', function (): void {
+    expect(Str::sanitizeUrl('data:image/svg+xml;base64,PHN2Zy8+'))->toBeNull();
+});
+
+it('rejects plain `vbscript:` URLs', function (): void {
+    expect(Str::sanitizeUrl('vbscript:msgbox(1)'))->toBeNull();
+});
+
+it('rejects `file:` URLs', function (): void {
+    expect(Str::sanitizeUrl('file:///etc/passwd'))->toBeNull();
+});
+
+it('rejects `ftp:` URLs', function (): void {
+    expect(Str::sanitizeUrl('ftp://example.com/foo'))->toBeNull();
+});
+
+it('rejects `mailto:` URLs', function (): void {
+    expect(Str::sanitizeUrl('mailto:hacker@example.com'))->toBeNull();
+});
+
+it('rejects `tel:` URLs', function (): void {
+    expect(Str::sanitizeUrl('tel:+15551234567'))->toBeNull();
+});
+
+it('rejects `blob:` URLs', function (): void {
+    expect(Str::sanitizeUrl('blob:https://example.com/uuid'))->toBeNull();
+});
+
+it('rejects `about:` URLs', function (): void {
+    expect(Str::sanitizeUrl('about:blank'))->toBeNull();
+});
+
+it('rejects `javascript:` with mixed case', function (): void {
+    expect(Str::sanitizeUrl('JavaScript:alert(1)'))->toBeNull()
+        ->and(Str::sanitizeUrl('JAVASCRIPT:alert(1)'))->toBeNull()
+        ->and(Str::sanitizeUrl('jAvAsCrIpT:alert(1)'))->toBeNull();
+});
+
+it('rejects `javascript:` with leading spaces', function (): void {
+    expect(Str::sanitizeUrl('  javascript:alert(1)'))->toBeNull();
+});
+
+it('rejects `javascript:` with leading tabs', function (): void {
+    expect(Str::sanitizeUrl("\tjavascript:alert(1)"))->toBeNull();
+});
+
+it('rejects `javascript:` with leading newlines', function (): void {
+    expect(Str::sanitizeUrl("\njavascript:alert(1)"))->toBeNull()
+        ->and(Str::sanitizeUrl("\rjavascript:alert(1)"))->toBeNull()
+        ->and(Str::sanitizeUrl("\r\njavascript:alert(1)"))->toBeNull();
+});
+
+it('rejects `javascript:` with leading null bytes', function (): void {
+    expect(Str::sanitizeUrl("\0javascript:alert(1)"))->toBeNull();
+});
+
+it('rejects `javascript:` with leading form-feed and vertical-tab', function (): void {
+    expect(Str::sanitizeUrl("\fjavascript:alert(1)"))->toBeNull()
+        ->and(Str::sanitizeUrl("\x0Bjavascript:alert(1)"))->toBeNull();
+});
+
+it('rejects `javascript:` with leading mixed control characters', function (): void {
+    expect(Str::sanitizeUrl("\0\t\r\n  javascript:alert(1)"))->toBeNull();
+});
+
+it('rejects `javascript:` with embedded tab inside the scheme', function (): void {
+    expect(Str::sanitizeUrl("java\tscript:alert(1)"))->toBeNull();
+});
+
+it('rejects `javascript:` with embedded newline inside the scheme', function (): void {
+    expect(Str::sanitizeUrl("java\nscript:alert(1)"))->toBeNull()
+        ->and(Str::sanitizeUrl("java\rscript:alert(1)"))->toBeNull();
+});
+
+it('rejects `javascript:` with embedded null byte inside the scheme', function (): void {
+    expect(Str::sanitizeUrl("ja\0vascript:alert(1)"))->toBeNull();
+});
+
+it('rejects `javascript:` with `\x7F` DEL inside the scheme', function (): void {
+    expect(Str::sanitizeUrl("javascript\x7F:alert(1)"))->toBeNull();
+});
+
+it('rejects `javascript:` with whitespace before the colon', function (): void {
+    expect(Str::sanitizeUrl('javascript :alert(1)'))->toBeNull()
+        ->and(Str::sanitizeUrl("javascript\t:alert(1)"))->toBeNull();
+});
+
+it('rejects `javascript:` with every kind of obfuscation combined', function (): void {
+    expect(Str::sanitizeUrl("\0\t  Ja\nVa\rScRiPt\t:alert(1)"))->toBeNull();
+});
+
+it('rejects `data:` with case and whitespace variants', function (): void {
+    expect(Str::sanitizeUrl('DATA:text/html,foo'))->toBeNull()
+        ->and(Str::sanitizeUrl("  Data:text/html,foo"))->toBeNull()
+        ->and(Str::sanitizeUrl("da\tta:text/html,foo"))->toBeNull();
+});
+
+it('rejects `vbscript:` with case and whitespace variants', function (): void {
+    expect(Str::sanitizeUrl('VBScript:msgbox(1)'))->toBeNull()
+        ->and(Str::sanitizeUrl("\tvbscript:msgbox(1)"))->toBeNull();
+});
+
+it('does not naively decode percent-encoded schemes', function (): void {
+    // The browser does not percent-decode the scheme, so `%6Aavascript:`
+    // is treated as a scheme literally named `%6Aavascript`, which is not
+    // registered. The allowlist still rejects it because it isn't `http`
+    // or `https`, but the regex sees a leading `%` and matches no scheme,
+    // so the URL is also considered schemeless. Either outcome is safe.
+    expect(Str::sanitizeUrl('%6Aavascript:alert(1)'))
+        ->toBe('%6Aavascript:alert(1)');
+});
+
+it('rejects URLs with only a dangerous scheme and no body', function (): void {
+    expect(Str::sanitizeUrl('javascript:'))->toBeNull()
+        ->and(Str::sanitizeUrl('data:'))->toBeNull();
+});
+
+it('rejects URLs with a dangerous scheme followed by a fragment', function (): void {
+    expect(Str::sanitizeUrl('javascript:void(0)#foo'))->toBeNull();
+});
+
+it('preserves percent-encoded whitespace inside a safe URL path', function (): void {
+    expect(Str::sanitizeUrl('https://example.com/file%20name.pdf'))
+        ->toBe('https://example.com/file%20name.pdf');
+});
+
+it('rejects URLs with leading whitespace', function (): void {
+    // Legitimate URLs do not carry leading whitespace — rejecting up front
+    // matches Symfony's HtmlSanitizer and forces callers to hand us a clean
+    // value rather than relying on silent rewrites.
+    expect(Str::sanitizeUrl('  https://example.com'))->toBeNull();
+});
+
+it('rejects URLs with embedded control characters', function (): void {
+    expect(Str::sanitizeUrl("http://exa\tmple.com/\nfile.pdf"))->toBeNull()
+        ->and(Str::sanitizeUrl("http://example.com/\x00file.pdf"))->toBeNull()
+        ->and(Str::sanitizeUrl("http://example.com\x7F"))->toBeNull();
+});
+
+it('returns `null` when the URL is only control characters', function (): void {
+    expect(Str::sanitizeUrl("\x01"))->toBeNull()
+        ->and(Str::sanitizeUrl("\x00\x01\x02"))->toBeNull()
+        ->and(Str::sanitizeUrl("\t\r\n"))->toBeNull();
+});
+
+it('rejects URLs containing embedded ASCII spaces', function (): void {
+    // Legitimate URLs percent-encode spaces; a raw space anywhere in the
+    // URL is either a typo or an obfuscation attempt that could resolve to
+    // a different host than the visible string suggests.
+    expect(Str::sanitizeUrl('http://example.com /path'))->toBeNull()
+        ->and(Str::sanitizeUrl('https://exa mple.com'))->toBeNull()
+        ->and(Str::sanitizeUrl('http://example.com/path?q=hello world'))->toBeNull();
+});
+
+it('rejects URLs with trailing whitespace', function (): void {
+    expect(Str::sanitizeUrl('https://example.com '))->toBeNull()
+        ->and(Str::sanitizeUrl("https://example.com\t"))->toBeNull();
+});
+
+it('still accepts percent-encoded spaces in the path', function (): void {
+    // %20 is the safe, encoded form — only raw whitespace is rejected.
+    expect(Str::sanitizeUrl('https://example.com/file%20name.pdf'))
+        ->toBe('https://example.com/file%20name.pdf');
+});
+
+it('exposes a `Stringable` macro', function (): void {
+    expect(Str::of('javascript:alert(1)')->sanitizeUrl())
+        ->toBeInstanceOf(Stringable::class)
+        ->and((string) Str::of('javascript:alert(1)')->sanitizeUrl())
+        ->toBe('')
+        ->and((string) Str::of('https://example.com')->sanitizeUrl())
+        ->toBe('https://example.com');
+});
+
+it('allows extra schemes when passed via the `$allowedSchemes` argument', function (): void {
+    expect(Str::sanitizeUrl('mailto:foo@example.com', ['http', 'https', 'mailto']))
+        ->toBe('mailto:foo@example.com')
+        ->and(Str::sanitizeUrl('tel:+15551234567', ['http', 'https', 'tel']))
+        ->toBe('tel:+15551234567');
+});
+
+it('still rejects dangerous schemes when an opt-in list is supplied', function (): void {
+    expect(Str::sanitizeUrl('javascript:alert(1)', ['http', 'https', 'mailto']))
+        ->toBeNull()
+        ->and(Str::sanitizeUrl('data:text/html,foo', ['http', 'https', 'mailto', 'tel']))
+        ->toBeNull();
+});
+
+it('matches `$allowedSchemes` case-insensitively', function (): void {
+    expect(Str::sanitizeUrl('MAILTO:foo@example.com', ['mailto']))
+        ->toBe('MAILTO:foo@example.com')
+        ->and(Str::sanitizeUrl('mailto:foo@example.com', ['MailTo']))
+        ->toBe('mailto:foo@example.com');
+});
+
+it('rejects every scheme when `$allowedSchemes` is empty but keeps relative URLs', function (): void {
+    expect(Str::sanitizeUrl('http://example.com', []))->toBeNull()
+        ->and(Str::sanitizeUrl('https://example.com', []))->toBeNull()
+        ->and(Str::sanitizeUrl('/storage/file.pdf', []))->toBe('/storage/file.pdf')
+        ->and(Str::sanitizeUrl('//cdn.example.com/file.pdf', []))->toBe('//cdn.example.com/file.pdf');
+});
+
+it('rejects `http(s)` when only an opt-in scheme is listed', function (): void {
+    expect(Str::sanitizeUrl('https://example.com', ['mailto']))->toBeNull();
+});
+
+it('rejects obfuscation even when checking against a custom `$allowedSchemes`', function (): void {
+    expect(Str::sanitizeUrl("\tMaIl\nTo:foo@example.com", ['mailto']))->toBeNull();
+});
+
+it('passes `$allowedSchemes` through the `Stringable` macro', function (): void {
+    expect((string) Str::of('mailto:foo@example.com')->sanitizeUrl(['mailto']))
+        ->toBe('mailto:foo@example.com')
+        ->and((string) Str::of('javascript:alert(1)')->sanitizeUrl(['mailto']))
+        ->toBe('');
+});


### PR DESCRIPTION
Instead of users manually sanitising URLs before passing them to Filament functions, this provides them with an easy-to-use `Str::sanitizeUrl()`.