### PR TITLE
fix: stale dependent fields after item actions in `live()` Repeater & Builder

### DIFF
--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -1213,16 +1213,10 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
 
     public function shouldPartiallyRenderAfterActionsCalled(): bool
     {
-        if (($condition = $this->evaluate($this->shouldPartiallyRenderAfterActionsCalled)) !== null) {
+        $condition = $this->evaluate($this->shouldPartiallyRenderAfterActionsCalled);
+
+        if ($condition !== null) {
             return (bool) $condition;
-        }
-
-        if (is_bool($this->isLive)) {
-            return ! $this->isLive;
-        }
-
-        if (! isset($this->container)) {
-            return true;
         }
 
         return ! $this->isLive();

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -99,6 +99,8 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
 
     protected Width | string | Closure | null $blockPickerWidth = null;
 
+    protected bool $hasPartiallyRenderAfterActionsCalledBeenConfigured = false;
+
     protected bool | Closure $shouldPartiallyRenderAfterActionsCalled = true;
 
     protected function setUp(): void
@@ -1206,6 +1208,8 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
 
     public function partiallyRenderAfterActionsCalled(bool | Closure $condition = true): static
     {
+        $this->hasPartiallyRenderAfterActionsCalledBeenConfigured = true;
+
         $this->shouldPartiallyRenderAfterActionsCalled = $condition;
 
         return $this;
@@ -1213,6 +1217,21 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
 
     public function shouldPartiallyRenderAfterActionsCalled(): bool
     {
+        if (
+            (! $this->hasPartiallyRenderAfterActionsCalledBeenConfigured) &&
+            ($this->shouldPartiallyRenderAfterActionsCalled === true)
+        ) {
+            if (is_bool($this->isLive)) {
+                return ! $this->isLive;
+            }
+
+            if (! isset($this->container)) {
+                return true;
+            }
+
+            return ! $this->isLive();
+        }
+
         return (bool) $this->evaluate($this->shouldPartiallyRenderAfterActionsCalled);
     }
 

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -99,9 +99,7 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
 
     protected Width | string | Closure | null $blockPickerWidth = null;
 
-    protected bool $hasPartiallyRenderAfterActionsCalledBeenConfigured = false;
-
-    protected bool | Closure $shouldPartiallyRenderAfterActionsCalled = true;
+    protected bool | Closure | null $shouldPartiallyRenderAfterActionsCalled = null;
 
     protected function setUp(): void
     {
@@ -1206,10 +1204,8 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
         $rules["{$this->getStatePath()}.*.type"] = ['required'];
     }
 
-    public function partiallyRenderAfterActionsCalled(bool | Closure $condition = true): static
+    public function partiallyRenderAfterActionsCalled(bool | Closure | null $condition = true): static
     {
-        $this->hasPartiallyRenderAfterActionsCalledBeenConfigured = true;
-
         $this->shouldPartiallyRenderAfterActionsCalled = $condition;
 
         return $this;
@@ -1217,22 +1213,19 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
 
     public function shouldPartiallyRenderAfterActionsCalled(): bool
     {
-        if (
-            (! $this->hasPartiallyRenderAfterActionsCalledBeenConfigured) &&
-            ($this->shouldPartiallyRenderAfterActionsCalled === true)
-        ) {
-            if (is_bool($this->isLive)) {
-                return ! $this->isLive;
-            }
-
-            if (! isset($this->container)) {
-                return true;
-            }
-
-            return ! $this->isLive();
+        if (($condition = $this->evaluate($this->shouldPartiallyRenderAfterActionsCalled)) !== null) {
+            return (bool) $condition;
         }
 
-        return (bool) $this->evaluate($this->shouldPartiallyRenderAfterActionsCalled);
+        if (is_bool($this->isLive)) {
+            return ! $this->isLive;
+        }
+
+        if (! isset($this->container)) {
+            return true;
+        }
+
+        return ! $this->isLive();
     }
 
     public function blockHeaders(bool | Closure $condition = true): static

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -125,9 +125,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
 
     protected bool $shouldMergeHydratedDefaultStateWithItemsStateAfterStateHydrated = true;
 
-    protected bool $hasPartiallyRenderAfterActionsCalledBeenConfigured = false;
-
-    protected bool | Closure $shouldPartiallyRenderAfterActionsCalled = true;
+    protected bool | Closure | null $shouldPartiallyRenderAfterActionsCalled = null;
 
     protected function setUp(): void
     {
@@ -1525,10 +1523,8 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return 1;
     }
 
-    public function partiallyRenderAfterActionsCalled(bool | Closure $condition = true): static
+    public function partiallyRenderAfterActionsCalled(bool | Closure | null $condition = true): static
     {
-        $this->hasPartiallyRenderAfterActionsCalledBeenConfigured = true;
-
         $this->shouldPartiallyRenderAfterActionsCalled = $condition;
 
         return $this;
@@ -1536,21 +1532,18 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
 
     public function shouldPartiallyRenderAfterActionsCalled(): bool
     {
-        if (
-            (! $this->hasPartiallyRenderAfterActionsCalledBeenConfigured) &&
-            ($this->shouldPartiallyRenderAfterActionsCalled === true)
-        ) {
-            if (is_bool($this->isLive)) {
-                return ! $this->isLive;
-            }
-
-            if (! isset($this->container)) {
-                return true;
-            }
-
-            return ! $this->isLive();
+        if (($condition = $this->evaluate($this->shouldPartiallyRenderAfterActionsCalled)) !== null) {
+            return (bool) $condition;
         }
 
-        return (bool) $this->evaluate($this->shouldPartiallyRenderAfterActionsCalled);
+        if (is_bool($this->isLive)) {
+            return ! $this->isLive;
+        }
+
+        if (! isset($this->container)) {
+            return true;
+        }
+
+        return ! $this->isLive();
     }
 }

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1532,16 +1532,10 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
 
     public function shouldPartiallyRenderAfterActionsCalled(): bool
     {
-        if (($condition = $this->evaluate($this->shouldPartiallyRenderAfterActionsCalled)) !== null) {
+        $condition = $this->evaluate($this->shouldPartiallyRenderAfterActionsCalled);
+
+        if ($condition !== null) {
             return (bool) $condition;
-        }
-
-        if (is_bool($this->isLive)) {
-            return ! $this->isLive;
-        }
-
-        if (! isset($this->container)) {
-            return true;
         }
 
         return ! $this->isLive();

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -125,6 +125,8 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
 
     protected bool $shouldMergeHydratedDefaultStateWithItemsStateAfterStateHydrated = true;
 
+    protected bool $hasPartiallyRenderAfterActionsCalledBeenConfigured = false;
+
     protected bool | Closure $shouldPartiallyRenderAfterActionsCalled = true;
 
     protected function setUp(): void
@@ -1525,6 +1527,8 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
 
     public function partiallyRenderAfterActionsCalled(bool | Closure $condition = true): static
     {
+        $this->hasPartiallyRenderAfterActionsCalledBeenConfigured = true;
+
         $this->shouldPartiallyRenderAfterActionsCalled = $condition;
 
         return $this;
@@ -1532,6 +1536,21 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
 
     public function shouldPartiallyRenderAfterActionsCalled(): bool
     {
+        if (
+            (! $this->hasPartiallyRenderAfterActionsCalledBeenConfigured) &&
+            ($this->shouldPartiallyRenderAfterActionsCalled === true)
+        ) {
+            if (is_bool($this->isLive)) {
+                return ! $this->isLive;
+            }
+
+            if (! isset($this->container)) {
+                return true;
+            }
+
+            return ! $this->isLive();
+        }
+
         return (bool) $this->evaluate($this->shouldPartiallyRenderAfterActionsCalled);
     }
 }

--- a/tests/src/Forms/Components/BuilderTest.php
+++ b/tests/src/Forms/Components/BuilderTest.php
@@ -520,9 +520,11 @@ describe('properties', function (): void {
     it('can set `partiallyRenderAfterActionsCalled()` and check `shouldPartiallyRenderAfterActionsCalled()`', function (): void {
         $enabled = Builder::make('content')->partiallyRenderAfterActionsCalled();
         $disabled = Builder::make('content')->partiallyRenderAfterActionsCalled(false);
+        $liveEnabled = Builder::make('content')->live()->partiallyRenderAfterActionsCalled();
 
         expect($enabled->shouldPartiallyRenderAfterActionsCalled())->toBeTrue();
         expect($disabled->shouldPartiallyRenderAfterActionsCalled())->toBeFalse();
+        expect($liveEnabled->shouldPartiallyRenderAfterActionsCalled())->toBeTrue();
     });
 
     it('can set `addActionAlignment()` and get with `getAddActionAlignment()`', function (): void {
@@ -965,10 +967,20 @@ describe('boolean properties', function (): void {
         expect($builder->shouldPartiallyRenderAfterActionsCalled())->toBeFalse();
     });
 
-    it('defaults `shouldPartiallyRenderAfterActionsCalled()` to `true`', function (): void {
-        $builder = Builder::make('content');
+    it('defaults `shouldPartiallyRenderAfterActionsCalled()` based on `live()`', function (): void {
+        $default = Builder::make('content');
+        $live = Builder::make('content')->live();
+        [$conditionallyLive, $conditionallyNotLive] = Schema::make(Livewire::make())
+            ->components([
+                Builder::make('conditionallyLive')->live(condition: static fn (): bool => true),
+                Builder::make('conditionallyNotLive')->live(condition: static fn (): bool => false),
+            ])
+            ->getComponents();
 
-        expect($builder->shouldPartiallyRenderAfterActionsCalled())->toBeTrue();
+        expect($default->shouldPartiallyRenderAfterActionsCalled())->toBeTrue();
+        expect($live->shouldPartiallyRenderAfterActionsCalled())->toBeFalse();
+        expect($conditionallyLive->shouldPartiallyRenderAfterActionsCalled())->toBeFalse();
+        expect($conditionallyNotLive->shouldPartiallyRenderAfterActionsCalled())->toBeTrue();
     });
 });
 

--- a/tests/src/Forms/Components/BuilderTest.php
+++ b/tests/src/Forms/Components/BuilderTest.php
@@ -968,10 +968,10 @@ describe('boolean properties', function (): void {
     });
 
     it('defaults `shouldPartiallyRenderAfterActionsCalled()` based on `live()`', function (): void {
-        $default = Builder::make('content');
-        $live = Builder::make('content')->live();
-        [$conditionallyLive, $conditionallyNotLive] = Schema::make(Livewire::make())
+        [$default, $live, $conditionallyLive, $conditionallyNotLive] = Schema::make(Livewire::make())
             ->components([
+                Builder::make('default'),
+                Builder::make('live')->live(),
                 Builder::make('conditionallyLive')->live(condition: static fn (): bool => true),
                 Builder::make('conditionallyNotLive')->live(condition: static fn (): bool => false),
             ])

--- a/tests/src/Forms/Components/RepeaterTest.php
+++ b/tests/src/Forms/Components/RepeaterTest.php
@@ -1994,10 +1994,10 @@ describe('properties', function (): void {
     });
 
     it('defaults `shouldPartiallyRenderAfterActionsCalled()` based on `live()`', function (): void {
-        $default = Repeater::make('items');
-        $live = Repeater::make('items')->live();
-        [$conditionallyLive, $conditionallyNotLive] = Schema::make(Livewire::make())
+        [$default, $live, $conditionallyLive, $conditionallyNotLive] = Schema::make(Livewire::make())
             ->components([
+                Repeater::make('default'),
+                Repeater::make('live')->live(),
                 Repeater::make('conditionallyLive')->live(condition: static fn (): bool => true),
                 Repeater::make('conditionallyNotLive')->live(condition: static fn (): bool => false),
             ])

--- a/tests/src/Forms/Components/RepeaterTest.php
+++ b/tests/src/Forms/Components/RepeaterTest.php
@@ -1986,9 +1986,27 @@ describe('properties', function (): void {
     it('can set `partiallyRenderAfterActionsCalled()` and check `shouldPartiallyRenderAfterActionsCalled()`', function (): void {
         $enabled = Repeater::make('items')->partiallyRenderAfterActionsCalled();
         $disabled = Repeater::make('items')->partiallyRenderAfterActionsCalled(false);
+        $liveEnabled = Repeater::make('items')->live()->partiallyRenderAfterActionsCalled();
 
         expect($enabled->shouldPartiallyRenderAfterActionsCalled())->toBeTrue();
         expect($disabled->shouldPartiallyRenderAfterActionsCalled())->toBeFalse();
+        expect($liveEnabled->shouldPartiallyRenderAfterActionsCalled())->toBeTrue();
+    });
+
+    it('defaults `shouldPartiallyRenderAfterActionsCalled()` based on `live()`', function (): void {
+        $default = Repeater::make('items');
+        $live = Repeater::make('items')->live();
+        [$conditionallyLive, $conditionallyNotLive] = Schema::make(Livewire::make())
+            ->components([
+                Repeater::make('conditionallyLive')->live(condition: static fn (): bool => true),
+                Repeater::make('conditionallyNotLive')->live(condition: static fn (): bool => false),
+            ])
+            ->getComponents();
+
+        expect($default->shouldPartiallyRenderAfterActionsCalled())->toBeTrue();
+        expect($live->shouldPartiallyRenderAfterActionsCalled())->toBeFalse();
+        expect($conditionallyLive->shouldPartiallyRenderAfterActionsCalled())->toBeFalse();
+        expect($conditionallyNotLive->shouldPartiallyRenderAfterActionsCalled())->toBeTrue();
     });
 
     it('can set `addActionAlignment()` and get with `getAddActionAlignment()`', function (): void {


### PR DESCRIPTION

## Description
### Fixes: #19914 
Item actions on a `->live()` Repeater only call `partiallyRender()` on the Repeater itself, so sibling fields computed via `$get` are not re-evaluated.

Default `shouldPartiallyRenderAfterActionsCalled()` to `false` on `->live()` Repeaters so the parent Livewire component re-renders fully and dependent fields are recomputed.


## Visual changes

### Before


https://github.com/user-attachments/assets/a5425c4b-6397-4f13-839d-204d6c9c067a



### After


https://github.com/user-attachments/assets/e10b8064-3acf-4aec-acb5-af7f273ae3f6





## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
