### PR TITLE
fix: render sidebar navigation item children when parent has no URL

### DIFF
--- a/packages/panels/resources/views/components/sidebar/item.blade.php
+++ b/packages/panels/resources/views/components/sidebar/item.blade.php
@@ -112,7 +112,7 @@
         @endif
     </a>
 
-    @if (($active || $activeChildItems) && $childItems)
+    @if ($childItems && (blank($url) || $active || $activeChildItems))
         <ul class="fi-sidebar-sub-group-items">
             @foreach ($childItems as $childItem)
                 @php


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Closes #19989.

When a top-level \`NavigationItem\` is registered via \`->navigationItems([...])\` with \`->childItems([...])\` and no \`->url(...)\` on the parent, the children never render in the sidebar. The reporter's repro (also in https://github.com/gigili/filament-navitem-bug):

\`\`\`php
->navigationItems([
    NavigationItem::make('tools')
        ->label(__('landing.nav.tools'))
        ->icon(Heroicon::WrenchScrewdriver)
        ->childItems([
            NavigationItem::make('all')->label('test'),
        ]),
])
\`\`\`

The gate at \`packages/panels/resources/views/components/sidebar/item.blade.php:115\` requires the parent or one of its children to be \`active\` before the children-\`<ul>\` is emitted:

\`\`\`blade
@if (($active || $activeChildItems) && $childItems)
\`\`\`

For a parent with no URL, \`$active\` is always false (no URL to match against the current route) and \`$activeChildItems\` is false (the children have no URLs either). So the gate fails and the children-\`<ul>\` is never written to the DOM.

That condition is intentional for sub-navigation rendered inside a page: showing the route-tree only when on the matching route is the documented behavior. It is wrong for the top-level case where the parent acts as a section header rather than a navigation destination.

This change adds \`blank(\$url)\` to the OR chain so the children render whenever the parent has no URL:

\`\`\`blade
@if (\$childItems && (blank(\$url) || \$active || \$activeChildItems))
\`\`\`

When the parent has a URL, the existing gate fires unchanged; sub-navigation behavior is preserved. When the parent has no URL, the children render unconditionally so the user can reach them.

## Visual changes

Before: a top-level \`NavigationItem\` with no URL and \`childItems\` renders only the parent button. Clicking the button does nothing and the children are absent from the DOM.

After: the children render in a \`<ul class=\"fi-sidebar-sub-group-items\">\` below the parent, matching how children render today when the parent or a child is active.

## Functional changes

- [x] Code style has been fixed by running the \`composer cs\` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.