### PR TITLE
fix: Navigation group enum respects `collapsible()` when `collapsed`

### DIFF
--- a/packages/panels/src/Navigation/NavigationGroup.php
+++ b/packages/panels/src/Navigation/NavigationGroup.php
@@ -141,8 +141,8 @@ class NavigationGroup extends Component
         }
 
         if ($case instanceof Collapsible) {
-            $group->collapsible($case->isCollapsible());
             $group->collapsed($case->isCollapsed());
+            $group->collapsible($case->isCollapsible());
         }
 
         return $group;

--- a/tests/src/Panels/Navigation/NavigationTest.php
+++ b/tests/src/Panels/Navigation/NavigationTest.php
@@ -5,6 +5,7 @@ use Filament\Navigation\NavigationGroup;
 use Filament\Navigation\NavigationItem;
 use Filament\Pages\Page;
 use Filament\Resources\Pages\ListRecords;
+use Filament\Support\Contracts\Collapsible;
 use Filament\Tests\Fixtures\Clusters\UserManagement;
 use Filament\Tests\Fixtures\Clusters\UserManagement\Pages\ManageAdmins;
 use Filament\Tests\Fixtures\Clusters\WithoutSubNavigationCluster;
@@ -113,6 +114,15 @@ describe('registration and ordering', function (): void {
             );
     });
 
+});
+
+describe('navigation groups from enums', function (): void {
+    it('can use enum `Collapsible` to make a group collapsible but not collapsed', function (): void {
+        $group = NavigationGroup::fromEnum(CollapsibleNavigationGroupEnum::Group);
+
+        expect($group->isCollapsible())->toBeTrue();
+        expect($group->isCollapsed())->toBeFalse();
+    });
 });
 
 describe('sub-navigation parent-child', function (): void {
@@ -364,3 +374,18 @@ describe('cluster sub-navigation', function (): void {
         expect(WithoutSubNavigationCluster::shouldRegisterSubNavigation())->toBeFalse();
     });
 });
+
+enum CollapsibleNavigationGroupEnum implements Collapsible
+{
+    case Group;
+
+    public function isCollapsible(): bool
+    {
+        return true;
+    }
+
+    public function isCollapsed(): bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION

## Description
### Fixes: #20054 

`collapsed()` also sets the collapsible state, so calling it after `collapsible()` in `fromEnum()` overwrote the enum's `isCollapsible()`. Swap the order.


## Visual changes
### Before

<img width="632" height="278" alt="image" src="https://github.com/user-attachments/assets/89d3f988-f32e-4fb9-ab60-82a23b41f56b" />


### After
<img width="610" height="324" alt="image" src="https://github.com/user-attachments/assets/1c33de0a-97f3-4b64-9ff3-7b15e5c3a1f7" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
