### PR TITLE
fix: restore default action badge colors

### DIFF
--- a/packages/support/src/View/Concerns/CanGenerateButtonHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateButtonHtml.php
@@ -53,6 +53,7 @@ trait CanGenerateButtonHtml
         string | Htmlable | null $tooltip = null,
         ?string $type = 'button',
     ): string {
+        $badgeColor ??= 'primary';
         $color ??= 'primary';
 
         if (! $iconPosition instanceof IconPosition) {

--- a/packages/support/src/View/Concerns/CanGenerateDropdownItemHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateDropdownItemHtml.php
@@ -46,6 +46,7 @@ trait CanGenerateDropdownItemHtml
         string | Htmlable | null $tooltip = null,
         ?string $type = 'button',
     ): string {
+        $badgeColor ??= 'primary';
         $color ??= 'gray';
 
         if (filled($iconSize) && (! $iconSize instanceof IconSize)) {

--- a/packages/support/src/View/Concerns/CanGenerateIconButtonHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateIconButtonHtml.php
@@ -48,6 +48,7 @@ trait CanGenerateIconButtonHtml
         string | Htmlable | null $tooltip = null,
         ?string $type = 'button',
     ): string {
+        $badgeColor ??= 'primary';
         $color ??= 'primary';
 
         if (! $size instanceof Size) {

--- a/packages/support/src/View/Concerns/CanGenerateLinkHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateLinkHtml.php
@@ -53,6 +53,7 @@ trait CanGenerateLinkHtml
         ?string $type = 'button',
         string | FontWeight | null $weight = null,
     ): string {
+        $badgeColor ??= 'primary';
         $color ??= 'primary';
 
         if (! $iconPosition instanceof IconPosition) {


### PR DESCRIPTION
## Description

Restored the default `primary` badge color in optimized action rendering paths when an action has a badge but no explicit badge color.

This matches the existing Blade component defaults and ensures default action badges receive the expected `fi-color-primary` classes.


## Visual changes

### Before
<img width="644" height="380" alt="image" src="https://github.com/user-attachments/assets/2ca75556-9d81-4138-abaa-c7d29c9b8074" />


### After

<img width="616" height="376" alt="image" src="https://github.com/user-attachments/assets/7cc7e944-c66d-42fa-9f34-fc73026a13b7" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
