### PR TITLE
Fix: skip relationship query when Repeater has no parent model

### DIFF
--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1183,7 +1183,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         }
 
         if (! $this->getModelInstance()?->exists) {
-            return new Collection;
+            return $this->cachedExistingRecords = new Collection;
         }
 
         $relationship = $this->getRelationship();

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1182,6 +1182,10 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
             return $this->cachedExistingRecords;
         }
 
+        if (! $this->getModelInstance()?->exists) {
+            return new Collection;
+        }
+
         $relationship = $this->getRelationship();
         $relatedKeyName = $relationship->getRelated()->getKeyName();
 


### PR DESCRIPTION
## Description

A `Repeater` with `->relationship()` queries the related table on a Create page even though no parent model exists yet. `getCachedExistingRecords()` does not short-circuit when there is no model, so it runs `select * from "posts" where "posts"."author_id" is null and "posts"."author_id" is not null` — one redundant query per relationship Repeater per create-page render. Fixed by short-circuiting when there is no persisted model, mirroring `EntanglesStateWithSingularRelationship` which already guards with `! $record?->exists`.

Reproduction: https://github.com/FS-Baz/filament-repeater-repro

## Visual changes

None — internal behavior only, no UI change.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.