### PR TITLE
fix(tables): resolve BelongsToMany records with the correct primary key

### DIFF
--- a/packages/tables/src/Table/Concerns/HasQuery.php
+++ b/packages/tables/src/Table/Concerns/HasQuery.php
@@ -127,6 +127,12 @@ trait HasQuery
             ];
         }
 
+        $baseQuery = $query instanceof Relation ? $query->getQuery()->getQuery() : $query->getQuery();
+        $baseQuery->columns = array_values(array_filter(
+            $baseQuery->columns ?? [],
+            fn ($column): bool => ! in_array($column, $columns, true),
+        ));
+
         $query->addSelect($columns);
 
         return $query;

--- a/tests/src/Fixtures/Resources/Tickets/RelationManagers/DepartmentsWithSubquerySelectAndDetachRelationManager.php
+++ b/tests/src/Fixtures/Resources/Tickets/RelationManagers/DepartmentsWithSubquerySelectAndDetachRelationManager.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Resources\Tickets\RelationManagers;
+
+use Filament\Actions\DetachAction;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Table;
+use Filament\Tests\Fixtures\Resources\Departments\Tables\DepartmentsTable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
+
+class DepartmentsWithSubquerySelectAndDetachRelationManager extends RelationManager
+{
+    protected static string $relationship = 'departments';
+
+    public function table(Table $table): Table
+    {
+        return DepartmentsTable::configure($table)
+            ->modifyQueryUsing(fn (Builder $query): Builder => $query->addSelect([
+                'ticket_count' => DB::table('department_ticket')
+                    ->whereColumn('department_ticket.department_id', 'departments.id')
+                    ->selectRaw('count(*)'),
+            ]))
+            ->recordActions([
+                DetachAction::make(),
+            ]);
+    }
+}

--- a/tests/src/Panels/Resources/RelationManagerTest.php
+++ b/tests/src/Panels/Resources/RelationManagerTest.php
@@ -4,6 +4,7 @@ use Filament\Actions\AttachAction;
 use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\DetachAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\ForceDeleteAction;
 use Filament\Actions\ForceDeleteBulkAction;
@@ -26,6 +27,7 @@ use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithMi
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithModifiedQueryRelationManager;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithPivotAndModifiedQueryRelationManager;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithPivotSummaryRelationManager;
+use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithSubquerySelectAndDetachRelationManager;
 use Filament\Tests\Panels\Resources\TestCase;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Support\Str;
@@ -441,6 +443,45 @@ it('resolves pivot columns and `modifyQueryUsing()` virtual columns across multi
         ->assertTableColumnStateSet('pivot.price', 200, $departments[1]->getKey())
         ->assertTableColumnStateSet('virtual_label', 'preserved', $departments[0]->getKey())
         ->assertTableColumnStateSet('virtual_label', 'preserved', $departments[1]->getKey());
+});
+
+it('resolves a `BelongsToMany` record with the related model\'s primary key when `modifyQueryUsing()` adds a subquery via `addSelect()`', function (): void {
+    // `addSelect(['alias' => $queryable])` triggers Laravel's `Query\Builder::addSelect()`
+    // to prepend `departments.*` before the subquery is appended. Without the fix, the
+    // related table's wildcard then comes before the pivot table's wildcard in the final
+    // SELECT, so `PDO::FETCH_ASSOC` resolves the `id` column to the pivot row's `id`
+    // instead of the related model's `id`. Seeding two unrelated departments first
+    // forces the attached department's PK to diverge from the pivot row's PK, so the
+    // wrong value becomes detectable.
+    Department::factory()->count(2)->create();
+    $department = Department::factory()->create();
+    $ticket = Ticket::factory()->create();
+    $ticket->departments()->attach($department);
+
+    $resolved = livewire(DepartmentsWithSubquerySelectAndDetachRelationManager::class, [
+        'ownerRecord' => $ticket,
+        'pageClass' => EditTicket::class,
+    ])
+        ->instance()
+        ->getTableRecord((string) $department->getKey());
+
+    expect($resolved)->not->toBeNull();
+    expect($resolved->getKey())->toBe($department->getKey());
+});
+
+it('passes the related model with the correct primary key into a `BelongsToMany` `DetachAction` when `modifyQueryUsing()` adds a subquery via `addSelect()`', function (): void {
+    Department::factory()->count(2)->create();
+    $department = Department::factory()->create();
+    $ticket = Ticket::factory()->create();
+    $ticket->departments()->attach($department);
+
+    livewire(DepartmentsWithSubquerySelectAndDetachRelationManager::class, [
+        'ownerRecord' => $ticket,
+        'pageClass' => EditTicket::class,
+    ])
+        ->callAction(TestAction::make(DetachAction::class)->table($department));
+
+    expect($ticket->refresh()->departments)->toHaveCount(0);
 });
 
 it('can summarize both pivot and non-pivot columns in a `BelongsToMany` `RelationManager`', function (): void {

--- a/tests/src/Panels/Resources/RelationManagerTest.php
+++ b/tests/src/Panels/Resources/RelationManagerTest.php
@@ -446,13 +446,6 @@ it('resolves pivot columns and `modifyQueryUsing()` virtual columns across multi
 });
 
 it('resolves a `BelongsToMany` record with the related model\'s primary key when `modifyQueryUsing()` adds a subquery via `addSelect()`', function (): void {
-    // `addSelect(['alias' => $queryable])` triggers Laravel's `Query\Builder::addSelect()`
-    // to prepend `departments.*` before the subquery is appended. Without the fix, the
-    // related table's wildcard then comes before the pivot table's wildcard in the final
-    // SELECT, so `PDO::FETCH_ASSOC` resolves the `id` column to the pivot row's `id`
-    // instead of the related model's `id`. Seeding two unrelated departments first
-    // forces the attached department's PK to diverge from the pivot row's PK, so the
-    // wrong value becomes detectable.
     Department::factory()->count(2)->create();
     $department = Department::factory()->create();
     $ticket = Ticket::factory()->create();


### PR DESCRIPTION
## Description

  Fixes a regression introduced by #19860 that causes `BelongsToMany` records resolved via single-record paths (e.g. `getTableRecord()`) to be hydrated with the pivot row's `id` instead of the related model's primary key.
   The most painful manifestations are action callbacks (`DetachAction`, custom `Action::action(fn ($record) => …)`) receiving the wrong `$record`, `detach($record)` silently no-opping (or detaching the wrong row), and
  route-key generation pointing at the wrong URL.

  ### Root cause

  PR #19860 switched `selectPivotDataInQuery()` from `$query->select($columns)` to `$query->addSelect($columns)` so that user-defined `modifyQueryUsing()` subqueries survive. 

  When a user's `modifyQueryUsing()` uses the `addSelect(['alias' => $queryable])` form, `Query\Builder::addSelect()` auto-prepends `{related}.*` to the empty columns array before appending the subquery. When `selectPivotDataInQuery()` then runs, its `{related}.*` is deduplicated away, and `{pivot}.*` ends up as the *last* wildcard in the SELECT.

  Both wildcards expand to include columns of the same name (canonically `id`). Under `PDO::FETCH_ASSOC`, identically-named columns are overwritten by later values — so the hydrated model gets `id = pivot.id`
  (auto-increment) instead of `id = related.id`. `resolveTableRecord()` then returns a model whose `getKey()` doesn't match the queried key, and every downstream consumer that compares against, joins on, or detaches by
  that PK silently misbehaves.

  ### Fix

  Strip any prior occurrence of the pivot/related wildcards from the base query before re-appending them in canonical order — `[user subqueries, pivot aliases, pivot.*, related.*]`. With `related.*` last, its columns win
  in `PDO::FETCH_ASSOC` while `modifyQueryUsing()` subqueries from #19860 are still preserved.

  ### Tests

  Adds two regression tests in `tests/src/Panels/Resources/RelationManagerTest.php` plus one fixture `RelationManager` that combines the subquery `addSelect()` pattern with a `DetachAction`:

  - Asserts `getTableRecord($key)->getKey() === $key`.
  - Asserts a full attach/detach round-trip through a `DetachAction` succeeds end-to-end.

  Both tests fail on `4.x` HEAD without the fix and pass with it.

  ## Visual changes

  None

  ## Functional changes

  - [x] Code style has been fixed by running the `composer cs` command.
  - [x] Changes have been tested to not break existing functionality.
  - [x] Documentation is up-to-date. (no changes required)