### PR TITLE
Allow `pragmarx/google2fa-qrcode` v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^2.1",
         "pragmarx/google2fa": "^8.0|^9.0",
-        "pragmarx/google2fa-qrcode": "^3.0",
+        "pragmarx/google2fa-qrcode": "^3.0|^4.0",
         "rector/rector": "^2.0",
         "spatie/laravel-google-fonts": "^1.5",
         "spatie/laravel-medialibrary": "^11.21",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "25dae0e1d41124598412f5770865af55",
+    "content-hash": "aa17ba8099fd5b5ecef5de06cd845b8c",
     "packages": [],
     "packages-dev": [
         {
@@ -8315,27 +8315,28 @@
         },
         {
             "name": "pragmarx/google2fa-qrcode",
-            "version": "v3.0.0",
+            "version": "v4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antonioribeiro/google2fa-qrcode.git",
-                "reference": "ce4d8a729b6c93741c607cfb2217acfffb5bf76b"
+                "reference": "16159f84fa0838c276f35d46de57fd90dfbb385c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antonioribeiro/google2fa-qrcode/zipball/ce4d8a729b6c93741c607cfb2217acfffb5bf76b",
-                "reference": "ce4d8a729b6c93741c607cfb2217acfffb5bf76b",
+                "url": "https://api.github.com/repos/antonioribeiro/google2fa-qrcode/zipball/16159f84fa0838c276f35d46de57fd90dfbb385c",
+                "reference": "16159f84fa0838c276f35d46de57fd90dfbb385c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1",
-                "pragmarx/google2fa": ">=4.0"
+                "php": "^8.1",
+                "pragmarx/google2fa": "^8.0|^9.0"
             },
             "require-dev": {
-                "bacon/bacon-qr-code": "^2.0",
-                "chillerlan/php-qrcode": "^1.0|^2.0|^3.0|^4.0",
+                "bacon/bacon-qr-code": "^2.0|^3.0",
+                "chillerlan/php-qrcode": "^5.0|^6.0",
                 "khanamiryan/qrcode-detector-decoder": "^1.0",
-                "phpunit/phpunit": "~4|~5|~6|~7|~8|~9"
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "~9|~10|~11|~12|~13"
             },
             "suggest": {
                 "bacon/bacon-qr-code": "For QR Code generation, requires imagick",
@@ -8376,9 +8377,9 @@
             ],
             "support": {
                 "issues": "https://github.com/antonioribeiro/google2fa-qrcode/issues",
-                "source": "https://github.com/antonioribeiro/google2fa-qrcode/tree/v3.0.0"
+                "source": "https://github.com/antonioribeiro/google2fa-qrcode/tree/v4.0.0"
             },
-            "time": "2021-08-15T12:53:48+00:00"
+            "time": "2026-05-08T19:24:44+00:00"
         },
         {
             "name": "psr/clock",

--- a/packages/panels/composer.json
+++ b/packages/panels/composer.json
@@ -19,7 +19,7 @@
         "filament/tables": "self.version",
         "filament/widgets": "self.version",
         "pragmarx/google2fa": "^8.0|^9.0",
-        "pragmarx/google2fa-qrcode": "^3.0"
+        "pragmarx/google2fa-qrcode": "^3.0|^4.0"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
## Description

`pragmarx/google2fa-qrcode` v4.0.0 supports `pragmarx/google2fa` `^8.0|^9.0`, while v3.0.x caps at `^8.0`. Users who attempt to upgrade `pragmarx/google2fa` to v9 are blocked solely by this transitive constraint in `filament/panels`.

This PR widens the constraint to `^3.0|^4.0`, allowing both versions.

## Compatibility

The only API surface that `filament/panels` uses from `pragmarx/google2fa-qrcode` is `Google2FA::getQRCodeInline($company, $holder, $secret)` (`packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php` line 144). Its signature is identical between v3 and v4.

The v4 changes are internal:
- Constructor parameters became typed (`?QRCodeServiceContract`, `?ImageBackEndInterface`) — backward-compatible defaults preserved
- `getQrCodeService()` → `getQRCodeService()` (casing) — not used by panels
- Exception class renamed `MissingQrCodeServiceException` → `MissingQRCodeServiceException` — not caught by panels

Keeping `^3.0` in the alternation preserves backward compatibility for users still on v3.

## Why

Without this change, users running Filament cannot upgrade `pragmarx/google2fa` past v8 even though the `pragmarx/google2fa` constraint already allows `^8.0|^9.0`. Composer correctly resolves the conflict via the transitive `google2fa-qrcode` dependency.