### PR TITLE
fix: prevent native select from showing the wrong dynamic option

### DIFF
--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -8,6 +8,7 @@
     $isReorderable = $isReorderable();
     $isSearchable = $isSearchable();
     $hasInitialNoOptionsMessage = $hasInitialNoOptionsMessage();
+    $hasDynamicOptions = $hasDynamicOptions();
     $canOptionLabelsWrap = $canOptionLabelsWrap();
     $isRequired = $isRequired();
     $isConcealed = $isConcealed();
@@ -59,6 +60,10 @@
         "
     >
         @if ($isNative)
+            @php
+                $options = $getOptions();
+            @endphp
+
             <select
                 {{
                     $extraInputAttributeBag
@@ -67,6 +72,7 @@
                             'disabled' => $isDisabled,
                             'id' => $id,
                             'required' => $isRequired && (! $isConcealed),
+                            'wire:key' => $hasDynamicOptions ? ($livewireKey . '.' . substr(md5(serialize($options)), 0, 64)) : null,
                             $applyStateBindingModifiers('wire:model') => $statePath,
                         ], escape: false)
                         ->class([
@@ -83,7 +89,7 @@
                     </option>
                 @endif
 
-                @foreach ($getOptions() as $value => $label)
+                @foreach ($options as $value => $label)
                     @if (is_array($label))
                         <optgroup label="{{ $value }}">
                             @foreach ($label as $groupedValue => $groupedLabel)
@@ -156,7 +162,7 @@
                                     { search },
                                 )
                             },
-                            hasDynamicOptions: @js($hasDynamicOptions()),
+                            hasDynamicOptions: @js($hasDynamicOptions),
                             hasDynamicSearchResults: @js($hasDynamicSearchResults()),
                             hasInitialNoOptionsMessage: @js($hasInitialNoOptionsMessage),
                             initialOptionLabel: @js((blank($state) || $isMultiple) ? null : $getOptionLabel()),

--- a/tests/src/Fixtures/Pages/SelectTest.php
+++ b/tests/src/Fixtures/Pages/SelectTest.php
@@ -5,6 +5,7 @@ namespace Filament\Tests\Fixtures\Pages;
 use BackedEnum;
 use Filament\Forms\Components\Select;
 use Filament\Pages\Page;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 
@@ -135,6 +136,28 @@ class SelectTest extends Page
                     ])
                     ->native(false)
                     ->extraAttributes(['data-testid' => 'clearable-with-placeholder-select']),
+
+                Select::make('native_dynamic_options_context')
+                    ->label('Native Dynamic Options Context')
+                    ->live()
+                    ->options([
+                        'first' => 'First context',
+                        'second' => 'Second context',
+                    ])
+                    ->extraInputAttributes(['data-testid' => 'native-dynamic-options-context-select']),
+
+                Select::make('native_dynamic_options_value')
+                    ->label('Native Dynamic Options Value')
+                    ->options(fn (Get $get): array => match ($get('native_dynamic_options_context')) {
+                        'first' => [
+                            'first_only' => 'First only',
+                        ],
+                        'second' => [
+                            'second_only' => 'Second only',
+                        ],
+                        default => [],
+                    })
+                    ->extraInputAttributes(['data-testid' => 'native-dynamic-options-value-select']),
             ])
             ->statePath('data');
     }

--- a/tests/src/Forms/Components/SelectTest.php
+++ b/tests/src/Forms/Components/SelectTest.php
@@ -1651,6 +1651,22 @@ describe('browser interactions', function (): void {
                 ->assertNoSmoke();
         });
     });
+
+    it('leaves a native `Select` unselected after its selected option is removed in the browser', function (): void {
+        retry(10, function (): void {
+            $this->actingAs(User::factory()->create());
+
+            visit('/select-test')
+                ->select('[data-testid="native-dynamic-options-context-select"]', 'first')
+                ->waitForEvent('networkidle')
+                ->select('[data-testid="native-dynamic-options-value-select"]', 'first_only')
+                ->assertValue('[data-testid="native-dynamic-options-value-select"]', 'first_only')
+                ->select('[data-testid="native-dynamic-options-context-select"]', 'second')
+                ->waitForEvent('networkidle')
+                ->assertValue('[data-testid="native-dynamic-options-value-select"]', '')
+                ->assertNoSmoke();
+        });
+    });
 });
 
 describe('option labels', function (): void {

--- a/tests/src/Forms/Components/SelectTest.php
+++ b/tests/src/Forms/Components/SelectTest.php
@@ -1652,7 +1652,7 @@ describe('browser interactions', function (): void {
         });
     });
 
-    it('leaves a native `Select` unselected after its selected option is removed in the browser', function (): void {
+    it('does not show another native `Select` option for a missing value in the browser', function (): void {
         retry(10, function (): void {
             $this->actingAs(User::factory()->create());
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

### Fixes: #19856

  Native `Select` fields with dynamic `options()` can keep a stale selected option when their option list changes.

  This adds a dynamic `wire:key` to the native select input so it is remounted when the resolved options change.

  This does not change the field state when the current value is no longer present in the resolved options. It only prevents the native select from visually selecting a different option after Livewire morphs the option list.

  Static option lists keep the existing markup unchanged.

## Visual changes

### Before


https://github.com/user-attachments/assets/c03404c2-5655-4edb-9b54-742d210ec453




### After


https://github.com/user-attachments/assets/fd6872b7-9189-4c2f-b204-7b28e52933c6





## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
