### PR TITLE
fix(query-builder): Correct aggregate min/max keys

### DIFF
--- a/packages/query-builder/src/Constraints/NumberConstraint/Operators/Concerns/CanAggregateRelationships.php
+++ b/packages/query-builder/src/Constraints/NumberConstraint/Operators/Concerns/CanAggregateRelationships.php
@@ -115,8 +115,8 @@ trait CanAggregateRelationships
             ->options([
                 static::getAggregateSumKey() => __('filament-query-builder::query-builder.operators.number.aggregates.sum.label'),
                 static::getAggregateAverageKey() => __('filament-query-builder::query-builder.operators.number.aggregates.average.label'),
-                static::getAggregateMinKey() => __('filament-query-builder::query-builder.operators.number.aggregates.max.label'),
-                static::getAggregateMaxKey() => __('filament-query-builder::query-builder.operators.number.aggregates.min.label'),
+                static::getAggregateMaxKey() => __('filament-query-builder::query-builder.operators.number.aggregates.max.label'),
+                static::getAggregateMinKey() => __('filament-query-builder::query-builder.operators.number.aggregates.min.label'),
             ])
             ->visible($this->getConstraint()->queriesRelationships());
     }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Showing incorrect label in active filters badge in table header


## Visual changes

### Before

[before.webm](https://github.com/user-attachments/assets/2bb0b5e2-f503-4bd4-ac9a-c5a35dc9d3c9)

### After

[after.webm](https://github.com/user-attachments/assets/f3aee29c-8cfe-4c00-88c2-7200d9aa1f8f)



