### PR TITLE
fix: avoid `null` cache key in `getComponentByStatePath()`

### DIFF
--- a/packages/schemas/src/Concerns/HasComponents.php
+++ b/packages/schemas/src/Concerns/HasComponents.php
@@ -240,7 +240,7 @@ trait HasComponents
 
         $skipIds = array_map('spl_object_id', $skipComponentsChildContainersWhileSearching);
         sort($skipIds);
-        $cacheKey = $skipIds ? implode('-', $skipIds) : null;
+        $cacheKey = $skipIds ? implode('-', $skipIds) : '';
 
         return $this->cachedComponentsByStatePath[$withHidden][$cacheKey][$statePath] ??= $search($this);
     }


### PR DESCRIPTION
## Description
### Fixes: #19991 

getComponentByStatePath() used null as a cache array offset, which PHP 8.5 deprecates; this uses an empty string instead.

## Visual changes


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
