### PR TITLE
Fix Czech typo: aktulizace -> aktualizace

### DIFF
--- a/packages/notifications/resources/lang/cs/database.php
+++ b/packages/notifications/resources/lang/cs/database.php
@@ -19,7 +19,7 @@ return [
         ],
 
         'empty' => [
-            'heading' => 'Nemáme pro vás žádné aktulizace',
+            'heading' => 'Nemáme pro vás žádné aktualizace',
             'description' => 'Zkuste to prosím později',
         ],
 


### PR DESCRIPTION
The `empty.heading` string in `packages/notifications/resources/lang/cs/database.php` was misspelled `aktulizace` (missing a `u`). Fixed to `aktualizace`, matching `modal.heading` ("Moje aktualizace") just above.