### PR TITLE
fix: support Closure in `Builder::blockPickerColumns()`

### DIFF
--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -93,7 +93,7 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
     protected bool | Closure $isBlockLabelTruncated = true;
 
     /**
-     * @var array<string, ?int> | null
+     * @var array<string | int, int | Closure | null> | null
      */
     protected ?array $blockPickerColumns = [];
 
@@ -1062,10 +1062,16 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
     }
 
     /**
-     * @param  array<string, ?int> | int | null  $columns
+     * @param  array<string, int | Closure | null> | int | Closure | null  $columns
      */
-    public function blockPickerColumns(array | int | null $columns = 2): static
+    public function blockPickerColumns(array | int | Closure | null $columns = 2): static
     {
+        if ($columns instanceof Closure) {
+            $this->blockPickerColumns[] = $columns;
+
+            return $this;
+        }
+
         if (! is_array($columns)) {
             $columns = [
                 'lg' => $columns,
@@ -1093,6 +1099,37 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
             'xl' => null,
             '2xl' => null,
         ];
+
+        foreach ($this->blockPickerColumns ?? [] as $columnBreakpoint => $column) {
+            $column = $this->evaluate($column);
+
+            if (is_array($column)) {
+                $columns = [
+                    ...$columns,
+                    ...$column,
+                ];
+
+                unset($columns[$columnBreakpoint]);
+
+                continue;
+            }
+
+            if (blank($columnBreakpoint)) {
+                unset($columns[$columnBreakpoint]);
+
+                continue;
+            }
+
+            if (! is_string($columnBreakpoint)) {
+                $columns['lg'] = $column;
+
+                unset($columns[$columnBreakpoint]);
+
+                continue;
+            }
+
+            $columns[$columnBreakpoint] = $column;
+        }
 
         if ($breakpoint !== null) {
             return $columns[$breakpoint] ?? null;

--- a/tests/src/Forms/Components/BuilderTest.php
+++ b/tests/src/Forms/Components/BuilderTest.php
@@ -728,6 +728,13 @@ it('can set `blockPickerColumns()` with responsive breakpoints', function (): vo
     expect($builder->getBlockPickerColumns('xl'))->toBeNull();
 });
 
+it('can set `blockPickerColumns()` with a `Closure`', function (): void {
+    $builder = Builder::make('content')
+        ->blockPickerColumns(static fn (): int => 2);
+
+    expect($builder->getBlockPickerColumns('lg'))->toBe(2);
+});
+
 it('can set `addActionLabel()` with a `Closure`', function (): void {
     $builder = Builder::make('content')
         ->addActionLabel(static fn (): string => 'Add custom block');


### PR DESCRIPTION

## Description
### Fixes: #19879
`Builder::blockPickerColumns()` currently only accepts static column values, even though it follows the same responsive column configuration pattern as other APIs.

This updates it to accept closures and resolve them consistently with those APIs.

## Visual changes


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
