### PR TITLE
fix: Clear cached child schemas after setting raw schema state

### DIFF
--- a/packages/schemas/src/Components/Utilities/Set.php
+++ b/packages/schemas/src/Components/Utilities/Set.php
@@ -34,6 +34,8 @@ class Set
             $shouldCallUpdatedHooks && $component->callAfterStateUpdated();
         } else {
             data_set($livewire, $path, $state);
+
+            $this->component->getRootContainer()->clearCachedDefaultChildSchemas();
         }
 
         return $state;

--- a/tests/src/Schemas/Components/Utilities/SetTest.php
+++ b/tests/src/Schemas/Components/Utilities/SetTest.php
@@ -2,6 +2,7 @@
 
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
@@ -64,6 +65,32 @@ it('returns the state value from `__invoke()`', function (): void {
             'target' => 'test',
             'returned' => 'test',
         ]);
+});
+
+it('clears cached default child schemas when setting a path without a component', function (): void {
+    Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            $source = TextInput::make('source'),
+            $repeater = Repeater::make('equipment_data.burners')
+                ->schema([
+                    TextInput::make('name'),
+                ])
+                ->default([
+                    'old-burner' => ['name' => 'Old burner'],
+                ]),
+        ])
+        ->fill();
+
+    $repeater->getChildSchema('old-burner');
+
+    $source->makeSetUtility()('equipment_data', [
+        'burners' => [
+            'new-burner' => ['name' => 'New burner'],
+        ],
+    ]);
+
+    expect($repeater->getChildSchema('new-burner'))->not->toBeNull();
 });
 
 it('can set `skipComponentsChildContainersWhileSearching()`', function (): void {


### PR DESCRIPTION

## Description

### Fixes: #19997
`$set()` can write to a raw schema state path when there is no matching component, bypassing the normal `rawState()` cache invalidation.

Clear cached child schemas after that write so repeaters rebuild their item schemas from the updated state.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
