### PR TITLE
Fix #19997: Ensure Repeater cache coherence when state diverges

### DIFF
--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -891,6 +891,20 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return $this->evaluate($this->isReorderableWithButtons) && $this->isReorderable();
     }
 
+    public function getChildSchema($key = null): ?Schema
+    {
+        if (
+            filled($key) &&
+            (! array_key_exists($key, $this->cachedDefaultChildSchemas ?? [])) &&
+            is_array($state = $this->getState()) &&
+            array_key_exists($key, $state)
+        ) {
+            $this->clearCachedDefaultChildSchemas();
+        }
+
+        return parent::getChildSchema($key);
+    }
+
     public function isAddable(): bool
     {
         if ($this->isDisabled()) {

--- a/tests/src/Forms/Components/RepeaterTest.php
+++ b/tests/src/Forms/Components/RepeaterTest.php
@@ -2341,6 +2341,32 @@ describe('item labels', function (): void {
         expect($repeater->getItemLabel($itemKeys[2], 2))->toBe('Item 2: third');
     });
 
+    it('does not crash when getting item label for state mutated via data_set', function (): void {
+        $component = Schema::make(Livewire::make())
+            ->statePath('data')
+            ->components([
+                $repeater = Repeater::make('items')
+                    ->schema([
+                        TextInput::make('name'),
+                    ])
+                    ->itemLabel(static fn (array $state): string => "Item: {$state['name']}")
+                    ->default([
+                        'item-1' => ['name' => 'first'],
+                    ]),
+            ])
+            ->fill();
+
+        // Access child schema to warm the cache
+        $repeater->getChildSchema('item-1');
+
+        // Mutate the state directly bypassing the cache invalidation
+        $livewire = $component->getLivewire();
+        data_set($livewire, 'data.items.item-2', ['name' => 'second']);
+
+        // This would crash before the coherence fix because item-2 is not in the cache
+        expect($repeater->getItemLabel('item-2'))->toBe('Item: second');
+    });
+
     it('can set `itemNumbers()` with a `Closure`', function (): void {
         $repeater = Repeater::make('items')
             ->itemNumbers(static fn (): bool => true);


### PR DESCRIPTION
Fixes #19997.

## Problem

A `Repeater` configured with `->itemLabel(...)` can fatally crash a Livewire render when its raw state is updated directly via Livewire properties (e.g. `data_set()`) instead of Filament's internal state mutation APIs.

This happens because the Repeater caches the structural schemas of its child items during a request. When state is updated directly through Livewire, the internal child schema cache (`$cachedDefaultChildSchemas`) is not cleared. During the render cycle, the Blade view iterates over the newly added raw items and asks the Repeater for the label of an un-cached key. The cache lookup misses, returns `null`, and `getItemLabel()` blindly calls `getStateSnapshot()` on that null value, crashing the app.

A previous PR (#20018) attempted to fix this by adding a simple `if ($container === null)` check inside `getItemLabel()`. As @danharrin pointed out, this was just patching over a symptom: "The schema should always exist if the original method is invoked." 

## Solution

This PR fixes the root architectural issue by ensuring **Cache Coherence**.

Instead of papering over the crash, we now override `getChildSchema()` in the `Repeater` component to make it intelligent:
If a schema is requested for a key that exists in the true raw state but *is missing from the cache*, it indicates that the state has diverged due to a direct state mutation. When this divergence is detected, the Repeater flushes its outdated cache and forces a fresh rebuild from the true raw state. 

This ensures `getItemLabel` always gets a valid schema container and effectively fixes the state mismatch regardless of how the user mutated the Livewire data array.

I have also added a comprehensive Pest test to explicitly simulate this scenario (`data_set()`) to guarantee it no longer crashes.
