### PR TITLE
Handle unicode whitespace consistently in form inputs

### DIFF
--- a/packages/schemas/src/Components/Concerns/CanTrimState.php
+++ b/packages/schemas/src/Components/Concerns/CanTrimState.php
@@ -3,6 +3,7 @@
 namespace Filament\Schemas\Components\Concerns;
 
 use Closure;
+use Illuminate\Support\Str;
 
 trait CanTrimState
 {
@@ -32,6 +33,6 @@ trait CanTrimState
             return $state;
         }
 
-        return trim($state);
+        return Str::trim($state);
     }
 }

--- a/tests/src/Forms/Components/TagsInputTest.php
+++ b/tests/src/Forms/Components/TagsInputTest.php
@@ -26,6 +26,11 @@ it('can trim whitespace from TagsInput array values', function (mixed $input, mi
     [null, null],
     [[], []],
     [['  tag1  ', 123, '  tag2  '], ['tag1', 123, 'tag2']],
+    [["\t tag1 \n", "\n tag2 \t"], ['tag1', 'tag2']],
+    [['　tag1　', '　tag2　'], ['tag1', 'tag2']],
+    [[" \t　tag1　\n ", "　 tag2\t "], ['tag1', 'tag2']],
+    [['   ', "\t\n　"], ['', '']],
+    [['  tag1  ', null, true, '　tag2　'], ['tag1', null, true, 'tag2']],
 ]);
 
 it('can strip characters from TagsInput array values', function (mixed $input, mixed $expected): void {

--- a/tests/src/Forms/Components/TextInputTest.php
+++ b/tests/src/Forms/Components/TextInputTest.php
@@ -27,6 +27,11 @@ it('can `trim()` whitespace from `TextInput`', function (mixed $input, mixed $ex
     [null, null],
     ['', ''],
     [123, 123],
+    ["\t test value \n", 'test value'],
+    ['　test value　', 'test value'],
+    [" \t　test value　\n ", 'test value'],
+    ['   ', ''],
+    ["\t\n　", ''],
 ]);
 
 it('can strip characters before applying `numeric()` state cast', function (mixed $input, mixed $expected): void {

--- a/tests/src/Forms/Components/TextareaTest.php
+++ b/tests/src/Forms/Components/TextareaTest.php
@@ -26,6 +26,11 @@ it('can `trim()` whitespace from `Textarea`', function (mixed $input, mixed $exp
     [null, null],
     ['', ''],
     [123, 123],
+    ["\t test content \n", 'test content'],
+    ['　test content　', 'test content'],
+    [" \t　test content　\n ", 'test content'],
+    ['   ', ''],
+    ["\t\n　", ''],
 ]);
 
 it('can set `autosize()`', function (): void {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Replace native `trim()` calls with `Str::trim()` to normalize whitespace consistently across form inputs.

This change improves handling of Unicode and multibyte whitespace characters (such as full-width spaces) in addition to standard ASCII whitespace.

This behavior now matches Laravel's `TrimStrings` middleware.

## Visual changes

No changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
