### PR TITLE
fix: guard null child schema in Repeater::getItemLabel()

### DIFF
--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1231,6 +1231,10 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     {
         $container = $this->getChildSchema($key);
 
+        if ($container === null) {
+            return null;
+        }
+
         return $this->evaluate($this->itemLabel, [
             'container' => $container,
             'item' => $container,

--- a/tests/src/Forms/Components/RepeaterTest.php
+++ b/tests/src/Forms/Components/RepeaterTest.php
@@ -2341,6 +2341,24 @@ describe('item labels', function (): void {
         expect($repeater->getItemLabel($itemKeys[2], 2))->toBe('Item 2: third');
     });
 
+    it('returns `null` for `getItemLabel()` when the child schema is missing for the given key', function (): void {
+        Schema::make(Livewire::make())
+            ->statePath('data')
+            ->components([
+                $repeater = Repeater::make('items')
+                    ->schema([
+                        TextInput::make('name'),
+                    ])
+                    ->itemLabel(static fn (array $state): string => "Item: {$state['name']}")
+                    ->default([
+                        ['name' => 'first'],
+                    ]),
+            ])
+            ->fill();
+
+        expect($repeater->getItemLabel('this-key-has-no-cached-child-schema', 0))->toBeNull();
+    });
+
     it('can set `itemNumbers()` with a `Closure`', function (): void {
         $repeater = Repeater::make('items')
             ->itemNumbers(static fn (): bool => true);


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Closes #19997.

A \`Repeater\` configured with \`->itemLabel(...)\` can fatally crash a Livewire render with:

\`\`\`
Call to a member function getStateSnapshot() on null
vendor/filament/forms/src/Components/Repeater.php:1239
\`\`\`

\`Repeater::getItemLabel(\$key)\` resolves the child container via \`\$this->getChildSchema(\$key)\` and then dereferences \`\$container->getStateSnapshot()\` unconditionally. \`getChildSchema()\` (in \`HasChildComponents\`) returns the schema only when \`\$key\` is present in the lazily-built \`cachedDefaultChildSchemas\`; for any other key it falls through and returns \`null\`.

The blade view (\`repeater/index.blade.php\`) iterates \`\$getItems()\` (recomputed fresh per render) and calls \`\$getItemLabel(\$itemKey)\` per item. When the cached child schemas were warmed earlier in the same request with a different set of keys than the current raw state (e.g. a sibling component called \`\$set()\` into the repeater path, a modal action wrote the parent array via \`fillForm()\`, or two overlapping Livewire requests left a stale cache), \`getChildSchema(\$itemKey)\` returns \`null\` and the next line fatally crashes the whole render. Only repeaters using \`->itemLabel()\` are affected, since \`getItemLabel()\` is the only caller that dereferences the child schema without a null check.

The reporter provided a public reproduction at https://github.com/MadBox-99/filament-repeater-itemlabel-crash with a Pest test that triggers the crash deterministically.

The method's return signature is already \`string | Htmlable | null\`, and the only consumer (the blade view at line 108) tests visibility with \`filled(\$itemLabel)\`, so \`null\` is a legitimate "no label for this item" return value. This change adds an explicit early return when the child schema cannot be resolved, instead of letting the closure run against a null container:

\`\`\`php
\$container = \$this->getChildSchema(\$key);

if (\$container === null) {
    return null;
}
\`\`\`

The new regression test exercises the failing path directly: a repeater with a single default item is asked for the label of a key that was never cached, and is expected to return \`null\` rather than crash.

## Visual changes

None. \`null\` was already a permitted return value, and the blade view treats a null item label as "no label", which is what the crash-free path now yields when the cache disagrees with the current raw state. Repeaters that hit this path no longer take the entire render down.

## Functional changes

- [x] Code style has been fixed by running the \`composer cs\` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.