### PR TITLE
Fix `getItemLabel` null dereference and distinct validation for booleans in repeaters

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -685,7 +685,9 @@ trait CanBeValidated
                         return;
                     }
 
-                    $fail(__($validationMessages['distinct.must_be_selected'] ?? 'filament-forms::validation.distinct.must_be_selected', ['attribute' => $component->getValidationAttribute()]));
+                    if ($component->isRequired()) {
+                        $fail(__($validationMessages['distinct.must_be_selected'] ?? 'filament-forms::validation.distinct.must_be_selected', ['attribute' => $component->getValidationAttribute()]));
+                    }
 
                     return;
                 }

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1236,7 +1236,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
             'item' => $container,
             'key' => $key,
             'schema' => $container,
-            'state' => $container->getStateSnapshot(),
+            'state' => $container?->getStateSnapshot(),
             'uuid' => $key,
             'index' => $index,
         ]);

--- a/tests/src/Forms/Components/CheckboxTest.php
+++ b/tests/src/Forms/Components/CheckboxTest.php
@@ -367,3 +367,63 @@ class TestComponentWithLabelledCheckbox extends Livewire
             ->statePath('data');
     }
 }
+
+it('respects required state for distinct validation in repeaters', function (): void {
+    $component = new class () extends Livewire {
+        public function form(Schema $form): Schema
+        {
+            return $form
+                ->components([
+                    \Filament\Forms\Components\Repeater::make('items')
+                        ->schema([
+                            \Filament\Forms\Components\Checkbox::make('primary')->distinct(),
+                        ]),
+                ])
+                ->statePath('data');
+        }
+
+        public function save(): void
+        {
+            $this->form->getState();
+        }
+    };
+
+    \Filament\Tests\livewire($component::class)
+        ->fillForm([
+            'items' => [
+                'item-1' => ['primary' => false],
+                'item-2' => ['primary' => false],
+            ],
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors(['items.item-1.primary', 'items.item-2.primary']);
+
+    $componentRequired = new class () extends Livewire {
+        public function form(Schema $form): Schema
+        {
+            return $form
+                ->components([
+                    \Filament\Forms\Components\Repeater::make('items')
+                        ->schema([
+                            \Filament\Forms\Components\Checkbox::make('primary')->distinct()->required(),
+                        ]),
+                ])
+                ->statePath('data');
+        }
+
+        public function save(): void
+        {
+            $this->form->getState();
+        }
+    };
+
+    \Filament\Tests\livewire($componentRequired::class)
+        ->fillForm([
+            'items' => [
+                'item-1' => ['primary' => false],
+                'item-2' => ['primary' => false],
+            ],
+        ])
+        ->call('save')
+        ->assertHasFormErrors(['items.item-1.primary', 'items.item-2.primary']);
+});

--- a/tests/src/Forms/Components/RepeaterTest.php
+++ b/tests/src/Forms/Components/RepeaterTest.php
@@ -2827,3 +2827,18 @@ class RepeaterWithTranslatableContentDriver extends Component implements HasActi
         return view('livewire.form');
     }
 }
+
+it('does not crash when evaluating repeater item label without warmed child schema cache', function (): void {
+    $repeater = Repeater::make('normal')
+        ->itemLabel(fn (array $state): ?string => $state['title'] ?? null)
+        ->schema([
+            TextInput::make('title'),
+        ]);
+
+    $component = new TestComponentWithRepeater();
+
+    $container = \Filament\Schemas\ComponentContainer::make($component)
+        ->components([$repeater]);
+
+    expect($repeater->getItemLabel('missing-uuid'))->toBeNull();
+});


### PR DESCRIPTION
This PR fixes two bugs with the `Repeater` component:

1. **Fixes #19997 (Null dereference when evaluating repeater item label without warmed child schema cache):**
When the repeater's cache is missing the item's key, `getChildSchema` evaluates to a fallback `ComponentContainer`. If a cache miss occurs, calling `getStateSnapshot()` on it caused a fatal error. The fix introduces the null-safe operator `$container?->getStateSnapshot()` in `Repeater::getItemLabel()`, gracefully preventing fatal errors. A test for this is added to `RepeaterTest.php`.

2. **Fixes #19995 (Repeater distinct() forces selection for Checkbox/Toggle when multiple items exist despite nullable/optional state):**
When using `->distinct()` on a boolean field (like Checkbox) inside a repeater, Filament was erroneously forcing at least one item to be selected, even if the field wasn't explicitly `required`. This fix adds a check `if ($component->isRequired())` around the `distinct.must_be_selected` failure, meaning that `distinct()` on an optional boolean will now appropriately behave as "at most one can be selected". A test case for this logic is added to `CheckboxTest.php`.