### PR TITLE
fix(select): correct dropdown position in nested modals

### DIFF
--- a/packages/support/resources/js/utilities/select.js
+++ b/packages/support/resources/js/utilities/select.js
@@ -1362,17 +1362,35 @@ export class Select {
         return false
     }
 
+    usesFixedDropdownPositioning() {
+        const fixedPositioningContext = this.selectButton.closest(
+            '.fi-fixed-positioning-context',
+        )
+        const absolutePositioningContext = this.selectButton.closest(
+            '.fi-absolute-positioning-context',
+        )
+
+        if (
+            fixedPositioningContext !== null &&
+            absolutePositioningContext === null
+        ) {
+            return true
+        }
+
+        const modal = this.selectButton.closest('.fi-modal')
+
+        return (
+            modal !== null &&
+            (modal.parentElement?.closest('.fi-modal') ?? null) !== null
+        )
+    }
+
     async openDropdown() {
         // Make dropdown visible but with position absolute by default, or fixed in containers with .fi-fixed-positioning-context class, and opacity 0 for measurement
         this.dropdown.style.display = 'block'
         this.dropdown.style.opacity = '0'
 
-        // Check if the select is inside a container that opts in to fixed positioning
-        const useFixedPositioning =
-            this.selectButton.closest('.fi-fixed-positioning-context') !==
-                null &&
-            this.selectButton.closest('.fi-absolute-positioning-context') ===
-                null
+        const useFixedPositioning = this.usesFixedDropdownPositioning()
         this.dropdown.style.position = useFixedPositioning
             ? 'fixed'
             : 'absolute'
@@ -1530,12 +1548,7 @@ export class Select {
             middleware.push(flip()) // Flip to top if not enough space at bottom
         }
 
-        // Check if the select is inside a container that opts in to fixed positioning
-        const useFixedPositioning =
-            this.selectButton.closest('.fi-fixed-positioning-context') !==
-                null &&
-            this.selectButton.closest('.fi-absolute-positioning-context') ===
-                null
+        const useFixedPositioning = this.usesFixedDropdownPositioning()
 
         computePosition(this.selectButton, this.dropdown, {
             placement: placement,


### PR DESCRIPTION
Fix incorrect dropdown positioning for Select component when used inside nested Filament modals.

1. Problem
Dropdown position breaks in nested modal scenarios due to absolute positioning context inherited from parent modal.

2. Solution
- Introduce usesFixedDropdownPositioning() helper
- Detect nested modal structure
- Force fixed positioning when Select is inside nested modals
- Ensure Floating UI strategy and DOM positioning are consistent

3. Impact
- No changes to normal Select usage
- No changes to modal behavior in single-level modals
- Only affects Select inside nested modals