### PR TITLE
fix: `WithFileUploads` trait clash in test fixtures

### DIFF
--- a/tests/src/Fixtures/Livewire/SpatieMediaLibraryFileUploadForm.php
+++ b/tests/src/Fixtures/Livewire/SpatieMediaLibraryFileUploadForm.php
@@ -11,13 +11,11 @@ use Filament\Schemas\Schema;
 use Filament\Tests\Fixtures\Models\MediaPost;
 use Illuminate\Contracts\View\View;
 use Livewire\Component;
-use Livewire\WithFileUploads;
 
 class SpatieMediaLibraryFileUploadForm extends Component implements HasActions, HasSchemas
 {
     use InteractsWithActions;
     use InteractsWithSchemas;
-    use WithFileUploads;
 
     public $data = [];
 

--- a/tests/src/SpatieMediaLibraryPlugin/SpatieMediaLibraryFileUploadTest.php
+++ b/tests/src/SpatieMediaLibraryPlugin/SpatieMediaLibraryFileUploadTest.php
@@ -15,7 +15,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 use Livewire\Component;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
-use Livewire\WithFileUploads;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 use function Filament\Tests\livewire;
@@ -513,7 +512,6 @@ class ReorderableSpatieMediaLibraryFileUploadForm extends Component implements H
 {
     use InteractsWithActions;
     use InteractsWithSchemas;
-    use WithFileUploads;
 
     public $data = [];
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Removed the redundant `use WithFileUploads` causing a trait clash in these two fixtures.
## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
