### PR TITLE
feat: add global default alignment for header actions

### DIFF
--- a/docs/06-navigation/02-custom-pages.md
+++ b/docs/06-navigation/02-custom-pages.md
@@ -59,12 +59,33 @@ protected function getHeaderActions(): array
 
 #### Aligning header actions
 
-By default, header actions are aligned to the left on mobile. To change the alignment of the header actions on mobile, set `$headerActionsAlignment`:
+By default, header actions are aligned to the start of the header on mobile (the left in left-to-right languages). To change the alignment of the header actions on mobile for a specific page, set the `$headerActionsAlignment` property:
 
 ```php
 use Filament\Support\Enums\Alignment;
 
 protected ?Alignment $headerActionsAlignment = Alignment::End;
+```
+
+<Aside variant="tip">
+    If you need to set the alignment conditionally, you can use the `headerActionsAlignment()` method instead, for example in the `mount()` method of the page:
+
+    ```php
+    use Filament\Support\Enums\Alignment;
+
+    public function mount(): void
+    {
+        $this->headerActionsAlignment(Alignment::End);
+    }
+    ```
+</Aside>
+
+To change the default header actions alignment for every page in your app, call the `alignHeaderActionsStart()`, `alignHeaderActionsCenter()` or `alignHeaderActionsEnd()` method in the `boot()` method of a service provider such as `AppServiceProvider`:
+
+```php
+use Filament\Pages\Page;
+
+Page::alignHeaderActionsEnd();
 ```
 
 ### Opening an action modal when a page loads

--- a/packages/panels/src/Pages/Concerns/InteractsWithHeaderActions.php
+++ b/packages/panels/src/Pages/Concerns/InteractsWithHeaderActions.php
@@ -13,7 +13,9 @@ trait InteractsWithHeaderActions
      */
     protected array $cachedHeaderActions = [];
 
-    protected ?Alignment $headerActionsAlignment = null;
+    public static string | Alignment $defaultHeaderActionsAlignment = Alignment::Start;
+
+    protected string | Alignment | null $headerActionsAlignment = null;
 
     public function cacheInteractsWithHeaderActions(): void
     {
@@ -67,8 +69,35 @@ trait InteractsWithHeaderActions
         return [];
     }
 
-    public function getHeaderActionsAlignment(): ?Alignment
+    public function headerActionsAlignment(string | Alignment | null $alignment): static
     {
-        return $this->headerActionsAlignment;
+        $this->headerActionsAlignment = $alignment;
+
+        return $this;
+    }
+
+    public function getHeaderActionsAlignment(): string | Alignment | null
+    {
+        return $this->headerActionsAlignment ?? static::$defaultHeaderActionsAlignment;
+    }
+
+    public static function alignHeaderActionsStart(): void
+    {
+        static::$defaultHeaderActionsAlignment = Alignment::Start;
+    }
+
+    public static function alignHeaderActionsCenter(): void
+    {
+        static::$defaultHeaderActionsAlignment = Alignment::Center;
+    }
+
+    public static function alignHeaderActionsEnd(): void
+    {
+        static::$defaultHeaderActionsAlignment = Alignment::End;
+    }
+
+    public static function defaultHeaderActionsAlignment(string | Alignment $alignment): void
+    {
+        static::$defaultHeaderActionsAlignment = $alignment;
     }
 }

--- a/tests/src/Panels/Pages/HeaderActionsAlignmentTest.php
+++ b/tests/src/Panels/Pages/HeaderActionsAlignmentTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use Filament\Pages\Page;
+use Filament\Support\Enums\Alignment;
+use Filament\Tests\Fixtures\Pages\Actions;
+use Filament\Tests\Fixtures\Pages\Settings;
+use Filament\Tests\Panels\Pages\TestCase;
+
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+afterEach(function (): void {
+    Page::$defaultHeaderActionsAlignment = Alignment::Start;
+});
+
+it('has `Alignment::Start` as the default `getHeaderActionsAlignment()` value', function (): void {
+    expect(livewire(Settings::class)->instance()->getHeaderActionsAlignment())
+        ->toBe(Alignment::Start);
+});
+
+it('can use `alignHeaderActionsStart()`, `alignHeaderActionsCenter()` and `alignHeaderActionsEnd()` to set a global default header actions alignment', function (): void {
+    Settings::alignHeaderActionsEnd();
+
+    expect(livewire(Settings::class)->instance()->getHeaderActionsAlignment())
+        ->toBe(Alignment::End);
+
+    Settings::alignHeaderActionsCenter();
+
+    expect(livewire(Settings::class)->instance()->getHeaderActionsAlignment())
+        ->toBe(Alignment::Center);
+
+    Settings::alignHeaderActionsStart();
+
+    expect(livewire(Settings::class)->instance()->getHeaderActionsAlignment())
+        ->toBe(Alignment::Start);
+});
+
+it('can use `defaultHeaderActionsAlignment()` to set a global default header actions alignment using a raw string', function (): void {
+    Settings::defaultHeaderActionsAlignment('center');
+
+    expect(livewire(Settings::class)->instance()->getHeaderActionsAlignment())
+        ->toBe('center');
+});
+
+it('shares the global default header actions alignment across every page that uses `InteractsWithHeaderActions`', function (): void {
+    Actions::alignHeaderActionsEnd();
+
+    expect(livewire(Settings::class)->instance()->getHeaderActionsAlignment())
+        ->toBe(Alignment::End);
+});
+
+it('can use `headerActionsAlignment()` to override the global default header actions alignment for a single page instance', function (): void {
+    $page = livewire(Actions::class)->instance();
+
+    expect($page->headerActionsAlignment(Alignment::Center))
+        ->toBe($page);
+
+    expect($page->getHeaderActionsAlignment())
+        ->toBe(Alignment::Center);
+
+    Actions::alignHeaderActionsEnd();
+
+    expect($page->getHeaderActionsAlignment())
+        ->toBe(Alignment::Center);
+});
+
+it('can use `headerActionsAlignment(null)` to unset a page instance override and fall back to the global default', function (): void {
+    $page = livewire(Actions::class)->instance();
+
+    $page->headerActionsAlignment(Alignment::Center);
+    $page->headerActionsAlignment(null);
+
+    expect($page->getHeaderActionsAlignment())
+        ->toBe(Alignment::Start);
+});


### PR DESCRIPTION
Header actions only had a per-page instance property for controlling their mobile alignment, with a getter but no setter. Form actions already have a global default alignment API on BasePage (alignFormActionsStart/Center/End(), formActionsAlignment()). This adds the equivalent for header actions on InteractsWithHeaderActions, plus a fluent instance setter that was also missing.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->
Before:
<img width="142" height="296" alt="image" src="https://github.com/user-attachments/assets/e04da9f2-56f8-40af-8d95-ca1ffb1fce25" />

After:
<img width="131" height="282" alt="image" src="https://github.com/user-attachments/assets/0b37ae36-4e61-4baa-9b0c-14d583e5c3c4" />



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
