### PR TITLE
fix: SPA navigation missing on optimized action links

### DIFF
--- a/packages/actions/src/Action.php
+++ b/packages/actions/src/Action.php
@@ -44,6 +44,7 @@ use Illuminate\View\ComponentAttributeBag;
 use Livewire\Component;
 use Livewire\Drawer\Utils;
 
+use function Filament\Support\generate_href_html;
 use function Filament\Support\generate_icon_html;
 use function Filament\Support\generate_loading_indicator_html;
 
@@ -887,9 +888,9 @@ class Action extends ViewComponent implements Arrayable
 
         if (filled($url)) {
             $iconHtml = $icon ? generate_icon_html($icon, size: IconSize::Small)?->toHtml() : '';
-            $href = e($url);
+            $hrefHtml = generate_href_html($url)->toHtml();
 
-            return "<a href=\"{$href}\"{$wireKeyAttribute} class=\"{$classString}\"{$styleString}>{$iconHtml}{$label}</a>";
+            return "<a {$hrefHtml}{$wireKeyAttribute} class=\"{$classString}\"{$styleString}>{$iconHtml}{$label}</a>";
         }
 
         $handler = $this->getLivewireClickHandler();
@@ -971,9 +972,9 @@ class Action extends ViewComponent implements Arrayable
                 $icon,
                 attributes: (new FilamentComponentAttributeBag)->color(IconComponent::class, $color),
             )?->toHtml() : '';
-            $href = e($url);
+            $hrefHtml = generate_href_html($url)->toHtml();
 
-            return "<a href=\"{$href}\"{$wireKeyAttribute} class=\"{$classString}\"{$styleString}>{$iconHtml}<span class=\"fi-dropdown-list-item-label\">{$label}</span></a>";
+            return "<a {$hrefHtml}{$wireKeyAttribute} class=\"{$classString}\"{$styleString}>{$iconHtml}<span class=\"fi-dropdown-list-item-label\">{$label}</span></a>";
         }
 
         $handler = $this->getLivewireClickHandler();

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -12,6 +12,7 @@ use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Support\Colors\Color;
 use Filament\Support\Enums\Size;
 use Filament\Support\Enums\Width;
+use Filament\Support\Facades\FilamentView;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
@@ -1561,6 +1562,23 @@ describe('construction and properties', function (): void {
 });
 
 describe('rendering', function (): void {
+    it('can render an optimized URL `link()` action with SPA navigation attributes', function (): void {
+        FilamentView::spa();
+
+        $html = Action::make('link')
+            ->link()
+            ->defaultSize(Size::Small)
+            ->url('/foo')
+            ->toHtml();
+
+        expect($html)
+            ->toStartWith('<a ')
+            ->toContain('wire:navigate')
+            ->toContain('href="/foo"');
+
+        FilamentView::spa(false);
+    });
+
     it('can render a link action with an array `color()` and a URL', function (): void {
         $html = Action::make('test')
             ->link()


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The optimized action URL rendering path was missing SPA mode handling.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
