### PR TITLE
fix: double quote values in forms

### DIFF
--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -101,7 +101,7 @@
                                 $extraInputAttributeBag
                                     ->merge([
                                         'disabled' => $isDisabled || $isOptionDisabled($value, $label),
-                                        'value' => $value,
+                                        'value' => e($value),
                                         'wire:loading.attr' => 'disabled',
                                         $wireModelAttribute => $statePath,
                                         'x-on:change' => $isBulkToggleable ? 'checkIfAllCheckboxesAreChecked()' : null,

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -29,9 +29,9 @@
                     ->merge([
                         'autofocus' => $loop->first && $isAutofocused(),
                         'disabled' => $isDisabled || $isOptionDisabled($value, $label),
-                        'id' => $id . '-' . $value,
+                        'id' => e($id . '-' . $value),
                         'name' => $id,
-                        'value' => $value,
+                        'value' => e($value),
                         $wireModelAttribute => $statePath,
                     ], escape: false);
             @endphp

--- a/tests/src/Forms/Components/CheckboxListTest.php
+++ b/tests/src/Forms/Components/CheckboxListTest.php
@@ -1435,6 +1435,12 @@ describe('rendering', function (): void {
             ->assertSeeHtml('Active')
             ->assertSeeHtml('Archived');
     });
+
+    it('can render option values containing double quotes', function (): void {
+        livewire(RenderCheckboxListWithQuotedOptionValues::class)
+            ->assertSuccessful()
+            ->assertSeeHtml('value="1/2&quot; wrench"');
+    });
 });
 
 it('can render `CheckboxList` in the browser', function (): void {
@@ -1979,6 +1985,37 @@ class RenderCheckboxListWithDisabledOptionWhen extends Component implements HasA
                         'archived' => 'Archived',
                     ])
                     ->disableOptionWhen(static fn (string $value): bool => $value === 'archived'),
+            ])
+            ->statePath('data');
+    }
+
+    public function render(): View
+    {
+        return view('livewire.form');
+    }
+}
+
+class RenderCheckboxListWithQuotedOptionValues extends Component implements HasActions, HasSchemas
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+
+    public $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->schema([
+                CheckboxList::make('items')
+                    ->options([
+                        '1/2" wrench' => '1/2" wrench',
+                        '3/8" wrench' => '3/8" wrench',
+                    ]),
             ])
             ->statePath('data');
     }

--- a/tests/src/Forms/Components/RadioTest.php
+++ b/tests/src/Forms/Components/RadioTest.php
@@ -328,6 +328,12 @@ describe('rendering', function (): void {
             ->assertSeeHtml('On')
             ->assertSeeHtml('Off');
     });
+
+    it('can render option values containing double quotes', function (): void {
+        livewire(RenderRadioWithQuotedOptionValues::class)
+            ->assertSuccessful()
+            ->assertSeeHtml('value="1/2&quot; wrench"');
+    });
 });
 
 it('can render `Radio` in the browser', function (): void {
@@ -401,6 +407,20 @@ class RenderRadioWithCustomBooleanLabels extends Livewire
         return $form->schema([
             Radio::make('active')
                 ->boolean(trueLabel: 'On', falseLabel: 'Off'),
+        ])->statePath('data');
+    }
+}
+
+class RenderRadioWithQuotedOptionValues extends Livewire
+{
+    public function form(Schema $form): Schema
+    {
+        return $form->schema([
+            Radio::make('size')
+                ->options([
+                    '1/2" wrench' => '1/2" wrench',
+                    '3/8" wrench' => '3/8" wrench',
+                ]),
         ])->statePath('data');
     }
 }


### PR DESCRIPTION
Fix `Radio` and `CheckboxList` options with double quotes failing validation

## Description

When a `Radio` or `CheckboxList` option value contains a double quote (e.g. `Tom "Iceman"` or `1/2" wrench`), selecting that option and submitting the form fails validation with "The selected value is invalid", even though the option is genuinely one of the configured options.

## Cause

Both views build their `<input>` element through `ComponentAttributeBag::merge([...], escape: false)`:

```blade
$extraInputAttributeBag->merge([
    'value' => $value,
    // ...
], escape: false)
```

Because escaping is disabled, the raw option value is handed to `ComponentAttributeBag::__toString()`, which escapes a `"` to `\"` — a JavaScript-style escape that has no meaning in HTML. The browser therefore terminates the `value` attribute at the first `"`:

```html
<input type="checkbox" value="1/2\" wrench\"="" ...>
```

On submit, the value posted back (`1/2\`) no longer matches the option key, so the implicit `in` validation rule rejects it.

The server-side validation rule itself is correct — Laravel's `In::__toString()` escapes quotes properly. The bug is purely in how the option value is rendered into the HTML attribute.

## Solution

Escape the user-supplied value with `e()` before it enters the attribute bag, so it is encoded as `&quot;` (valid HTML) instead of `\"`:

```blade
'id' => e($id . '-' . $value),
'value' => e($value),
```

This mirrors the existing pattern in `support/resources/views/components/icon-button.blade.php`, which already uses `'aria-label' => e($label)` for the same reason.

`Select` and `ToggleButtons` are unaffected — they render their values through `value="{{ $value }}"`, which Blade escapes automatically.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
