### PR TITLE
fix: make badges fit content

### DIFF
--- a/packages/support/resources/css/components/badge.css
+++ b/packages/support/resources/css/components/badge.css
@@ -1,5 +1,5 @@
 .fi-badge {
-    @apply inline-flex min-w-[theme(spacing.6)] items-center justify-center gap-x-1 rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-gray-600/10 ring-inset dark:bg-gray-400/10 dark:text-gray-200 dark:ring-gray-400/20;
+    @apply inline-flex min-w-[theme(spacing.6)] w-fit items-center justify-center gap-x-1 rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-gray-600/10 ring-inset dark:bg-gray-400/10 dark:text-gray-200 dark:ring-gray-400/20;
 
     &:not(.fi-wrapped) {
         @apply truncate;


### PR DESCRIPTION
## Description

Displaying a text column as a badge stretches the badge in the whole column. It used to do so but broke with a recent update.

## Visual changes

before: 
<img width="184" height="114" alt="image" src="https://github.com/user-attachments/assets/86b8fa5d-be2a-4e2a-982d-4ae6938bbfd6" />
After: 
<img width="162" height="111" alt="image" src="https://github.com/user-attachments/assets/70e8fba7-c0bf-4a19-ac93-d9bd7ba7163f" />

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
