### PR TITLE
Fix: distinct validation for booleans respects field required state (#19995)

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -685,7 +685,9 @@ trait CanBeValidated
                         return;
                     }
 
-                    $fail(__($validationMessages['distinct.must_be_selected'] ?? 'filament-forms::validation.distinct.must_be_selected', ['attribute' => $component->getValidationAttribute()]));
+                    if ($component->isRequired()) {
+                        $fail(__($validationMessages['distinct.must_be_selected'] ?? 'filament-forms::validation.distinct.must_be_selected', ['attribute' => $component->getValidationAttribute()]));
+                    }
 
                     return;
                 }

--- a/tests/src/Forms/Components/CheckboxTest.php
+++ b/tests/src/Forms/Components/CheckboxTest.php
@@ -3,6 +3,7 @@
 namespace Filament\Tests\Forms\Components;
 
 use Filament\Forms\Components\Checkbox;
+use Filament\Forms\Components\Repeater;
 use Filament\Schemas\Schema;
 use Filament\Tests\Fixtures\Livewire\Livewire;
 use Filament\Tests\Fixtures\Models\User;
@@ -368,27 +369,8 @@ class TestComponentWithLabelledCheckbox extends Livewire
     }
 }
 
-it('respects required state for distinct validation in repeaters', function (): void {
-    $component = new class () extends Livewire {
-        public function form(Schema $form): Schema
-        {
-            return $form
-                ->components([
-                    \Filament\Forms\Components\Repeater::make('items')
-                        ->schema([
-                            \Filament\Forms\Components\Checkbox::make('primary')->distinct(),
-                        ]),
-                ])
-                ->statePath('data');
-        }
-
-        public function save(): void
-        {
-            $this->form->getState();
-        }
-    };
-
-    \Filament\Tests\livewire($component::class)
+it('does not force an optional `distinct()` checkbox to be selected when sibling repeater items exist', function (): void {
+    livewire(TestComponentWithDistinctCheckboxInRepeater::class)
         ->fillForm([
             'items' => [
                 'item-1' => ['primary' => false],
@@ -397,27 +379,34 @@ it('respects required state for distinct validation in repeaters', function (): 
         ])
         ->call('save')
         ->assertHasNoFormErrors(['items.item-1.primary', 'items.item-2.primary']);
+});
 
-    $componentRequired = new class () extends Livewire {
-        public function form(Schema $form): Schema
-        {
-            return $form
-                ->components([
-                    \Filament\Forms\Components\Repeater::make('items')
-                        ->schema([
-                            \Filament\Forms\Components\Checkbox::make('primary')->distinct()->required(),
-                        ]),
-                ])
-                ->statePath('data');
-        }
+it('allows a single `distinct()` checkbox to be selected across repeater items', function (): void {
+    livewire(TestComponentWithDistinctCheckboxInRepeater::class)
+        ->fillForm([
+            'items' => [
+                'item-1' => ['primary' => true],
+                'item-2' => ['primary' => false],
+            ],
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors(['items.item-1.primary', 'items.item-2.primary']);
+});
 
-        public function save(): void
-        {
-            $this->form->getState();
-        }
-    };
+it('does not allow more than one `distinct()` checkbox to be selected across repeater items', function (): void {
+    livewire(TestComponentWithDistinctCheckboxInRepeater::class)
+        ->fillForm([
+            'items' => [
+                'item-1' => ['primary' => true],
+                'item-2' => ['primary' => true],
+            ],
+        ])
+        ->call('save')
+        ->assertHasFormErrors(['items.item-1.primary', 'items.item-2.primary']);
+});
 
-    \Filament\Tests\livewire($componentRequired::class)
+it('forces a `required()` `distinct()` checkbox to be selected across repeater items', function (): void {
+    livewire(TestComponentWithRequiredDistinctCheckboxInRepeater::class)
         ->fillForm([
             'items' => [
                 'item-1' => ['primary' => false],
@@ -427,3 +416,46 @@ it('respects required state for distinct validation in repeaters', function (): 
         ->call('save')
         ->assertHasFormErrors(['items.item-1.primary', 'items.item-2.primary']);
 });
+
+class TestComponentWithDistinctCheckboxInRepeater extends Livewire
+{
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->components([
+                Repeater::make('items')
+                    ->schema([
+                        Checkbox::make('primary')
+                            ->distinct(),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
+    }
+}
+
+class TestComponentWithRequiredDistinctCheckboxInRepeater extends Livewire
+{
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->components([
+                Repeater::make('items')
+                    ->schema([
+                        Checkbox::make('primary')
+                            ->distinct()
+                            ->required(),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
+    }
+}

--- a/tests/src/Forms/Components/CheckboxTest.php
+++ b/tests/src/Forms/Components/CheckboxTest.php
@@ -3,7 +3,6 @@
 namespace Filament\Tests\Forms\Components;
 
 use Filament\Forms\Components\Checkbox;
-use Filament\Forms\Components\Repeater;
 use Filament\Schemas\Schema;
 use Filament\Tests\Fixtures\Livewire\Livewire;
 use Filament\Tests\Fixtures\Models\User;
@@ -366,96 +365,5 @@ class TestComponentWithLabelledCheckbox extends Livewire
                     ->label('I Accept the Terms'),
             ])
             ->statePath('data');
-    }
-}
-
-it('does not force an optional `distinct()` checkbox to be selected when sibling repeater items exist', function (): void {
-    livewire(TestComponentWithDistinctCheckboxInRepeater::class)
-        ->fillForm([
-            'items' => [
-                'item-1' => ['primary' => false],
-                'item-2' => ['primary' => false],
-            ],
-        ])
-        ->call('save')
-        ->assertHasNoFormErrors(['items.item-1.primary', 'items.item-2.primary']);
-});
-
-it('allows a single `distinct()` checkbox to be selected across repeater items', function (): void {
-    livewire(TestComponentWithDistinctCheckboxInRepeater::class)
-        ->fillForm([
-            'items' => [
-                'item-1' => ['primary' => true],
-                'item-2' => ['primary' => false],
-            ],
-        ])
-        ->call('save')
-        ->assertHasNoFormErrors(['items.item-1.primary', 'items.item-2.primary']);
-});
-
-it('does not allow more than one `distinct()` checkbox to be selected across repeater items', function (): void {
-    livewire(TestComponentWithDistinctCheckboxInRepeater::class)
-        ->fillForm([
-            'items' => [
-                'item-1' => ['primary' => true],
-                'item-2' => ['primary' => true],
-            ],
-        ])
-        ->call('save')
-        ->assertHasFormErrors(['items.item-1.primary', 'items.item-2.primary']);
-});
-
-it('forces a `required()` `distinct()` checkbox to be selected across repeater items', function (): void {
-    livewire(TestComponentWithRequiredDistinctCheckboxInRepeater::class)
-        ->fillForm([
-            'items' => [
-                'item-1' => ['primary' => false],
-                'item-2' => ['primary' => false],
-            ],
-        ])
-        ->call('save')
-        ->assertHasFormErrors(['items.item-1.primary', 'items.item-2.primary']);
-});
-
-class TestComponentWithDistinctCheckboxInRepeater extends Livewire
-{
-    public function form(Schema $form): Schema
-    {
-        return $form
-            ->components([
-                Repeater::make('items')
-                    ->schema([
-                        Checkbox::make('primary')
-                            ->distinct(),
-                    ]),
-            ])
-            ->statePath('data');
-    }
-
-    public function save(): void
-    {
-        $this->form->getState();
-    }
-}
-
-class TestComponentWithRequiredDistinctCheckboxInRepeater extends Livewire
-{
-    public function form(Schema $form): Schema
-    {
-        return $form
-            ->components([
-                Repeater::make('items')
-                    ->schema([
-                        Checkbox::make('primary')
-                            ->distinct()
-                            ->required(),
-                    ]),
-            ])
-            ->statePath('data');
-    }
-
-    public function save(): void
-    {
-        $this->form->getState();
     }
 }

--- a/tests/src/Forms/Components/CheckboxTest.php
+++ b/tests/src/Forms/Components/CheckboxTest.php
@@ -367,3 +367,63 @@ class TestComponentWithLabelledCheckbox extends Livewire
             ->statePath('data');
     }
 }
+
+it('respects required state for distinct validation in repeaters', function (): void {
+    $component = new class () extends Livewire {
+        public function form(Schema $form): Schema
+        {
+            return $form
+                ->components([
+                    \Filament\Forms\Components\Repeater::make('items')
+                        ->schema([
+                            \Filament\Forms\Components\Checkbox::make('primary')->distinct(),
+                        ]),
+                ])
+                ->statePath('data');
+        }
+
+        public function save(): void
+        {
+            $this->form->getState();
+        }
+    };
+
+    \Filament\Tests\livewire($component::class)
+        ->fillForm([
+            'items' => [
+                'item-1' => ['primary' => false],
+                'item-2' => ['primary' => false],
+            ],
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors(['items.item-1.primary', 'items.item-2.primary']);
+
+    $componentRequired = new class () extends Livewire {
+        public function form(Schema $form): Schema
+        {
+            return $form
+                ->components([
+                    \Filament\Forms\Components\Repeater::make('items')
+                        ->schema([
+                            \Filament\Forms\Components\Checkbox::make('primary')->distinct()->required(),
+                        ]),
+                ])
+                ->statePath('data');
+        }
+
+        public function save(): void
+        {
+            $this->form->getState();
+        }
+    };
+
+    \Filament\Tests\livewire($componentRequired::class)
+        ->fillForm([
+            'items' => [
+                'item-1' => ['primary' => false],
+                'item-2' => ['primary' => false],
+            ],
+        ])
+        ->call('save')
+        ->assertHasFormErrors(['items.item-1.primary', 'items.item-2.primary']);
+});

--- a/tests/src/Forms/Components/RepeaterTest.php
+++ b/tests/src/Forms/Components/RepeaterTest.php
@@ -5,9 +5,11 @@ use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
 use Filament\Actions\Testing\TestAction;
 use Filament\Forms\Components\Builder;
+use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Schemas\Components\Group;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Set;
@@ -800,6 +802,154 @@ class TestComponentWithRepeaterAndBuilder extends Livewire
                                             ->distinct(),
                                     ]),
                             ]),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
+    }
+}
+
+describe('`distinct()` validation on boolean fields', function (): void {
+    it('does not force an optional `distinct()` boolean field to be selected when sibling items exist', function (string $component): void {
+        livewire($component)
+            ->fillForm([
+                'items' => [
+                    'item-1' => ['primary' => false],
+                    'item-2' => ['primary' => false],
+                ],
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors(['items.item-1.primary', 'items.item-2.primary']);
+    })->with([
+        'checkbox' => TestComponentWithDistinctBooleanCheckboxInRepeater::class,
+        'toggle' => TestComponentWithDistinctBooleanToggleInRepeater::class,
+    ]);
+
+    it('allows a single `distinct()` boolean field to be selected across sibling items', function (string $component): void {
+        livewire($component)
+            ->fillForm([
+                'items' => [
+                    'item-1' => ['primary' => true],
+                    'item-2' => ['primary' => false],
+                ],
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors(['items.item-1.primary', 'items.item-2.primary']);
+    })->with([
+        'checkbox' => TestComponentWithDistinctBooleanCheckboxInRepeater::class,
+        'toggle' => TestComponentWithDistinctBooleanToggleInRepeater::class,
+    ]);
+
+    it('does not allow more than one `distinct()` boolean field to be selected across sibling items', function (string $component): void {
+        livewire($component)
+            ->fillForm([
+                'items' => [
+                    'item-1' => ['primary' => true],
+                    'item-2' => ['primary' => true],
+                ],
+            ])
+            ->call('save')
+            ->assertHasFormErrors(['items.item-1.primary', 'items.item-2.primary']);
+    })->with([
+        'checkbox' => TestComponentWithDistinctBooleanCheckboxInRepeater::class,
+        'toggle' => TestComponentWithDistinctBooleanToggleInRepeater::class,
+    ]);
+
+    it('forces a `required()` `distinct()` boolean field to be selected across sibling items', function (string $component): void {
+        livewire($component)
+            ->fillForm([
+                'items' => [
+                    'item-1' => ['primary' => false],
+                    'item-2' => ['primary' => false],
+                ],
+            ])
+            ->call('save')
+            ->assertHasFormErrors(['items.item-1.primary', 'items.item-2.primary']);
+    })->with([
+        'checkbox' => TestComponentWithRequiredDistinctBooleanCheckboxInRepeater::class,
+        'toggle' => TestComponentWithRequiredDistinctBooleanToggleInRepeater::class,
+    ]);
+});
+
+class TestComponentWithDistinctBooleanCheckboxInRepeater extends Livewire
+{
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->components([
+                Repeater::make('items')
+                    ->schema([
+                        Checkbox::make('primary')
+                            ->distinct(),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
+    }
+}
+
+class TestComponentWithDistinctBooleanToggleInRepeater extends Livewire
+{
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->components([
+                Repeater::make('items')
+                    ->schema([
+                        Toggle::make('primary')
+                            ->distinct(),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
+    }
+}
+
+class TestComponentWithRequiredDistinctBooleanCheckboxInRepeater extends Livewire
+{
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->components([
+                Repeater::make('items')
+                    ->schema([
+                        Checkbox::make('primary')
+                            ->distinct()
+                            ->required(),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
+    }
+}
+
+class TestComponentWithRequiredDistinctBooleanToggleInRepeater extends Livewire
+{
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->components([
+                Repeater::make('items')
+                    ->schema([
+                        Toggle::make('primary')
+                            ->distinct()
+                            ->required(),
                     ]),
             ])
             ->statePath('data');


### PR DESCRIPTION
This PR resolves #19995 (Repeater distinct() forces selection for Checkbox/Toggle when multiple items exist despite nullable/optional state).

### Problem description
When using `->distinct()` on a boolean field (like `Checkbox` or `Toggle`) inside a repeater, Filament was erroneously forcing at least one item to be selected, even if the field wasn't explicitly `required`.

### Fix
This fix adds a check `if ($component->isRequired())` around the `distinct.must_be_selected` failure. This ensures that `distinct()` on an optional boolean will now appropriately behave as "at most one can be selected".

A test case for this logic is added to `CheckboxTest.php`.