### PR TITLE
Pass Length in One time code input

### DIFF
--- a/packages/forms/resources/views/components/one-time-code-input.blade.php
+++ b/packages/forms/resources/views/components/one-time-code-input.blade.php
@@ -18,7 +18,9 @@
             :attributes="
                 \Filament\Support\prepare_inherited_attributes(
                     $getExtraAttributeBag()->merge($getExtraAlpineAttributes(), escape: false),
-                )
+                )->merge([
+                    'length' => $getLength(),
+                ], escape: false)
             "
         >
             <x-slot

--- a/packages/forms/resources/views/components/one-time-code-input.blade.php
+++ b/packages/forms/resources/views/components/one-time-code-input.blade.php
@@ -19,7 +19,7 @@
                 \Filament\Support\prepare_inherited_attributes(
                     $getExtraAttributeBag()->merge($getExtraAlpineAttributes(), escape: false),
                 )->merge([
-                    'length' => $getLength(),
+                    'length' => $length,
                 ], escape: false)
             "
         >

--- a/tests/src/Forms/Components/OneTimeCodeInputTest.php
+++ b/tests/src/Forms/Components/OneTimeCodeInputTest.php
@@ -135,6 +135,18 @@ describe('rendering', function (): void {
             ->assertSuccessful();
     });
 
+    it('renders the correct number of inputs for `length()` of `8`', function (): void {
+        $html = livewire(RenderOneTimeCodeInputWithClosureLength::class)->html();
+
+        expect(substr_count($html, 'fi-one-time-code-input-digit'))->toBe(8);
+    });
+
+    it('renders the correct number of inputs for `length()` of `4`', function (): void {
+        $html = livewire(TestComponentWithFourDigitCodeInput::class)->html();
+
+        expect(substr_count($html, 'fi-one-time-code-input-digit'))->toBe(4);
+    });
+
     it('can render with `readOnly()`', function (): void {
         livewire(RenderOneTimeCodeInputWithReadOnly::class)
             ->assertSuccessful();


### PR DESCRIPTION
## Description
perviesely, the OneTimeCodeInput component shows only 6 inputs, the `$length` wasent passed corecttly to the blade component.

## Visual changes

nothing visually changed, only now will show the correct inputs:

- Before:

<img width="582" height="279" alt="before" src="https://github.com/user-attachments/assets/e9250b8d-93f4-4dbc-90ae-735911bda0bf" />

- After:

<img width="647" height="278" alt="after" src="https://github.com/user-attachments/assets/0f150bd4-2aef-49c1-9a87-0e1da3f04177" />

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
