### PR TITLE
Improve Str::sanitizeUrl to reject malformed javascript URLs

### DIFF
--- a/docs/09-advanced/06-security.md
+++ b/docs/09-advanced/06-security.md
@@ -67,7 +67,7 @@ Many Filament configuration methods accept closures that can return dynamic valu
 
 For example, the `url()` method on columns, entries, and actions renders an `<a href="...">` tag with whatever value you provide. If you pass a URL sourced from user input without validation, a malicious value like `javascript:alert(document.cookie)` could be rendered as a clickable link, leading to XSS. Always validate that URLs use a safe scheme such as `http` or `https` before passing them to Filament.
 
-Filament ships a `Str::sanitizeUrl()` helper that returns the URL when it is schemeless (relative) or uses the `http`/`https` scheme, and returns `null` for anything else. It also normalizes obfuscation tricks such as leading whitespace, embedded control characters (`\t`, `\n`, `\r`, NUL bytes), and mixed-case schemes before checking — so values like `"\tJaVa\nScRiPt:alert(1)"` are rejected, and even on a safe URL the return value has those bytes stripped so they cannot reach the rendered HTML:
+Filament ships a `Str::sanitizeUrl()` helper that returns the URL when it is schemeless (relative) or uses the `http`/`https` scheme, and returns `null` for anything else. Before checking the scheme, it accounts for the obfuscation tricks that browsers silently undo when parsing an `href` value — HTML entity references (numeric like `&#9;`/`&#x09;` and named like `&Tab;`/`&NewLine;`/`&colon;`), percent-encoded control characters (`%09`, `%0A`), embedded raw control characters and whitespace (`\t`, `\n`, `\r`, NUL bytes), and mixed-case schemes — so values like `"\tJaVa\nScRiPt:alert(1)"` or `"java&#x09;script:alert(1)"` are rejected. The return value is the original input unchanged when it passes the check; the helper never rewrites a URL.
 
 ```php
 use Filament\Tables\Columns\TextColumn;
@@ -93,7 +93,7 @@ TextColumn::make('contact')
 
 - check that the host belongs to a domain you control (open-redirect protection),
 - check that the URL is safe for the server to fetch (SSRF protection),
-- decode percent-encoded or HTML-entity-encoded payloads (the browser's URL parser doesn't either, so this is intentional, but it means callers that decode the value before rendering need their own check on the decoded form),
+- guarantee safety for non-standard rendering contexts — the safety analysis assumes the URL will be placed in an HTML attribute like `href`, where the browser performs a single HTML-entity decode and strips whitespace/control characters before parsing the scheme. If your code applies additional transformations to the return value before rendering (for example, calling `urldecode()` and then setting `location.href`), apply your own scheme check to the transformed value,
 - validate that an `http(s)` URL is reachable or trusted in any other way.
 
 If you need any of those guarantees, layer your own check on top of the helper's return value.

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -335,8 +335,8 @@ class SupportServiceProvider extends PackageServiceProvider
 
             // PHP's html_entity_decode() with ENT_HTML5 replaces control character entities with U+FFFD.
             // We manually decode ASCII numeric entities first so we can properly detect them.
-            $htmlDecoded = preg_replace_callback('/&#(?:x([0-9a-f]+)|([0-9]+));?/i', function (array $match) {
-                $code = (isset($match[1]) && $match[1] !== '') ? hexdec($match[1]) : (int) $match[2];
+            $htmlDecoded = preg_replace_callback('/&#(?:x([0-9a-f]+)|([0-9]+));?/i', function (array $match): string {
+                $code = ($match[1] !== '') ? hexdec($match[1]) : (int) $match[2];
 
                 // We only need to manually decode ASCII characters for control character checks.
                 return ($code >= 0 && $code <= 127) ? chr((int) $code) : $match[0];
@@ -351,7 +351,7 @@ class SupportServiceProvider extends PackageServiceProvider
             }
 
             // Decode URL encoding to unmask encoded control characters
-            $urlDecoded = urldecode($htmlDecoded);
+            $urlDecoded = rawurldecode($htmlDecoded);
 
             // Reject URLs containing control characters after URL decoding (excluding space)
             if (preg_match('/[\x00-\x1F\x7F]/', $urlDecoded)) {

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -327,18 +327,45 @@ class SupportServiceProvider extends PackageServiceProvider
                 return null;
             }
 
-            // Reject whitespace and control characters instead of stripping
-            // them: browsers ignore those bytes when parsing URLs, so an
-            // input like "\tjavascript:..." would resolve to a scheme the
-            // visible string does not suggest.
-            if (preg_match('/[\s\x00-\x1F\x7F]/', $url)) {
+            // Reject URLs containing raw control characters or spaces
+            // (Legitimate URLs must percent-encode spaces and should not contain raw control characters)
+            if (preg_match('/[\x00-\x20\x7F]/', $url)) {
                 return null;
             }
 
-            if (preg_match('#^([a-z][a-z0-9+\-.]*):#i', $url, $matches)) {
-                $allowedSchemes = array_map(strtolower(...), $allowedSchemes);
+            // PHP's html_entity_decode() with ENT_HTML5 replaces control character entities with U+FFFD.
+            // We manually decode ASCII numeric entities first so we can properly detect them.
+            $htmlDecoded = preg_replace_callback('/&#(?:x([0-9a-f]+)|([0-9]+));?/i', function (array $match) {
+                $code = (isset($match[1]) && $match[1] !== '') ? hexdec($match[1]) : (int) $match[2];
 
-                if (! in_array(strtolower($matches[1]), $allowedSchemes, strict: true)) {
+                // We only need to manually decode ASCII characters for control character checks.
+                return ($code >= 0 && $code <= 127) ? chr((int) $code) : $match[0];
+            }, $url);
+
+            // Decode named HTML entities
+            $htmlDecoded = html_entity_decode($htmlDecoded, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+            // Reject URLs containing control characters after HTML decoding (excluding space, which is \x20)
+            if (preg_match('/[\x00-\x1F\x7F]/', $htmlDecoded)) {
+                return null;
+            }
+
+            // Decode URL encoding to unmask encoded control characters
+            $urlDecoded = urldecode($htmlDecoded);
+
+            // Reject URLs containing control characters after URL decoding (excluding space)
+            if (preg_match('/[\x00-\x1F\x7F]/', $urlDecoded)) {
+                return null;
+            }
+
+            // Extract the scheme and check against the allowed list.
+            // We parse the scheme from the HTML-decoded string, NOT the URL-decoded string,
+            // to match browser behavior (avoiding naive execution of percent-encoded schemes).
+            if (preg_match('/^([a-zA-Z][a-zA-Z0-9\+\-\.]*):/', $htmlDecoded, $matches)) {
+                $scheme = strtolower($matches[1]);
+                $allowed = array_map('strtolower', $allowedSchemes);
+
+                if (! in_array($scheme, $allowed, true)) {
                     return null;
                 }
             }

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -327,47 +327,44 @@ class SupportServiceProvider extends PackageServiceProvider
                 return null;
             }
 
-            // Reject URLs containing raw control characters or spaces
-            // (Legitimate URLs must percent-encode spaces and should not contain raw control characters)
+            // Reject URLs containing raw whitespace or control characters. Legitimate URLs
+            // percent-encode these; a raw byte here is either a typo or an obfuscation attempt.
             if (preg_match('/[\x00-\x20\x7F]/', $url)) {
                 return null;
             }
 
-            // PHP's html_entity_decode() with ENT_HTML5 replaces control character entities with U+FFFD.
-            // We manually decode ASCII numeric entities first so we can properly detect them.
-            $htmlDecoded = preg_replace_callback('/&#(?:x([0-9a-f]+)|([0-9]+));?/i', function (array $match): string {
-                $code = ($match[1] !== '') ? hexdec($match[1]) : (int) $match[2];
+            // Predict the scheme the browser will see after HTML-decoding the attribute value.
+            // We pre-decode ASCII numeric entities ourselves because `html_entity_decode(ENT_HTML5)`
+            // replaces "forbidden" C0 control character entities (e.g. `&#0;`) with U+FFFD, which
+            // would mask them from the control-character strip below.
+            $decoded = preg_replace_callback(
+                '/&#(?:x([0-9a-f]+)|([0-9]+));?/i',
+                function (array $match): string {
+                    $code = ($match[1] !== '') ? hexdec($match[1]) : (int) $match[2];
 
-                // We only need to manually decode ASCII characters for control character checks.
-                return ($code >= 0 && $code <= 127) ? chr((int) $code) : $match[0];
-            }, $url);
+                    return ($code <= 127) ? chr((int) $code) : $match[0];
+                },
+                $url,
+            );
+            $decoded = html_entity_decode($decoded, ENT_QUOTES | ENT_HTML5, 'UTF-8');
 
-            // Decode named HTML entities
-            $htmlDecoded = html_entity_decode($htmlDecoded, ENT_QUOTES | ENT_HTML5, 'UTF-8');
-
-            // Reject URLs containing control characters after HTML decoding (excluding space, which is \x20)
-            if (preg_match('/[\x00-\x1F\x7F]/', $htmlDecoded)) {
+            // Reject if either the HTML-decoded form or its percent-decoded form contains
+            // control characters — catches `%09`-style obfuscation that would be dangerous
+            // if the URL is later decoded by other code.
+            if (
+                preg_match('/[\x00-\x1F\x7F]/', $decoded) ||
+                preg_match('/[\x00-\x1F\x7F]/', rawurldecode($decoded))
+            ) {
                 return null;
             }
 
-            // Decode URL encoding to unmask encoded control characters
-            $urlDecoded = rawurldecode($htmlDecoded);
-
-            // Reject URLs containing control characters after URL decoding (excluding space)
-            if (preg_match('/[\x00-\x1F\x7F]/', $urlDecoded)) {
+            // Scheme check uses the HTML-decoded form only — the browser does NOT percent-decode
+            // the scheme, so a `%6A` literally in the scheme position is not dangerous.
+            if (
+                preg_match('/^([a-z][a-z0-9+\-.]*):/i', $decoded, $matches) &&
+                (! in_array(strtolower($matches[1]), array_map(strtolower(...), $allowedSchemes), strict: true))
+            ) {
                 return null;
-            }
-
-            // Extract the scheme and check against the allowed list.
-            // We parse the scheme from the HTML-decoded string, NOT the URL-decoded string,
-            // to match browser behavior (avoiding naive execution of percent-encoded schemes).
-            if (preg_match('/^([a-zA-Z][a-zA-Z0-9\+\-\.]*):/', $htmlDecoded, $matches)) {
-                $scheme = strtolower($matches[1]);
-                $allowed = array_map('strtolower', $allowedSchemes);
-
-                if (! in_array($scheme, $allowed, true)) {
-                    return null;
-                }
             }
 
             return $url;

--- a/tests/src/Support/UrlSanitizerTest.php
+++ b/tests/src/Support/UrlSanitizerTest.php
@@ -192,6 +192,26 @@ it('rejects URLs containing HTML5 named character entities for control character
     expect(Str::sanitizeUrl('java&NewLine;script:alert(1)'))->toBeNull();
 });
 
+it('passes legitimate URLs with multiple query parameters through unchanged', function (): void {
+    expect(Str::sanitizeUrl('https://example.com/?a=1&b=2'))->toBe('https://example.com/?a=1&b=2');
+    expect(Str::sanitizeUrl('https://example.com/search?q=hello&page=2&sort=desc'))
+        ->toBe('https://example.com/search?q=hello&page=2&sort=desc');
+});
+
+it('passes legitimate URLs containing escaped ampersand entities through unchanged', function (): void {
+    expect(Str::sanitizeUrl('https://example.com/?a=1&amp;b=2'))->toBe('https://example.com/?a=1&amp;b=2');
+});
+
+it('passes URLs whose query string literally contains the text `javascript:` through unchanged', function (): void {
+    expect(Str::sanitizeUrl('https://example.com/?q=javascript%3Aalert(1)'))
+        ->toBe('https://example.com/?q=javascript%3Aalert(1)');
+});
+
+it('does not recursively decode double-encoded entities — single decode matches browser behaviour', function (): void {
+    expect(Str::sanitizeUrl('https://example.com/?q=java&amp;#9;script:1'))
+        ->toBe('https://example.com/?q=java&amp;#9;script:1');
+});
+
 it('rejects `javascript:` with whitespace before the colon', function (): void {
     expect(Str::sanitizeUrl('javascript :alert(1)'))->toBeNull()
         ->and(Str::sanitizeUrl("javascript\t:alert(1)"))->toBeNull();

--- a/tests/src/Support/UrlSanitizerTest.php
+++ b/tests/src/Support/UrlSanitizerTest.php
@@ -163,6 +163,35 @@ it('rejects `javascript:` with `\x7F` DEL inside the scheme', function (): void 
     expect(Str::sanitizeUrl("javascript\x7F:alert(1)"))->toBeNull();
 });
 
+it('rejects URLs containing whitespace after HTML entity decoding', function (): void {
+    expect(Str::sanitizeUrl('java&#x09;script:alert(1)'))->toBeNull();
+    expect(Str::sanitizeUrl('java&#10;script:alert(1)'))->toBeNull();
+    expect(Str::sanitizeUrl('java&#13;script:alert(1)'))->toBeNull();
+});
+
+it('rejects URLs containing encoded control characters', function (): void {
+    expect(Str::sanitizeUrl('java%09script:alert(1)'))->toBeNull();
+    expect(Str::sanitizeUrl('java%0Ascript:alert(1)'))->toBeNull();
+});
+
+it('rejects URLs containing raw control characters', function (): void {
+    expect(Str::sanitizeUrl("javascript\x7F:alert(1)"))->toBeNull();
+});
+
+it('rejects URLs containing HTML entity encoded separators', function (): void {
+    expect(Str::sanitizeUrl('javascript&colon;alert(1)'))->toBeNull();
+    expect(Str::sanitizeUrl('javascript&#58;alert(1)'))->toBeNull();
+});
+
+it('rejects URLs containing control characters after HTML entity decoding', function (): void {
+    expect(Str::sanitizeUrl('javascript&#x7F;:alert(1)'))->toBeNull();
+});
+
+it('rejects URLs containing HTML5 named character entities for control characters', function (): void {
+    expect(Str::sanitizeUrl('java&Tab;script:alert(1)'))->toBeNull();
+    expect(Str::sanitizeUrl('java&NewLine;script:alert(1)'))->toBeNull();
+});
+
 it('rejects `javascript:` with whitespace before the colon', function (): void {
     expect(Str::sanitizeUrl('javascript :alert(1)'))->toBeNull()
         ->and(Str::sanitizeUrl("javascript\t:alert(1)"))->toBeNull();

--- a/tests/src/Support/UrlSanitizerTest.php
+++ b/tests/src/Support/UrlSanitizerTest.php
@@ -212,6 +212,75 @@ it('does not recursively decode double-encoded entities — single decode matche
         ->toBe('https://example.com/?q=java&amp;#9;script:1');
 });
 
+it('rejects schemes assembled entirely from numeric HTML entities', function (): void {
+    // &#106; is `j`, &#x61; is `a`, etc. Defends against an attacker
+    // disguising the whole scheme name in entities so it doesn't read as
+    // "javascript" in the raw source.
+    expect(Str::sanitizeUrl('&#106;&#x61;v&#97;script:alert(1)'))->toBeNull();
+});
+
+it('rejects schemes assembled from mixed entity and percent encoding', function (): void {
+    // `java&#9;script%3Aalert(1)` — entity decodes to TAB (control-char
+    // rejection); percent-encoded colon is irrelevant because the TAB
+    // rejection fires first.
+    expect(Str::sanitizeUrl('java&#9;script%3Aalert(1)'))->toBeNull();
+});
+
+it('rejects NULL byte hidden in a numeric entity', function (): void {
+    // &#0; decodes to NUL via the manual pre-decode (html_entity_decode
+    // would otherwise replace it with U+FFFD and hide the attack).
+    expect(Str::sanitizeUrl('java&#0;script:alert(1)'))->toBeNull();
+    expect(Str::sanitizeUrl('java&#x00;script:alert(1)'))->toBeNull();
+});
+
+it('does not decode named HTML entities that require a trailing semicolon when the semicolon is missing', function (): void {
+    // `&Tab` without trailing `;` is not a valid HTML5 entity (only legacy
+    // entities like `&amp` decode without the semicolon). Both the browser
+    // and `html_entity_decode(ENT_HTML5)` leave it as literal text, so the
+    // URL passes through. We document the behaviour either way.
+    $result = Str::sanitizeUrl('https://example.com/?q=&Tab');
+    expect($result)->toBe('https://example.com/?q=&Tab');
+});
+
+it('rejects schemes containing `+` that are not on the allowlist', function (): void {
+    // RFC 3986 allows `+` in schemes (e.g. `coap+tcp`, `git+ssh`). Make sure
+    // unusual but valid-looking schemes are still gated by the allowlist.
+    expect(Str::sanitizeUrl('git+ssh://example.com/repo.git'))->toBeNull();
+    expect(Str::sanitizeUrl('coap+tcp://example.com/'))->toBeNull();
+});
+
+it('passes through URLs whose path or fragment legitimately contains a literal `:`', function (): void {
+    // A `:` inside a path segment isn't a scheme delimiter — only the
+    // first `:` matters, and our regex correctly anchors with `^`.
+    expect(Str::sanitizeUrl('https://example.com/path:with:colons'))
+        ->toBe('https://example.com/path:with:colons');
+    expect(Str::sanitizeUrl('https://example.com/#section:1'))
+        ->toBe('https://example.com/#section:1');
+});
+
+it('handles URLs that consist of only a scheme and colon, with no body', function (): void {
+    expect(Str::sanitizeUrl('https:'))->toBe('https:');
+    expect(Str::sanitizeUrl('javascript:'))->toBeNull();
+});
+
+it('returns `null` when the allowlist is empty and the URL has an absolute scheme', function (): void {
+    expect(Str::sanitizeUrl('https://example.com', []))->toBeNull();
+    expect(Str::sanitizeUrl('http://example.com', []))->toBeNull();
+});
+
+it('does not catastrophically backtrack on long pathological inputs', function (): void {
+    // Sanity check against accidental ReDoS: a long URL of just allowed
+    // scheme characters should complete in well under a millisecond.
+    $long = 'https://example.com/' . str_repeat('a', 10000);
+
+    $start = hrtime(true);
+    $result = Str::sanitizeUrl($long);
+    $elapsedMs = (hrtime(true) - $start) / 1_000_000;
+
+    expect($result)->toBe($long);
+    expect($elapsedMs)->toBeLessThan(50.0);
+});
+
 it('rejects `javascript:` with whitespace before the colon', function (): void {
     expect(Str::sanitizeUrl('javascript :alert(1)'))->toBeNull()
         ->and(Str::sanitizeUrl("javascript\t:alert(1)"))->toBeNull();


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR enhances `Str::sanitizeUrl()` to detect and reject various advanced XSS obfuscation and bypass techniques. Specifically, it ensures that potentially malicious `javascript:` URLs are properly neutralized (`return null`) even when attackers attempt to hide them using HTML entities, URL encoding, hidden control characters, or alternative separators.

## Visual changes

No changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
