### PR TITLE
fix: Skip cell attribute caching when hiddenFrom or visibleFrom use a Closure

### DIFF
--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -216,6 +216,8 @@ class Column extends ViewComponent
             $this->hasDynamicExtraCellAttributes()
             || $this->hasDynamicAlignment()
             || $this->hasDynamicVerticalAlignment()
+            || $this->hasDynamicHiddenFrom()
+            || $this->hasDynamicVisibleFrom()
         ) {
             return $this->getCellAttributeHtml();
         }

--- a/packages/tables/src/Columns/Concerns/CanBeHiddenResponsively.php
+++ b/packages/tables/src/Columns/Concerns/CanBeHiddenResponsively.php
@@ -33,4 +33,14 @@ trait CanBeHiddenResponsively
     {
         return $this->evaluate($this->visibleFrom);
     }
+
+    public function hasDynamicHiddenFrom(): bool
+    {
+        return $this->hiddenFrom instanceof Closure;
+    }
+
+    public function hasDynamicVisibleFrom(): bool
+    {
+        return $this->visibleFrom instanceof Closure;
+    }
 }


### PR DESCRIPTION

## Description

Added missing `hasDynamicHiddenFrom()` and `hasDynamicVisibleFrom()` checks  to the cell attribute cache guard.

## Visual changes
## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
