### PR TITLE
Restrict ImportCsv $rows unserialize via allowed_classes => false

### DIFF
--- a/packages/actions/src/Imports/Jobs/ImportCsv.php
+++ b/packages/actions/src/Imports/Jobs/ImportCsv.php
@@ -77,7 +77,7 @@ class ImportCsv implements ShouldQueue
             $processedRows = 0;
             $successfulRows = 0;
 
-            $rows = is_array($this->rows) ? $this->rows : unserialize(base64_decode($this->rows));
+            $rows = is_array($this->rows) ? $this->rows : unserialize(base64_decode($this->rows), ['allowed_classes' => false]);
 
             DB::transaction(function () use (&$processedRows, $rows, &$successfulRows): void {
                 foreach ($rows as $row) {


### PR DESCRIPTION
## Summary

One-line defense-in-depth fix for `Filament\Actions\Imports\Jobs\ImportCsv::handle()` — adds `['allowed_classes' => false]` to the inner `unserialize` call on `$this->rows`.

`$rows` is documented as `array<array<string, string>>` (primitives only — the row content of a parsed CSV chunk). The legitimate data path returns the same arrays. Any would-be class instantiation from a tampered payload becomes a `__PHP_Incomplete_Class` whose destructor is inert.

## Context

Per Dan's response on GHSA-j9ff-qgcx-g445: the Laravel queue layer already calls `unserialize()` on the outer job command field without `allowed_classes` (`Illuminate\Queue\CallQueuedHandler::call`), so an attacker with queue-store write access lands a destructor gadget at the framework level before this Filament code path ever runs. The plugin-level finding is downstream-of-already-RCE-able-layer and not CVE-warranting.

This PR is the zero-cost hardening Dan acknowledged would be acceptable — defense-in-depth that costs nothing if the framework one day adds queue payload signing or the threat model otherwise tightens.

## Test plan

- [ ] CSV import flow still works end-to-end (legitimate `array<string, string>` rows round-trip unchanged)
- [ ] Existing test suite green

The `allowed_classes => false` flag only affects how PHP handles object instantiation during deserialization; serialized arrays and primitives deserialize identically.

## Refs

- Advisory: https://github.com/filamentphp/filament/security/advisories/GHSA-j9ff-qgcx-g445