### PR TITLE
include `RestrictsFileUploadsToSchemaComponents` to components example

### DIFF
--- a/docs/12-components/02-action.md
+++ b/docs/12-components/02-action.md
@@ -41,6 +41,7 @@ You must use the `InteractsWithActions` and `InteractsWithSchemas` traits, and i
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Concerns\RestrictsFileUploadsToSchemaComponents;
 use Filament\Schemas\Contracts\HasSchemas;
 use Livewire\Component;
 
@@ -48,6 +49,7 @@ class ManagePost extends Component implements HasActions, HasSchemas
 {
     use InteractsWithActions;
     use InteractsWithSchemas;
+    use RestrictsFileUploadsToSchemaComponents;
 
     // ...
 }
@@ -63,6 +65,7 @@ use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Concerns\RestrictsFileUploadsToSchemaComponents;
 use Filament\Schemas\Contracts\HasSchemas;
 use Livewire\Component;
 
@@ -70,6 +73,7 @@ class ManagePost extends Component implements HasActions, HasSchemas
 {
     use InteractsWithActions;
     use InteractsWithSchemas;
+    use RestrictsFileUploadsToSchemaComponents;
 
     public Post $post;
 

--- a/docs/12-components/02-form.md
+++ b/docs/12-components/02-form.md
@@ -57,6 +57,7 @@ namespace App\Livewire;
 use Filament\Forms\Components\MarkdownEditor;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Concerns\RestrictsFileUploadsToSchemaComponents;
 use Filament\Schemas\Contracts\HasSchemas;
 use Illuminate\Contracts\View\View;
 use Filament\Schemas\Schema;
@@ -65,6 +66,7 @@ use Livewire\Component;
 class CreatePost extends Component implements HasSchemas
 {
     use InteractsWithSchemas;
+    use RestrictsFileUploadsToSchemaComponents;
     
     public ?array $data = [];
     

--- a/docs/12-components/02-infolist.md
+++ b/docs/12-components/02-infolist.md
@@ -39,12 +39,14 @@ You must use the `InteractsWithSchemas` trait, and implement the `HasSchemas` in
 
 ```php
 use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Concerns\RestrictsFileUploadsToSchemaComponents;
 use Filament\Schemas\Contracts\HasSchemas;
 use Livewire\Component;
 
 class ViewProduct extends Component implements HasSchemas
 {
     use InteractsWithSchemas;
+    use RestrictsFileUploadsToSchemaComponents;
 
     // ...
 }

--- a/docs/12-components/02-schema.md
+++ b/docs/12-components/02-schema.md
@@ -39,12 +39,14 @@ You must use the `InteractsWithSchemas` trait, and implement the `HasSchemas` in
 
 ```php
 use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Concerns\RestrictsFileUploadsToSchemaComponents;
 use Filament\Schemas\Contracts\HasSchemas;
 use Livewire\Component;
 
 class ViewProduct extends Component implements HasSchemas
 {
     use InteractsWithSchemas;
+    use RestrictsFileUploadsToSchemaComponents;
 
     // ...
 }

--- a/docs/12-components/02-table.md
+++ b/docs/12-components/02-table.md
@@ -52,6 +52,7 @@ use App\Models\Shop\Product;
 use Filament\Actions\Concerns\InteractsWithActions;  
 use Filament\Actions\Contracts\HasActions;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Concerns\RestrictsFileUploadsToSchemaComponents;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
@@ -65,6 +66,7 @@ class ListProducts extends Component implements HasActions, HasSchemas, HasTable
     use InteractsWithActions;
     use InteractsWithSchemas;
     use InteractsWithTable;
+    use RestrictsFileUploadsToSchemaComponents;
     
     public function table(Table $table): Table
     {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Include recent changes for [security about file uploads](https://github.com/filamentphp/filament/pull/19886) on Components example.

Why: when I create [custom pages](https://filamentphp.com/docs/5.x/navigation/custom-pages#creating-a-page), after it generated I go and check components docs and copy paste what I want to display on that page, so copying `RestrictsFileUploadsToSchemaComponents` traits will make it more secure

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
