### PR TITLE
Fix binary record attributes in form state

### DIFF
--- a/packages/actions/src/EditAction.php
+++ b/packages/actions/src/EditAction.php
@@ -14,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Arr;
 
+use function Filament\Support\filter_invalid_utf8_strings;
+
 class EditAction extends Action
 {
     use CanCustomizeProcess;
@@ -75,7 +77,7 @@ class EditAction extends Action
                 $data = $this->evaluate($this->mutateRecordDataUsing, ['data' => $data]);
             }
 
-            return $data;
+            return filter_invalid_utf8_strings($data);
         });
 
         $this->action(function (): void {

--- a/packages/actions/src/ReplicateAction.php
+++ b/packages/actions/src/ReplicateAction.php
@@ -11,6 +11,8 @@ use Filament\Support\Icons\Heroicon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 
+use function Filament\Support\filter_invalid_utf8_strings;
+
 class ReplicateAction extends Action
 {
     use CanCustomizeProcess;
@@ -50,7 +52,7 @@ class ReplicateAction extends Action
                 $data = $this->evaluate($this->mutateRecordDataUsing, ['data' => $data]);
             }
 
-            return $data;
+            return filter_invalid_utf8_strings($data);
         });
 
         $this->action(function () {

--- a/packages/actions/src/ViewAction.php
+++ b/packages/actions/src/ViewAction.php
@@ -10,6 +10,8 @@ use Filament\Support\Facades\FilamentIcon;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Database\Eloquent\Model;
 
+use function Filament\Support\filter_invalid_utf8_strings;
+
 class ViewAction extends Action
 {
     protected ?Closure $mutateRecordDataUsing = null;
@@ -48,7 +50,7 @@ class ViewAction extends Action
                 $data = $this->evaluate($this->mutateRecordDataUsing, ['data' => $data]);
             }
 
-            return $data;
+            return filter_invalid_utf8_strings($data);
         });
     }
 

--- a/packages/forms/src/Commands/FileGenerators/Concerns/CanGenerateModelForms.php
+++ b/packages/forms/src/Commands/FileGenerators/Concerns/CanGenerateModelForms.php
@@ -85,6 +85,10 @@ trait CanGenerateModelForms
 
             $type = $this->parseColumnType($column);
 
+            if (! $this->canGenerateSchemaComponentForColumnType($type)) {
+                continue;
+            }
+
             $componentData = [];
 
             $componentData['type'] = match (true) {

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -27,6 +27,7 @@ use LogicException;
 
 use function Filament\Forms\array_move_after;
 use function Filament\Forms\array_move_before;
+use function Filament\Support\filter_invalid_utf8_strings;
 
 class Repeater extends Field implements CanConcealComponents, HasExtraItemActions
 {
@@ -1116,7 +1117,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
                     $translatableContentDriver->getRecordAttributesToArray($record) :
                     $record->attributesToArray();
 
-                return $this->mutateRelationshipDataBeforeFill($data);
+                return filter_invalid_utf8_strings($this->mutateRelationshipDataBeforeFill($data));
             })
             ->toArray();
     }

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -40,6 +40,7 @@ use Livewire\Attributes\Renderless;
 use LogicException;
 use Znck\Eloquent\Relations\BelongsToThrough;
 
+use function Filament\Support\filter_invalid_utf8_strings;
 use function Filament\Support\generate_search_column_expression;
 use function Filament\Support\generate_search_term_expression;
 
@@ -967,7 +968,9 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
         });
 
         $this->fillEditOptionActionFormUsing(static function (Select $component): ?array {
-            return $component->getSelectedRecord()?->attributesToArray();
+            $record = $component->getSelectedRecord();
+
+            return $record ? filter_invalid_utf8_strings($record->attributesToArray()) : null;
         });
 
         $this->updateOptionUsing(static function (array $data, Schema $schema): void {

--- a/packages/infolists/src/Commands/FileGenerators/Concerns/CanGenerateModelInfolists.php
+++ b/packages/infolists/src/Commands/FileGenerators/Concerns/CanGenerateModelInfolists.php
@@ -55,6 +55,10 @@ trait CanGenerateModelInfolists
 
             $type = $this->parseColumnType($column);
 
+            if (! $this->canGenerateSchemaComponentForColumnType($type)) {
+                continue;
+            }
+
             if (in_array($type['name'], [
                 'json',
             ])) {

--- a/packages/panels/src/Auth/Pages/EditProfile.php
+++ b/packages/panels/src/Auth/Pages/EditProfile.php
@@ -43,6 +43,8 @@ use LogicException;
 use SensitiveParameter;
 use Throwable;
 
+use function Filament\Support\filter_invalid_utf8_strings;
+
 /**
  * @property-read Schema $form
  */
@@ -115,6 +117,7 @@ class EditProfile extends Page
         $this->callHook('beforeFill');
 
         $data = $this->mutateFormDataBeforeFill($data);
+        $data = filter_invalid_utf8_strings($data);
 
         $this->form->fill($data);
 

--- a/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
+++ b/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
@@ -23,6 +23,7 @@ use Livewire\Attributes\Locked;
 use Throwable;
 
 use function Filament\authorize;
+use function Filament\Support\filter_invalid_utf8_strings;
 
 /**
  * @property-read Schema $form
@@ -85,6 +86,7 @@ abstract class EditTenantProfile extends Page
         $this->callHook('beforeFill');
 
         $data = $this->mutateFormDataBeforeFill($data);
+        $data = filter_invalid_utf8_strings($data);
 
         $this->form->fill($data);
 

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -35,6 +35,8 @@ use Illuminate\Support\Js;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Throwable;
 
+use function Filament\Support\filter_invalid_utf8_strings;
+
 /**
  * @template TModel of Model = Model
  *
@@ -125,6 +127,8 @@ class EditRecord extends Page
             ...$extraData,
         ]);
 
+        $data = filter_invalid_utf8_strings($data);
+
         $this->form->fill($data);
 
         $this->callHook('afterFill');
@@ -136,7 +140,7 @@ class EditRecord extends Page
     public function refreshFormData(array $statePaths): void
     {
         $this->form->fillPartially(
-            $this->mutateFormDataBeforeFill($this->getRecord()->attributesToArray()),
+            filter_invalid_utf8_strings($this->mutateFormDataBeforeFill($this->getRecord()->attributesToArray())),
             $statePaths,
         );
     }

--- a/packages/panels/src/Resources/Pages/ViewRecord.php
+++ b/packages/panels/src/Resources/Pages/ViewRecord.php
@@ -19,6 +19,8 @@ use Filament\View\PanelsIconAlias;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 
+use function Filament\Support\filter_invalid_utf8_strings;
+
 /**
  * @template TModel of Model = Model
  *
@@ -110,6 +112,8 @@ class ViewRecord extends Page
             ...$extraData,
         ]);
 
+        $data = filter_invalid_utf8_strings($data);
+
         $this->form->fill($data);
 
         $this->callHook('afterFill');
@@ -121,7 +125,7 @@ class ViewRecord extends Page
     public function refreshFormData(array $statePaths): void
     {
         $this->form->fillPartially(
-            $this->mutateFormDataBeforeFill($this->getRecord()->attributesToArray()),
+            filter_invalid_utf8_strings($this->mutateFormDataBeforeFill($this->getRecord()->attributesToArray())),
             $statePaths,
         );
     }

--- a/packages/schemas/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
+++ b/packages/schemas/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
@@ -14,6 +14,8 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Support\Arr;
 use Livewire\Component as LivewireComponent;
 
+use function Filament\Support\filter_invalid_utf8_strings;
+
 trait EntanglesStateWithSingularRelationship
 {
     protected ?Model $cachedExistingRecord = null;
@@ -191,6 +193,8 @@ trait EntanglesStateWithSingularRelationship
         $data = $this->mutateRelationshipDataBeforeFill(
             $this->getStateFromRelatedRecord($record),
         );
+
+        $data = filter_invalid_utf8_strings($data);
 
         $this->getChildSchema()->fill($data, shouldCallHydrationHooks: false, shouldFillStateWithNull: false, shouldApplyStateCasts: false);
     }

--- a/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
+++ b/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
@@ -143,6 +143,7 @@ trait CanReadModelSchemas
             'timestamp', 'timestamptz' => 'timestamp',
             'text', 'tinytext', 'longtext', 'mediumtext', 'ntext' => 'text',
             'json', 'jsonb' => 'json',
+            'binary', 'varbinary', 'blob', 'tinyblob', 'mediumblob', 'longblob', 'bytea' => 'binary',
             default => $column['type_name'],
         };
 
@@ -157,6 +158,16 @@ trait CanReadModelSchemas
         };
 
         return array_merge(['name' => $type], array_filter($values));
+    }
+
+    /**
+     * @param  array<string, mixed>  $type
+     */
+    protected function canGenerateSchemaComponentForColumnType(array $type): bool
+    {
+        return ! in_array($type['name'], [
+            'binary',
+        ], strict: true);
     }
 
     /**

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -110,12 +110,7 @@ if (! function_exists('Filament\Support\filter_invalid_utf8_strings')) {
         foreach ($values as $key => $value) {
             if (is_array($value)) {
                 $values[$key] = filter_invalid_utf8_strings($value);
-
-                continue;
-            }
-
-            if (! is_string($value)) {
-                continue;
+                $value = $values[$key];
             }
 
             try {

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Str;
 use Illuminate\Translation\MessageSelector;
 use Illuminate\View\ComponentAttributeBag;
 use Illuminate\View\ComponentSlot;
+use JsonException;
 use Throwable;
 
 if (! function_exists('Filament\Support\format_money')) {
@@ -96,6 +97,35 @@ if (! function_exists('Filament\Support\prepare_inherited_attributes')) {
         );
 
         return $attributes;
+    }
+}
+
+if (! function_exists('Filament\Support\filter_invalid_utf8_strings')) {
+    /**
+     * @param  array<array-key, mixed>  $values
+     * @return array<array-key, mixed>
+     */
+    function filter_invalid_utf8_strings(array $values): array
+    {
+        foreach ($values as $key => $value) {
+            if (is_array($value)) {
+                $values[$key] = filter_invalid_utf8_strings($value);
+
+                continue;
+            }
+
+            if (! is_string($value)) {
+                continue;
+            }
+
+            try {
+                json_encode($value, JSON_THROW_ON_ERROR);
+            } catch (JsonException) {
+                unset($values[$key]);
+            }
+        }
+
+        return $values;
     }
 }
 

--- a/packages/tables/src/Commands/FileGenerators/Concerns/CanGenerateModelTables.php
+++ b/packages/tables/src/Commands/FileGenerators/Concerns/CanGenerateModelTables.php
@@ -74,6 +74,10 @@ trait CanGenerateModelTables
 
             $type = $this->parseColumnType($column);
 
+            if (! $this->canGenerateSchemaComponentForColumnType($type)) {
+                continue;
+            }
+
             if (in_array($type['name'], [
                 'json',
                 'text',

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -7,5 +7,19 @@ expect()->extend('toBeSameModel', function (Model $model) {
         ->is($model)->toBeTrue();
 });
 
+function set_invalid_utf8_record_attribute(Model $record, string $attribute): Model
+{
+    $connection = $record->getConnection();
+
+    $connection
+        ->table($record->getTable())
+        ->where($record->getKeyName(), $record->getKey())
+        ->update([
+            $attribute => $connection->raw($connection->escape("\xB1\x31", binary: true)),
+        ]);
+
+    return $record->refresh();
+}
+
 pest()->browser()
     ->timeout(10000);

--- a/tests/database/migrations/0003_create_departments_table.php
+++ b/tests/database/migrations/0003_create_departments_table.php
@@ -11,6 +11,7 @@ return new class extends Migration
         Schema::create('departments', function (Blueprint $table): void {
             $table->id();
             $table->string('name');
+            $table->binary('location')->nullable();
             $table->timestamps();
             $table->softDeletes();
         });

--- a/tests/database/migrations/0004_create_posts_table.php
+++ b/tests/database/migrations/0004_create_posts_table.php
@@ -13,6 +13,7 @@ return new class extends Migration
             $table->foreignId('author_id')->nullable();
             $table->text('content')->nullable();
             $table->boolean('is_published')->default(true);
+            $table->binary('location')->nullable();
             $table->unsignedTinyInteger('rating')->default(0);
             $table->jsonb('tags')->nullable();
             $table->string('title');

--- a/tests/src/Actions/EditActionTest.php
+++ b/tests/src/Actions/EditActionTest.php
@@ -41,6 +41,26 @@ it('can fill form with record data in `EditAction`', function (): void {
         ]);
 });
 
+it('does not fill form data with invalid UTF-8 record attributes in `EditAction`', function (): void {
+    $ticket = Ticket::factory()->create();
+    $department = Department::factory()->hasAttached($ticket)->create([
+        'name' => 'Original Name',
+        'location' => "\xB1\x31",
+    ]);
+
+    $component = livewire(DepartmentsRelationManager::class, ['ownerRecord' => $ticket, 'pageClass' => EditTicket::class])
+        ->mountAction(TestAction::make(EditAction::class)->table($department))
+        ->assertSchemaStateSet([
+            'name' => 'Original Name',
+        ]);
+
+    expect($component->instance()->mountedActions[0]['data'])
+        ->not->toHaveKey('location');
+
+    expect(json_encode($component->instance()->mountedActions, JSON_THROW_ON_ERROR))
+        ->toBeString();
+});
+
 it('can validate form data in `EditAction`', function (): void {
     $ticket = Ticket::factory()->create();
     $department = Department::factory()->hasAttached($ticket)->create();

--- a/tests/src/Actions/EditActionTest.php
+++ b/tests/src/Actions/EditActionTest.php
@@ -43,10 +43,9 @@ it('can fill form with record data in `EditAction`', function (): void {
 
 it('does not fill form data with invalid UTF-8 record attributes in `EditAction`', function (): void {
     $ticket = Ticket::factory()->create();
-    $department = Department::factory()->hasAttached($ticket)->create([
+    $department = set_invalid_utf8_record_attribute(Department::factory()->hasAttached($ticket)->create([
         'name' => 'Original Name',
-        'location' => "\xB1\x31",
-    ]);
+    ]), 'location');
 
     $component = livewire(DepartmentsRelationManager::class, ['ownerRecord' => $ticket, 'pageClass' => EditTicket::class])
         ->mountAction(TestAction::make(EditAction::class)->table($department))

--- a/tests/src/Actions/ViewActionTest.php
+++ b/tests/src/Actions/ViewActionTest.php
@@ -42,10 +42,9 @@ it('can display record data in `ViewAction`', function (): void {
 
 it('does not fill form data with invalid UTF-8 record attributes in `ViewAction`', function (): void {
     $ticket = Ticket::factory()->create();
-    $department = Department::factory()->hasAttached($ticket)->create([
+    $department = set_invalid_utf8_record_attribute(Department::factory()->hasAttached($ticket)->create([
         'name' => 'Test Department',
-        'location' => "\xB1\x31",
-    ]);
+    ]), 'location');
 
     $component = livewire(DepartmentsRelationManager::class, ['ownerRecord' => $ticket, 'pageClass' => EditTicket::class])
         ->mountAction(TestAction::make(ViewAction::class)->table($department))

--- a/tests/src/Actions/ViewActionTest.php
+++ b/tests/src/Actions/ViewActionTest.php
@@ -40,6 +40,26 @@ it('can display record data in `ViewAction`', function (): void {
         ]);
 });
 
+it('does not fill form data with invalid UTF-8 record attributes in `ViewAction`', function (): void {
+    $ticket = Ticket::factory()->create();
+    $department = Department::factory()->hasAttached($ticket)->create([
+        'name' => 'Test Department',
+        'location' => "\xB1\x31",
+    ]);
+
+    $component = livewire(DepartmentsRelationManager::class, ['ownerRecord' => $ticket, 'pageClass' => EditTicket::class])
+        ->mountAction(TestAction::make(ViewAction::class)->table($department))
+        ->assertSchemaStateSet([
+            'name' => 'Test Department',
+        ]);
+
+    expect($component->instance()->mountedActions[0]['data'])
+        ->not->toHaveKey('location');
+
+    expect(json_encode($component->instance()->mountedActions, JSON_THROW_ON_ERROR))
+        ->toBeString();
+});
+
 it('displays form as disabled in `ViewAction`', function (): void {
     $ticket = Ticket::factory()->create();
     $department = Department::factory()->hasAttached($ticket)->create(['name' => 'Test Department']);

--- a/tests/src/Panels/Resources/Pages/EditRecordTest.php
+++ b/tests/src/Panels/Resources/Pages/EditRecordTest.php
@@ -50,6 +50,25 @@ it('can retrieve data', function (): void {
         ]);
 });
 
+it('does not retrieve invalid UTF-8 record attributes', function (): void {
+    $post = Post::factory()->create([
+        'location' => "\xB1\x31",
+    ]);
+
+    $component = livewire(EditPost::class, [
+        'record' => $post->getKey(),
+    ])
+        ->assertSchemaStateSet([
+            'title' => $post->title,
+        ]);
+
+    expect($component->instance()->data)
+        ->not->toHaveKey('location');
+
+    expect(json_encode($component->instance()->data, JSON_THROW_ON_ERROR))
+        ->toBeString();
+});
+
 it('can save', function (): void {
     Event::fake([
         RecordUpdated::class,

--- a/tests/src/Panels/Resources/Pages/EditRecordTest.php
+++ b/tests/src/Panels/Resources/Pages/EditRecordTest.php
@@ -51,9 +51,7 @@ it('can retrieve data', function (): void {
 });
 
 it('does not retrieve invalid UTF-8 record attributes', function (): void {
-    $post = Post::factory()->create([
-        'location' => "\xB1\x31",
-    ]);
+    $post = set_invalid_utf8_record_attribute(Post::factory()->create(), 'location');
 
     $component = livewire(EditPost::class, [
         'record' => $post->getKey(),

--- a/tests/src/Panels/Resources/Pages/ViewRecordTest.php
+++ b/tests/src/Panels/Resources/Pages/ViewRecordTest.php
@@ -44,6 +44,25 @@ it('can retrieve data', function (): void {
         ]);
 });
 
+it('does not retrieve invalid UTF-8 record attributes', function (): void {
+    $post = Post::factory()->create([
+        'location' => "\xB1\x31",
+    ]);
+
+    $component = livewire(ViewPost::class, [
+        'record' => $post->getKey(),
+    ])
+        ->assertSchemaStateSet([
+            'title' => $post->title,
+        ]);
+
+    expect($component->instance()->data)
+        ->not->toHaveKey('location');
+
+    expect(json_encode($component->instance()->data, JSON_THROW_ON_ERROR))
+        ->toBeString();
+});
+
 it('can refresh data', function (): void {
     $post = Post::factory()->create();
 

--- a/tests/src/Panels/Resources/Pages/ViewRecordTest.php
+++ b/tests/src/Panels/Resources/Pages/ViewRecordTest.php
@@ -45,9 +45,7 @@ it('can retrieve data', function (): void {
 });
 
 it('does not retrieve invalid UTF-8 record attributes', function (): void {
-    $post = Post::factory()->create([
-        'location' => "\xB1\x31",
-    ]);
+    $post = set_invalid_utf8_record_attribute(Post::factory()->create(), 'location');
 
     $component = livewire(ViewPost::class, [
         'record' => $post->getKey(),

--- a/tests/src/Support/helpersTest.php
+++ b/tests/src/Support/helpersTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Query\Grammars\PostgresGrammar;
 use Illuminate\View\ComponentAttributeBag;
 
 use function Filament\get_authorization_response;
+use function Filament\Support\filter_invalid_utf8_strings;
 use function Filament\Support\generate_search_column_expression;
 use function Filament\Support\prepare_inherited_attributes;
 
@@ -47,6 +48,29 @@ it('will prepare data attributes', function (): void {
 
     expect($attributes->getAttributes())->toBe([
         'data-foo' => 'bar',
+    ]);
+});
+
+it('will filter invalid UTF-8 strings from arrays', function (): void {
+    expect(filter_invalid_utf8_strings([
+        'name' => 'Engineering',
+        'location' => "\xB1\x31",
+        'metadata' => [
+            'valid' => 'yes',
+            'invalid' => "\xB1\x31",
+        ],
+        'coordinates' => [
+            'valid',
+            "\xB1\x31",
+        ],
+    ]))->toBe([
+        'name' => 'Engineering',
+        'metadata' => [
+            'valid' => 'yes',
+        ],
+        'coordinates' => [
+            0 => 'valid',
+        ],
     ]);
 });
 

--- a/tests/src/Support/helpersTest.php
+++ b/tests/src/Support/helpersTest.php
@@ -52,9 +52,12 @@ it('will prepare data attributes', function (): void {
 });
 
 it('will filter invalid UTF-8 strings from arrays', function (): void {
+    $stream = fopen('php://memory', 'r+');
+
     expect(filter_invalid_utf8_strings([
         'name' => 'Engineering',
         'location' => "\xB1\x31",
+        'stream' => $stream,
         'metadata' => [
             'valid' => 'yes',
             'invalid' => "\xB1\x31",
@@ -72,6 +75,8 @@ it('will filter invalid UTF-8 strings from arrays', function (): void {
             0 => 'valid',
         ],
     ]);
+
+    fclose($stream);
 });
 
 it('can handle policy being an object when method does not exist', function (): void {


### PR DESCRIPTION
## Summary
- Filter invalid UTF-8 strings from Eloquent attribute arrays before filling Livewire form state
- Apply the filtering to resource pages, record actions, relationship-backed form state, and profile pages
- Add regression coverage for binary model attributes in form state

Fixes #13568

## Tests
- vendor/bin/pest tests/src/Support/helpersTest.php tests/src/Actions/EditActionTest.php tests/src/Actions/ViewActionTest.php tests/src/Panels/Resources/Pages/EditRecordTest.php tests/src/Panels/Resources/Pages/ViewRecordTest.php
- composer run pint -- packages/actions/src/EditAction.php packages/actions/src/ReplicateAction.php packages/actions/src/ViewAction.php packages/forms/src/Components/Repeater.php packages/forms/src/Components/Select.php packages/panels/src/Auth/Pages/EditProfile.php packages/panels/src/Pages/Tenancy/EditTenantProfile.php packages/panels/src/Resources/Pages/EditRecord.php packages/panels/src/Resources/Pages/ViewRecord.php packages/schemas/src/Components/Concerns/EntanglesStateWithSingularRelationship.php packages/support/src/helpers.php tests/database/migrations/0003_create_departments_table.php tests/database/migrations/0004_create_posts_table.php tests/src/Actions/EditActionTest.php tests/src/Actions/ViewActionTest.php tests/src/Panels/Resources/Pages/EditRecordTest.php tests/src/Panels/Resources/Pages/ViewRecordTest.php tests/src/Support/helpersTest.php