### PR TITLE
Update the column name typo for ternary filter example in documentation

### DIFF
--- a/packages/tables/docs/03-filters/03-ternary.md
+++ b/packages/tables/docs/03-filters/03-ternary.md
@@ -5,12 +5,12 @@ import AutoScreenshot from "@components/AutoScreenshot.astro"
 
 ## Introduction
 
-Ternary filters allow you to easily create a select filter which has three states - usually true, false and blank. To filter a column named `is_admin` to be `true` or `false`, you may use the ternary filter:
+Ternary filters allow you to easily create a select filter which has three states - usually true, false and blank. To filter a column named `is_featured` to be `true` or `false`, you may use the ternary filter:
 
 ```php
 use Filament\Tables\Filters\TernaryFilter;
 
-TernaryFilter::make('is_admin')
+TernaryFilter::make('is_featured')
 ```
 
 <AutoScreenshot name="tables/filters/ternary" alt="Ternary filter" version="4.x" />


### PR DESCRIPTION
## Description
Update column name typo to match the screenshot from `is_admin` to `is_featured`.