### PR TITLE
Change ImageColumn from 'avatar' to 'header_image'

### DIFF
--- a/packages/tables/docs/02-columns/04-image.md
+++ b/packages/tables/docs/02-columns/04-image.md
@@ -12,12 +12,12 @@ Tables can render images, based on the path in the state of the column:
 ```php
 use Filament\Tables\Columns\ImageColumn;
 
-ImageColumn::make('header_image')
+ImageColumn::make('avatar')
 ```
 
-In this case, the `header_image` state could contain `posts/header-images/4281246003439.jpg`, which is relative to the root directory of the storage disk. The storage disk is defined in the [configuration file](../../introduction/installation#publishing-configuration), `local` by default. You can also set the `FILESYSTEM_DISK` environment variable to change this.
+In this case, the `avatar` state could contain `users/avatars/4281246003439.jpg`, which is relative to the root directory of the storage disk. The storage disk is defined in the [configuration file](../../introduction/installation#publishing-configuration), `local` by default. You can also set the `FILESYSTEM_DISK` environment variable to change this.
 
-Alternatively, the state could contain an absolute URL to an image, such as `https://example.com/images/header.jpg`.
+Alternatively, the state could contain an absolute URL to an image, such as `https://example.com/images/avatar.jpg`.
 
 <AutoScreenshot name="tables/columns/image/simple" alt="Image column" version="4.x" />
 

--- a/packages/tables/docs/02-columns/04-image.md
+++ b/packages/tables/docs/02-columns/04-image.md
@@ -12,7 +12,7 @@ Tables can render images, based on the path in the state of the column:
 ```php
 use Filament\Tables\Columns\ImageColumn;
 
-ImageColumn::make('avatar')
+ImageColumn::make('header_image')
 ```
 
 In this case, the `header_image` state could contain `posts/header-images/4281246003439.jpg`, which is relative to the root directory of the storage disk. The storage disk is defined in the [configuration file](../../introduction/installation#publishing-configuration), `local` by default. You can also set the `FILESYSTEM_DISK` environment variable to change this.


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Update ImageColumn example to use 'header_image' instead of 'avatar' to match the following texts.

## Visual changes

NA

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
