### PR TITLE
Add multi-column table sorting

### DIFF
--- a/docs/10-testing/03-testing-tables.md
+++ b/docs/10-testing/03-testing-tables.md
@@ -110,6 +110,8 @@ it('can search posts by title column', function () {
 
 To sort table records, you can call `sortTable()`, passing the name of the column to sort by. You can use `'desc'` in the second parameter of `sortTable()` to reverse the sorting direction.
 
+To test sorting by multiple columns, pass `true` as the third parameter of `sortTable()` when adding another column to the current sort.
+
 Once the table is sorted, you can ensure that the table records are rendered in order using `assertCanSeeTableRecords()` with the `inOrder` parameter:
 
 ```php
@@ -126,6 +128,24 @@ it('can sort posts by title', function () {
         ->assertCanSeeTableRecords($sortedPostsAsc, inOrder: true)
         ->sortTable('title', 'desc')
         ->assertCanSeeTableRecords($sortedPostsDesc, inOrder: true);
+});
+```
+
+```php
+use function Pest\Livewire\livewire;
+
+it('can sort posts by title and publish date', function () {
+    Post::factory()->count(10)->create();
+
+    $sortedPosts = Post::query()
+        ->orderBy('title')
+        ->orderByDesc('published_at')
+        ->get();
+
+    livewire(PostResource\Pages\ListPosts::class)
+        ->sortTable('title')
+        ->sortTable('published_at', 'desc', true)
+        ->assertCanSeeTableRecords($sortedPosts, inOrder: true);
 });
 ```
 

--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -48,8 +48,11 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
     #[Url(as: 'search')]
     public $tableSearch = '';
 
+    /**
+     * @var array<string, string> | string | null
+     */
     #[Url(as: 'sort')]
-    public ?string $tableSort = null;
+    public array | string | null $tableSort = null;
 
     #[Url(as: 'tab')]
     public ?string $activeTab = null;

--- a/packages/panels/src/Resources/Pages/ManageRelatedRecords.php
+++ b/packages/panels/src/Resources/Pages/ManageRelatedRecords.php
@@ -69,8 +69,11 @@ class ManageRelatedRecords extends Page implements Tables\Contracts\HasTable
     #[Url(as: 'search')]
     public $tableSearch = '';
 
+    /**
+     * @var array<string, string> | string | null
+     */
     #[Url(as: 'sort')]
-    public ?string $tableSort = null;
+    public array | string | null $tableSort = null;
 
     #[Url(as: 'tab')]
     public ?string $activeTab = null;

--- a/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
+++ b/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
@@ -46,8 +46,11 @@ trait InteractsWithPageTable /** @phpstan-ignore trait.unused */
     #[Reactive]
     public $tableSearch = '';
 
+    /**
+     * @var array<string, string> | string | null
+     */
     #[Reactive]
-    public ?string $tableSort = null;
+    public array | string | null $tableSort = null;
 
     #[Reactive]
     public ?string $activeTab = null;

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -47,7 +47,7 @@ namespace Livewire\Features\SupportTesting {
 
         public function assertTableSelectColumnDoesNotHaveOptions(string $name, array $options, $record): static {}
 
-        public function sortTable(?string $name = null, ?string $direction = null): static {}
+        public function sortTable(?string $name = null, ?string $direction = null, bool $isMultiSort = false): static {}
 
         public function searchTable(?string $search = null): static {}
 

--- a/packages/tables/docs/02-columns/01-overview.md
+++ b/packages/tables/docs/02-columns/01-overview.md
@@ -210,6 +210,8 @@ TextColumn::make('name')
     ->sortable()
 ```
 
+Users may sort by multiple columns by holding <kbd>Shift</kbd> while clicking another sortable column header. Shift-clicking a sorted column will toggle that column between ascending, descending, and unsorted. Clicking a column header without holding <kbd>Shift</kbd> will reset the table back to sorting by that column only.
+
 <AutoScreenshot name="tables/columns/sortable" alt="Table with sortable column" version="4.x" />
 
 Using the name of the column, Filament will apply an `orderBy()` clause to the Eloquent query. This is useful for simple cases where the column name matches the database column name. It can also handle [relationships](#displaying-data-from-relationships).

--- a/packages/tables/docs/09-custom-data.md
+++ b/packages/tables/docs/09-custom-data.md
@@ -68,7 +68,9 @@ TextColumn::make('is_featured')
 
 Filament's built-in [sorting](columns#sorting) function uses SQL to sort data. When working with custom data, you'll need to handle sorting yourself.
 
-To access the currently sorted column and direction, you can inject `$sortColumn` and `$sortDirection` into the `records()` function. These variables are `null` if no sorting is applied.
+To access the first currently sorted column and direction, you can inject `$sortColumn` and `$sortDirection` into the `records()` function. These variables are `null` if no sorting is applied.
+
+If you need to handle [multi-column sorting](columns#sorting), you can inject `$sorts` instead. This is an array keyed by column name, where each value is either `'asc'` or `'desc'`.
 
 In the example below, a [collection](https://laravel.com/docs/collections#method-sortby) is used to sort the data by key. The collection is returned instead of an array, and Filament handles it the same way. However, using a collection is not required to use this feature.
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -143,7 +143,7 @@
     $reorderRecordsTriggerAction = $getReorderRecordsTriggerAction($isReordering);
     $page = $this->getTablePage();
     $defaultSortOptionLabel = $getDefaultSortOptionLabel();
-    $sortDirection = $getSortDirection();
+    $sorts = $getSorts();
 
     if (count($defaultRecordActions) && (! $isReordering)) {
         $columnsCount++;
@@ -886,43 +886,28 @@
                                                 sort: $wire.$entangle('tableSort', true),
                                                 column: null,
                                                 direction: null,
+                                                syncSortInputs() {
+                                                    let column = null
+                                                    let direction = null
+
+                                                    if (typeof this.sort === 'string') {
+                                                        ;[column, direction] = this.sort.split(':')
+                                                    } else if (this.sort && typeof this.sort === 'object') {
+                                                        column = Object.keys(this.sort)[0] ?? null
+                                                        direction = column ? this.sort[column] : null
+                                                    }
+
+                                                    this.column = column
+                                                    this.direction = column ? (direction === 'desc' ? 'desc' : 'asc') : null
+                                                },
+                                                updateSortFromInputs() {
+                                                    this.sort = this.column ? `${this.column}:${this.direction || 'asc'}` : null
+                                                },
                                             }"
                                             x-init="
-                                                if (sort) {
-                                                    ;[column, direction] = sort.split(':')
-                                                    direction ??= 'asc'
-                                                }
+                                                syncSortInputs()
 
-                                                $watch('sort', function () {
-                                                    if (! sort) {
-                                                        return
-                                                    }
-
-                                                    ;[column, direction] = sort.split(':')
-                                                    direction ??= 'asc'
-                                                })
-
-                                                $watch('direction', function () {
-                                                    sort = column ? `${column}:${direction}` : null
-                                                })
-
-                                                $watch('column', function (newColumn, oldColumn) {
-                                                    if (! newColumn) {
-                                                        direction = null
-                                                        sort = column ? `${column}:${direction}` : null
-
-                                                        return
-                                                    }
-
-                                                    if (oldColumn) {
-                                                        sort = column ? `${column}:${direction}` : null
-
-                                                        return
-                                                    }
-
-                                                    direction = 'asc'
-                                                    sort = column ? `${column}:${direction}` : null
-                                                })
+                                                $watch('sort', () => syncSortInputs())
                                             "
                                             class="fi-ta-sorting-settings"
                                         >
@@ -932,6 +917,10 @@
                                                 >
                                                     <x-filament::input.select
                                                         x-model="column"
+                                                        x-on:change="
+                                                            direction = column ? (direction || 'asc') : null
+                                                            updateSortFromInputs()
+                                                        "
                                                     >
                                                         <option value="">
                                                             {{ $defaultSortOptionLabel }}
@@ -956,6 +945,7 @@
                                                 <x-filament::input.wrapper>
                                                     <x-filament::input.select
                                                         x-model="direction"
+                                                        x-on:change="updateSortFromInputs()"
                                                     >
                                                         <option value="asc">
                                                             {{ __('filament-tables::table.sorting.fields.direction.options.asc') }}
@@ -1383,43 +1373,28 @@
                                                         sort: $wire.$entangle('tableSort', true),
                                                         column: null,
                                                         direction: null,
+                                                        syncSortInputs() {
+                                                            let column = null
+                                                            let direction = null
+
+                                                            if (typeof this.sort === 'string') {
+                                                                ;[column, direction] = this.sort.split(':')
+                                                            } else if (this.sort && typeof this.sort === 'object') {
+                                                                column = Object.keys(this.sort)[0] ?? null
+                                                                direction = column ? this.sort[column] : null
+                                                            }
+
+                                                            this.column = column
+                                                            this.direction = column ? (direction === 'desc' ? 'desc' : 'asc') : null
+                                                        },
+                                                        updateSortFromInputs() {
+                                                            this.sort = this.column ? `${this.column}:${this.direction || 'asc'}` : null
+                                                        },
                                                     }"
                                                     x-init="
-                                                        if (sort) {
-                                                            ;[column, direction] = sort.split(':')
-                                                            direction ??= 'asc'
-                                                        }
+                                                        syncSortInputs()
 
-                                                        $watch('sort', function () {
-                                                            if (! sort) {
-                                                                return
-                                                            }
-
-                                                            ;[column, direction] = sort.split(':')
-                                                            direction ??= 'asc'
-                                                        })
-
-                                                        $watch('direction', function () {
-                                                            sort = column ? `${column}:${direction}` : null
-                                                        })
-
-                                                        $watch('column', function (newColumn, oldColumn) {
-                                                            if (! newColumn) {
-                                                                direction = null
-                                                                sort = column ? `${column}:${direction}` : null
-
-                                                                return
-                                                            }
-
-                                                            if (oldColumn) {
-                                                                sort = column ? `${column}:${direction}` : null
-
-                                                                return
-                                                            }
-
-                                                            direction = 'asc'
-                                                            sort = column ? `${column}:${direction}` : null
-                                                        })
+                                                        $watch('sort', () => syncSortInputs())
                                                     "
                                                     class="fi-ta-table-stacked-sorting"
                                                 >
@@ -1429,6 +1404,10 @@
                                                         >
                                                             <x-filament::input.select
                                                                 x-model="column"
+                                                                x-on:change="
+                                                                    direction = column ? (direction || 'asc') : null
+                                                                    updateSortFromInputs()
+                                                                "
                                                             >
                                                                 <option
                                                                     value=""
@@ -1460,6 +1439,7 @@
                                                         <x-filament::input.wrapper>
                                                             <x-filament::input.select
                                                                 x-model="direction"
+                                                                x-on:change="updateSortFromInputs()"
                                                             >
                                                                 <option
                                                                     value="asc"
@@ -1667,7 +1647,8 @@
                                                 $columnLabel = $column->getLabel();
                                                 $columnAlignment = $column->getAlignment();
                                                 $columnWidth = $column->getWidth();
-                                                $isColumnActivelySorted = $getSortColumn() === $column->getName();
+                                                $columnSortDirection = $sorts[$columnName] ?? null;
+                                                $isColumnActivelySorted = filled($columnSortDirection);
                                                 $isColumnSortable = $column->isSortable() && (! $isReordering);
                                                 $columnHeaderTooltip = $column->getHeaderTooltip();
                                                 $columnHeaderTooltipAttribute = ($columnHeaderTooltip instanceof \Illuminate\Contracts\Support\Htmlable)
@@ -1677,7 +1658,7 @@
 
                                             <th
                                                 @if ($isColumnActivelySorted)
-                                                    aria-sort="{{ $sortDirection === 'asc' ? 'ascending' : 'descending' }}"
+                                                    aria-sort="{{ $columnSortDirection === 'asc' ? 'ascending' : 'descending' }}"
                                                 @endif
                                                 {{
                                                     $column->getExtraHeaderAttributeBag()
@@ -1702,9 +1683,9 @@
                                                         aria-label="{{ trim(strip_tags($columnLabel)) }}"
                                                         role="button"
                                                         tabindex="0"
-                                                        wire:click="sortTable('{{ $columnName }}')"
-                                                        x-on:keydown.enter.prevent.stop="$wire.sortTable('{{ $columnName }}')"
-                                                        x-on:keydown.space.prevent.stop="$wire.sortTable('{{ $columnName }}')"
+                                                        x-on:click="$wire.sortTable(@js($columnName), null, $event.shiftKey)"
+                                                        x-on:keydown.enter.prevent.stop="$wire.sortTable(@js($columnName), null, $event.shiftKey)"
+                                                        x-on:keydown.space.prevent.stop="$wire.sortTable(@js($columnName), null, $event.shiftKey)"
                                                         wire:loading.attr="disabled"
                                                         class="fi-ta-header-cell-sort-btn"
                                                     >
@@ -1723,20 +1704,20 @@
                                                         @endif
 
                                                         {{
-                                                            \Filament\Support\generate_icon_html(($isColumnActivelySorted && $sortDirection === 'asc') ? \Filament\Support\Icons\Heroicon::ChevronUp : \Filament\Support\Icons\Heroicon::ChevronDown, alias: match (true) {
-                                                                $isColumnActivelySorted && ($sortDirection === 'asc') => \Filament\Tables\View\TablesIconAlias::HEADER_CELL_SORT_ASC_BUTTON,
-                                                                $isColumnActivelySorted && ($sortDirection === 'desc') => \Filament\Tables\View\TablesIconAlias::HEADER_CELL_SORT_DESC_BUTTON,
+                                                            \Filament\Support\generate_icon_html(($isColumnActivelySorted && $columnSortDirection === 'asc') ? \Filament\Support\Icons\Heroicon::ChevronUp : \Filament\Support\Icons\Heroicon::ChevronDown, alias: match (true) {
+                                                                $isColumnActivelySorted && ($columnSortDirection === 'asc') => \Filament\Tables\View\TablesIconAlias::HEADER_CELL_SORT_ASC_BUTTON,
+                                                                $isColumnActivelySorted && ($columnSortDirection === 'desc') => \Filament\Tables\View\TablesIconAlias::HEADER_CELL_SORT_DESC_BUTTON,
                                                                 default => \Filament\Tables\View\TablesIconAlias::HEADER_CELL_SORT_BUTTON,
                                                             }, attributes: (new \Illuminate\View\ComponentAttributeBag([
                                                                 'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => true,
-                                                                'wire:target' => "sortTable('{$columnName}')",
+                                                                'wire:target' => 'sortTable',
                                                             ])))
                                                         }}
 
                                                         {{
                                                             \Filament\Support\generate_loading_indicator_html(new \Illuminate\View\ComponentAttributeBag([
                                                                 'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
-                                                                'wire:target' => "sortTable('{$columnName}')",
+                                                                'wire:target' => 'sortTable',
                                                             ]))
                                                         }}
                                                     </span>

--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -31,6 +31,7 @@ trait CanSortRecords
             $direction ??= match ($currentDirection) {
                 'asc' => 'desc',
                 'desc' => null,
+                default => 'asc',
             };
         } else {
             $direction ??= 'asc';

--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -6,49 +6,101 @@ use Illuminate\Database\Eloquent\Builder;
 
 trait CanSortRecords
 {
-    public ?string $tableSort = null;
+    /**
+     * @var array<string, string> | string | null
+     */
+    public array | string | null $tableSort = null;
 
-    public function sortTable(?string $column = null, ?string $direction = null): void
+    public function sortTable(?string $column = null, ?string $direction = null, bool $isMultiSort = false): void
     {
-        if ($column === $this->getTableSortColumn()) {
-            $direction ??= match ($this->getTableSortDirection()) {
+        if (blank($column)) {
+            $this->tableSort = null;
+
+            $this->updatedTableSort();
+
+            return;
+        }
+
+        $sorts = $this->getTableSorts();
+
+        $currentDirection = $isMultiSort
+            ? ($sorts[$column] ?? null)
+            : ((count($sorts) === 1) && (array_key_first($sorts) === $column) ? $sorts[$column] : null);
+
+        if ($currentDirection) {
+            $direction ??= match ($currentDirection) {
                 'asc' => 'desc',
                 'desc' => null,
-                default => 'asc',
             };
         } else {
             $direction ??= 'asc';
         }
 
-        $this->tableSort = $direction ? "{$column}:{$direction}" : null;
+        if ($isMultiSort) {
+            if ($direction) {
+                $sorts[$column] = $this->normalizeTableSortDirection($direction) ?? 'asc';
+            } else {
+                unset($sorts[$column]);
+            }
+        } elseif ($direction) {
+            $sorts = [$column => $this->normalizeTableSortDirection($direction) ?? 'asc'];
+        } else {
+            $sorts = [];
+        }
+
+        $this->tableSort = $this->normalizeTableSortForStorage($sorts);
 
         $this->updatedTableSort();
     }
 
-    public function getTableSortColumn(): ?string
+    /**
+     * @return array<string, string>
+     */
+    public function getTableSorts(): array
     {
         if (blank($this->tableSort)) {
+            return [];
+        }
+
+        if (is_array($this->tableSort)) {
+            $sorts = [];
+
+            foreach ($this->tableSort as $column => $direction) {
+                if (blank($column)) {
+                    continue;
+                }
+
+                $sorts[$column] = $this->normalizeTableSortDirection($direction) ?? 'asc';
+            }
+
+            return $sorts;
+        }
+
+        $column = (string) str($this->tableSort)->before(':');
+
+        if (blank($column)) {
+            return [];
+        }
+
+        return [$column => $this->getTableSortDirectionFromString($this->tableSort) ?? 'asc'];
+    }
+
+    public function getTableSortColumn(): ?string
+    {
+        if (blank($sorts = $this->getTableSorts())) {
             return null;
         }
 
-        return (string) str($this->tableSort)->before(':');
+        return array_key_first($sorts);
     }
 
     public function getTableSortDirection(): ?string
     {
-        if (blank($this->tableSort)) {
+        if (blank($sorts = $this->getTableSorts())) {
             return null;
         }
 
-        if (! str($this->tableSort)->contains(':')) {
-            return 'asc';
-        }
-
-        return match ((string) str($this->tableSort)->after(':')) {
-            'asc' => 'asc',
-            'desc' => 'desc',
-            default => null,
-        };
+        return reset($sorts);
     }
 
     public function updatedTableSort(): void
@@ -85,13 +137,13 @@ trait CanSortRecords
             return $query->orderBy($this->getTable()->getReorderColumn(), $this->getTable()->getReorderDirection());
         }
 
-        $tableSortColumn = $this->getTableSortColumn();
+        $tableSorts = $this->getTableSorts();
+        $tableSortColumns = array_keys($tableSorts);
 
-        if (
-            $tableSortColumn &&
-            $column = $this->getTable()->getSortableVisibleColumn($tableSortColumn)
-        ) {
-            $sortDirection = $this->getTableSortDirection() === 'desc' ? 'desc' : 'asc';
+        foreach ($tableSorts as $tableSortColumn => $sortDirection) {
+            if (! $column = $this->getTable()->getSortableVisibleColumn($tableSortColumn)) {
+                continue;
+            }
 
             $column->applySort($query, $sortDirection);
         }
@@ -101,13 +153,13 @@ trait CanSortRecords
 
         if (
             is_string($defaultSort) &&
-            ($defaultSort !== $tableSortColumn) &&
+            (! in_array($defaultSort, $tableSortColumns, strict: true)) &&
             ($sortColumn = $this->getTable()->getSortableVisibleColumn($defaultSort))
         ) {
             $sortColumn->applySort($query, $sortDirection);
         } elseif (
             is_string($defaultSort) &&
-            $defaultSort !== $tableSortColumn
+            (! in_array($defaultSort, $tableSortColumns, strict: true))
         ) {
             $query->orderBy($defaultSort, $sortDirection);
         }
@@ -161,6 +213,47 @@ trait CanSortRecords
         $table = md5($this::class);
 
         return "tables.{$table}_sort";
+    }
+
+    protected function getTableSortDirectionFromString(string $sort): ?string
+    {
+        if (! str($sort)->contains(':')) {
+            return 'asc';
+        }
+
+        return $this->normalizeTableSortDirection((string) str($sort)->after(':'));
+    }
+
+    protected function normalizeTableSortDirection(mixed $direction): ?string
+    {
+        if (! is_scalar($direction)) {
+            return null;
+        }
+
+        return match (strtolower(strval($direction))) {
+            'asc' => 'asc',
+            'desc' => 'desc',
+            default => null,
+        };
+    }
+
+    /**
+     * @param  array<string, string>  $sorts
+     * @return array<string, string> | string | null
+     */
+    protected function normalizeTableSortForStorage(array $sorts): array | string | null
+    {
+        if (blank($sorts)) {
+            return null;
+        }
+
+        if (count($sorts) === 1) {
+            $column = array_key_first($sorts);
+
+            return "{$column}:{$sorts[$column]}";
+        }
+
+        return $sorts;
     }
 
     /**

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -108,6 +108,7 @@ trait HasRecords
                 'sort' => fn (): array => [$this->getTableSortColumn(), $this->getTableSortDirection()],
                 'sortColumn' => fn (): ?string => $this->getTableSortColumn(),
                 'sortDirection' => fn (): ?string => $this->getTableSortDirection(),
+                'sorts' => fn (): array => $this->getTableSorts(),
             ]);
 
             if (is_array($records)) {

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -146,8 +146,10 @@ trait InteractsWithTable
             session()->has($sortSessionKey)
         ) {
             $sessionSort = session()->get($sortSessionKey);
-            $this->tableSort = is_string($sessionSort) ? $sessionSort : null;
+            $this->tableSort = (is_string($sessionSort) || is_array($sessionSort)) ? $sessionSort : null;
         }
+
+        $this->tableSort = $this->normalizeTableSortForStorage($this->getTableSorts());
 
         if ($shouldPersistSortInSession) {
             session()->put(

--- a/packages/tables/src/Contracts/HasTable.php
+++ b/packages/tables/src/Contracts/HasTable.php
@@ -75,6 +75,11 @@ interface HasTable
 
     public function getTableSortDirection(): ?string;
 
+    /**
+     * @return array<string, string>
+     */
+    public function getTableSorts(): array;
+
     public function getAllTableSummaryQuery(): ?Builder;
 
     public function getPageTableSummaryQuery(): ?Builder;

--- a/packages/tables/src/Table/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSortRecords.php
@@ -116,6 +116,14 @@ trait CanSortRecords
         return $this->getLivewire()->getTableSortColumn();
     }
 
+    /**
+     * @return array<string, string>
+     */
+    public function getSorts(): array
+    {
+        return $this->getLivewire()->getTableSorts();
+    }
+
     public function getSortDirection(): ?string
     {
         return $this->getLivewire()->getTableSortDirection();

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -618,8 +618,8 @@ class TestsColumns
 
     public function sortTable(): Closure
     {
-        return function (?string $name = null, ?string $direction = null): static {
-            $this->call('sortTable', $name, $direction);
+        return function (?string $name = null, ?string $direction = null, bool $isMultiSort = false): static {
+            $this->call('sortTable', $name, $direction, $isMultiSort);
 
             return $this;
         };

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -51,6 +51,52 @@ describe('rendering and sorting', function (): void {
             ->assertCanSeeTableRecords($sortedDesc, inOrder: true);
     });
 
+    it('can sort records by multiple columns', function (): void {
+        $alice = User::factory()->create(['name' => 'Alice']);
+        $bob = User::factory()->create(['name' => 'Bob']);
+
+        Post::factory()->for($bob, 'author')->create(['title' => 'Alpha']);
+        Post::factory()->for($alice, 'author')->create(['title' => 'Alpha']);
+        Post::factory()->for($bob, 'author')->create(['title' => 'Beta']);
+        Post::factory()->for($alice, 'author')->create(['title' => 'Beta']);
+
+        $authorNameSortQuery = User::query()
+            ->select('name')
+            ->whereColumn('users.id', 'posts.author_id')
+            ->limit(1);
+
+        $sortedAsc = Post::query()
+            ->orderBy('title')
+            ->orderBy($authorNameSortQuery)
+            ->orderBy('posts.id')
+            ->get();
+
+        $sortedDesc = Post::query()
+            ->orderBy('title')
+            ->orderByDesc($authorNameSortQuery)
+            ->orderBy('posts.id')
+            ->get();
+
+        livewire(PostsTable::class)
+            ->sortTable('title')
+            ->sortTable('author.name', null, true)
+            ->assertSet('tableSort', [
+                'title' => 'asc',
+                'author.name' => 'asc',
+            ])
+            ->assertCanSeeTableRecords($sortedAsc, inOrder: true)
+            ->sortTable('author.name', null, true)
+            ->assertSet('tableSort', [
+                'title' => 'asc',
+                'author.name' => 'desc',
+            ])
+            ->assertCanSeeTableRecords($sortedDesc, inOrder: true)
+            ->sortTable('author.name', null, true)
+            ->assertSet('tableSort', 'title:asc')
+            ->sortTable('author.name')
+            ->assertSet('tableSort', 'author.name:asc');
+    });
+
     it('can sort records with relationship', function (): void {
         Post::factory()->count(10)->create();
 


### PR DESCRIPTION
## Summary
- Allow table sort state to store multiple ordered columns while preserving existing single-column string state
- Apply all active sortable columns to table queries and expose sort maps to tables and custom data sources
- Add Shift-click header sorting, tests, and docs for multi-column sorting

Fixes #15485

## Tests
- vendor/bin/pest --configuration=phpunit.sqlite.xml tests/src/Tables/ColumnTest.php --filter "can sort records"
- vendor/bin/pest --configuration=phpunit.sqlite.xml tests/src/Panels/Resources/Pages/ListRecordsTest.php --filter "sort"
- vendor/bin/pest --configuration=phpunit.sqlite.xml tests/src/Tables/Columns/ColumnTest.php tests/src/Tables/ColumnTest.php --filter "sortable|sort records by multiple columns|can sort records$"