### PR TITLE
feat: allow navigation parent items to be referenced by class name

### DIFF
--- a/docs/06-navigation/01-overview.md
+++ b/docs/06-navigation/01-overview.md
@@ -124,7 +124,21 @@ All items in the same navigation group will be displayed together under the same
 
 ### Grouping navigation items under other items
 
-You may group navigation items as children of other items, by passing the label of the parent item as the `$navigationParentItem`:
+You may group navigation items as children of other items by setting the `$navigationParentItem` property.
+
+You may reference the parent item either by its label or by its page/resource class:
+
+```php
+use App\Filament\Resources\NotificationsResource;
+use UnitEnum;
+
+// By class name
+protected static ?string $navigationParentItem = NotificationsResource::class;
+
+protected static string | UnitEnum | null $navigationGroup = 'Settings';
+```
+
+You may still reference the parent by its label:
 
 ```php
 use UnitEnum;
@@ -134,7 +148,18 @@ protected static ?string $navigationParentItem = 'Notifications';
 protected static string | UnitEnum | null $navigationGroup = 'Settings';
 ```
 
-You may also use the `getNavigationParentItem()` method to set a dynamic parent item label:
+You may also use the `getNavigationParentItem()` method to determine the parent dynamically:
+
+```php
+use App\Filament\Resources\NotificationsResource;
+
+public static function getNavigationParentItem(): ?string
+{
+    return NotificationsResource::class;
+}
+```
+
+or
 
 ```php
 public static function getNavigationParentItem(): ?string

--- a/packages/panels/src/Navigation/NavigationManager.php
+++ b/packages/panels/src/Navigation/NavigationManager.php
@@ -63,12 +63,14 @@ class NavigationManager
                 $group = $item->getGroup();
 
                 return serialize($group);
-            })
+            }, preserveKeys: true)
             ->map(function (Collection $items, string $groupIndex) use ($groups): NavigationGroup {
-                $parentItems = $items->groupBy(fn (NavigationItem $item): string => $item->getParentItem() ?? '');
+                $parentItems = $items->groupBy(fn (NavigationItem $item): string => $item->getParentItem() ?? '',
+                    preserveKeys: true
+                );
 
                 $items = $parentItems->get('', collect())
-                    ->keyBy(fn (NavigationItem $item): string => $item->getLabel());
+                    ->keyBy(fn (NavigationItem $item, int|string $key): string => is_string($key) ? $key : $item->getLabel());
 
                 $parentItems->except([''])->each(function (Collection $parentItemItems, string $parentItemLabel) use ($items): void {
                     if (! $items->has($parentItemLabel)) {

--- a/packages/panels/src/Pages/Page.php
+++ b/packages/panels/src/Pages/Page.php
@@ -147,7 +147,7 @@ abstract class Page extends BasePage
         $activeRoutePattern = static::getNavigationItemActiveRoutePattern();
 
         return [
-            NavigationItem::make(static::getNavigationLabel())
+            static::class => NavigationItem::make(static::getNavigationLabel())
                 ->group(static::getNavigationGroup())
                 ->parentItem(static::getNavigationParentItem())
                 ->icon(static::getNavigationIcon())

--- a/packages/panels/src/Resources/Pages/Page.php
+++ b/packages/panels/src/Resources/Pages/Page.php
@@ -73,7 +73,7 @@ abstract class Page extends BasePage
     public static function getNavigationItems(array $urlParameters = []): array
     {
         return [
-            NavigationItem::make(static::getNavigationLabel())
+            static::class => NavigationItem::make(static::getNavigationLabel())
                 ->group(static::getNavigationGroup())
                 ->parentItem(static::getNavigationParentItem())
                 ->icon(static::getNavigationIcon())

--- a/packages/panels/src/Resources/Resource/Concerns/HasNavigation.php
+++ b/packages/panels/src/Resources/Resource/Concerns/HasNavigation.php
@@ -67,7 +67,7 @@ trait HasNavigation
         $activeRoutePattern = static::getNavigationItemActiveRoutePattern();
 
         return [
-            NavigationItem::make(static::getNavigationLabel())
+            static::class => NavigationItem::make(static::getNavigationLabel())
                 ->group(static::getNavigationGroup())
                 ->parentItem(static::getNavigationParentItem())
                 ->icon(static::getNavigationIcon())


### PR DESCRIPTION
This PR adds support for referencing parent navigation items by their class name, while preserving the existing behavior of referencing them by their label.

Using class names provides a more hierarchical and refactor-friendly approach.

## Example

Previously, child items had to reference the parent label:

```php
protected static ?string $navigationParentItem = 'Notifications';

protected static string | UnitEnum | null $navigationGroup = 'Settings';
```

With this PR, they can also reference the parent page or resource directly:

```php
protected static ?string $navigationParentItem = NotificationsResource::class;

protected static string | UnitEnum | null $navigationGroup = 'Settings';
```

Label-based references continue to work unchanged.

## Implementation

- `Page::getNavigationItems()`
- `Resources\Pages\Page::getNavigationItems()`
- `Resources\Resource\Concerns\HasNavigation::getNavigationItems()`

now return navigation items keyed by `static::class`:

```php
return [
    static::class => NavigationItem::make(...),
];
```

`NavigationManager` was updated to preserve collection keys during grouping and resolve parent items using either:

1. the item class name (collection key), or
2. the item label (existing behavior).

This preserves backward compatibility while allowing parent-child relationships to be defined independently from labels.