### PR TITLE
Add bulk actions (attach, detach, manage) to Spatie Laravel Tags Plugin

### DIFF
--- a/packages/spatie-laravel-tags-plugin/README.md
+++ b/packages/spatie-laravel-tags-plugin/README.md
@@ -187,7 +187,7 @@ AttachSpatieTagsBulkAction::make()
 
 When no `type()` is passed, the actions match tags across every type, in the same way as the `SpatieTagsInput` field. The [security caveats around tag types and privilege namespaces](#security-tag-types-and-privilege-namespaces) apply equally to these bulk actions, so pass `->type(...)` (or `->type(null)` for untyped tags only) when tag types are used as a privilege namespace in your application.
 
-You may authorize each selected record individually using [`authorizeIndividualRecords()`](https://filamentphp.com/docs/actions/create#authorization), passing the name of a policy method. Records that fail the authorization check are skipped, and the user is notified:
+You may authorize each selected record individually using [`authorizeIndividualRecords()`](https://filamentphp.com/docs/actions/overview#authorization), passing the name of a policy method. Records that fail the authorization check are skipped, and the user is notified:
 
 ```php
 use Filament\Actions\AttachSpatieTagsBulkAction;

--- a/packages/spatie-laravel-tags-plugin/README.md
+++ b/packages/spatie-laravel-tags-plugin/README.md
@@ -157,25 +157,6 @@ public function table(Table $table): Table
 
 Each action opens a modal with a tags input, which suggests existing tags from the database. Attaching tags preserves any tags that the records already have, and creates any tags that do not exist yet. Detaching tags removes the chosen tags from the selected records, without deleting the tags themselves from the database.
 
-### Managing tags with a single bulk action
-
-Instead of separate attach and detach actions, you may use `ManageSpatieTagsBulkAction`, which opens a single modal with two tags inputs, allowing your users to attach some tags and detach others in a single pass over the selected records:
-
-```php
-use Filament\Actions\ManageSpatieTagsBulkAction;
-use Filament\Tables\Table;
-
-public function table(Table $table): Table
-{
-    return $table
-        ->toolbarActions([
-            ManageSpatieTagsBulkAction::make(),
-        ]);
-}
-```
-
-At least one of the two fields must be filled in, and the same tag may not be attached and detached at the same time. Attaching and detaching behave identically to the standalone actions.
-
 Optionally, you may pass a [`type()`](https://spatie.be/docs/laravel-tags/advanced-usage/using-types), which scopes the tags that the action can attach or detach:
 
 ```php
@@ -197,3 +178,22 @@ AttachSpatieTagsBulkAction::make()
 ```
 
 The bulk actions support all the customization options of [regular bulk actions](https://filamentphp.com/docs/actions/overview), such as `label()` and `successNotificationTitle()`.
+
+### Managing tags with a single bulk action
+
+Instead of separate attach and detach actions, you may use `ManageSpatieTagsBulkAction`, which opens a single modal with two tags inputs, allowing your users to attach some tags and detach others in a single pass over the selected records:
+
+```php
+use Filament\Actions\ManageSpatieTagsBulkAction;
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->toolbarActions([
+            ManageSpatieTagsBulkAction::make(),
+        ]);
+}
+```
+
+At least one of the two fields must be filled in, and the same tag may not be attached and detached at the same time. Attaching and detaching behave identically to the standalone actions. The `type()`, `authorizeIndividualRecords()`, and other customization options described above apply to this action too.

--- a/packages/spatie-laravel-tags-plugin/README.md
+++ b/packages/spatie-laravel-tags-plugin/README.md
@@ -135,3 +135,88 @@ SpatieTagsEntry::make('tags')
 The [type](https://spatie.be/docs/laravel-tags/advanced-usage/using-types) allows you to group tags into collections.
 
 The tags entry supports all the customization options of the [text entry](https://filamentphp.com/docs/infolists/entries/text).
+
+## Bulk actions
+
+You may add bulk actions to a table, allowing your users to attach tags to all selected records, or detach tags from them:
+
+```php
+use Filament\Actions\AttachSpatieTagsBulkAction;
+use Filament\Actions\DetachSpatieTagsBulkAction;
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->toolbarActions([
+            AttachSpatieTagsBulkAction::make(),
+            DetachSpatieTagsBulkAction::make(),
+        ]);
+}
+```
+
+Each action opens a modal with a tags input, which suggests existing tags from the database. Attaching tags preserves any tags that the records already have, and creates any tags that do not exist yet. Detaching tags removes the chosen tags from the selected records, without deleting the tags themselves from the database.
+
+### Managing tags with a single bulk action
+
+Instead of separate attach and detach actions, you may use `ManageSpatieTagsBulkAction`, which opens a single modal with two tags inputs, allowing your users to attach some tags and detach others in a single pass over the selected records:
+
+```php
+use Filament\Actions\ManageSpatieTagsBulkAction;
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->toolbarActions([
+            ManageSpatieTagsBulkAction::make(),
+        ]);
+}
+```
+
+At least one of the two fields must be filled in, and the same tag may not be attached and detached at the same time. Attaching and detaching behave identically to the standalone actions.
+
+You may restrict the action to attaching only or detaching only, using the `attachable()` and `detachable()` methods. The corresponding field is hidden from the modal, and the action's label adapts to describe what it does:
+
+```php
+use Filament\Actions\ManageSpatieTagsBulkAction;
+
+ManageSpatieTagsBulkAction::make()
+    ->detachable(false) // Attach only, labeled "Attach tags"
+
+ManageSpatieTagsBulkAction::make()
+    ->attachable(false) // Detach only, labeled "Detach tags"
+```
+
+Both methods also accept a closure, which is useful for conditionally restricting the action, for example based on the authenticated user:
+
+```php
+use Filament\Actions\ManageSpatieTagsBulkAction;
+
+ManageSpatieTagsBulkAction::make()
+    ->detachable(fn (): bool => auth()->user()->isAdmin())
+```
+
+If both `attachable(false)` and `detachable(false)` are set, the action is hidden.
+
+Optionally, you may pass a [`type()`](https://spatie.be/docs/laravel-tags/advanced-usage/using-types), which scopes the tags that the action can attach or detach:
+
+```php
+use Filament\Actions\AttachSpatieTagsBulkAction;
+
+AttachSpatieTagsBulkAction::make()
+    ->type('categories')
+```
+
+When no `type()` is passed, the actions match tags across every type, in the same way as the `SpatieTagsInput` field. The [security caveats around tag types and privilege namespaces](#security-tag-types-and-privilege-namespaces) apply equally to these bulk actions, so pass `->type(...)` (or `->type(null)` for untyped tags only) when tag types are used as a privilege namespace in your application.
+
+You may authorize each selected record individually using [`authorizeIndividualRecords()`](https://filamentphp.com/docs/actions/create#authorization), passing the name of a policy method. Records that fail the authorization check are skipped, and the user is notified:
+
+```php
+use Filament\Actions\AttachSpatieTagsBulkAction;
+
+AttachSpatieTagsBulkAction::make()
+    ->authorizeIndividualRecords('update')
+```
+
+The bulk actions support all the customization options of [regular bulk actions](https://filamentphp.com/docs/actions/overview), such as `label()` and `successNotificationTitle()`.

--- a/packages/spatie-laravel-tags-plugin/README.md
+++ b/packages/spatie-laravel-tags-plugin/README.md
@@ -176,29 +176,6 @@ public function table(Table $table): Table
 
 At least one of the two fields must be filled in, and the same tag may not be attached and detached at the same time. Attaching and detaching behave identically to the standalone actions.
 
-You may restrict the action to attaching only or detaching only, using the `attachable()` and `detachable()` methods. The corresponding field is hidden from the modal, and the action's label adapts to describe what it does:
-
-```php
-use Filament\Actions\ManageSpatieTagsBulkAction;
-
-ManageSpatieTagsBulkAction::make()
-    ->detachable(false) // Attach only, labeled "Attach tags"
-
-ManageSpatieTagsBulkAction::make()
-    ->attachable(false) // Detach only, labeled "Detach tags"
-```
-
-Both methods also accept a closure, which is useful for conditionally restricting the action, for example based on the authenticated user:
-
-```php
-use Filament\Actions\ManageSpatieTagsBulkAction;
-
-ManageSpatieTagsBulkAction::make()
-    ->detachable(fn (): bool => auth()->user()->isAdmin())
-```
-
-If both `attachable(false)` and `detachable(false)` are set, the action is hidden.
-
 Optionally, you may pass a [`type()`](https://spatie.be/docs/laravel-tags/advanced-usage/using-types), which scopes the tags that the action can attach or detach:
 
 ```php

--- a/packages/spatie-laravel-tags-plugin/composer.json
+++ b/packages/spatie-laravel-tags-plugin/composer.json
@@ -17,6 +17,13 @@
             "Filament\\": "src"
         }
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Filament\\SpatieLaravelTagsPluginServiceProvider"
+            ]
+        }
+    },
     "config": {
         "sort-packages": true
     },

--- a/packages/spatie-laravel-tags-plugin/resources/lang/en/attach-tags.php
+++ b/packages/spatie-laravel-tags-plugin/resources/lang/en/attach-tags.php
@@ -1,0 +1,49 @@
+<?php
+
+return [
+
+    'label' => 'Attach tags',
+
+    'modal' => [
+
+        'heading' => 'Attach tags to selected :label',
+
+        'form' => [
+
+            'tags' => [
+                'label' => 'Tags',
+            ],
+
+        ],
+
+        'actions' => [
+
+            'attach' => [
+                'label' => 'Attach',
+            ],
+
+        ],
+
+    ],
+
+    'notifications' => [
+
+        'attached' => [
+            'title' => 'Attached tags',
+        ],
+
+        'attached_partial' => [
+            'title' => 'Attached tags to :count of :total',
+            'missing_authorization_failure_message' => 'You don\'t have permission to attach tags to :count.',
+            'missing_processing_failure_message' => 'Tags could not be attached to :count.',
+        ],
+
+        'attached_none' => [
+            'title' => 'Failed to attach tags',
+            'missing_authorization_failure_message' => 'You don\'t have permission to attach tags to :count.',
+            'missing_processing_failure_message' => 'Tags could not be attached to :count.',
+        ],
+
+    ],
+
+];

--- a/packages/spatie-laravel-tags-plugin/resources/lang/en/detach-tags.php
+++ b/packages/spatie-laravel-tags-plugin/resources/lang/en/detach-tags.php
@@ -1,0 +1,49 @@
+<?php
+
+return [
+
+    'label' => 'Detach tags',
+
+    'modal' => [
+
+        'heading' => 'Detach tags from selected :label',
+
+        'form' => [
+
+            'tags' => [
+                'label' => 'Tags',
+            ],
+
+        ],
+
+        'actions' => [
+
+            'detach' => [
+                'label' => 'Detach',
+            ],
+
+        ],
+
+    ],
+
+    'notifications' => [
+
+        'detached' => [
+            'title' => 'Detached tags',
+        ],
+
+        'detached_partial' => [
+            'title' => 'Detached tags from :count of :total',
+            'missing_authorization_failure_message' => 'You don\'t have permission to detach tags from :count.',
+            'missing_processing_failure_message' => 'Tags could not be detached from :count.',
+        ],
+
+        'detached_none' => [
+            'title' => 'Failed to detach tags',
+            'missing_authorization_failure_message' => 'You don\'t have permission to detach tags from :count.',
+            'missing_processing_failure_message' => 'Tags could not be detached from :count.',
+        ],
+
+    ],
+
+];

--- a/packages/spatie-laravel-tags-plugin/resources/lang/en/manage-tags.php
+++ b/packages/spatie-laravel-tags-plugin/resources/lang/en/manage-tags.php
@@ -1,0 +1,56 @@
+<?php
+
+return [
+
+    'label' => 'Manage tags',
+
+    'modal' => [
+
+        'heading' => 'Manage tags for selected :label',
+
+        'form' => [
+
+            'tags_to_attach' => [
+                'label' => 'Tags to attach',
+            ],
+
+            'tags_to_detach' => [
+                'label' => 'Tags to detach',
+                'validation' => [
+                    'attached_and_detached' => 'The following tags cannot be attached and detached at the same time: :tags.',
+                ],
+            ],
+
+        ],
+
+        'actions' => [
+
+            'save' => [
+                'label' => 'Save',
+            ],
+
+        ],
+
+    ],
+
+    'notifications' => [
+
+        'updated' => [
+            'title' => 'Updated tags',
+        ],
+
+        'updated_partial' => [
+            'title' => 'Updated tags for :count of :total',
+            'missing_authorization_failure_message' => 'You don\'t have permission to update tags for :count.',
+            'missing_processing_failure_message' => 'Tags could not be updated for :count.',
+        ],
+
+        'updated_none' => [
+            'title' => 'Failed to update tags',
+            'missing_authorization_failure_message' => 'You don\'t have permission to update tags for :count.',
+            'missing_processing_failure_message' => 'Tags could not be updated for :count.',
+        ],
+
+    ],
+
+];

--- a/packages/spatie-laravel-tags-plugin/src/Actions/AttachSpatieTagsBulkAction.php
+++ b/packages/spatie-laravel-tags-plugin/src/Actions/AttachSpatieTagsBulkAction.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Filament\Actions;
+
+use Filament\Actions\Concerns\CanCustomizeProcess;
+use Filament\Actions\Concerns\InteractsWithSpatieTags;
+use Filament\Forms\Components\TagsInput;
+use Filament\SpatieLaravelTagsPlugin\Types\AllTagTypes;
+use Filament\Support\Enums\Width;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Number;
+use Throwable;
+
+class AttachSpatieTagsBulkAction extends BulkAction
+{
+    use CanCustomizeProcess;
+    use InteractsWithSpatieTags;
+
+    public static function getDefaultName(): ?string
+    {
+        return 'attachTags';
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->type(new AllTagTypes);
+
+        $this->label(__('filament-spatie-laravel-tags-plugin::attach-tags.label'));
+
+        $this->modalHeading(fn (): string => __('filament-spatie-laravel-tags-plugin::attach-tags.modal.heading', ['label' => $this->getTitleCasePluralModelLabel()]));
+
+        $this->modalSubmitActionLabel(__('filament-spatie-laravel-tags-plugin::attach-tags.modal.actions.attach.label'));
+
+        $this->successNotificationTitle(__('filament-spatie-laravel-tags-plugin::attach-tags.notifications.attached.title'));
+
+        $this->failureNotificationTitle(function (int $successCount, int $totalCount): string {
+            if ($successCount) {
+                return trans_choice('filament-spatie-laravel-tags-plugin::attach-tags.notifications.attached_partial.title', $successCount, [
+                    'count' => Number::format($successCount),
+                    'total' => Number::format($totalCount),
+                ]);
+            }
+
+            return trans_choice('filament-spatie-laravel-tags-plugin::attach-tags.notifications.attached_none.title', $totalCount, [
+                'count' => Number::format($totalCount),
+                'total' => Number::format($totalCount),
+            ]);
+        });
+
+        $this->missingBulkAuthorizationFailureNotificationMessage(function (int $failureCount, int $totalCount): string {
+            return trans_choice(
+                ($failureCount === $totalCount)
+                    ? 'filament-spatie-laravel-tags-plugin::attach-tags.notifications.attached_none.missing_authorization_failure_message'
+                    : 'filament-spatie-laravel-tags-plugin::attach-tags.notifications.attached_partial.missing_authorization_failure_message',
+                $failureCount,
+                ['count' => Number::format($failureCount)],
+            );
+        });
+
+        $this->missingBulkProcessingFailureNotificationMessage(function (int $failureCount, int $totalCount): string {
+            return trans_choice(
+                ($failureCount === $totalCount)
+                    ? 'filament-spatie-laravel-tags-plugin::attach-tags.notifications.attached_none.missing_processing_failure_message'
+                    : 'filament-spatie-laravel-tags-plugin::attach-tags.notifications.attached_partial.missing_processing_failure_message',
+                $failureCount,
+                ['count' => Number::format($failureCount)],
+            );
+        });
+
+        $this->icon(Heroicon::Tag);
+
+        $this->modalIcon(Heroicon::OutlinedTag);
+
+        $this->modalWidth(Width::Large);
+
+        $this->schema(fn (AttachSpatieTagsBulkAction $action): array => [
+            TagsInput::make('tags')
+                ->label(__('filament-spatie-laravel-tags-plugin::attach-tags.modal.form.tags.label'))
+                ->suggestions(static fn (): array => $action->getTagSuggestions())
+                ->required(),
+        ]);
+
+        $this->action(function (): void {
+            $this->process(static function (AttachSpatieTagsBulkAction $action, array $data, EloquentCollection | Collection | LazyCollection $records): void {
+                if (! $action->shouldFetchSelectedRecords()) {
+                    $records = $action->getSelectedRecordsQuery()->cursor();
+                }
+
+                $tagIds = $action->resolveTagsForAttaching($data['tags'] ?? [])->pluck('id')->all();
+
+                if (empty($tagIds)) {
+                    return;
+                }
+
+                $isFirstException = true;
+
+                $records->each(static function (Model $record) use ($action, $tagIds, &$isFirstException): void {
+                    if (! method_exists($record, 'tags')) {
+                        $action->reportBulkProcessingFailure();
+
+                        return;
+                    }
+
+                    try {
+                        $record->tags()->syncWithoutDetaching($tagIds);
+                        $record->unsetRelation('tags');
+                    } catch (Throwable $exception) {
+                        $action->reportBulkProcessingFailure();
+
+                        if ($isFirstException) {
+                            // Only report the first exception so as to not flood error logs. Even
+                            // if Filament did not catch exceptions like this, only the first
+                            // would be reported as the rest of the process would be halted.
+                            report($exception);
+
+                            $isFirstException = false;
+                        }
+                    }
+                });
+            });
+        });
+
+        $this->deselectRecordsAfterCompletion();
+    }
+}

--- a/packages/spatie-laravel-tags-plugin/src/Actions/AttachSpatieTagsBulkAction.php
+++ b/packages/spatie-laravel-tags-plugin/src/Actions/AttachSpatieTagsBulkAction.php
@@ -83,6 +83,10 @@ class AttachSpatieTagsBulkAction extends BulkAction
             TagsInput::make('tags')
                 ->label(__('filament-spatie-laravel-tags-plugin::attach-tags.modal.form.tags.label'))
                 ->suggestions(static fn (): array => $action->getTagSuggestions())
+                // Tag names come from client-writable Livewire state. Validate each entry as a
+                // `string` so a tampered payload with a nested array fails validation instead of
+                // reaching the `string`-typed resolution closures and throwing a `TypeError`.
+                ->nestedRecursiveRules(['string'])
                 ->required(),
         ]);
 
@@ -92,7 +96,19 @@ class AttachSpatieTagsBulkAction extends BulkAction
                     $records = $action->getSelectedRecordsQuery()->cursor();
                 }
 
-                $tagIds = $action->resolveTagsForAttaching($data['tags'] ?? [])->pluck('id')->all();
+                try {
+                    // Resolving the tags runs find-or-create queries before any record is processed.
+                    // If that throws (e.g. a `findOrCreate()` race against a user-added unique index,
+                    // or a transient database error), report a complete failure so the user gets the
+                    // failure notification instead of an uncaught error, mirroring `DeleteBulkAction`.
+                    $tagIds = $action->resolveTagsForAttaching($data['tags'] ?? [])->pluck('id')->all();
+                } catch (Throwable $exception) {
+                    $action->reportCompleteBulkProcessingFailure();
+
+                    report($exception);
+
+                    return;
+                }
 
                 if (empty($tagIds)) {
                     return;

--- a/packages/spatie-laravel-tags-plugin/src/Actions/Concerns/InteractsWithSpatieTags.php
+++ b/packages/spatie-laravel-tags-plugin/src/Actions/Concerns/InteractsWithSpatieTags.php
@@ -12,9 +12,17 @@ trait InteractsWithSpatieTags
 {
     protected string | Closure | AllTagTypes | null $type;
 
+    /**
+     * @var array<string> | null
+     */
+    protected ?array $cachedTagSuggestions = null;
+
     public function type(string | Closure | AllTagTypes | null $type): static
     {
         $this->type = $type;
+
+        // The suggestions depend on the resolved `type`, so drop the memoized list when it changes.
+        $this->cachedTagSuggestions = null;
 
         return $this;
     }
@@ -46,6 +54,10 @@ trait InteractsWithSpatieTags
      */
     public function getTagSuggestions(): array
     {
+        if ($this->cachedTagSuggestions !== null) {
+            return $this->cachedTagSuggestions;
+        }
+
         $type = $this->getType();
         $query = $this->getTagClassName()::query();
 
@@ -57,7 +69,12 @@ trait InteractsWithSpatieTags
             );
         }
 
-        return $query->pluck('name')->all();
+        // `ManageSpatieTagsBulkAction` renders two `TagsInput`s whose `->suggestions()` closures both
+        // call this method, and the tags-input view re-runs them on every render. Memoizing the result
+        // keeps the identical unbounded `SELECT name FROM tags` query from running once per input per
+        // render. The `type()` is fixed for the request (and resets the cache when changed), so the
+        // memoized list stays valid.
+        return $this->cachedTagSuggestions = $query->pluck('name')->all();
     }
 
     /**

--- a/packages/spatie-laravel-tags-plugin/src/Actions/Concerns/InteractsWithSpatieTags.php
+++ b/packages/spatie-laravel-tags-plugin/src/Actions/Concerns/InteractsWithSpatieTags.php
@@ -75,7 +75,12 @@ trait InteractsWithSpatieTags
         $tagClassName = $this->getTagClassName();
 
         if (! $this->isAnyTagTypeAllowed()) {
-            return collect($tagClassName::findOrCreate($tagNames, $this->getType()));
+            $type = $this->getType();
+
+            // An empty string type means "untyped", mirroring `getTagSuggestions()`, which uses
+            // `filled()` to surface untyped tags. Normalize it to `null` so Spatie finds or creates
+            // untyped tags rather than a distinct empty-string type.
+            return collect($tagClassName::findOrCreate($tagNames, filled($type) ? $type : null));
         }
 
         return collect($tagNames)
@@ -111,6 +116,11 @@ trait InteractsWithSpatieTags
 
         if (! $this->isAnyTagTypeAllowed()) {
             $type = $this->getType();
+
+            // An empty string type means "untyped", mirroring `getTagSuggestions()`, which uses
+            // `filled()` to surface untyped tags. Normalize it to `null` so an untyped tag can be
+            // matched for detaching instead of silently no-opping against a distinct empty-string type.
+            $type = filled($type) ? $type : null;
 
             return collect($tagNames)
                 ->map(static fn (string $tagName) => $tagClassName::findFromString($tagName, $type))

--- a/packages/spatie-laravel-tags-plugin/src/Actions/Concerns/InteractsWithSpatieTags.php
+++ b/packages/spatie-laravel-tags-plugin/src/Actions/Concerns/InteractsWithSpatieTags.php
@@ -79,7 +79,7 @@ trait InteractsWithSpatieTags
         }
 
         return collect($tagNames)
-            ->map(static function (string $tagName) use ($tagClassName) { /** @phpstan-ignore argument.templateType */
+            ->map(static function (string $tagName) use ($tagClassName) {
                 $locale = $tagClassName::getLocale();
 
                 $tags = $tagClassName::findFromStringOfAnyType($tagName, $locale);
@@ -113,12 +113,12 @@ trait InteractsWithSpatieTags
             $type = $this->getType();
 
             return collect($tagNames)
-                ->map(static fn (string $tagName) => $tagClassName::findFromString($tagName, $type)) /** @phpstan-ignore argument.templateType */
+                ->map(static fn (string $tagName) => $tagClassName::findFromString($tagName, $type))
                 ->filter();
         }
 
         return collect($tagNames)
-            ->map(static fn (string $tagName) => $tagClassName::findFromStringOfAnyType($tagName)) /** @phpstan-ignore argument.templateType */
+            ->map(static fn (string $tagName) => $tagClassName::findFromStringOfAnyType($tagName))
             ->flatten()
             ->filter();
     }

--- a/packages/spatie-laravel-tags-plugin/src/Actions/Concerns/InteractsWithSpatieTags.php
+++ b/packages/spatie-laravel-tags-plugin/src/Actions/Concerns/InteractsWithSpatieTags.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Filament\Actions\Concerns;
+
+use Closure;
+use Filament\SpatieLaravelTagsPlugin\Types\AllTagTypes;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Spatie\Tags\Tag;
+
+trait InteractsWithSpatieTags
+{
+    protected string | Closure | AllTagTypes | null $type;
+
+    public function type(string | Closure | AllTagTypes | null $type): static
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getType(): string | AllTagTypes | null
+    {
+        return $this->evaluate($this->type);
+    }
+
+    public function isAnyTagTypeAllowed(): bool
+    {
+        return $this->getType() instanceof AllTagTypes;
+    }
+
+    /**
+     * @return class-string<Tag>
+     */
+    public function getTagClassName(): string
+    {
+        $model = $this->getModel();
+
+        return ($model && method_exists($model, 'getTagClassName'))
+            ? $model::getTagClassName()
+            : config('tags.tag_model', Tag::class);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getTagSuggestions(): array
+    {
+        $type = $this->getType();
+        $query = $this->getTagClassName()::query();
+
+        if (! $this->isAnyTagTypeAllowed()) {
+            $query->when(
+                filled($type),
+                fn (Builder $query) => $query->where('type', $type),
+                fn (Builder $query) => $query->where('type', null),
+            );
+        }
+
+        return $query->pluck('name')->all();
+    }
+
+    /**
+     * Resolves the tag names to tag models, creating any tags that do not already exist.
+     *
+     * When a specific type is set, tags are found or created with that type. When any tag
+     * type is allowed, existing tags of any type that match each name are used, and a new
+     * untyped tag is created if no match exists, mirroring the behavior of `SpatieTagsInput`.
+     *
+     * @param  array<string>  $tagNames
+     * @return Collection<int, Tag>
+     */
+    public function resolveTagsForAttaching(array $tagNames): Collection
+    {
+        $tagClassName = $this->getTagClassName();
+
+        if (! $this->isAnyTagTypeAllowed()) {
+            return collect($tagClassName::findOrCreate($tagNames, $this->getType()));
+        }
+
+        return collect($tagNames)
+            ->map(static function (string $tagName) use ($tagClassName) { /** @phpstan-ignore argument.templateType */
+                $locale = $tagClassName::getLocale();
+
+                $tags = $tagClassName::findFromStringOfAnyType($tagName, $locale);
+
+                if ($tags?->isEmpty() ?? true) {
+                    return $tagClassName::create([
+                        'name' => [$locale => $tagName],
+                    ]);
+                }
+
+                return $tags;
+            })
+            ->flatten();
+    }
+
+    /**
+     * Resolves the tag names to existing tag models. Tags that do not exist are ignored,
+     * since there is nothing to detach.
+     *
+     * When a specific type is set, only tags of that type are matched. When any tag type
+     * is allowed, all tags of any type that match each name are detached.
+     *
+     * @param  array<string>  $tagNames
+     * @return Collection<int, Tag>
+     */
+    public function resolveTagsForDetaching(array $tagNames): Collection
+    {
+        $tagClassName = $this->getTagClassName();
+
+        if (! $this->isAnyTagTypeAllowed()) {
+            $type = $this->getType();
+
+            return collect($tagNames)
+                ->map(static fn (string $tagName) => $tagClassName::findFromString($tagName, $type)) /** @phpstan-ignore argument.templateType */
+                ->filter();
+        }
+
+        return collect($tagNames)
+            ->map(static fn (string $tagName) => $tagClassName::findFromStringOfAnyType($tagName)) /** @phpstan-ignore argument.templateType */
+            ->flatten()
+            ->filter();
+    }
+}

--- a/packages/spatie-laravel-tags-plugin/src/Actions/DetachSpatieTagsBulkAction.php
+++ b/packages/spatie-laravel-tags-plugin/src/Actions/DetachSpatieTagsBulkAction.php
@@ -85,6 +85,10 @@ class DetachSpatieTagsBulkAction extends BulkAction
             TagsInput::make('tags')
                 ->label(__('filament-spatie-laravel-tags-plugin::detach-tags.modal.form.tags.label'))
                 ->suggestions(static fn (): array => $action->getTagSuggestions())
+                // Tag names come from client-writable Livewire state. Validate each entry as a
+                // `string` so a tampered payload with a nested array fails validation instead of
+                // reaching the `string`-typed resolution closures and throwing a `TypeError`.
+                ->nestedRecursiveRules(['string'])
                 ->required(),
         ]);
 
@@ -94,7 +98,19 @@ class DetachSpatieTagsBulkAction extends BulkAction
                     $records = $action->getSelectedRecordsQuery()->cursor();
                 }
 
-                $tagIds = $action->resolveTagsForDetaching($data['tags'] ?? [])->pluck('id')->all();
+                try {
+                    // Resolving the tags runs find-or-create queries before any record is processed.
+                    // If that throws (e.g. a `findOrCreate()` race against a user-added unique index,
+                    // or a transient database error), report a complete failure so the user gets the
+                    // failure notification instead of an uncaught error, mirroring `DeleteBulkAction`.
+                    $tagIds = $action->resolveTagsForDetaching($data['tags'] ?? [])->pluck('id')->all();
+                } catch (Throwable $exception) {
+                    $action->reportCompleteBulkProcessingFailure();
+
+                    report($exception);
+
+                    return;
+                }
 
                 if (empty($tagIds)) {
                     return;

--- a/packages/spatie-laravel-tags-plugin/src/Actions/DetachSpatieTagsBulkAction.php
+++ b/packages/spatie-laravel-tags-plugin/src/Actions/DetachSpatieTagsBulkAction.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Filament\Actions;
+
+use Filament\Actions\Concerns\CanCustomizeProcess;
+use Filament\Actions\Concerns\InteractsWithSpatieTags;
+use Filament\Forms\Components\TagsInput;
+use Filament\SpatieLaravelTagsPlugin\Types\AllTagTypes;
+use Filament\Support\Enums\Width;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Number;
+use Throwable;
+
+class DetachSpatieTagsBulkAction extends BulkAction
+{
+    use CanCustomizeProcess;
+    use InteractsWithSpatieTags;
+
+    public static function getDefaultName(): ?string
+    {
+        return 'detachTags';
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->type(new AllTagTypes);
+
+        $this->label(__('filament-spatie-laravel-tags-plugin::detach-tags.label'));
+
+        $this->modalHeading(fn (): string => __('filament-spatie-laravel-tags-plugin::detach-tags.modal.heading', ['label' => $this->getTitleCasePluralModelLabel()]));
+
+        $this->modalSubmitActionLabel(__('filament-spatie-laravel-tags-plugin::detach-tags.modal.actions.detach.label'));
+
+        $this->successNotificationTitle(__('filament-spatie-laravel-tags-plugin::detach-tags.notifications.detached.title'));
+
+        $this->failureNotificationTitle(function (int $successCount, int $totalCount): string {
+            if ($successCount) {
+                return trans_choice('filament-spatie-laravel-tags-plugin::detach-tags.notifications.detached_partial.title', $successCount, [
+                    'count' => Number::format($successCount),
+                    'total' => Number::format($totalCount),
+                ]);
+            }
+
+            return trans_choice('filament-spatie-laravel-tags-plugin::detach-tags.notifications.detached_none.title', $totalCount, [
+                'count' => Number::format($totalCount),
+                'total' => Number::format($totalCount),
+            ]);
+        });
+
+        $this->missingBulkAuthorizationFailureNotificationMessage(function (int $failureCount, int $totalCount): string {
+            return trans_choice(
+                ($failureCount === $totalCount)
+                    ? 'filament-spatie-laravel-tags-plugin::detach-tags.notifications.detached_none.missing_authorization_failure_message'
+                    : 'filament-spatie-laravel-tags-plugin::detach-tags.notifications.detached_partial.missing_authorization_failure_message',
+                $failureCount,
+                ['count' => Number::format($failureCount)],
+            );
+        });
+
+        $this->missingBulkProcessingFailureNotificationMessage(function (int $failureCount, int $totalCount): string {
+            return trans_choice(
+                ($failureCount === $totalCount)
+                    ? 'filament-spatie-laravel-tags-plugin::detach-tags.notifications.detached_none.missing_processing_failure_message'
+                    : 'filament-spatie-laravel-tags-plugin::detach-tags.notifications.detached_partial.missing_processing_failure_message',
+                $failureCount,
+                ['count' => Number::format($failureCount)],
+            );
+        });
+
+        $this->defaultColor('danger');
+
+        $this->icon(Heroicon::Tag);
+
+        $this->modalIcon(Heroicon::OutlinedTag);
+
+        $this->modalWidth(Width::Large);
+
+        $this->schema(fn (DetachSpatieTagsBulkAction $action): array => [
+            TagsInput::make('tags')
+                ->label(__('filament-spatie-laravel-tags-plugin::detach-tags.modal.form.tags.label'))
+                ->suggestions(static fn (): array => $action->getTagSuggestions())
+                ->required(),
+        ]);
+
+        $this->action(function (): void {
+            $this->process(static function (DetachSpatieTagsBulkAction $action, array $data, EloquentCollection | Collection | LazyCollection $records): void {
+                if (! $action->shouldFetchSelectedRecords()) {
+                    $records = $action->getSelectedRecordsQuery()->cursor();
+                }
+
+                $tagIds = $action->resolveTagsForDetaching($data['tags'] ?? [])->pluck('id')->all();
+
+                if (empty($tagIds)) {
+                    return;
+                }
+
+                $isFirstException = true;
+
+                $records->each(static function (Model $record) use ($action, $tagIds, &$isFirstException): void {
+                    if (! method_exists($record, 'tags')) {
+                        $action->reportBulkProcessingFailure();
+
+                        return;
+                    }
+
+                    try {
+                        $record->tags()->detach($tagIds);
+                        $record->unsetRelation('tags');
+                    } catch (Throwable $exception) {
+                        $action->reportBulkProcessingFailure();
+
+                        if ($isFirstException) {
+                            // Only report the first exception so as to not flood error logs. Even
+                            // if Filament did not catch exceptions like this, only the first
+                            // would be reported as the rest of the process would be halted.
+                            report($exception);
+
+                            $isFirstException = false;
+                        }
+                    }
+                });
+            });
+        });
+
+        $this->deselectRecordsAfterCompletion();
+    }
+}

--- a/packages/spatie-laravel-tags-plugin/src/Actions/ManageSpatieTagsBulkAction.php
+++ b/packages/spatie-laravel-tags-plugin/src/Actions/ManageSpatieTagsBulkAction.php
@@ -22,10 +22,6 @@ class ManageSpatieTagsBulkAction extends BulkAction
     use CanCustomizeProcess;
     use InteractsWithSpatieTags;
 
-    protected bool | Closure $canAttachTags = true;
-
-    protected bool | Closure $canDetachTags = true;
-
     public static function getDefaultName(): ?string
     {
         return 'manageTags';
@@ -37,23 +33,11 @@ class ManageSpatieTagsBulkAction extends BulkAction
 
         $this->type(new AllTagTypes);
 
-        $this->label(fn (): string => match (true) {
-            ! $this->canDetachTags() => __('filament-spatie-laravel-tags-plugin::attach-tags.label'),
-            ! $this->canAttachTags() => __('filament-spatie-laravel-tags-plugin::detach-tags.label'),
-            default => __('filament-spatie-laravel-tags-plugin::manage-tags.label'),
-        });
+        $this->label(__('filament-spatie-laravel-tags-plugin::manage-tags.label'));
 
-        $this->modalHeading(fn (): string => match (true) {
-            ! $this->canDetachTags() => __('filament-spatie-laravel-tags-plugin::attach-tags.modal.heading', ['label' => $this->getTitleCasePluralModelLabel()]),
-            ! $this->canAttachTags() => __('filament-spatie-laravel-tags-plugin::detach-tags.modal.heading', ['label' => $this->getTitleCasePluralModelLabel()]),
-            default => __('filament-spatie-laravel-tags-plugin::manage-tags.modal.heading', ['label' => $this->getTitleCasePluralModelLabel()]),
-        });
+        $this->modalHeading(fn (): string => __('filament-spatie-laravel-tags-plugin::manage-tags.modal.heading', ['label' => $this->getTitleCasePluralModelLabel()]));
 
-        $this->modalSubmitActionLabel(fn (): string => match (true) {
-            ! $this->canDetachTags() => __('filament-spatie-laravel-tags-plugin::attach-tags.modal.actions.attach.label'),
-            ! $this->canAttachTags() => __('filament-spatie-laravel-tags-plugin::detach-tags.modal.actions.detach.label'),
-            default => __('filament-spatie-laravel-tags-plugin::manage-tags.modal.actions.save.label'),
-        });
+        $this->modalSubmitActionLabel(__('filament-spatie-laravel-tags-plugin::manage-tags.modal.actions.save.label'));
 
         $this->successNotificationTitle(__('filament-spatie-laravel-tags-plugin::manage-tags.notifications.updated.title'));
 
@@ -101,12 +85,10 @@ class ManageSpatieTagsBulkAction extends BulkAction
             TagsInput::make('tagsToAttach')
                 ->label(__('filament-spatie-laravel-tags-plugin::manage-tags.modal.form.tags_to_attach.label'))
                 ->suggestions(static fn (): array => $action->getTagSuggestions())
-                ->visible($action->canAttachTags())
                 ->requiredWithout('tagsToDetach'),
             TagsInput::make('tagsToDetach')
                 ->label(__('filament-spatie-laravel-tags-plugin::manage-tags.modal.form.tags_to_detach.label'))
                 ->suggestions(static fn (): array => $action->getTagSuggestions())
-                ->visible($action->canDetachTags())
                 ->requiredWithout('tagsToAttach')
                 ->rules([
                     static fn (Get $get): Closure => static function (string $attribute, mixed $value, Closure $fail) use ($get): void {
@@ -129,13 +111,9 @@ class ManageSpatieTagsBulkAction extends BulkAction
                     $records = $action->getSelectedRecordsQuery()->cursor();
                 }
 
-                $tagIdsToAttach = $action->canAttachTags()
-                    ? $action->resolveTagsForAttaching($data['tagsToAttach'] ?? [])->pluck('id')->all()
-                    : [];
+                $tagIdsToAttach = $action->resolveTagsForAttaching($data['tagsToAttach'] ?? [])->pluck('id')->all();
 
-                $tagIdsToDetach = $action->canDetachTags()
-                    ? $action->resolveTagsForDetaching($data['tagsToDetach'] ?? [])->pluck('id')->all()
-                    : [];
+                $tagIdsToDetach = $action->resolveTagsForDetaching($data['tagsToDetach'] ?? [])->pluck('id')->all();
 
                 if (empty($tagIdsToAttach) && empty($tagIdsToDetach)) {
                     return;
@@ -177,31 +155,5 @@ class ManageSpatieTagsBulkAction extends BulkAction
         });
 
         $this->deselectRecordsAfterCompletion();
-
-        $this->hidden(fn (): bool => ! ($this->canAttachTags() || $this->canDetachTags()));
-    }
-
-    public function attachable(bool | Closure $condition = true): static
-    {
-        $this->canAttachTags = $condition;
-
-        return $this;
-    }
-
-    public function detachable(bool | Closure $condition = true): static
-    {
-        $this->canDetachTags = $condition;
-
-        return $this;
-    }
-
-    public function canAttachTags(): bool
-    {
-        return (bool) $this->evaluate($this->canAttachTags);
-    }
-
-    public function canDetachTags(): bool
-    {
-        return (bool) $this->evaluate($this->canDetachTags);
     }
 }

--- a/packages/spatie-laravel-tags-plugin/src/Actions/ManageSpatieTagsBulkAction.php
+++ b/packages/spatie-laravel-tags-plugin/src/Actions/ManageSpatieTagsBulkAction.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Filament\Actions;
+
+use Closure;
+use Filament\Actions\Concerns\CanCustomizeProcess;
+use Filament\Actions\Concerns\InteractsWithSpatieTags;
+use Filament\Forms\Components\TagsInput;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\SpatieLaravelTagsPlugin\Types\AllTagTypes;
+use Filament\Support\Enums\Width;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Number;
+use Throwable;
+
+class ManageSpatieTagsBulkAction extends BulkAction
+{
+    use CanCustomizeProcess;
+    use InteractsWithSpatieTags;
+
+    protected bool | Closure $canAttachTags = true;
+
+    protected bool | Closure $canDetachTags = true;
+
+    public static function getDefaultName(): ?string
+    {
+        return 'manageTags';
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->type(new AllTagTypes);
+
+        $this->label(fn (): string => match (true) {
+            ! $this->canDetachTags() => __('filament-spatie-laravel-tags-plugin::attach-tags.label'),
+            ! $this->canAttachTags() => __('filament-spatie-laravel-tags-plugin::detach-tags.label'),
+            default => __('filament-spatie-laravel-tags-plugin::manage-tags.label'),
+        });
+
+        $this->modalHeading(fn (): string => match (true) {
+            ! $this->canDetachTags() => __('filament-spatie-laravel-tags-plugin::attach-tags.modal.heading', ['label' => $this->getTitleCasePluralModelLabel()]),
+            ! $this->canAttachTags() => __('filament-spatie-laravel-tags-plugin::detach-tags.modal.heading', ['label' => $this->getTitleCasePluralModelLabel()]),
+            default => __('filament-spatie-laravel-tags-plugin::manage-tags.modal.heading', ['label' => $this->getTitleCasePluralModelLabel()]),
+        });
+
+        $this->modalSubmitActionLabel(fn (): string => match (true) {
+            ! $this->canDetachTags() => __('filament-spatie-laravel-tags-plugin::attach-tags.modal.actions.attach.label'),
+            ! $this->canAttachTags() => __('filament-spatie-laravel-tags-plugin::detach-tags.modal.actions.detach.label'),
+            default => __('filament-spatie-laravel-tags-plugin::manage-tags.modal.actions.save.label'),
+        });
+
+        $this->successNotificationTitle(__('filament-spatie-laravel-tags-plugin::manage-tags.notifications.updated.title'));
+
+        $this->failureNotificationTitle(function (int $successCount, int $totalCount): string {
+            if ($successCount) {
+                return trans_choice('filament-spatie-laravel-tags-plugin::manage-tags.notifications.updated_partial.title', $successCount, [
+                    'count' => Number::format($successCount),
+                    'total' => Number::format($totalCount),
+                ]);
+            }
+
+            return trans_choice('filament-spatie-laravel-tags-plugin::manage-tags.notifications.updated_none.title', $totalCount, [
+                'count' => Number::format($totalCount),
+                'total' => Number::format($totalCount),
+            ]);
+        });
+
+        $this->missingBulkAuthorizationFailureNotificationMessage(function (int $failureCount, int $totalCount): string {
+            return trans_choice(
+                ($failureCount === $totalCount)
+                    ? 'filament-spatie-laravel-tags-plugin::manage-tags.notifications.updated_none.missing_authorization_failure_message'
+                    : 'filament-spatie-laravel-tags-plugin::manage-tags.notifications.updated_partial.missing_authorization_failure_message',
+                $failureCount,
+                ['count' => Number::format($failureCount)],
+            );
+        });
+
+        $this->missingBulkProcessingFailureNotificationMessage(function (int $failureCount, int $totalCount): string {
+            return trans_choice(
+                ($failureCount === $totalCount)
+                    ? 'filament-spatie-laravel-tags-plugin::manage-tags.notifications.updated_none.missing_processing_failure_message'
+                    : 'filament-spatie-laravel-tags-plugin::manage-tags.notifications.updated_partial.missing_processing_failure_message',
+                $failureCount,
+                ['count' => Number::format($failureCount)],
+            );
+        });
+
+        $this->icon(Heroicon::Tag);
+
+        $this->modalIcon(Heroicon::OutlinedTag);
+
+        $this->modalWidth(Width::Large);
+
+        $this->schema(fn (ManageSpatieTagsBulkAction $action): array => [
+            TagsInput::make('tagsToAttach')
+                ->label(__('filament-spatie-laravel-tags-plugin::manage-tags.modal.form.tags_to_attach.label'))
+                ->suggestions(static fn (): array => $action->getTagSuggestions())
+                ->visible($action->canAttachTags())
+                ->requiredWithout('tagsToDetach'),
+            TagsInput::make('tagsToDetach')
+                ->label(__('filament-spatie-laravel-tags-plugin::manage-tags.modal.form.tags_to_detach.label'))
+                ->suggestions(static fn (): array => $action->getTagSuggestions())
+                ->visible($action->canDetachTags())
+                ->requiredWithout('tagsToAttach')
+                ->rules([
+                    static fn (Get $get): Closure => static function (string $attribute, mixed $value, Closure $fail) use ($get): void {
+                        $conflictingTags = array_intersect($get('tagsToAttach') ?? [], $value ?? []);
+
+                        if (empty($conflictingTags)) {
+                            return;
+                        }
+
+                        $fail(__('filament-spatie-laravel-tags-plugin::manage-tags.modal.form.tags_to_detach.validation.attached_and_detached', [
+                            'tags' => implode(', ', $conflictingTags),
+                        ]));
+                    },
+                ]),
+        ]);
+
+        $this->action(function (): void {
+            $this->process(static function (ManageSpatieTagsBulkAction $action, array $data, EloquentCollection | Collection | LazyCollection $records): void {
+                if (! $action->shouldFetchSelectedRecords()) {
+                    $records = $action->getSelectedRecordsQuery()->cursor();
+                }
+
+                $tagIdsToAttach = $action->canAttachTags()
+                    ? $action->resolveTagsForAttaching($data['tagsToAttach'] ?? [])->pluck('id')->all()
+                    : [];
+
+                $tagIdsToDetach = $action->canDetachTags()
+                    ? $action->resolveTagsForDetaching($data['tagsToDetach'] ?? [])->pluck('id')->all()
+                    : [];
+
+                if (empty($tagIdsToAttach) && empty($tagIdsToDetach)) {
+                    return;
+                }
+
+                $isFirstException = true;
+
+                $records->each(static function (Model $record) use ($action, $tagIdsToAttach, $tagIdsToDetach, &$isFirstException): void {
+                    if (! method_exists($record, 'tags')) {
+                        $action->reportBulkProcessingFailure();
+
+                        return;
+                    }
+
+                    try {
+                        if (! empty($tagIdsToAttach)) {
+                            $record->tags()->syncWithoutDetaching($tagIdsToAttach);
+                        }
+
+                        if (! empty($tagIdsToDetach)) {
+                            $record->tags()->detach($tagIdsToDetach);
+                        }
+
+                        $record->unsetRelation('tags');
+                    } catch (Throwable $exception) {
+                        $action->reportBulkProcessingFailure();
+
+                        if ($isFirstException) {
+                            // Only report the first exception so as to not flood error logs. Even
+                            // if Filament did not catch exceptions like this, only the first
+                            // would be reported as the rest of the process would be halted.
+                            report($exception);
+
+                            $isFirstException = false;
+                        }
+                    }
+                });
+            });
+        });
+
+        $this->deselectRecordsAfterCompletion();
+
+        $this->hidden(fn (): bool => ! ($this->canAttachTags() || $this->canDetachTags()));
+    }
+
+    public function attachable(bool | Closure $condition = true): static
+    {
+        $this->canAttachTags = $condition;
+
+        return $this;
+    }
+
+    public function detachable(bool | Closure $condition = true): static
+    {
+        $this->canDetachTags = $condition;
+
+        return $this;
+    }
+
+    public function canAttachTags(): bool
+    {
+        return (bool) $this->evaluate($this->canAttachTags);
+    }
+
+    public function canDetachTags(): bool
+    {
+        return (bool) $this->evaluate($this->canDetachTags);
+    }
+}

--- a/packages/spatie-laravel-tags-plugin/src/Actions/ManageSpatieTagsBulkAction.php
+++ b/packages/spatie-laravel-tags-plugin/src/Actions/ManageSpatieTagsBulkAction.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Number;
+use Illuminate\Support\Str;
 use Throwable;
 
 class ManageSpatieTagsBulkAction extends BulkAction
@@ -92,7 +93,19 @@ class ManageSpatieTagsBulkAction extends BulkAction
                 ->requiredWithout('tagsToAttach')
                 ->rules([
                     static fn (Get $get): Closure => static function (string $attribute, mixed $value, Closure $fail) use ($get): void {
-                        $conflictingTags = array_intersect($get('tagsToAttach') ?? [], $value ?? []);
+                        // Tags resolve by name *or* slug (see `InteractsWithSpatieTags` and
+                        // Spatie's `findFromStringOfAnyType()`), so `PHP`/`php` or `Front End`/`front-end`
+                        // point at the same tag. Comparing slugs catches conflicts that a raw string
+                        // comparison would miss and silently detach a tag the user asked to attach.
+                        $tagsToAttachSlugs = array_map(
+                            static fn (string $tag): string => Str::slug($tag),
+                            $get('tagsToAttach') ?? [],
+                        );
+
+                        $conflictingTags = array_filter(
+                            $value ?? [],
+                            static fn (string $tag): bool => in_array(Str::slug($tag), $tagsToAttachSlugs, strict: true),
+                        );
 
                         if (empty($conflictingTags)) {
                             return;

--- a/packages/spatie-laravel-tags-plugin/src/Actions/ManageSpatieTagsBulkAction.php
+++ b/packages/spatie-laravel-tags-plugin/src/Actions/ManageSpatieTagsBulkAction.php
@@ -13,6 +13,7 @@ use Filament\Support\Icons\Heroicon;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Number;
 use Illuminate\Support\Str;
@@ -86,10 +87,15 @@ class ManageSpatieTagsBulkAction extends BulkAction
             TagsInput::make('tagsToAttach')
                 ->label(__('filament-spatie-laravel-tags-plugin::manage-tags.modal.form.tags_to_attach.label'))
                 ->suggestions(static fn (): array => $action->getTagSuggestions())
+                // Tag names come from client-writable Livewire state. Validate each entry as a
+                // `string` so a tampered payload with a nested array fails validation instead of
+                // reaching the `string`-typed resolution closures and throwing a `TypeError`.
+                ->nestedRecursiveRules(['string'])
                 ->requiredWithout('tagsToDetach'),
             TagsInput::make('tagsToDetach')
                 ->label(__('filament-spatie-laravel-tags-plugin::manage-tags.modal.form.tags_to_detach.label'))
                 ->suggestions(static fn (): array => $action->getTagSuggestions())
+                ->nestedRecursiveRules(['string'])
                 ->requiredWithout('tagsToAttach')
                 ->rules([
                     static fn (Get $get): Closure => static function (string $attribute, mixed $value, Closure $fail) use ($get): void {
@@ -97,13 +103,18 @@ class ManageSpatieTagsBulkAction extends BulkAction
                         // Spatie's `findFromStringOfAnyType()`), so `PHP`/`php` or `Front End`/`front-end`
                         // point at the same tag. Comparing slugs catches conflicts that a raw string
                         // comparison would miss and silently detach a tag the user asked to attach.
+                        //
+                        // Both fields come from client-writable Livewire state. `nestedRecursiveRules(['string'])`
+                        // reports any non-string entry as its own validation error, but this closure still runs
+                        // over the raw arrays, so filter to strings first to keep a tampered nested-array payload
+                        // from reaching the `string`-typed callbacks and throwing a `TypeError`.
                         $tagsToAttachSlugs = array_map(
                             static fn (string $tag): string => Str::slug($tag),
-                            $get('tagsToAttach') ?? [],
+                            array_filter($get('tagsToAttach') ?? [], 'is_string'),
                         );
 
                         $conflictingTags = array_filter(
-                            $value ?? [],
+                            array_filter($value ?? [], 'is_string'),
                             static fn (string $tag): bool => in_array(Str::slug($tag), $tagsToAttachSlugs, strict: true),
                         );
 
@@ -124,9 +135,21 @@ class ManageSpatieTagsBulkAction extends BulkAction
                     $records = $action->getSelectedRecordsQuery()->cursor();
                 }
 
-                $tagIdsToAttach = $action->resolveTagsForAttaching($data['tagsToAttach'] ?? [])->pluck('id')->all();
+                try {
+                    // Resolving the tags runs find-or-create queries before any record is processed.
+                    // If that throws (e.g. a `findOrCreate()` race against a user-added unique index,
+                    // or a transient database error), report a complete failure so the user gets the
+                    // failure notification instead of an uncaught error, mirroring `DeleteBulkAction`.
+                    $tagIdsToAttach = $action->resolveTagsForAttaching($data['tagsToAttach'] ?? [])->pluck('id')->all();
 
-                $tagIdsToDetach = $action->resolveTagsForDetaching($data['tagsToDetach'] ?? [])->pluck('id')->all();
+                    $tagIdsToDetach = $action->resolveTagsForDetaching($data['tagsToDetach'] ?? [])->pluck('id')->all();
+                } catch (Throwable $exception) {
+                    $action->reportCompleteBulkProcessingFailure();
+
+                    report($exception);
+
+                    return;
+                }
 
                 if (empty($tagIdsToAttach) && empty($tagIdsToDetach)) {
                     return;
@@ -142,13 +165,19 @@ class ManageSpatieTagsBulkAction extends BulkAction
                     }
 
                     try {
-                        if (! empty($tagIdsToAttach)) {
-                            $record->tags()->syncWithoutDetaching($tagIdsToAttach);
-                        }
+                        // Attaching and detaching are two dependent writes. Wrap them in a
+                        // transaction so a failure between them cannot leave the record
+                        // half-updated while it is reported as a failure that implies nothing
+                        // changed. Nests via savepoints under an opt-in `->databaseTransaction()`.
+                        DB::transaction(static function () use ($record, $tagIdsToAttach, $tagIdsToDetach): void {
+                            if (! empty($tagIdsToAttach)) {
+                                $record->tags()->syncWithoutDetaching($tagIdsToAttach);
+                            }
 
-                        if (! empty($tagIdsToDetach)) {
-                            $record->tags()->detach($tagIdsToDetach);
-                        }
+                            if (! empty($tagIdsToDetach)) {
+                                $record->tags()->detach($tagIdsToDetach);
+                            }
+                        });
 
                         $record->unsetRelation('tags');
                     } catch (Throwable $exception) {

--- a/packages/spatie-laravel-tags-plugin/src/SpatieLaravelTagsPluginServiceProvider.php
+++ b/packages/spatie-laravel-tags-plugin/src/SpatieLaravelTagsPluginServiceProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Filament;
+
+use Illuminate\Support\ServiceProvider;
+
+class SpatieLaravelTagsPluginServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->loadTranslationsFrom(__DIR__ . '/../resources/lang', 'filament-spatie-laravel-tags-plugin');
+    }
+}

--- a/tests/src/Fixtures/Livewire/SpatieTagsBulkActionsNonTaggableTable.php
+++ b/tests/src/Fixtures/Livewire/SpatieTagsBulkActionsNonTaggableTable.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Livewire;
+
+use Filament\Actions\AttachSpatieTagsBulkAction;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Actions\DetachSpatieTagsBulkAction;
+use Filament\Actions\ManageSpatieTagsBulkAction;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Filament\Tests\Fixtures\Models\Post;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Builder;
+use Livewire\Component;
+
+/**
+ * The Spatie tags bulk actions mounted on a table whose model is not taggable. `Post` has no
+ * `tags()` relationship method (its `tags` column is an unrelated array cast), so
+ * `method_exists($record, 'tags')` is `false` for every record. This exercises the defensive
+ * branch in each action that reports a processing failure instead of throwing a
+ * `BadMethodCallException` when a record cannot receive tags.
+ */
+class SpatieTagsBulkActionsNonTaggableTable extends Component implements HasActions, HasSchemas, HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use InteractsWithTable;
+
+    protected function getTableQuery(): Builder
+    {
+        return Post::query();
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('title'),
+            ])
+            ->toolbarActions([
+                AttachSpatieTagsBulkAction::make(),
+                DetachSpatieTagsBulkAction::make(),
+                ManageSpatieTagsBulkAction::make(),
+            ]);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.table');
+    }
+}

--- a/tests/src/Fixtures/Livewire/SpatieTagsBulkActionsTable.php
+++ b/tests/src/Fixtures/Livewire/SpatieTagsBulkActionsTable.php
@@ -28,10 +28,6 @@ class SpatieTagsBulkActionsTable extends Component implements HasActions, HasSch
 
     public bool $useNullType = false;
 
-    public bool $isManageActionAttachable = true;
-
-    public bool $isManageActionDetachable = true;
-
     protected function getTableQuery(): Builder
     {
         return Article::query();
@@ -41,9 +37,7 @@ class SpatieTagsBulkActionsTable extends Component implements HasActions, HasSch
     {
         $attachTagsAction = AttachSpatieTagsBulkAction::make();
         $detachTagsAction = DetachSpatieTagsBulkAction::make();
-        $manageTagsAction = ManageSpatieTagsBulkAction::make()
-            ->attachable($this->isManageActionAttachable)
-            ->detachable($this->isManageActionDetachable);
+        $manageTagsAction = ManageSpatieTagsBulkAction::make();
 
         if ($this->useNullType) {
             $attachTagsAction->type(null);

--- a/tests/src/Fixtures/Livewire/SpatieTagsBulkActionsTable.php
+++ b/tests/src/Fixtures/Livewire/SpatieTagsBulkActionsTable.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Livewire;
+
+use Filament\Actions\AttachSpatieTagsBulkAction;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Actions\DetachSpatieTagsBulkAction;
+use Filament\Actions\ManageSpatieTagsBulkAction;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Filament\Tests\Fixtures\Models\Article;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Builder;
+use Livewire\Component;
+
+class SpatieTagsBulkActionsTable extends Component implements HasActions, HasSchemas, HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use InteractsWithTable;
+
+    public ?string $tagType = null;
+
+    public bool $useNullType = false;
+
+    public bool $isManageActionAttachable = true;
+
+    public bool $isManageActionDetachable = true;
+
+    protected function getTableQuery(): Builder
+    {
+        return Article::query();
+    }
+
+    public function table(Table $table): Table
+    {
+        $attachTagsAction = AttachSpatieTagsBulkAction::make();
+        $detachTagsAction = DetachSpatieTagsBulkAction::make();
+        $manageTagsAction = ManageSpatieTagsBulkAction::make()
+            ->attachable($this->isManageActionAttachable)
+            ->detachable($this->isManageActionDetachable);
+
+        if ($this->useNullType) {
+            $attachTagsAction->type(null);
+            $detachTagsAction->type(null);
+            $manageTagsAction->type(null);
+        } elseif ($this->tagType !== null) {
+            $attachTagsAction->type($this->tagType);
+            $detachTagsAction->type($this->tagType);
+            $manageTagsAction->type($this->tagType);
+        }
+
+        return $table
+            ->columns([
+                TextColumn::make('title'),
+            ])
+            ->toolbarActions([
+                $attachTagsAction,
+                $detachTagsAction,
+                $manageTagsAction,
+            ]);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.table');
+    }
+}

--- a/tests/src/Fixtures/Livewire/SpatieTagsBulkActionsTable.php
+++ b/tests/src/Fixtures/Livewire/SpatieTagsBulkActionsTable.php
@@ -28,6 +28,10 @@ class SpatieTagsBulkActionsTable extends Component implements HasActions, HasSch
 
     public bool $useNullType = false;
 
+    public bool $shouldFetchSelectedRecords = true;
+
+    public bool $authorizeUsingPublished = false;
+
     protected function getTableQuery(): Builder
     {
         return Article::query();
@@ -39,25 +43,32 @@ class SpatieTagsBulkActionsTable extends Component implements HasActions, HasSch
         $detachTagsAction = DetachSpatieTagsBulkAction::make();
         $manageTagsAction = ManageSpatieTagsBulkAction::make();
 
-        if ($this->useNullType) {
-            $attachTagsAction->type(null);
-            $detachTagsAction->type(null);
-            $manageTagsAction->type(null);
-        } elseif ($this->tagType !== null) {
-            $attachTagsAction->type($this->tagType);
-            $detachTagsAction->type($this->tagType);
-            $manageTagsAction->type($this->tagType);
+        $actions = [$attachTagsAction, $detachTagsAction, $manageTagsAction];
+
+        foreach ($actions as $action) {
+            if ($this->useNullType) {
+                $action->type(null);
+            } elseif ($this->tagType !== null) {
+                $action->type($this->tagType);
+            }
+
+            if (! $this->shouldFetchSelectedRecords) {
+                // Exercises the `getSelectedRecordsQuery()->cursor()` branch instead of the eager fetch.
+                $action->fetchSelectedRecords(false);
+            }
+
+            if ($this->authorizeUsingPublished) {
+                // Skips unpublished records so the individual-authorization path documented in the
+                // README is exercised: authorized records are processed and denied ones are reported.
+                $action->authorizeIndividualRecords(fn (Article $record): bool => (bool) $record->is_published);
+            }
         }
 
         return $table
             ->columns([
                 TextColumn::make('title'),
             ])
-            ->toolbarActions([
-                $attachTagsAction,
-                $detachTagsAction,
-                $manageTagsAction,
-            ]);
+            ->toolbarActions($actions);
     }
 
     public function render(): View

--- a/tests/src/Fixtures/Models/ThrowingTag.php
+++ b/tests/src/Fixtures/Models/ThrowingTag.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Models;
+
+use RuntimeException;
+use Spatie\Tags\Tag;
+
+/**
+ * A `Tag` model whose lookup throws, used to prove that the Spatie tags bulk actions report a
+ * graceful failure when resolving the entered tags fails, instead of letting the exception escape
+ * as an uncaught error. Wire it up with `config(['tags.tag_model' => ThrowingTag::class])`.
+ */
+class ThrowingTag extends Tag
+{
+    protected $table = 'tags';
+
+    public static function findFromStringOfAnyType(string $name, ?string $locale = null)
+    {
+        throw new RuntimeException('Simulated tag resolution failure.');
+    }
+}

--- a/tests/src/SpatieTagsPlugin/AttachSpatieTagsBulkActionTest.php
+++ b/tests/src/SpatieTagsPlugin/AttachSpatieTagsBulkActionTest.php
@@ -2,11 +2,15 @@
 
 use Filament\Actions\AttachSpatieTagsBulkAction;
 use Filament\Actions\Testing\TestAction;
+use Filament\Notifications\Notification;
 use Filament\SpatieLaravelTagsPlugin\Types\AllTagTypes;
+use Filament\Tests\Fixtures\Livewire\SpatieTagsBulkActionsNonTaggableTable;
 use Filament\Tests\Fixtures\Livewire\SpatieTagsBulkActionsTable;
 use Filament\Tests\Fixtures\Models\Article;
+use Filament\Tests\Fixtures\Models\Post;
 use Filament\Tests\Fixtures\Models\ThrowingTag;
 use Filament\Tests\TestCase;
+use Illuminate\Support\Number;
 use Spatie\Tags\Tag;
 
 use function Filament\Tests\livewire;
@@ -283,5 +287,110 @@ describe('integration', function (): void {
         foreach ($records as $record) {
             expect(Article::with('tags')->find($record->getKey())->getRelationValue('tags'))->toBeEmpty();
         }
+    });
+});
+
+describe('failure and authorization paths', function (): void {
+    it('attaches tags via a database cursor when `fetchSelectedRecords(false)` is set', function (): void {
+        $records = Article::factory()->count(3)->create();
+
+        // `fetchSelectedRecords(false)` makes the action iterate `getSelectedRecordsQuery()->cursor()`
+        // instead of an eagerly-fetched collection. The outcome must be identical to the eager path.
+        livewire(SpatieTagsBulkActionsTable::class, ['shouldFetchSelectedRecords' => false])
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(AttachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['Laravel'],
+            ])
+            ->assertHasNoFormErrors()
+            ->assertNotified(__('filament-spatie-laravel-tags-plugin::attach-tags.notifications.attached.title'));
+
+        foreach ($records as $record) {
+            expect(Article::with('tags')->find($record->getKey())->getRelationValue('tags')->pluck('name')->all())
+                ->toBe(['Laravel']);
+        }
+    });
+
+    it('skips records that fail `authorizeIndividualRecords()` and reports a partial failure', function (): void {
+        $authorizedRecords = Article::factory()->count(2)->create(['is_published' => true]);
+        $unauthorizedRecord = Article::factory()->create(['is_published' => false]);
+
+        livewire(SpatieTagsBulkActionsTable::class, ['authorizeUsingPublished' => true])
+            ->selectTableRecords([...$authorizedRecords->modelKeys(), $unauthorizedRecord->getKey()])
+            ->callAction(TestAction::make(AttachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['Laravel'],
+            ])
+            ->assertHasNoFormErrors()
+            ->assertNotified(
+                Notification::make()
+                    ->warning()
+                    ->title(trans_choice('filament-spatie-laravel-tags-plugin::attach-tags.notifications.attached_partial.title', 2, [
+                        'count' => Number::format(2),
+                        'total' => Number::format(3),
+                    ]))
+                    ->body('<p>' . trans_choice('filament-spatie-laravel-tags-plugin::attach-tags.notifications.attached_partial.missing_authorization_failure_message', 1, [
+                        'count' => Number::format(1),
+                    ]) . '</p>')
+                    ->persistent(),
+            );
+
+        foreach ($authorizedRecords as $record) {
+            expect(Article::with('tags')->find($record->getKey())->getRelationValue('tags')->pluck('name')->all())
+                ->toBe(['Laravel']);
+        }
+
+        expect(Article::with('tags')->find($unauthorizedRecord->getKey())->getRelationValue('tags'))->toBeEmpty();
+    });
+
+    it('reports a complete failure when `authorizeIndividualRecords()` denies every record', function (): void {
+        $records = Article::factory()->count(2)->create(['is_published' => false]);
+
+        livewire(SpatieTagsBulkActionsTable::class, ['authorizeUsingPublished' => true])
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(AttachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['Laravel'],
+            ])
+            ->assertHasNoFormErrors()
+            ->assertNotified(
+                Notification::make()
+                    ->danger()
+                    ->title(trans_choice('filament-spatie-laravel-tags-plugin::attach-tags.notifications.attached_none.title', 2, [
+                        'count' => Number::format(2),
+                        'total' => Number::format(2),
+                    ]))
+                    ->body('<p>' . trans_choice('filament-spatie-laravel-tags-plugin::attach-tags.notifications.attached_none.missing_authorization_failure_message', 2, [
+                        'count' => Number::format(2),
+                    ]) . '</p>')
+                    ->persistent(),
+            );
+
+        foreach ($records as $record) {
+            expect(Article::with('tags')->find($record->getKey())->getRelationValue('tags'))->toBeEmpty();
+        }
+    });
+
+    it('reports a processing failure instead of throwing when a selected record is not taggable', function (): void {
+        $records = Post::factory()->count(2)->create();
+
+        // `Post` has no `tags()` relationship method, so every record hits the `method_exists()` guard
+        // and is reported via `reportBulkProcessingFailure()`, exercising the processing-failure
+        // notification message and its lang keys rather than throwing a `BadMethodCallException`.
+        livewire(SpatieTagsBulkActionsNonTaggableTable::class)
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(AttachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['Laravel'],
+            ])
+            ->assertHasNoFormErrors()
+            ->assertNotified(
+                Notification::make()
+                    ->danger()
+                    ->title(trans_choice('filament-spatie-laravel-tags-plugin::attach-tags.notifications.attached_none.title', 2, [
+                        'count' => Number::format(2),
+                        'total' => Number::format(2),
+                    ]))
+                    ->body('<p>' . trans_choice('filament-spatie-laravel-tags-plugin::attach-tags.notifications.attached_none.missing_processing_failure_message', 2, [
+                        'count' => Number::format(2),
+                    ]) . '</p>')
+                    ->persistent(),
+            );
     });
 });

--- a/tests/src/SpatieTagsPlugin/AttachSpatieTagsBulkActionTest.php
+++ b/tests/src/SpatieTagsPlugin/AttachSpatieTagsBulkActionTest.php
@@ -1,0 +1,247 @@
+<?php
+
+use Filament\Actions\AttachSpatieTagsBulkAction;
+use Filament\Actions\Testing\TestAction;
+use Filament\SpatieLaravelTagsPlugin\Types\AllTagTypes;
+use Filament\Tests\Fixtures\Livewire\SpatieTagsBulkActionsTable;
+use Filament\Tests\Fixtures\Models\Article;
+use Filament\Tests\TestCase;
+use Spatie\Tags\Tag;
+
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+it('uses `attachTags` as the default name', function (): void {
+    expect(AttachSpatieTagsBulkAction::getDefaultName())->toBe('attachTags');
+});
+
+describe('type', function (): void {
+    it('defaults `getType()` to `AllTagTypes`', function (): void {
+        $action = AttachSpatieTagsBulkAction::make();
+
+        expect($action->getType())->toBeInstanceOf(AllTagTypes::class);
+        expect($action->isAnyTagTypeAllowed())->toBeTrue();
+    });
+
+    it('can set `type()` with a string', function (): void {
+        $action = AttachSpatieTagsBulkAction::make()
+            ->type('category');
+
+        expect($action->getType())->toBe('category');
+        expect($action->isAnyTagTypeAllowed())->toBeFalse();
+    });
+
+    it('can set `type()` with a `Closure`', function (): void {
+        $action = AttachSpatieTagsBulkAction::make()
+            ->type(static fn (): string => 'dynamic');
+
+        expect($action->getType())->toBe('dynamic');
+        expect($action->isAnyTagTypeAllowed())->toBeFalse();
+    });
+
+    it('can set `type()` to `null`', function (): void {
+        $action = AttachSpatieTagsBulkAction::make()
+            ->type(null);
+
+        expect($action->getType())->toBeNull();
+        expect($action->isAnyTagTypeAllowed())->toBeFalse();
+    });
+});
+
+describe('suggestions', function (): void {
+    it('suggests all tags when any tag type is allowed', function (): void {
+        Tag::findOrCreate('Laravel', 'framework');
+        Tag::findOrCreate('PHP', 'language');
+        Tag::findOrCreate('Untyped');
+
+        $suggestions = AttachSpatieTagsBulkAction::make()->getTagSuggestions();
+
+        expect($suggestions)->toContain('Laravel');
+        expect($suggestions)->toContain('PHP');
+        expect($suggestions)->toContain('Untyped');
+    });
+
+    it('suggests only tags of the given type when a `type()` is set', function (): void {
+        Tag::findOrCreate('Laravel', 'framework');
+        Tag::findOrCreate('PHP', 'language');
+
+        $suggestions = AttachSpatieTagsBulkAction::make()
+            ->type('framework')
+            ->getTagSuggestions();
+
+        expect($suggestions)->toContain('Laravel');
+        expect($suggestions)->not->toContain('PHP');
+    });
+
+    it('suggests only untyped tags when `type()` is `null`', function (): void {
+        Tag::findOrCreate('Typed', 'category');
+        Tag::findOrCreate('Untyped');
+
+        $suggestions = AttachSpatieTagsBulkAction::make()
+            ->type(null)
+            ->getTagSuggestions();
+
+        expect($suggestions)->toContain('Untyped');
+        expect($suggestions)->not->toContain('Typed');
+    });
+});
+
+describe('integration', function (): void {
+    it('can attach tags to the selected records', function (): void {
+        $records = Article::factory()->count(3)->create();
+        $unselectedRecord = Article::factory()->create();
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(AttachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['Laravel', 'PHP'],
+            ])
+            ->assertHasNoFormErrors()
+            ->assertNotified();
+
+        foreach ($records as $record) {
+            $freshRecord = Article::with('tags')->find($record->getKey());
+
+            expect($freshRecord->getRelationValue('tags')->pluck('name')->sort()->values()->all())
+                ->toBe(['Laravel', 'PHP']);
+        }
+
+        $freshUnselectedRecord = Article::with('tags')->find($unselectedRecord->getKey());
+
+        expect($freshUnselectedRecord->getRelationValue('tags'))->toBeEmpty();
+    });
+
+    it('requires at least one tag to be entered', function (): void {
+        $records = Article::factory()->count(2)->create();
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(AttachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => [],
+            ])
+            ->assertHasFormErrors(['tags' => ['required']]);
+    });
+
+    it('keeps the existing tags of the selected records', function (): void {
+        $record = Article::factory()->create();
+        $record->attachTags(['Old']);
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(AttachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['New'],
+            ]);
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+
+        expect($freshRecord->getRelationValue('tags')->pluck('name')->sort()->values()->all())
+            ->toBe(['New', 'Old']);
+    });
+
+    it('does not duplicate tags that are already attached to a selected record', function (): void {
+        $record = Article::factory()->create();
+        $record->attachTags(['Laravel']);
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(AttachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['Laravel', 'PHP'],
+            ]);
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+
+        expect($freshRecord->getRelationValue('tags'))->toHaveCount(2);
+        expect(Tag::count())->toBe(2);
+    });
+
+    it('reuses existing tags instead of creating new ones', function (): void {
+        $existingTag = Tag::findOrCreate('Laravel');
+        $record = Article::factory()->create();
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(AttachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['Laravel'],
+            ]);
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+
+        expect($freshRecord->getRelationValue('tags')->pluck('id')->all())
+            ->toBe([$existingTag->getKey()]);
+        expect(Tag::count())->toBe(1);
+    });
+
+    it('can attach tags of a specific `type()`', function (): void {
+        $records = Article::factory()->count(2)->create();
+
+        livewire(SpatieTagsBulkActionsTable::class, ['tagType' => 'framework'])
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(AttachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['Laravel'],
+            ]);
+
+        foreach ($records as $record) {
+            $freshRecord = Article::with('tags')->find($record->getKey());
+            $tags = $freshRecord->getRelationValue('tags');
+
+            expect($tags)->toHaveCount(1);
+            expect($tags->first()->type)->toBe('framework');
+            expect($tags->first()->name)->toBe('Laravel');
+        }
+    });
+
+    it('does not attach an existing tag of another type when a `type()` is set', function (): void {
+        $privilegedTag = Tag::findOrCreate('admin', 'role');
+        $record = Article::factory()->create();
+
+        livewire(SpatieTagsBulkActionsTable::class, ['tagType' => 'category'])
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(AttachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['admin'],
+            ]);
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+        $attachedTags = $freshRecord->getRelationValue('tags');
+
+        expect($attachedTags)->toHaveCount(1);
+        expect($attachedTags->first()->type)->toBe('category');
+        expect($attachedTags->first()->getKey())->not->toBe($privilegedTag->getKey());
+    });
+
+    it('attaches a tag as untyped when `type()` is `null`, and does not attach a privileged tag of the same name', function (): void {
+        $privilegedTag = Tag::findOrCreate('admin', 'role');
+        $record = Article::factory()->create();
+
+        livewire(SpatieTagsBulkActionsTable::class, ['useNullType' => true])
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(AttachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['admin'],
+            ]);
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+        $attachedTags = $freshRecord->getRelationValue('tags');
+
+        expect($attachedTags)->toHaveCount(1);
+        expect($attachedTags->first()->type)->toBeNull();
+        expect($attachedTags->first()->getKey())->not->toBe($privilegedTag->getKey());
+    });
+
+    it('attaches every existing tag of any type matching the name when any tag type is allowed', function (): void {
+        $typedTag = Tag::findOrCreate('admin', 'role');
+        $untypedTag = Tag::findOrCreate('admin');
+        $record = Article::factory()->create();
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(AttachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['admin'],
+            ]);
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+        $attachedTagIds = $freshRecord->getRelationValue('tags')->pluck('id')->all();
+
+        expect($attachedTagIds)->toContain($typedTag->getKey());
+        expect($attachedTagIds)->toContain($untypedTag->getKey());
+    });
+});

--- a/tests/src/SpatieTagsPlugin/AttachSpatieTagsBulkActionTest.php
+++ b/tests/src/SpatieTagsPlugin/AttachSpatieTagsBulkActionTest.php
@@ -5,6 +5,7 @@ use Filament\Actions\Testing\TestAction;
 use Filament\SpatieLaravelTagsPlugin\Types\AllTagTypes;
 use Filament\Tests\Fixtures\Livewire\SpatieTagsBulkActionsTable;
 use Filament\Tests\Fixtures\Models\Article;
+use Filament\Tests\Fixtures\Models\ThrowingTag;
 use Filament\Tests\TestCase;
 use Spatie\Tags\Tag;
 
@@ -243,5 +244,44 @@ describe('integration', function (): void {
 
         expect($attachedTagIds)->toContain($typedTag->getKey());
         expect($attachedTagIds)->toContain($untypedTag->getKey());
+    });
+
+    it('rejects a tag entry that is not a string', function (): void {
+        $record = Article::factory()->create();
+
+        // Tag names come from client-writable Livewire state, so a tampered payload can contain a
+        // nested array. `nestedRecursiveRules(['string'])` must reject it during validation rather
+        // than let it reach the `string`-typed resolution closures and throw a `TypeError`.
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(AttachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => [['Laravel']],
+            ])
+            ->assertHasFormErrors(['tags.0']);
+
+        expect(Tag::count())->toBe(0);
+    });
+
+    it('reports a failure notification instead of throwing when resolving the tags fails', function (): void {
+        $records = Article::factory()->count(2)->create();
+
+        // Force `resolveTagsForAttaching()` to throw to prove the action reports a graceful failure
+        // instead of letting the exception escape as an uncaught error that would leave the records
+        // selected with no notification.
+        config(['tags.tag_model' => ThrowingTag::class]);
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(AttachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['Laravel'],
+            ])
+            ->assertNotified();
+
+        // Restore the real tag model so the relationship's pivot key resolves when inspecting results.
+        config(['tags.tag_model' => Tag::class]);
+
+        foreach ($records as $record) {
+            expect(Article::with('tags')->find($record->getKey())->getRelationValue('tags'))->toBeEmpty();
+        }
     });
 });

--- a/tests/src/SpatieTagsPlugin/DetachSpatieTagsBulkActionTest.php
+++ b/tests/src/SpatieTagsPlugin/DetachSpatieTagsBulkActionTest.php
@@ -123,16 +123,23 @@ describe('integration', function (): void {
         expect($freshTaggedRecord->getRelationValue('tags'))->toBeEmpty();
     });
 
-    it('does nothing when none of the tags exist in the database', function (): void {
+    it('reports success and changes nothing when none of the entered tags exist in the database', function (): void {
         $record = Article::factory()->create();
         $record->attachTags(['Laravel']);
 
+        // Detaching is declarative: the goal is to ensure the named tags are absent. When none of
+        // the entered names resolve to existing tags via `resolveTagsForDetaching()`, that goal is
+        // already satisfied, so the action reports success rather than a processing failure. This
+        // mirrors detaching an existing tag from a record that does not have it (see the
+        // `succeeds when a selected record does not have one of the tags` test); success must not
+        // depend on whether the typed name happens to match a tag elsewhere in the database.
         livewire(SpatieTagsBulkActionsTable::class)
             ->selectTableRecords([$record->getKey()])
             ->callAction(TestAction::make(DetachSpatieTagsBulkAction::class)->table()->bulk(), data: [
                 'tags' => ['Nonexistent'],
             ])
-            ->assertHasNoFormErrors();
+            ->assertHasNoFormErrors()
+            ->assertNotified(__('filament-spatie-laravel-tags-plugin::detach-tags.notifications.detached.title'));
 
         $freshRecord = Article::with('tags')->find($record->getKey());
 

--- a/tests/src/SpatieTagsPlugin/DetachSpatieTagsBulkActionTest.php
+++ b/tests/src/SpatieTagsPlugin/DetachSpatieTagsBulkActionTest.php
@@ -197,4 +197,22 @@ describe('integration', function (): void {
 
         expect($freshRecord->getRelationValue('tags'))->toBeEmpty();
     });
+
+    it('rejects a tag entry that is not a string', function (): void {
+        $record = Article::factory()->create();
+        $record->attachTags(['Laravel']);
+
+        // Tag names come from client-writable Livewire state, so a tampered payload can contain a
+        // nested array. `nestedRecursiveRules(['string'])` must reject it during validation rather
+        // than let it reach the `string`-typed resolution closures and throw a `TypeError`.
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(DetachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => [['Laravel']],
+            ])
+            ->assertHasFormErrors(['tags.0']);
+
+        expect(Article::with('tags')->find($record->getKey())->getRelationValue('tags')->pluck('name')->all())
+            ->toBe(['Laravel']);
+    });
 });

--- a/tests/src/SpatieTagsPlugin/DetachSpatieTagsBulkActionTest.php
+++ b/tests/src/SpatieTagsPlugin/DetachSpatieTagsBulkActionTest.php
@@ -1,0 +1,193 @@
+<?php
+
+use Filament\Actions\DetachSpatieTagsBulkAction;
+use Filament\Actions\Testing\TestAction;
+use Filament\SpatieLaravelTagsPlugin\Types\AllTagTypes;
+use Filament\Tests\Fixtures\Livewire\SpatieTagsBulkActionsTable;
+use Filament\Tests\Fixtures\Models\Article;
+use Filament\Tests\TestCase;
+use Spatie\Tags\Tag;
+
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+it('uses `detachTags` as the default name', function (): void {
+    expect(DetachSpatieTagsBulkAction::getDefaultName())->toBe('detachTags');
+});
+
+describe('type', function (): void {
+    it('defaults `getType()` to `AllTagTypes`', function (): void {
+        $action = DetachSpatieTagsBulkAction::make();
+
+        expect($action->getType())->toBeInstanceOf(AllTagTypes::class);
+        expect($action->isAnyTagTypeAllowed())->toBeTrue();
+    });
+
+    it('can set `type()` with a string', function (): void {
+        $action = DetachSpatieTagsBulkAction::make()
+            ->type('category');
+
+        expect($action->getType())->toBe('category');
+        expect($action->isAnyTagTypeAllowed())->toBeFalse();
+    });
+
+    it('can set `type()` with a `Closure`', function (): void {
+        $action = DetachSpatieTagsBulkAction::make()
+            ->type(static fn (): string => 'dynamic');
+
+        expect($action->getType())->toBe('dynamic');
+        expect($action->isAnyTagTypeAllowed())->toBeFalse();
+    });
+
+    it('can set `type()` to `null`', function (): void {
+        $action = DetachSpatieTagsBulkAction::make()
+            ->type(null);
+
+        expect($action->getType())->toBeNull();
+        expect($action->isAnyTagTypeAllowed())->toBeFalse();
+    });
+});
+
+describe('integration', function (): void {
+    it('can detach tags from the selected records', function (): void {
+        $records = Article::factory()->count(3)->create();
+        $unselectedRecord = Article::factory()->create();
+
+        foreach ([...$records, $unselectedRecord] as $record) {
+            $record->attachTags(['Laravel', 'PHP']);
+        }
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(DetachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['Laravel'],
+            ])
+            ->assertHasNoFormErrors()
+            ->assertNotified();
+
+        foreach ($records as $record) {
+            $freshRecord = Article::with('tags')->find($record->getKey());
+
+            expect($freshRecord->getRelationValue('tags')->pluck('name')->all())->toBe(['PHP']);
+        }
+
+        $freshUnselectedRecord = Article::with('tags')->find($unselectedRecord->getKey());
+
+        expect($freshUnselectedRecord->getRelationValue('tags')->pluck('name')->sort()->values()->all())
+            ->toBe(['Laravel', 'PHP']);
+    });
+
+    it('requires at least one tag to be entered', function (): void {
+        $records = Article::factory()->count(2)->create();
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(DetachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => [],
+            ])
+            ->assertHasFormErrors(['tags' => ['required']]);
+    });
+
+    it('does not delete the tag models from the database, only detaches them', function (): void {
+        $record = Article::factory()->create();
+        $record->attachTags(['Laravel']);
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(DetachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['Laravel'],
+            ]);
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+
+        expect($freshRecord->getRelationValue('tags'))->toBeEmpty();
+        expect(Tag::count())->toBe(1);
+    });
+
+    it('succeeds when a selected record does not have one of the tags', function (): void {
+        $taggedRecord = Article::factory()->create();
+        $taggedRecord->attachTags(['Laravel']);
+
+        $untaggedRecord = Article::factory()->create();
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords([$taggedRecord->getKey(), $untaggedRecord->getKey()])
+            ->callAction(TestAction::make(DetachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['Laravel'],
+            ])
+            ->assertNotified(__('filament-spatie-laravel-tags-plugin::detach-tags.notifications.detached.title'));
+
+        $freshTaggedRecord = Article::with('tags')->find($taggedRecord->getKey());
+
+        expect($freshTaggedRecord->getRelationValue('tags'))->toBeEmpty();
+    });
+
+    it('does nothing when none of the tags exist in the database', function (): void {
+        $record = Article::factory()->create();
+        $record->attachTags(['Laravel']);
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(DetachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['Nonexistent'],
+            ])
+            ->assertHasNoFormErrors();
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+
+        expect($freshRecord->getRelationValue('tags')->pluck('name')->all())->toBe(['Laravel']);
+    });
+
+    it('detaches only tags of the given `type()` when one is set', function (): void {
+        $record = Article::factory()->create();
+        $record->attachTag('admin', 'role');
+        $record->attachTag('admin');
+
+        livewire(SpatieTagsBulkActionsTable::class, ['tagType' => 'role'])
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(DetachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['admin'],
+            ]);
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+        $remainingTags = $freshRecord->getRelationValue('tags');
+
+        expect($remainingTags)->toHaveCount(1);
+        expect($remainingTags->first()->type)->toBeNull();
+    });
+
+    it('detaches only untyped tags when `type()` is `null`, preserving typed tags of the same name', function (): void {
+        $record = Article::factory()->create();
+        $record->attachTag('admin', 'role');
+        $record->attachTag('admin');
+
+        livewire(SpatieTagsBulkActionsTable::class, ['useNullType' => true])
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(DetachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['admin'],
+            ]);
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+        $remainingTags = $freshRecord->getRelationValue('tags');
+
+        expect($remainingTags)->toHaveCount(1);
+        expect($remainingTags->first()->type)->toBe('role');
+    });
+
+    it('detaches every tag of any type matching the name when any tag type is allowed', function (): void {
+        $record = Article::factory()->create();
+        $record->attachTag('admin', 'role');
+        $record->attachTag('admin');
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(DetachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['admin'],
+            ]);
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+
+        expect($freshRecord->getRelationValue('tags'))->toBeEmpty();
+    });
+});

--- a/tests/src/SpatieTagsPlugin/DetachSpatieTagsBulkActionTest.php
+++ b/tests/src/SpatieTagsPlugin/DetachSpatieTagsBulkActionTest.php
@@ -2,10 +2,14 @@
 
 use Filament\Actions\DetachSpatieTagsBulkAction;
 use Filament\Actions\Testing\TestAction;
+use Filament\Notifications\Notification;
 use Filament\SpatieLaravelTagsPlugin\Types\AllTagTypes;
+use Filament\Tests\Fixtures\Livewire\SpatieTagsBulkActionsNonTaggableTable;
 use Filament\Tests\Fixtures\Livewire\SpatieTagsBulkActionsTable;
 use Filament\Tests\Fixtures\Models\Article;
+use Filament\Tests\Fixtures\Models\Post;
 use Filament\Tests\TestCase;
+use Illuminate\Support\Number;
 use Spatie\Tags\Tag;
 
 use function Filament\Tests\livewire;
@@ -214,5 +218,127 @@ describe('integration', function (): void {
 
         expect(Article::with('tags')->find($record->getKey())->getRelationValue('tags')->pluck('name')->all())
             ->toBe(['Laravel']);
+    });
+});
+
+describe('failure and authorization paths', function (): void {
+    it('detaches tags via a database cursor when `fetchSelectedRecords(false)` is set', function (): void {
+        $records = Article::factory()->count(3)->create();
+
+        foreach ($records as $record) {
+            $record->attachTags(['Laravel', 'PHP']);
+        }
+
+        // `fetchSelectedRecords(false)` makes the action iterate `getSelectedRecordsQuery()->cursor()`
+        // instead of an eagerly-fetched collection. The outcome must be identical to the eager path.
+        livewire(SpatieTagsBulkActionsTable::class, ['shouldFetchSelectedRecords' => false])
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(DetachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['Laravel'],
+            ])
+            ->assertHasNoFormErrors()
+            ->assertNotified(__('filament-spatie-laravel-tags-plugin::detach-tags.notifications.detached.title'));
+
+        foreach ($records as $record) {
+            expect(Article::with('tags')->find($record->getKey())->getRelationValue('tags')->pluck('name')->all())
+                ->toBe(['PHP']);
+        }
+    });
+
+    it('skips records that fail `authorizeIndividualRecords()` and reports a partial failure', function (): void {
+        $authorizedRecords = Article::factory()->count(2)->create(['is_published' => true]);
+        $unauthorizedRecord = Article::factory()->create(['is_published' => false]);
+
+        foreach ([...$authorizedRecords, $unauthorizedRecord] as $record) {
+            $record->attachTags(['Laravel']);
+        }
+
+        livewire(SpatieTagsBulkActionsTable::class, ['authorizeUsingPublished' => true])
+            ->selectTableRecords([...$authorizedRecords->modelKeys(), $unauthorizedRecord->getKey()])
+            ->callAction(TestAction::make(DetachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['Laravel'],
+            ])
+            ->assertHasNoFormErrors()
+            ->assertNotified(
+                Notification::make()
+                    ->warning()
+                    ->title(trans_choice('filament-spatie-laravel-tags-plugin::detach-tags.notifications.detached_partial.title', 2, [
+                        'count' => Number::format(2),
+                        'total' => Number::format(3),
+                    ]))
+                    ->body('<p>' . trans_choice('filament-spatie-laravel-tags-plugin::detach-tags.notifications.detached_partial.missing_authorization_failure_message', 1, [
+                        'count' => Number::format(1),
+                    ]) . '</p>')
+                    ->persistent(),
+            );
+
+        foreach ($authorizedRecords as $record) {
+            expect(Article::with('tags')->find($record->getKey())->getRelationValue('tags'))->toBeEmpty();
+        }
+
+        expect(Article::with('tags')->find($unauthorizedRecord->getKey())->getRelationValue('tags')->pluck('name')->all())
+            ->toBe(['Laravel']);
+    });
+
+    it('reports a complete failure when `authorizeIndividualRecords()` denies every record', function (): void {
+        $records = Article::factory()->count(2)->create(['is_published' => false]);
+
+        foreach ($records as $record) {
+            $record->attachTags(['Laravel']);
+        }
+
+        livewire(SpatieTagsBulkActionsTable::class, ['authorizeUsingPublished' => true])
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(DetachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['Laravel'],
+            ])
+            ->assertHasNoFormErrors()
+            ->assertNotified(
+                Notification::make()
+                    ->danger()
+                    ->title(trans_choice('filament-spatie-laravel-tags-plugin::detach-tags.notifications.detached_none.title', 2, [
+                        'count' => Number::format(2),
+                        'total' => Number::format(2),
+                    ]))
+                    ->body('<p>' . trans_choice('filament-spatie-laravel-tags-plugin::detach-tags.notifications.detached_none.missing_authorization_failure_message', 2, [
+                        'count' => Number::format(2),
+                    ]) . '</p>')
+                    ->persistent(),
+            );
+
+        foreach ($records as $record) {
+            expect(Article::with('tags')->find($record->getKey())->getRelationValue('tags')->pluck('name')->all())
+                ->toBe(['Laravel']);
+        }
+    });
+
+    it('reports a processing failure instead of throwing when a selected record is not taggable', function (): void {
+        $records = Post::factory()->count(2)->create();
+
+        // The entered tag must resolve to an existing tag, otherwise `resolveTagsForDetaching()` yields
+        // no ids and the action short-circuits with success before reaching the per-record loop.
+        Tag::findOrCreate('Laravel');
+
+        // `Post` has no `tags()` relationship method, so every record hits the `method_exists()` guard
+        // and is reported via `reportBulkProcessingFailure()`, exercising the processing-failure
+        // notification message and its lang keys rather than throwing a `BadMethodCallException`.
+        livewire(SpatieTagsBulkActionsNonTaggableTable::class)
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(DetachSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tags' => ['Laravel'],
+            ])
+            ->assertHasNoFormErrors()
+            ->assertNotified(
+                Notification::make()
+                    ->danger()
+                    ->title(trans_choice('filament-spatie-laravel-tags-plugin::detach-tags.notifications.detached_none.title', 2, [
+                        'count' => Number::format(2),
+                        'total' => Number::format(2),
+                    ]))
+                    ->body('<p>' . trans_choice('filament-spatie-laravel-tags-plugin::detach-tags.notifications.detached_none.missing_processing_failure_message', 2, [
+                        'count' => Number::format(2),
+                    ]) . '</p>')
+                    ->persistent(),
+            );
     });
 });

--- a/tests/src/SpatieTagsPlugin/ManageSpatieTagsBulkActionTest.php
+++ b/tests/src/SpatieTagsPlugin/ManageSpatieTagsBulkActionTest.php
@@ -187,4 +187,33 @@ describe('integration', function (): void {
         expect($untypedTagNames)->toBe(['Old']);
     });
 
+    it('treats an empty string `type()` as untyped when attaching and detaching, matching the suggestions', function (): void {
+        $record = Article::factory()->create();
+
+        // An untyped tag already attached to the record, plus a pre-existing untyped tag that is
+        // not yet attached. `getTagSuggestions()` surfaces untyped tags for an empty string type
+        // (via `filled()`), so attaching and detaching must operate on those same untyped tags
+        // rather than a distinct empty-string type.
+        $record->attachTag('Old');
+        Tag::findOrCreate('New');
+
+        livewire(SpatieTagsBulkActionsTable::class, ['tagType' => ''])
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tagsToAttach' => ['New'],
+                'tagsToDetach' => ['Old'],
+            ])
+            ->assertHasNoFormErrors();
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+        $remainingTags = $freshRecord->getRelationValue('tags');
+
+        // The untyped `Old` was detached and the untyped `New` was attached.
+        expect($remainingTags->pluck('name')->all())->toBe(['New']);
+        expect($remainingTags->pluck('type')->all())->toBe([null]);
+
+        // The pre-existing untyped `New` tag was reused rather than duplicated as an empty-string type.
+        expect(Tag::all()->filter(fn (Tag $tag): bool => $tag->name === 'New'))->toHaveCount(1);
+    });
+
 });

--- a/tests/src/SpatieTagsPlugin/ManageSpatieTagsBulkActionTest.php
+++ b/tests/src/SpatieTagsPlugin/ManageSpatieTagsBulkActionTest.php
@@ -1,0 +1,250 @@
+<?php
+
+use Filament\Actions\ManageSpatieTagsBulkAction;
+use Filament\Actions\Testing\TestAction;
+use Filament\SpatieLaravelTagsPlugin\Types\AllTagTypes;
+use Filament\Tests\Fixtures\Livewire\SpatieTagsBulkActionsTable;
+use Filament\Tests\Fixtures\Models\Article;
+use Filament\Tests\TestCase;
+use Spatie\Tags\Tag;
+
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+it('uses `manageTags` as the default name', function (): void {
+    expect(ManageSpatieTagsBulkAction::getDefaultName())->toBe('manageTags');
+});
+
+it('defaults `getType()` to `AllTagTypes`', function (): void {
+    $action = ManageSpatieTagsBulkAction::make();
+
+    expect($action->getType())->toBeInstanceOf(AllTagTypes::class);
+    expect($action->isAnyTagTypeAllowed())->toBeTrue();
+});
+
+describe('configuration', function (): void {
+    it('allows attaching and detaching by default', function (): void {
+        $action = ManageSpatieTagsBulkAction::make();
+
+        expect($action->canAttachTags())->toBeTrue();
+        expect($action->canDetachTags())->toBeTrue();
+    });
+
+    it('can disable attaching with `attachable(false)`', function (): void {
+        $action = ManageSpatieTagsBulkAction::make()
+            ->attachable(false);
+
+        expect($action->canAttachTags())->toBeFalse();
+        expect($action->canDetachTags())->toBeTrue();
+    });
+
+    it('can disable detaching with `detachable(false)`', function (): void {
+        $action = ManageSpatieTagsBulkAction::make()
+            ->detachable(false);
+
+        expect($action->canAttachTags())->toBeTrue();
+        expect($action->canDetachTags())->toBeFalse();
+    });
+
+    it('can set `attachable()` and `detachable()` with a `Closure`', function (): void {
+        $action = ManageSpatieTagsBulkAction::make()
+            ->attachable(static fn (): bool => false)
+            ->detachable(static fn (): bool => true);
+
+        expect($action->canAttachTags())->toBeFalse();
+        expect($action->canDetachTags())->toBeTrue();
+    });
+
+    it('uses the `manage-tags` label by default', function (): void {
+        $action = ManageSpatieTagsBulkAction::make();
+
+        expect($action->getLabel())
+            ->toBe(__('filament-spatie-laravel-tags-plugin::manage-tags.label'));
+    });
+
+    it('uses the `attach-tags` label when detaching is disabled', function (): void {
+        $action = ManageSpatieTagsBulkAction::make()
+            ->detachable(false);
+
+        expect($action->getLabel())
+            ->toBe(__('filament-spatie-laravel-tags-plugin::attach-tags.label'));
+    });
+
+    it('uses the `detach-tags` label when attaching is disabled', function (): void {
+        $action = ManageSpatieTagsBulkAction::make()
+            ->attachable(false);
+
+        expect($action->getLabel())
+            ->toBe(__('filament-spatie-laravel-tags-plugin::detach-tags.label'));
+    });
+});
+
+describe('integration', function (): void {
+    it('can attach and detach tags from the selected records in a single call', function (): void {
+        $records = Article::factory()->count(3)->create();
+
+        foreach ($records as $record) {
+            $record->attachTags(['Old', 'Kept']);
+        }
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tagsToAttach' => ['New'],
+                'tagsToDetach' => ['Old'],
+            ])
+            ->assertHasNoFormErrors()
+            ->assertNotified();
+
+        foreach ($records as $record) {
+            $freshRecord = Article::with('tags')->find($record->getKey());
+
+            expect($freshRecord->getRelationValue('tags')->pluck('name')->sort()->values()->all())
+                ->toBe(['Kept', 'New']);
+        }
+    });
+
+    it('can attach tags without detaching any', function (): void {
+        $record = Article::factory()->create();
+        $record->attachTags(['Old']);
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tagsToAttach' => ['New'],
+                'tagsToDetach' => [],
+            ])
+            ->assertHasNoFormErrors();
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+
+        expect($freshRecord->getRelationValue('tags')->pluck('name')->sort()->values()->all())
+            ->toBe(['New', 'Old']);
+    });
+
+    it('can detach tags without attaching any', function (): void {
+        $record = Article::factory()->create();
+        $record->attachTags(['Old', 'Kept']);
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tagsToAttach' => [],
+                'tagsToDetach' => ['Old'],
+            ])
+            ->assertHasNoFormErrors();
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+
+        expect($freshRecord->getRelationValue('tags')->pluck('name')->all())->toBe(['Kept']);
+    });
+
+    it('requires at least one of the two fields to be filled', function (): void {
+        $records = Article::factory()->count(2)->create();
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tagsToAttach' => [],
+                'tagsToDetach' => [],
+            ])
+            ->assertHasFormErrors([
+                'tagsToAttach' => ['required_without'],
+                'tagsToDetach' => ['required_without'],
+            ]);
+    });
+
+    it('does not allow the same tag to be attached and detached at the same time', function (): void {
+        $record = Article::factory()->create();
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tagsToAttach' => ['Laravel', 'PHP'],
+                'tagsToDetach' => ['Laravel'],
+            ])
+            ->assertHasFormErrors(['tagsToDetach']);
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+
+        expect($freshRecord->getRelationValue('tags'))->toBeEmpty();
+    });
+
+    it('respects the `type()` when attaching and detaching', function (): void {
+        $record = Article::factory()->create();
+        $record->attachTag('Old', 'framework');
+        $record->attachTag('Old');
+
+        livewire(SpatieTagsBulkActionsTable::class, ['tagType' => 'framework'])
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tagsToAttach' => ['New'],
+                'tagsToDetach' => ['Old'],
+            ]);
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+        $remainingTags = $freshRecord->getRelationValue('tags');
+
+        $frameworkTagNames = $remainingTags->filter(fn (Tag $tag): bool => $tag->type === 'framework')->pluck('name')->all();
+        $untypedTagNames = $remainingTags->filter(fn (Tag $tag): bool => $tag->type === null)->pluck('name')->all();
+
+        expect($frameworkTagNames)->toBe(['New']);
+        expect($untypedTagNames)->toBe(['Old']);
+    });
+
+    it('only attaches tags when detaching is disabled, even if detach data is submitted', function (): void {
+        $record = Article::factory()->create();
+        $record->attachTags(['Old']);
+
+        livewire(SpatieTagsBulkActionsTable::class, ['isManageActionDetachable' => false])
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tagsToAttach' => ['New'],
+                'tagsToDetach' => ['Old'],
+            ]);
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+
+        expect($freshRecord->getRelationValue('tags')->pluck('name')->sort()->values()->all())
+            ->toBe(['New', 'Old']);
+    });
+
+    it('only detaches tags when attaching is disabled, even if attach data is submitted', function (): void {
+        $record = Article::factory()->create();
+        $record->attachTags(['Old']);
+
+        livewire(SpatieTagsBulkActionsTable::class, ['isManageActionAttachable' => false])
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tagsToAttach' => ['New'],
+                'tagsToDetach' => ['Old'],
+            ]);
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+
+        expect($freshRecord->getRelationValue('tags'))->toBeEmpty();
+        expect(Tag::query()->where('name->en', 'New')->exists())->toBeFalse();
+    });
+
+    it('requires the attach field when detaching is disabled', function (): void {
+        $records = Article::factory()->count(2)->create();
+
+        livewire(SpatieTagsBulkActionsTable::class, ['isManageActionDetachable' => false])
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tagsToAttach' => [],
+            ])
+            ->assertHasFormErrors(['tagsToAttach' => ['required_without']]);
+    });
+
+    it('is hidden when both attaching and detaching are disabled', function (): void {
+        Article::factory()->create();
+
+        livewire(SpatieTagsBulkActionsTable::class, [
+            'isManageActionAttachable' => false,
+            'isManageActionDetachable' => false,
+        ])
+            ->assertActionHidden(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk());
+    });
+});

--- a/tests/src/SpatieTagsPlugin/ManageSpatieTagsBulkActionTest.php
+++ b/tests/src/SpatieTagsPlugin/ManageSpatieTagsBulkActionTest.php
@@ -123,6 +123,25 @@ describe('integration', function (): void {
         expect($freshRecord->getRelationValue('tags'))->toBeEmpty();
     });
 
+    it('does not allow the same tag to be attached and detached when the two spellings resolve to the same tag', function (array $tagsToAttach, array $tagsToDetach): void {
+        $record = Article::factory()->create();
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tagsToAttach' => $tagsToAttach,
+                'tagsToDetach' => $tagsToDetach,
+            ])
+            ->assertHasFormErrors(['tagsToDetach']);
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+
+        expect($freshRecord->getRelationValue('tags'))->toBeEmpty();
+    })->with([
+        'differing only by case' => [['PHP'], ['php']],
+        'name versus slug format' => [['Front End'], ['front-end']],
+    ]);
+
     it('respects the `type()` when attaching and detaching', function (): void {
         $record = Article::factory()->create();
         $record->attachTag('Old', 'framework');

--- a/tests/src/SpatieTagsPlugin/ManageSpatieTagsBulkActionTest.php
+++ b/tests/src/SpatieTagsPlugin/ManageSpatieTagsBulkActionTest.php
@@ -2,12 +2,16 @@
 
 use Filament\Actions\ManageSpatieTagsBulkAction;
 use Filament\Actions\Testing\TestAction;
+use Filament\Notifications\Notification;
 use Filament\SpatieLaravelTagsPlugin\Types\AllTagTypes;
+use Filament\Tests\Fixtures\Livewire\SpatieTagsBulkActionsNonTaggableTable;
 use Filament\Tests\Fixtures\Livewire\SpatieTagsBulkActionsTable;
 use Filament\Tests\Fixtures\Models\Article;
+use Filament\Tests\Fixtures\Models\Post;
 use Filament\Tests\Fixtures\Models\ThrowingTag;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Number;
 use Spatie\Tags\Tag;
 
 use function Filament\Tests\livewire;
@@ -305,4 +309,130 @@ describe('integration', function (): void {
         }
     });
 
+});
+
+describe('failure and authorization paths', function (): void {
+    it('attaches and detaches tags via a database cursor when `fetchSelectedRecords(false)` is set', function (): void {
+        $records = Article::factory()->count(3)->create();
+
+        foreach ($records as $record) {
+            $record->attachTags(['Old', 'Kept']);
+        }
+
+        // `fetchSelectedRecords(false)` makes the action iterate `getSelectedRecordsQuery()->cursor()`
+        // instead of an eagerly-fetched collection. The outcome must be identical to the eager path.
+        livewire(SpatieTagsBulkActionsTable::class, ['shouldFetchSelectedRecords' => false])
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tagsToAttach' => ['New'],
+                'tagsToDetach' => ['Old'],
+            ])
+            ->assertHasNoFormErrors()
+            ->assertNotified(__('filament-spatie-laravel-tags-plugin::manage-tags.notifications.updated.title'));
+
+        foreach ($records as $record) {
+            expect(Article::with('tags')->find($record->getKey())->getRelationValue('tags')->pluck('name')->sort()->values()->all())
+                ->toBe(['Kept', 'New']);
+        }
+    });
+
+    it('skips records that fail `authorizeIndividualRecords()` and reports a partial failure', function (): void {
+        $authorizedRecords = Article::factory()->count(2)->create(['is_published' => true]);
+        $unauthorizedRecord = Article::factory()->create(['is_published' => false]);
+
+        foreach ([...$authorizedRecords, $unauthorizedRecord] as $record) {
+            $record->attachTags(['Old']);
+        }
+
+        livewire(SpatieTagsBulkActionsTable::class, ['authorizeUsingPublished' => true])
+            ->selectTableRecords([...$authorizedRecords->modelKeys(), $unauthorizedRecord->getKey()])
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tagsToAttach' => ['New'],
+                'tagsToDetach' => ['Old'],
+            ])
+            ->assertHasNoFormErrors()
+            ->assertNotified(
+                Notification::make()
+                    ->warning()
+                    ->title(trans_choice('filament-spatie-laravel-tags-plugin::manage-tags.notifications.updated_partial.title', 2, [
+                        'count' => Number::format(2),
+                        'total' => Number::format(3),
+                    ]))
+                    ->body('<p>' . trans_choice('filament-spatie-laravel-tags-plugin::manage-tags.notifications.updated_partial.missing_authorization_failure_message', 1, [
+                        'count' => Number::format(1),
+                    ]) . '</p>')
+                    ->persistent(),
+            );
+
+        foreach ($authorizedRecords as $record) {
+            // `Old` was detached and `New` attached on the authorized records.
+            expect(Article::with('tags')->find($record->getKey())->getRelationValue('tags')->pluck('name')->all())
+                ->toBe(['New']);
+        }
+
+        // The unauthorized record was skipped entirely: it keeps `Old` and never received `New`.
+        expect(Article::with('tags')->find($unauthorizedRecord->getKey())->getRelationValue('tags')->pluck('name')->all())
+            ->toBe(['Old']);
+    });
+
+    it('reports a complete failure when `authorizeIndividualRecords()` denies every record', function (): void {
+        $records = Article::factory()->count(2)->create(['is_published' => false]);
+
+        foreach ($records as $record) {
+            $record->attachTags(['Old']);
+        }
+
+        livewire(SpatieTagsBulkActionsTable::class, ['authorizeUsingPublished' => true])
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tagsToAttach' => ['New'],
+                'tagsToDetach' => ['Old'],
+            ])
+            ->assertHasNoFormErrors()
+            ->assertNotified(
+                Notification::make()
+                    ->danger()
+                    ->title(trans_choice('filament-spatie-laravel-tags-plugin::manage-tags.notifications.updated_none.title', 2, [
+                        'count' => Number::format(2),
+                        'total' => Number::format(2),
+                    ]))
+                    ->body('<p>' . trans_choice('filament-spatie-laravel-tags-plugin::manage-tags.notifications.updated_none.missing_authorization_failure_message', 2, [
+                        'count' => Number::format(2),
+                    ]) . '</p>')
+                    ->persistent(),
+            );
+
+        foreach ($records as $record) {
+            expect(Article::with('tags')->find($record->getKey())->getRelationValue('tags')->pluck('name')->all())
+                ->toBe(['Old']);
+        }
+    });
+
+    it('reports a processing failure instead of throwing when a selected record is not taggable', function (): void {
+        $records = Post::factory()->count(2)->create();
+
+        // `Post` has no `tags()` relationship method, so every record hits the `method_exists()` guard
+        // and is reported via `reportBulkProcessingFailure()`, exercising the processing-failure
+        // notification message and its lang keys rather than throwing a `BadMethodCallException`.
+        // Attaching find-or-creates the tag, so the per-record loop is reached without pre-seeding.
+        livewire(SpatieTagsBulkActionsNonTaggableTable::class)
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tagsToAttach' => ['New'],
+                'tagsToDetach' => [],
+            ])
+            ->assertHasNoFormErrors()
+            ->assertNotified(
+                Notification::make()
+                    ->danger()
+                    ->title(trans_choice('filament-spatie-laravel-tags-plugin::manage-tags.notifications.updated_none.title', 2, [
+                        'count' => Number::format(2),
+                        'total' => Number::format(2),
+                    ]))
+                    ->body('<p>' . trans_choice('filament-spatie-laravel-tags-plugin::manage-tags.notifications.updated_none.missing_processing_failure_message', 2, [
+                        'count' => Number::format(2),
+                    ]) . '</p>')
+                    ->persistent(),
+            );
+    });
 });

--- a/tests/src/SpatieTagsPlugin/ManageSpatieTagsBulkActionTest.php
+++ b/tests/src/SpatieTagsPlugin/ManageSpatieTagsBulkActionTest.php
@@ -6,6 +6,7 @@ use Filament\SpatieLaravelTagsPlugin\Types\AllTagTypes;
 use Filament\Tests\Fixtures\Livewire\SpatieTagsBulkActionsTable;
 use Filament\Tests\Fixtures\Models\Article;
 use Filament\Tests\TestCase;
+use Illuminate\Support\Facades\DB;
 use Spatie\Tags\Tag;
 
 use function Filament\Tests\livewire;
@@ -29,6 +30,49 @@ describe('configuration', function (): void {
 
         expect($action->getLabel())
             ->toBe(__('filament-spatie-laravel-tags-plugin::manage-tags.label'));
+    });
+});
+
+describe('suggestions', function (): void {
+    it('memoizes `getTagSuggestions()` so the two inputs share a single query per request', function (): void {
+        // The attach and detach `TagsInput`s both resolve their suggestions from the same action via
+        // `->suggestions()` closures that the tags-input view re-runs on every render. Without the memo,
+        // each call repeats the unbounded `SELECT name FROM tags` scan; the cache keeps it to one query.
+        Tag::findOrCreate('Laravel');
+        Tag::findOrCreate('PHP');
+
+        $action = ManageSpatieTagsBulkAction::make();
+
+        DB::enableQueryLog();
+        DB::flushQueryLog();
+
+        $firstSuggestions = $action->getTagSuggestions();
+        $queriesAfterFirstCall = count(DB::getQueryLog());
+
+        DB::flushQueryLog();
+
+        $secondSuggestions = $action->getTagSuggestions();
+        $queriesAfterSecondCall = count(DB::getQueryLog());
+
+        DB::disableQueryLog();
+
+        expect($queriesAfterFirstCall)->toBeGreaterThan(0);
+        expect($queriesAfterSecondCall)->toBe(0);
+        expect($secondSuggestions)->toBe($firstSuggestions);
+        expect($firstSuggestions)->toContain('Laravel', 'PHP');
+    });
+
+    it('recomputes `getTagSuggestions()` after the `type()` changes', function (): void {
+        Tag::findOrCreate('Laravel', 'framework');
+        Tag::findOrCreate('PHP', 'language');
+
+        $action = ManageSpatieTagsBulkAction::make()->type('framework');
+
+        expect($action->getTagSuggestions())->toContain('Laravel')->not->toContain('PHP');
+
+        $action->type('language');
+
+        expect($action->getTagSuggestions())->toContain('PHP')->not->toContain('Laravel');
     });
 });
 

--- a/tests/src/SpatieTagsPlugin/ManageSpatieTagsBulkActionTest.php
+++ b/tests/src/SpatieTagsPlugin/ManageSpatieTagsBulkActionTest.php
@@ -5,6 +5,7 @@ use Filament\Actions\Testing\TestAction;
 use Filament\SpatieLaravelTagsPlugin\Types\AllTagTypes;
 use Filament\Tests\Fixtures\Livewire\SpatieTagsBulkActionsTable;
 use Filament\Tests\Fixtures\Models\Article;
+use Filament\Tests\Fixtures\Models\ThrowingTag;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Facades\DB;
 use Spatie\Tags\Tag;
@@ -258,6 +259,50 @@ describe('integration', function (): void {
 
         // The pre-existing untyped `New` tag was reused rather than duplicated as an empty-string type.
         expect(Tag::all()->filter(fn (Tag $tag): bool => $tag->name === 'New'))->toHaveCount(1);
+    });
+
+    it('rejects a tag entry that is not a string', function (string $field): void {
+        $record = Article::factory()->create();
+
+        // Tag names come from client-writable Livewire state, so a tampered payload can contain a
+        // nested array. `nestedRecursiveRules(['string'])` must reject it during validation rather
+        // than let it reach the `string`-typed resolution and conflict-validation closures and throw
+        // a `TypeError`.
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                $field => [['Laravel']],
+            ])
+            ->assertHasFormErrors(["{$field}.0"]);
+
+        expect(Tag::count())->toBe(0);
+    })->with([
+        'tagsToAttach',
+        'tagsToDetach',
+    ]);
+
+    it('reports a failure notification instead of throwing when resolving the tags fails', function (): void {
+        $records = Article::factory()->count(2)->create();
+
+        // Force `resolveTagsForAttaching()` to throw to prove the action reports a graceful failure
+        // instead of letting the exception escape as an uncaught error that would leave the records
+        // selected with no notification.
+        config(['tags.tag_model' => ThrowingTag::class]);
+
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords($records)
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tagsToAttach' => ['Laravel'],
+                'tagsToDetach' => [],
+            ])
+            ->assertNotified();
+
+        // Restore the real tag model so the relationship's pivot key resolves when inspecting results.
+        config(['tags.tag_model' => Tag::class]);
+
+        foreach ($records as $record) {
+            expect(Article::with('tags')->find($record->getKey())->getRelationValue('tags'))->toBeEmpty();
+        }
     });
 
 });

--- a/tests/src/SpatieTagsPlugin/ManageSpatieTagsBulkActionTest.php
+++ b/tests/src/SpatieTagsPlugin/ManageSpatieTagsBulkActionTest.php
@@ -92,6 +92,29 @@ describe('integration', function (): void {
         expect($freshRecord->getRelationValue('tags')->pluck('name')->all())->toBe(['Kept']);
     });
 
+    it('reports success and changes nothing when the only tags to detach do not exist', function (): void {
+        $record = Article::factory()->create();
+        $record->attachTags(['Kept']);
+
+        // Same declarative semantics as the detach action: with nothing to attach and none of the
+        // `tagsToDetach` resolving to existing tags via `resolveTagsForDetaching()`, the desired
+        // state is already satisfied, so the action reports success rather than a processing
+        // failure. Reporting failure here would make the outcome depend on whether the typed name
+        // happens to match a tag elsewhere in the database, unrelated to the selected records.
+        livewire(SpatieTagsBulkActionsTable::class)
+            ->selectTableRecords([$record->getKey()])
+            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
+                'tagsToAttach' => [],
+                'tagsToDetach' => ['Nonexistent'],
+            ])
+            ->assertHasNoFormErrors()
+            ->assertNotified(__('filament-spatie-laravel-tags-plugin::manage-tags.notifications.updated.title'));
+
+        $freshRecord = Article::with('tags')->find($record->getKey());
+
+        expect($freshRecord->getRelationValue('tags')->pluck('name')->all())->toBe(['Kept']);
+    });
+
     it('requires at least one of the two fields to be filled', function (): void {
         $records = Article::factory()->count(2)->create();
 

--- a/tests/src/SpatieTagsPlugin/ManageSpatieTagsBulkActionTest.php
+++ b/tests/src/SpatieTagsPlugin/ManageSpatieTagsBulkActionTest.php
@@ -24,59 +24,11 @@ it('defaults `getType()` to `AllTagTypes`', function (): void {
 });
 
 describe('configuration', function (): void {
-    it('allows attaching and detaching by default', function (): void {
-        $action = ManageSpatieTagsBulkAction::make();
-
-        expect($action->canAttachTags())->toBeTrue();
-        expect($action->canDetachTags())->toBeTrue();
-    });
-
-    it('can disable attaching with `attachable(false)`', function (): void {
-        $action = ManageSpatieTagsBulkAction::make()
-            ->attachable(false);
-
-        expect($action->canAttachTags())->toBeFalse();
-        expect($action->canDetachTags())->toBeTrue();
-    });
-
-    it('can disable detaching with `detachable(false)`', function (): void {
-        $action = ManageSpatieTagsBulkAction::make()
-            ->detachable(false);
-
-        expect($action->canAttachTags())->toBeTrue();
-        expect($action->canDetachTags())->toBeFalse();
-    });
-
-    it('can set `attachable()` and `detachable()` with a `Closure`', function (): void {
-        $action = ManageSpatieTagsBulkAction::make()
-            ->attachable(static fn (): bool => false)
-            ->detachable(static fn (): bool => true);
-
-        expect($action->canAttachTags())->toBeFalse();
-        expect($action->canDetachTags())->toBeTrue();
-    });
-
-    it('uses the `manage-tags` label by default', function (): void {
+    it('uses the `manage-tags` label', function (): void {
         $action = ManageSpatieTagsBulkAction::make();
 
         expect($action->getLabel())
             ->toBe(__('filament-spatie-laravel-tags-plugin::manage-tags.label'));
-    });
-
-    it('uses the `attach-tags` label when detaching is disabled', function (): void {
-        $action = ManageSpatieTagsBulkAction::make()
-            ->detachable(false);
-
-        expect($action->getLabel())
-            ->toBe(__('filament-spatie-laravel-tags-plugin::attach-tags.label'));
-    });
-
-    it('uses the `detach-tags` label when attaching is disabled', function (): void {
-        $action = ManageSpatieTagsBulkAction::make()
-            ->attachable(false);
-
-        expect($action->getLabel())
-            ->toBe(__('filament-spatie-laravel-tags-plugin::detach-tags.label'));
     });
 });
 
@@ -193,58 +145,4 @@ describe('integration', function (): void {
         expect($untypedTagNames)->toBe(['Old']);
     });
 
-    it('only attaches tags when detaching is disabled, even if detach data is submitted', function (): void {
-        $record = Article::factory()->create();
-        $record->attachTags(['Old']);
-
-        livewire(SpatieTagsBulkActionsTable::class, ['isManageActionDetachable' => false])
-            ->selectTableRecords([$record->getKey()])
-            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
-                'tagsToAttach' => ['New'],
-                'tagsToDetach' => ['Old'],
-            ]);
-
-        $freshRecord = Article::with('tags')->find($record->getKey());
-
-        expect($freshRecord->getRelationValue('tags')->pluck('name')->sort()->values()->all())
-            ->toBe(['New', 'Old']);
-    });
-
-    it('only detaches tags when attaching is disabled, even if attach data is submitted', function (): void {
-        $record = Article::factory()->create();
-        $record->attachTags(['Old']);
-
-        livewire(SpatieTagsBulkActionsTable::class, ['isManageActionAttachable' => false])
-            ->selectTableRecords([$record->getKey()])
-            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
-                'tagsToAttach' => ['New'],
-                'tagsToDetach' => ['Old'],
-            ]);
-
-        $freshRecord = Article::with('tags')->find($record->getKey());
-
-        expect($freshRecord->getRelationValue('tags'))->toBeEmpty();
-        expect(Tag::query()->where('name->en', 'New')->exists())->toBeFalse();
-    });
-
-    it('requires the attach field when detaching is disabled', function (): void {
-        $records = Article::factory()->count(2)->create();
-
-        livewire(SpatieTagsBulkActionsTable::class, ['isManageActionDetachable' => false])
-            ->selectTableRecords($records)
-            ->callAction(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk(), data: [
-                'tagsToAttach' => [],
-            ])
-            ->assertHasFormErrors(['tagsToAttach' => ['required_without']]);
-    });
-
-    it('is hidden when both attaching and detaching are disabled', function (): void {
-        Article::factory()->create();
-
-        livewire(SpatieTagsBulkActionsTable::class, [
-            'isManageActionAttachable' => false,
-            'isManageActionDetachable' => false,
-        ])
-            ->assertActionHidden(TestAction::make(ManageSpatieTagsBulkAction::class)->table()->bulk());
-    });
 });

--- a/tests/src/TestCase.php
+++ b/tests/src/TestCase.php
@@ -12,6 +12,7 @@ use Filament\Notifications\NotificationsServiceProvider;
 use Filament\QueryBuilder\QueryBuilderServiceProvider;
 use Filament\Schemas\SchemasServiceProvider;
 use Filament\SpatieLaravelSettingsPluginServiceProvider;
+use Filament\SpatieLaravelTagsPluginServiceProvider;
 use Filament\Support\SupportServiceProvider;
 use Filament\Tables\TablesServiceProvider;
 use Filament\Tests\Fixtures\Models\Department;
@@ -67,6 +68,7 @@ abstract class TestCase extends BaseTestCase
             QueryBuilderServiceProvider::class,
             SchemasServiceProvider::class,
             SpatieLaravelSettingsPluginServiceProvider::class,
+            SpatieLaravelTagsPluginServiceProvider::class,
             SupportServiceProvider::class,
             TablesServiceProvider::class,
             WidgetsServiceProvider::class,


### PR DESCRIPTION
## Description

This PR adds table bulk actions to the `filament/spatie-laravel-tags-plugin` package. Until now the plugin shipped a form field (`SpatieTagsInput`), a table column (`SpatieTagsColumn`), and an infolist entry (`SpatieTagsEntry`), but there was no way to tag many records at once. These actions fill that gap, mirroring the behavior and options of the existing `SpatieTagsInput`.

Three new bulk actions are added:
- `AttachSpatieTagsBulkAction` — opens a modal with a tags input and attaches the chosen tags to every selected record. Existing tags on a record are preserved (via `syncWithoutDetaching`), and tags that don't exist yet are created.
- `DetachSpatieTagsBulkAction` — removes the chosen tags from the selected records without deleting the tags themselves from the database.
- `ManageSpatieTagsBulkAction` — a single modal with two tags inputs, so users can attach some tags and detach others in one pass. Each record's attach + detach is wrapped in a `DB::transaction` so a mid-record failure can't leave it half-updated.

```php
use Filament\Actions\AttachSpatieTagsBulkAction;
use Filament\Actions\DetachSpatieTagsBulkAction;
use Filament\Actions\ManageSpatieTagsBulkAction;
use Filament\Tables\Table;

public function table(Table $table): Table
{
    return $table
        ->toolbarActions([
            AttachSpatieTagsBulkAction::make(),
            DetachSpatieTagsBulkAction::make(),
            // ...or, instead of the two above:
            ManageSpatieTagsBulkAction::make(),
        ]);
}
```

## Visual changes
<img width="485" height="339" alt="Screenshot 2026-07-08 at 1 45 45 PM" src="https://github.com/user-attachments/assets/5a8fa4fc-31a1-4496-9a61-fb9390850c75" />
<img width="536" height="300" alt="Screenshot 2026-07-08 at 1 44 00 PM" src="https://github.com/user-attachments/assets/3f6c452b-6c7e-4afb-b5a5-204b5c3ca4ef" />
<img width="532" height="259" alt="Screenshot 2026-07-08 at 1 44 11 PM" src="https://github.com/user-attachments/assets/2afab15d-77ca-4471-b8df-eedb2ecbbe89" />
<img width="534" height="425" alt="Screenshot 2026-07-08 at 1 44 22 PM" src="https://github.com/user-attachments/assets/c5ee8d3b-d5e6-4eee-a62d-11791cfddcb3" />

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
