### PR TITLE
Improve Japanese translations for force delete and restore actions

### DIFF
--- a/packages/actions/resources/lang/ja/force-delete.php
+++ b/packages/actions/resources/lang/ja/force-delete.php
@@ -4,16 +4,16 @@ return [
 
     'single' => [
 
-        'label' => '強制削除',
+        'label' => '完全に削除',
 
         'modal' => [
 
-            'heading' => ':label 強制削除',
+            'heading' => ':labelを完全に削除',
 
             'actions' => [
 
                 'delete' => [
-                    'label' => '削除',
+                    'label' => '完全に削除',
                 ],
 
             ],
@@ -23,7 +23,7 @@ return [
         'notifications' => [
 
             'deleted' => [
-                'title' => '削除しました',
+                'title' => '完全に削除しました',
             ],
 
         ],
@@ -32,16 +32,16 @@ return [
 
     'multiple' => [
 
-        'label' => '選択中を強制削除',
+        'label' => '選択中を完全に削除',
 
         'modal' => [
 
-            'heading' => '選択中の:labelを強制削除',
+            'heading' => '選択中の:labelを完全に削除',
 
             'actions' => [
 
                 'delete' => [
-                    'label' => '削除',
+                    'label' => '完全に削除',
                 ],
 
             ],
@@ -51,19 +51,19 @@ return [
         'notifications' => [
 
             'deleted' => [
-                'title' => '削除しました',
+                'title' => '完全に削除しました',
             ],
 
             'deleted_partial' => [
-                'title' => ':total件中:count件を削除しました',
-                'missing_authorization_failure_message' => ':count件を削除する権限がありません。',
-                'missing_processing_failure_message' => ':count件を削除できませんでした。',
+                'title' => ':total件中:count件を完全に削除しました',
+                'missing_authorization_failure_message' => ':count件を完全に削除する権限がありません。',
+                'missing_processing_failure_message' => ':count件を完全に削除できませんでした。',
             ],
 
             'deleted_none' => [
-                'title' => '削除に失敗しました',
-                'missing_authorization_failure_message' => ':count件を削除する権限がありません。',
-                'missing_processing_failure_message' => ':count件を削除できませんでした。',
+                'title' => '完全な削除に失敗しました',
+                'missing_authorization_failure_message' => ':count件を完全な削除する権限がありません。',
+                'missing_processing_failure_message' => ':count件を完全な削除できませんでした。',
             ],
 
         ],

--- a/packages/actions/resources/lang/ja/restore.php
+++ b/packages/actions/resources/lang/ja/restore.php
@@ -4,16 +4,16 @@ return [
 
     'single' => [
 
-        'label' => '復旧',
+        'label' => '復元',
 
         'modal' => [
 
-            'heading' => ':label 復旧',
+            'heading' => ':labelを復元',
 
             'actions' => [
 
                 'restore' => [
-                    'label' => '復旧',
+                    'label' => '復元',
                 ],
 
             ],
@@ -23,7 +23,7 @@ return [
         'notifications' => [
 
             'restored' => [
-                'title' => '復旧しました',
+                'title' => '復元しました',
             ],
 
         ],
@@ -32,16 +32,16 @@ return [
 
     'multiple' => [
 
-        'label' => '選択中を復旧',
+        'label' => '選択中を復元',
 
         'modal' => [
 
-            'heading' => '選択中の:labelを復旧',
+            'heading' => '選択中の::labelを復元',
 
             'actions' => [
 
                 'restore' => [
-                    'label' => '復旧',
+                    'label' => '復元',
                 ],
 
             ],


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Improve Japanese translations for force delete and restore actions

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
