### PR TITLE
fix: prevent embedded field label slots from being escaped

### DIFF
--- a/packages/forms/src/Components/Field.php
+++ b/packages/forms/src/Components/Field.php
@@ -341,8 +341,8 @@ class Field extends Component implements Contracts\HasValidationRules
             return view($absoluteView, [
                 'field' => $this,
                 'slot' => new ComponentSlot($html),
-                'labelPrefix' => $labelPrefix,
-                'labelSuffix' => $labelSuffix,
+                'labelPrefix' => filled($labelPrefix) ? new ComponentSlot($labelPrefix) : null,
+                'labelSuffix' => filled($labelSuffix) ? new ComponentSlot($labelSuffix) : null,
                 'inlineLabelVerticalAlignment' => $inlineLabelVerticalAlignment ?? VerticalAlignment::Start,
                 'labelTag' => $labelTag,
                 'attributes' => (new FilamentComponentAttributeBag)->merge($extraWrapperAttributes, escape: false),


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
