### PR TITLE
Add Bash, Kotlin, Ruby, and Rust to Language enum

### DIFF
--- a/packages/forms/src/Components/CodeEditor/Enums/Language.php
+++ b/packages/forms/src/Components/CodeEditor/Enums/Language.php
@@ -4,6 +4,8 @@ namespace Filament\Forms\Components\CodeEditor\Enums;
 
 enum Language: string
 {
+    case Bash = 'bash';
+
     case Cpp = 'cpp';
 
     case Css = 'css';
@@ -18,11 +20,17 @@ enum Language: string
 
     case Json = 'json';
 
+    case Kotlin = 'kotlin';
+
     case Markdown = 'markdown';
 
     case Php = 'php';
 
     case Python = 'python';
+
+    case Ruby = 'ruby';
+
+    case Rust = 'rust';
 
     case Sql = 'sql';
 


### PR DESCRIPTION
## Description

This PR extends the existing Language enum (defined as string) by adding support for additional programming languages: Bash, Kotlin, Ruby, and Rust.

These languages were missing from the enum, which caused limitations when tagging or categorizing content such as blog articles and code examples. For example, Bash-related articles could not be properly labeled due to the absence of a corresponding enum value.

This change ensures more accurate classification and better coverage of commonly used programming languages.
## Visual changes

No UI changes are introduced by this update.

## Functional changes

- [x] New languages added to the Language enum: Bash, Kotlin, Ruby, Rust
- [ ] Code style has been fixed by running the composer cs command
- [x] Changes have been tested to not break existing functionality
