### PR TITLE
Feature: FilterPanel component to place filters in multiple locations

### DIFF
--- a/packages/tables/docs/03-filters/06-layout.md
+++ b/packages/tables/docs/03-filters/06-layout.md
@@ -245,9 +245,30 @@ The `Dropdown` and `Modal` locations each render their own trigger, so a table w
 
 Each panel has its own reset action that clears only the filters shown in that panel. To clear every filter at once, use the "remove all" button in the active filter indicators above the table. The apply button (when deferring filters) and the indicators are always global - filter state is a single value, so applying always submits every panel's filters.
 
-### Adding filters to a location that already has a panel
+### Merging panels that share a location
 
-If a panel targets a location that another panel already occupies - for example a plugin appending `FilterPanel::make(FiltersLayout::Dropdown, [...])` to a table that already has a dropdown panel — its filters are **merged into the existing panel**, keeping the existing panel's configuration. This lets extensions add filters to a shared location without conflicting.
+Declaring more than one panel for the same location - whether twice in the same `filters()` array, or by appending one later with `pushFilters()` (for example from a plugin) — **merges their filters into a single panel** for that location. The configuration of the **first** panel at that location wins; any configuration set on the later panels is ignored:
+
+```php
+use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Filters\FilterPanel;
+use Filament\Tables\Filters\SelectFilter;
+
+$table
+    ->filters([
+        FilterPanel::make(FiltersLayout::AboveContent, [
+            SelectFilter::make('status'),
+        ])->columns(2),
+
+        // The same location again: its filters are merged into the panel above,
+        // and its own configuration (such as `columns()`) is ignored.
+        FilterPanel::make(FiltersLayout::AboveContent, [
+            SelectFilter::make('category'),
+        ]),
+    ]);
+```
+
+This lets a plugin add filters to a shared location (such as the dropdown) without conflicting with the table's own panels.
 
 <Aside variant="danger">
     A [custom filter form schema](#customizing-the-filter-form-schema) (`filtersFormSchema()`) cannot be combined with `FilterPanel` objects, as they are competing layout mechanisms. Use `filtersFormSchema()` with a flat `filters()` array only.

--- a/packages/tables/docs/03-filters/06-layout.md
+++ b/packages/tables/docs/03-filters/06-layout.md
@@ -226,24 +226,67 @@ FilterPanel::make(FiltersLayout::Dropdown, [
     ->triggerAction(fn (Action $action): Action => $action->label('Filter'));
 ```
 
-### Using the dropdown and a modal together
-
-The `Dropdown` and `Modal` locations each render their own trigger, so a table with a panel in both shows two filter icons — one opening a dropdown, the other opening a modal:
+Each option also accepts a closure, which can inject `$table` and `$livewire` like anywhere else in Filament:
 
 ```php
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Filters\FilterPanel;
+
+FilterPanel::make(FiltersLayout::AboveContent, [
+    // ...
+])->columns(fn (HasTable $livewire): int => $livewire->isTableReordering() ? 1 : 3);
+```
+
+<Aside variant="info">
+    `triggerAction()`, `width()` and `maxHeight()` only apply to a panel that opens - see [supported location combinations](#supported-location-combinations). A panel that is always visible, such as `AboveContent`, ignores them.
+</Aside>
+
+### Supported location combinations
+
+A table has a single filter trigger, so only one panel may be in a location that opens. These locations are **interactive**, and a table may use **at most one** of them:
+
+- `Dropdown`
+- `Modal`
+- `AboveContentCollapsible`
+- `BeforeContent`
+- `BeforeContentCollapsible`
+- `AfterContent`
+- `AfterContentCollapsible`
+
+`BeforeContent` and `AfterContent` are interactive even though they are not collapsible, because below the `lg` breakpoint they are hidden and open from the filter trigger as floating panels.
+
+That panel may be combined with any of the locations that are always rendered in place and have no trigger of their own:
+
+- `AboveContent`
+- `BelowContent`
+- `Hidden`
+
+```php
+use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Filters\FilterPanel;
+use Filament\Tables\Filters\SelectFilter;
+
 ->filters([
-    FilterPanel::make(FiltersLayout::Dropdown, [
-        // ...
+    FilterPanel::make(FiltersLayout::AboveContent, [
+        SelectFilter::make('status'),
     ]),
-    FilterPanel::make(FiltersLayout::Modal, [
-        // ...
+
+    FilterPanel::make(FiltersLayout::Dropdown, [
+        SelectFilter::make('author'),
     ]),
 ])
 ```
 
+`AboveContent` additionally cannot be combined with `AboveContentCollapsible`, since both render in the same place above the table.
+
+Any unsupported combination - such as `Dropdown` with `Modal`, or `BeforeContent` with `AfterContent` - throws a `LogicException` rather than silently dropping a panel.
+
 ### Resetting and applying filters across panels
 
-Each panel has its own reset action that clears only the filters shown in that panel. To clear every filter at once, use the "remove all" button in the active filter indicators above the table. The apply button (when deferring filters) and the indicators are always global - filter state is a single value, so applying always submits every panel's filters.
+Each panel has its own reset action that clears only the filters shown in that panel. When filters are deferred (the [default](overview#live-filters)), resetting a panel applies that panel's cleared filters without submitting changes still pending in any other panel. To clear every filter at once, use the "remove all" button in the active filter indicators above the table.
+
+The apply button and the indicators are always global - the apply button submits every panel's pending filters, whichever panel it was clicked in.
 
 ### Merging panels that share a location
 

--- a/packages/tables/docs/03-filters/06-layout.md
+++ b/packages/tables/docs/03-filters/06-layout.md
@@ -2,6 +2,7 @@
 title: Filter layout
 ---
 import AutoScreenshot from "@components/AutoScreenshot.astro"
+import Aside from "@components/Aside.astro"
 
 ## Positioning filters into grid columns
 
@@ -171,6 +172,86 @@ public function table(Table $table): Table
         ], layout: FiltersLayout::BeforeContentCollapsible); // or `FiltersLayout::AfterContentCollapsible`
 }
 ```
+
+## Placing filters in multiple locations at once
+
+By default, every filter renders together in a single location (the dropdown, unless you change it with `filtersLayout()`). To split filters across several locations at the same time - for example, a status filter that is always visible above the table while the rest stay in the dropdown — pass `FilterPanel` objects to `filters()` instead of a flat array. Each panel takes a location and the filters that belong there:
+
+```php
+use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Filters\FilterPanel;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->filters([
+            FilterPanel::make(FiltersLayout::AboveContent, [
+                SelectFilter::make('status'),
+                SelectFilter::make('category'),
+            ])->columns(2),
+
+            FilterPanel::make(FiltersLayout::Dropdown, [
+                SelectFilter::make('author'),
+            ]),
+        ]);
+}
+```
+
+Here, the `status` and `category` filters render above the table in a two-column grid, while `author` stays behind the dropdown trigger.
+
+<Aside variant="info">
+    A table's `filters()` array must be **either** all `FilterPanel` objects **or** all filters — mixing the two throws an exception (including across `pushFilters()` calls).
+</Aside>
+
+### Configuring a panel
+
+Each panel accepts the same presentation options as the table. Any option left unset on a panel falls through to the table-level `filtersForm*()` method, which itself falls back to a per-location default - so the table-level methods act as the defaults for every panel:
+
+```php
+use Filament\Actions\Action;
+use Filament\Support\Enums\Width;
+use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Enums\FiltersResetActionPosition;
+use Filament\Tables\Filters\FilterPanel;
+
+FilterPanel::make(FiltersLayout::Dropdown, [
+    // ...
+])
+    ->columns(2)
+    ->width(Width::Medium)
+    ->maxHeight('400px')
+    ->resetActionPosition(FiltersResetActionPosition::Footer)
+    ->triggerAction(fn (Action $action): Action => $action->label('Filter'));
+```
+
+### Using the dropdown and a modal together
+
+The `Dropdown` and `Modal` locations each render their own trigger, so a table with a panel in both shows two filter icons — one opening a dropdown, the other opening a modal:
+
+```php
+->filters([
+    FilterPanel::make(FiltersLayout::Dropdown, [
+        // ...
+    ]),
+    FilterPanel::make(FiltersLayout::Modal, [
+        // ...
+    ]),
+])
+```
+
+### Resetting and applying filters across panels
+
+Each panel has its own reset action that clears only the filters shown in that panel. To clear every filter at once, use the "remove all" button in the active filter indicators above the table. The apply button (when deferring filters) and the indicators are always global - filter state is a single value, so applying always submits every panel's filters.
+
+### Adding filters to a location that already has a panel
+
+If a panel targets a location that another panel already occupies - for example a plugin appending `FilterPanel::make(FiltersLayout::Dropdown, [...])` to a table that already has a dropdown panel — its filters are **merged into the existing panel**, keeping the existing panel's configuration. This lets extensions add filters to a shared location without conflicting.
+
+<Aside variant="danger">
+    A [custom filter form schema](#customizing-the-filter-form-schema) (`filtersFormSchema()`) cannot be combined with `FilterPanel` objects, as they are competing layout mechanisms. Use `filtersFormSchema()` with a flat `filters()` array only.
+</Aside>
 
 ## Hiding the filter indicators
 

--- a/packages/tables/resources/views/components/filters.blade.php
+++ b/packages/tables/resources/views/components/filters.blade.php
@@ -2,12 +2,14 @@
     'applyAction',
     'form',
     'headingTag' => 'h3',
+    'location' => null,
     'resetActionPosition' => null,
 ])
 
 @php
     use Filament\Support\View\ComponentAttributeBag;
     use Filament\Tables\Enums\FiltersResetActionPosition;
+    use Illuminate\Support\Js;
 
     $resetActionPosition ??= FiltersResetActionPosition::Header;
 @endphp
@@ -26,7 +28,7 @@
                             new ComponentAttributeBag([
                                 'color' => 'danger',
                                 'tag' => 'button',
-                                'wire:click' => 'resetTableFiltersForm',
+                                'wire:click' => filled($location) ? ('resetTableFiltersForm(' . Js::from($location) . ')') : 'resetTableFiltersForm',
                                 'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => '',
                                 'wire:target' => 'resetTableFiltersForm',
                             ])
@@ -50,7 +52,7 @@
             @if ($resetActionPosition === FiltersResetActionPosition::Footer)
                 <x-filament::button
                     color="danger"
-                    wire:click="resetTableFiltersForm"
+                    wire:click="resetTableFiltersForm({{ filled($location) ? Js::from($location) : '' }})"
                 >
                     {{ __('filament-tables::table.filters.actions.reset.label') }}
                 </x-filament::button>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -16,7 +16,6 @@
     use Filament\Tables\Enums\ColumnManagerLayout;
     use Filament\Tables\Enums\ColumnManagerResetActionPosition;
     use Filament\Tables\Enums\FiltersLayout;
-    use Filament\Tables\Enums\FiltersResetActionPosition;
     use Filament\Tables\Enums\RecordActionsPosition;
     use Filament\Tables\Enums\RecordCheckboxPosition;
     use Filament\Tables\Filters\Indicator;
@@ -52,8 +51,6 @@
     $contentFooter = $getContentFooter();
     $filterIndicators = $getFilterIndicators();
     $filtersApplyAction = $getFiltersApplyAction();
-    $filtersFormWidth = $getFiltersFormWidth();
-    $filtersResetActionPosition = $getFiltersResetActionPosition();
     $columnManagerResetActionPosition = $getColumnManagerResetActionPosition();
     $hasColumnGroups = $hasColumnGroups();
     $hasColumnsLayout = $hasColumnsLayout();
@@ -118,7 +115,6 @@
     $isStackedOnMobile = $isStackedOnMobile();
     $isLoaded = $isLoaded();
     $hasFilters = $isFilterable();
-    $filtersLayout = $getFiltersLayout();
     $filterPanels = $hasFilters ? $getFilterPanels() : [];
     $filterPanelsByLocation = [];
 
@@ -127,13 +123,10 @@
     }
 
     $filterPanelLocationNames = array_keys($filterPanelsByLocation);
-    $filtersTriggerAction = $getFiltersTriggerAction();
     $hasFiltersDialog = (bool) array_intersect($filterPanelLocationNames, [FiltersLayout::Dropdown->name, FiltersLayout::Modal->name]);
-    $hasFiltersAboveContent = (bool) array_intersect($filterPanelLocationNames, [FiltersLayout::AboveContent->name, FiltersLayout::AboveContentCollapsible->name]);
     $hasFiltersBelowContent = in_array(FiltersLayout::BelowContent->name, $filterPanelLocationNames, strict: true);
     $hasFiltersBeforeContent = (bool) array_intersect($filterPanelLocationNames, [FiltersLayout::BeforeContent->name, FiltersLayout::BeforeContentCollapsible->name]);
     $hasFiltersAfterContent = (bool) array_intersect($filterPanelLocationNames, [FiltersLayout::AfterContent->name, FiltersLayout::AfterContentCollapsible->name]);
-    $hasCollapsibleFilters = (bool) array_intersect($filterPanelLocationNames, [FiltersLayout::AboveContentCollapsible->name, FiltersLayout::BeforeContentCollapsible->name, FiltersLayout::AfterContentCollapsible->name]);
     $hasFiltersTrigger = $hasFilters && ($hasFiltersDialog || $hasFiltersBeforeContent || $hasFiltersAfterContent);
     $aboveContentPanel = $filterPanelsByLocation[FiltersLayout::AboveContent->name] ?? $filterPanelsByLocation[FiltersLayout::AboveContentCollapsible->name] ?? null;
     $beforeContentPanel = $filterPanelsByLocation[FiltersLayout::BeforeContent->name] ?? $filterPanelsByLocation[FiltersLayout::BeforeContentCollapsible->name] ?? null;
@@ -144,10 +137,15 @@
     $afterContentFiltersForm = $afterContentPanel ? $getFiltersFormForPanel($afterContentPanel) : null;
     $belowContentFiltersForm = $belowContentPanel ? $getFiltersFormForPanel($belowContentPanel) : null;
     $aboveContentActiveFiltersCount = $aboveContentPanel ? $getActiveFiltersCountForPanel($aboveContentPanel) : 0;
+    $aboveContentPanelIsCollapsible = (bool) $aboveContentPanel?->isCollapsible();
+    $aboveContentFiltersTriggerAction = $aboveContentPanel ? $getFiltersTriggerAction($aboveContentPanel) : null;
     $beforeContentActiveFiltersCount = $beforeContentPanel ? $getActiveFiltersCountForPanel($beforeContentPanel) : 0;
     $afterContentActiveFiltersCount = $afterContentPanel ? $getActiveFiltersCountForPanel($afterContentPanel) : 0;
+    $beforeContentFiltersFormWidth = $beforeContentPanel ? $getFiltersFormWidthForPanel($beforeContentPanel) : null;
+    $afterContentFiltersFormWidth = $afterContentPanel ? $getFiltersFormWidthForPanel($afterContentPanel) : null;
+    $sideFiltersTriggerAction = ($beforeContentPanel || $afterContentPanel) ? $getFiltersTriggerAction($beforeContentPanel ?? $afterContentPanel) : null;
+    $hasCollapsibleSideFilters = (bool) ($beforeContentPanel?->isCollapsible() || $afterContentPanel?->isCollapsible());
     $dialogPanels = array_values(array_filter($filterPanels, fn ($filterPanel): bool => in_array($filterPanel->getLocation()->name, [FiltersLayout::Dropdown->name, FiltersLayout::Modal->name], strict: true)));
-    $filtersFormMaxHeight = $getFiltersFormMaxHeight();
     $hasColumnManager = $hasColumnManager();
     $columnManagerLayout = $getColumnManagerLayout();
     $hasReorderableColumns = $hasReorderableColumns();
@@ -231,8 +229,12 @@
         $groupedSummarySelectedState = $this->getTableSummarySelectedState($this->getAllTableSummaryQuery(), modifyQueryUsing: fn (Builder $query) => $group->groupQuery($query, model: $getQuery()->getModel()));
     }
 
-    if (is_string($filtersFormWidth)) {
-        $filtersFormWidth = Width::tryFrom($filtersFormWidth) ?? $filtersFormWidth;
+    if (is_string($beforeContentFiltersFormWidth)) {
+        $beforeContentFiltersFormWidth = Width::tryFrom($beforeContentFiltersFormWidth) ?? $beforeContentFiltersFormWidth;
+    }
+
+    if (is_string($afterContentFiltersFormWidth)) {
+        $afterContentFiltersFormWidth = Width::tryFrom($afterContentFiltersFormWidth) ?? $afterContentFiltersFormWidth;
     }
 
     $loadingTargetsWireTarget = implode(',', Table::LOADING_TARGETS);
@@ -280,8 +282,8 @@
                 x-bind:class="{ 'fi-open': areFiltersOpen }"
                 @class([
                     'fi-ta-filters-before-content-ctn',
-                    'lg:fi-open' => ! $hasCollapsibleFilters,
-                    (($filtersFormWidth ??= Width::ExtraSmall) instanceof Width) ? "fi-width-{$filtersFormWidth->value}" : (is_string($filtersFormWidth) ? $filtersFormWidth : null),
+                    'lg:fi-open' => ! $beforeContentPanel->isCollapsible(),
+                    (($beforeContentFiltersFormWidth ??= Width::ExtraSmall) instanceof Width) ? "fi-width-{$beforeContentFiltersFormWidth->value}" : (is_string($beforeContentFiltersFormWidth) ? $beforeContentFiltersFormWidth : null),
                 ])
             >
                 <x-filament-tables::filters
@@ -290,7 +292,7 @@
                     :location="(count($filterPanels) > 1) ? $beforeContentPanel->getLocation()->name : null"
                     :heading-tag="$secondLevelHeadingTag"
                     class="fi-ta-filters-before-content"
-                    :reset-action-position="$filtersResetActionPosition"
+                    :reset-action-position="$getResetActionPositionForPanel($beforeContentPanel)"
                 />
             </div>
         @endif
@@ -345,9 +347,9 @@
 
                 {{ FilamentView::renderHook(TablesRenderHook::HEADER_AFTER, scopes: static::class) }}
 
-                @if ($hasFiltersAboveContent)
+                @if ($aboveContentPanel)
                     <div
-                        @if ($hasCollapsibleFilters)
+                        @if ($aboveContentPanelIsCollapsible)
                             x-bind:class="{ 'fi-open': areFiltersOpen }"
                         @endif
                         @class([
@@ -360,16 +362,16 @@
                             :location="(count($filterPanels) > 1) ? $aboveContentPanel->getLocation()->name : null"
                             :heading-tag="$secondLevelHeadingTag"
                             x-cloak
-                            :x-show="$hasCollapsibleFilters ? 'areFiltersOpen' : null"
-                            :reset-action-position="$filtersResetActionPosition"
+                            :x-show="$aboveContentPanelIsCollapsible ? 'areFiltersOpen' : null"
+                            :reset-action-position="$getResetActionPositionForPanel($aboveContentPanel)"
                         />
 
-                        @if ($hasCollapsibleFilters)
+                        @if ($aboveContentPanelIsCollapsible)
                             <span
                                 x-on:click="areFiltersOpen = ! areFiltersOpen"
                                 class="fi-ta-filters-trigger-action-ctn"
                             >
-                                {{ $filtersTriggerAction->badge($aboveContentActiveFiltersCount) }}
+                                {{ $aboveContentFiltersTriggerAction->badge($aboveContentActiveFiltersCount) }}
                             </span>
                         @endif
                     </div>
@@ -586,7 +588,7 @@
                                 @if ($hasFiltersDialog)
                                     @foreach ($dialogPanels as $dialogPanel)
                                         @php
-                                            $filtersTriggerAction = $getFiltersTriggerAction((count($filterPanels) > 1) ? $dialogPanel->getLocation() : null);
+                                            $filtersTriggerAction = $getFiltersTriggerAction($dialogPanel);
                                             $dialogFiltersForm = $getFiltersFormForPanel($dialogPanel);
                                             $dialogActiveFiltersCount = $getActiveFiltersCountForPanel($dialogPanel);
                                             $dialogFiltersFormWidth = $getFiltersFormWidthForPanel($dialogPanel);
@@ -667,7 +669,7 @@
                                                     :form="$dialogFiltersForm"
                                                     :location="(count($filterPanels) > 1) ? $dialogPanel->getLocation()->name : null"
                                                     :heading-tag="$secondLevelHeadingTag"
-                                                    :reset-action-position="$filtersResetActionPosition"
+                                                    :reset-action-position="$getResetActionPositionForPanel($dialogPanel)"
                                                 />
                                             </x-filament::dropdown>
                                         @endif
@@ -678,10 +680,10 @@
                                         x-on:click="toggleFiltersDropdown"
                                         @class([
                                             'fi-ta-filters-trigger-action-ctn',
-                                            'lg:fi-hidden' => ! $hasCollapsibleFilters,
+                                            'lg:fi-hidden' => ! $hasCollapsibleSideFilters,
                                         ])
                                     >
-                                        {{ $filtersTriggerAction->badge($beforeContentActiveFiltersCount + $afterContentActiveFiltersCount) }}
+                                        {{ $sideFiltersTriggerAction->badge($beforeContentActiveFiltersCount + $afterContentActiveFiltersCount) }}
                                     </span>
                                 @endif
 
@@ -2624,7 +2626,7 @@
                     :location="(count($filterPanels) > 1) ? $belowContentPanel->getLocation()->name : null"
                     :heading-tag="$secondLevelHeadingTag"
                     class="fi-ta-filters-below-content"
-                    :reset-action-position="$filtersResetActionPosition"
+                    :reset-action-position="$getResetActionPositionForPanel($belowContentPanel)"
                 />
             @endif
         </div>
@@ -2638,8 +2640,8 @@
                 x-bind:class="{ 'fi-open': areFiltersOpen }"
                 @class([
                     'fi-ta-filters-after-content-ctn',
-                    'lg:fi-open' => ! $hasCollapsibleFilters,
-                    (($filtersFormWidth ??= Width::ExtraSmall) instanceof Width) ? "fi-width-{$filtersFormWidth->value}" : (is_string($filtersFormWidth) ? $filtersFormWidth : null),
+                    'lg:fi-open' => ! $afterContentPanel->isCollapsible(),
+                    (($afterContentFiltersFormWidth ??= Width::ExtraSmall) instanceof Width) ? "fi-width-{$afterContentFiltersFormWidth->value}" : (is_string($afterContentFiltersFormWidth) ? $afterContentFiltersFormWidth : null),
                 ])
             >
                 <x-filament-tables::filters
@@ -2648,7 +2650,7 @@
                     :location="(count($filterPanels) > 1) ? $afterContentPanel->getLocation()->name : null"
                     :heading-tag="$secondLevelHeadingTag"
                     class="fi-ta-filters-after-content"
-                    :reset-action-position="$filtersResetActionPosition"
+                    :reset-action-position="$getResetActionPositionForPanel($afterContentPanel)"
                 />
             </div>
         @endif

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -42,7 +42,6 @@
         $recordActionsAlignment = filled($recordActionsAlignment) ? (Alignment::tryFrom($recordActionsAlignment) ?? $recordActionsAlignment) : null;
     }
 
-    $activeFiltersCount = $getActiveFiltersCount();
     $isSelectionDisabled = $isSelectionDisabled();
     $maxSelectableRecords = $getMaxSelectableRecords();
     $columns = $getVisibleColumns();
@@ -53,7 +52,6 @@
     $contentFooter = $getContentFooter();
     $filterIndicators = $getFilterIndicators();
     $filtersApplyAction = $getFiltersApplyAction();
-    $filtersForm = $getFiltersForm();
     $filtersFormWidth = $getFiltersFormWidth();
     $filtersResetActionPosition = $getFiltersResetActionPosition();
     $columnManagerResetActionPosition = $getColumnManagerResetActionPosition();
@@ -121,14 +119,34 @@
     $isLoaded = $isLoaded();
     $hasFilters = $isFilterable();
     $filtersLayout = $getFiltersLayout();
+    $filterPanels = $hasFilters ? $getFilterPanels() : [];
+    $filterPanelsByLocation = [];
+
+    foreach ($filterPanels as $filterPanel) {
+        $filterPanelsByLocation[$filterPanel->getLocation()->name] = $filterPanel;
+    }
+
+    $filterPanelLocationNames = array_keys($filterPanelsByLocation);
     $filtersTriggerAction = $getFiltersTriggerAction();
-    $hasFiltersDialog = $hasFilters && in_array($filtersLayout, [FiltersLayout::Dropdown, FiltersLayout::Modal]);
-    $hasFiltersAboveContent = $hasFilters && in_array($filtersLayout, [FiltersLayout::AboveContent, FiltersLayout::AboveContentCollapsible]);
-    $hasFiltersBelowContent = $hasFilters && ($filtersLayout === FiltersLayout::BelowContent);
-    $hasFiltersBeforeContent = $hasFilters && in_array($filtersLayout, [FiltersLayout::BeforeContent, FiltersLayout::BeforeContentCollapsible]);
-    $hasFiltersAfterContent = $hasFilters && in_array($filtersLayout, [FiltersLayout::AfterContent, FiltersLayout::AfterContentCollapsible]);
-    $hasCollapsibleFilters = $hasFilters && in_array($filtersLayout, [FiltersLayout::AboveContentCollapsible, FiltersLayout::BeforeContentCollapsible, FiltersLayout::AfterContentCollapsible]);
+    $hasFiltersDialog = (bool) array_intersect($filterPanelLocationNames, [FiltersLayout::Dropdown->name, FiltersLayout::Modal->name]);
+    $hasFiltersAboveContent = (bool) array_intersect($filterPanelLocationNames, [FiltersLayout::AboveContent->name, FiltersLayout::AboveContentCollapsible->name]);
+    $hasFiltersBelowContent = in_array(FiltersLayout::BelowContent->name, $filterPanelLocationNames, strict: true);
+    $hasFiltersBeforeContent = (bool) array_intersect($filterPanelLocationNames, [FiltersLayout::BeforeContent->name, FiltersLayout::BeforeContentCollapsible->name]);
+    $hasFiltersAfterContent = (bool) array_intersect($filterPanelLocationNames, [FiltersLayout::AfterContent->name, FiltersLayout::AfterContentCollapsible->name]);
+    $hasCollapsibleFilters = (bool) array_intersect($filterPanelLocationNames, [FiltersLayout::AboveContentCollapsible->name, FiltersLayout::BeforeContentCollapsible->name, FiltersLayout::AfterContentCollapsible->name]);
     $hasFiltersTrigger = $hasFilters && ($hasFiltersDialog || $hasFiltersBeforeContent || $hasFiltersAfterContent);
+    $aboveContentPanel = $filterPanelsByLocation[FiltersLayout::AboveContent->name] ?? $filterPanelsByLocation[FiltersLayout::AboveContentCollapsible->name] ?? null;
+    $beforeContentPanel = $filterPanelsByLocation[FiltersLayout::BeforeContent->name] ?? $filterPanelsByLocation[FiltersLayout::BeforeContentCollapsible->name] ?? null;
+    $afterContentPanel = $filterPanelsByLocation[FiltersLayout::AfterContent->name] ?? $filterPanelsByLocation[FiltersLayout::AfterContentCollapsible->name] ?? null;
+    $belowContentPanel = $filterPanelsByLocation[FiltersLayout::BelowContent->name] ?? null;
+    $aboveContentFiltersForm = $aboveContentPanel ? $getFiltersFormForPanel($aboveContentPanel) : null;
+    $beforeContentFiltersForm = $beforeContentPanel ? $getFiltersFormForPanel($beforeContentPanel) : null;
+    $afterContentFiltersForm = $afterContentPanel ? $getFiltersFormForPanel($afterContentPanel) : null;
+    $belowContentFiltersForm = $belowContentPanel ? $getFiltersFormForPanel($belowContentPanel) : null;
+    $aboveContentActiveFiltersCount = $aboveContentPanel ? $getActiveFiltersCountForPanel($aboveContentPanel) : 0;
+    $beforeContentActiveFiltersCount = $beforeContentPanel ? $getActiveFiltersCountForPanel($beforeContentPanel) : 0;
+    $afterContentActiveFiltersCount = $afterContentPanel ? $getActiveFiltersCountForPanel($afterContentPanel) : 0;
+    $dialogPanels = array_values(array_filter($filterPanels, fn ($filterPanel): bool => in_array($filterPanel->getLocation()->name, [FiltersLayout::Dropdown->name, FiltersLayout::Modal->name], strict: true)));
     $filtersFormMaxHeight = $getFiltersFormMaxHeight();
     $hasColumnManager = $hasColumnManager();
     $columnManagerLayout = $getColumnManagerLayout();
@@ -268,7 +286,7 @@
             >
                 <x-filament-tables::filters
                     :apply-action="$filtersApplyAction"
-                    :form="$filtersForm"
+                    :form="$beforeContentFiltersForm"
                     :heading-tag="$secondLevelHeadingTag"
                     class="fi-ta-filters-before-content"
                     :reset-action-position="$filtersResetActionPosition"
@@ -337,7 +355,7 @@
                     >
                         <x-filament-tables::filters
                             :apply-action="$filtersApplyAction"
-                            :form="$filtersForm"
+                            :form="$aboveContentFiltersForm"
                             :heading-tag="$secondLevelHeadingTag"
                             x-cloak
                             :x-show="$hasCollapsibleFilters ? 'areFiltersOpen' : null"
@@ -349,7 +367,7 @@
                                 x-on:click="areFiltersOpen = ! areFiltersOpen"
                                 class="fi-ta-filters-trigger-action-ctn"
                             >
-                                {{ $filtersTriggerAction->badge($activeFiltersCount) }}
+                                {{ $filtersTriggerAction->badge($aboveContentActiveFiltersCount) }}
                             </span>
                         @endif
                     </div>
@@ -564,7 +582,17 @@
 
                             @if ($hasFiltersTrigger || $hasColumnManager)
                                 @if ($hasFiltersDialog)
-                                    @if (($filtersLayout === FiltersLayout::Modal) || $filtersTriggerAction->isModalSlideOver())
+                                    @foreach ($dialogPanels as $dialogPanel)
+                                        @php
+                                            $dialogFiltersForm = $getFiltersFormForPanel($dialogPanel);
+                                            $dialogActiveFiltersCount = $getActiveFiltersCountForPanel($dialogPanel);
+                                            $dialogFiltersFormWidth = $getFiltersFormWidthForPanel($dialogPanel);
+                                            $dialogFiltersFormMaxHeight = $getFiltersFormMaxHeightForPanel($dialogPanel);
+                                            $dialogIsModal = ($dialogPanel->getLocation() === FiltersLayout::Modal) || $filtersTriggerAction->isModalSlideOver();
+                                            $dialogWireKey = $this->getId() . '.table.filters.' . $dialogPanel->getLocation()->name;
+                                        @endphp
+
+                                        @if ($dialogIsModal)
                                         @php
                                             $filtersTriggerActionModalAlignment = $filtersTriggerAction->getModalAlignment();
                                             $filtersTriggerActionIsModalAutofocused = $filtersTriggerAction->isModalAutofocused();
@@ -603,42 +631,43 @@
                                             :slide-over-position="$filtersTriggerActionModalSlideOverPosition"
                                             :sticky-footer="$filtersTriggerActionIsModalFooterSticky"
                                             :sticky-header="$filtersTriggerActionIsModalHeaderSticky"
-                                            :width="$filtersFormWidth"
-                                            :wire:key="$this->getId() . '.table.filters'"
+                                            :width="$dialogFiltersFormWidth"
+                                            :wire:key="$dialogWireKey"
                                             class="fi-ta-filters-modal"
                                         >
                                             <x-slot name="trigger">
-                                                {{ $filtersTriggerAction->badge($activeFiltersCount) }}
+                                                {{ $filtersTriggerAction->badge($dialogActiveFiltersCount) }}
                                             </x-slot>
 
                                             {{ $filtersTriggerAction->getModalContent() }}
 
-                                            {{ $filtersForm }}
+                                            {{ $dialogFiltersForm }}
 
                                             {{ $filtersTriggerAction->getModalContentFooter() }}
                                         </x-filament::modal>
                                     @else
                                         <x-filament::dropdown
-                                            :max-height="$filtersFormMaxHeight"
+                                            :max-height="$dialogFiltersFormMaxHeight"
                                             placement="bottom-end"
                                             shift
                                             :flip="false"
-                                            :width="$filtersFormWidth ?? Width::ExtraSmall"
-                                            :wire:key="$this->getId() . '.table.filters'"
+                                            :width="$dialogFiltersFormWidth ?? Width::ExtraSmall"
+                                            :wire:key="$dialogWireKey"
                                             class="fi-ta-filters-dropdown"
                                         >
                                             <x-slot name="trigger">
-                                                {{ $filtersTriggerAction->badge($activeFiltersCount) }}
+                                                {{ $filtersTriggerAction->badge($dialogActiveFiltersCount) }}
                                             </x-slot>
 
                                             <x-filament-tables::filters
                                                 :apply-action="$filtersApplyAction"
-                                                :form="$filtersForm"
+                                                :form="$dialogFiltersForm"
                                                 :heading-tag="$secondLevelHeadingTag"
                                                 :reset-action-position="$filtersResetActionPosition"
                                             />
                                         </x-filament::dropdown>
                                     @endif
+                                    @endforeach
                                 @elseif ($hasFiltersBeforeContent || $hasFiltersAfterContent)
                                     <span
                                         x-ref="filtersTriggerActionContainer"
@@ -648,7 +677,7 @@
                                             'lg:fi-hidden' => ! $hasCollapsibleFilters,
                                         ])
                                     >
-                                        {{ $filtersTriggerAction->badge($activeFiltersCount) }}
+                                        {{ $filtersTriggerAction->badge($beforeContentActiveFiltersCount + $afterContentActiveFiltersCount) }}
                                     </span>
                                 @endif
 
@@ -2587,7 +2616,7 @@
             @if ($hasFiltersBelowContent)
                 <x-filament-tables::filters
                     :apply-action="$filtersApplyAction"
-                    :form="$filtersForm"
+                    :form="$belowContentFiltersForm"
                     :heading-tag="$secondLevelHeadingTag"
                     class="fi-ta-filters-below-content"
                     :reset-action-position="$filtersResetActionPosition"
@@ -2610,7 +2639,7 @@
             >
                 <x-filament-tables::filters
                     :apply-action="$filtersApplyAction"
-                    :form="$filtersForm"
+                    :form="$afterContentFiltersForm"
                     :heading-tag="$secondLevelHeadingTag"
                     class="fi-ta-filters-after-content"
                     :reset-action-position="$filtersResetActionPosition"

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -287,6 +287,7 @@
                 <x-filament-tables::filters
                     :apply-action="$filtersApplyAction"
                     :form="$beforeContentFiltersForm"
+                    :location="(count($filterPanels) > 1) ? $beforeContentPanel->getLocation()->name : null"
                     :heading-tag="$secondLevelHeadingTag"
                     class="fi-ta-filters-before-content"
                     :reset-action-position="$filtersResetActionPosition"
@@ -356,6 +357,7 @@
                         <x-filament-tables::filters
                             :apply-action="$filtersApplyAction"
                             :form="$aboveContentFiltersForm"
+                            :location="(count($filterPanels) > 1) ? $aboveContentPanel->getLocation()->name : null"
                             :heading-tag="$secondLevelHeadingTag"
                             x-cloak
                             :x-show="$hasCollapsibleFilters ? 'areFiltersOpen' : null"
@@ -584,6 +586,7 @@
                                 @if ($hasFiltersDialog)
                                     @foreach ($dialogPanels as $dialogPanel)
                                         @php
+                                            $filtersTriggerAction = $getFiltersTriggerAction((count($filterPanels) > 1) ? $dialogPanel->getLocation() : null);
                                             $dialogFiltersForm = $getFiltersFormForPanel($dialogPanel);
                                             $dialogActiveFiltersCount = $getActiveFiltersCountForPanel($dialogPanel);
                                             $dialogFiltersFormWidth = $getFiltersFormWidthForPanel($dialogPanel);
@@ -662,6 +665,7 @@
                                             <x-filament-tables::filters
                                                 :apply-action="$filtersApplyAction"
                                                 :form="$dialogFiltersForm"
+                                                :location="(count($filterPanels) > 1) ? $dialogPanel->getLocation()->name : null"
                                                 :heading-tag="$secondLevelHeadingTag"
                                                 :reset-action-position="$filtersResetActionPosition"
                                             />
@@ -2617,6 +2621,7 @@
                 <x-filament-tables::filters
                     :apply-action="$filtersApplyAction"
                     :form="$belowContentFiltersForm"
+                    :location="(count($filterPanels) > 1) ? $belowContentPanel->getLocation()->name : null"
                     :heading-tag="$secondLevelHeadingTag"
                     class="fi-ta-filters-below-content"
                     :reset-action-position="$filtersResetActionPosition"
@@ -2640,6 +2645,7 @@
                 <x-filament-tables::filters
                     :apply-action="$filtersApplyAction"
                     :form="$afterContentFiltersForm"
+                    :location="(count($filterPanels) > 1) ? $afterContentPanel->getLocation()->name : null"
                     :heading-tag="$secondLevelHeadingTag"
                     class="fi-ta-filters-after-content"
                     :reset-action-position="$filtersResetActionPosition"

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -596,81 +596,81 @@
                                         @endphp
 
                                         @if ($dialogIsModal)
-                                        @php
-                                            $filtersTriggerActionModalAlignment = $filtersTriggerAction->getModalAlignment();
-                                            $filtersTriggerActionIsModalAutofocused = $filtersTriggerAction->isModalAutofocused();
-                                            $filtersTriggerActionHasModalCloseButton = $filtersTriggerAction->hasModalCloseButton();
-                                            $filtersTriggerActionIsModalClosedByClickingAway = $filtersTriggerAction->isModalClosedByClickingAway();
-                                            $filtersTriggerActionIsModalClosedByEscaping = $filtersTriggerAction->isModalClosedByEscaping();
-                                            $filtersTriggerActionModalDescription = $filtersTriggerAction->getModalDescription();
-                                            $filtersTriggerActionExtraModalWindowAttributeBag = $filtersTriggerAction->getExtraModalWindowAttributeBag();
-                                            $filtersTriggerActionExtraModalOverlayAttributeBag = $filtersTriggerAction->getExtraModalOverlayAttributeBag();
-                                            $filtersTriggerActionVisibleModalFooterActions = $filtersTriggerAction->getVisibleModalFooterActions();
-                                            $filtersTriggerActionModalFooterActionsAlignment = $filtersTriggerAction->getModalFooterActionsAlignment();
-                                            $filtersTriggerActionModalHeading = $filtersTriggerAction->getCustomModalHeading() ?? __('filament-tables::table.filters.heading');
-                                            $filtersTriggerActionModalIcon = $filtersTriggerAction->getModalIcon();
-                                            $filtersTriggerActionModalIconColor = $filtersTriggerAction->getModalIconColor();
-                                            $filtersTriggerActionIsModalSlideOver = $filtersTriggerAction->isModalSlideOver();
-                                            $filtersTriggerActionModalSlideOverPosition = $filtersTriggerAction->getModalSlideOverPosition();
-                                            $filtersTriggerActionIsModalFooterSticky = $filtersTriggerAction->isModalFooterSticky();
-                                            $filtersTriggerActionIsModalHeaderSticky = $filtersTriggerAction->isModalHeaderSticky();
-                                        @endphp
+                                            @php
+                                                $filtersTriggerActionModalAlignment = $filtersTriggerAction->getModalAlignment();
+                                                $filtersTriggerActionIsModalAutofocused = $filtersTriggerAction->isModalAutofocused();
+                                                $filtersTriggerActionHasModalCloseButton = $filtersTriggerAction->hasModalCloseButton();
+                                                $filtersTriggerActionIsModalClosedByClickingAway = $filtersTriggerAction->isModalClosedByClickingAway();
+                                                $filtersTriggerActionIsModalClosedByEscaping = $filtersTriggerAction->isModalClosedByEscaping();
+                                                $filtersTriggerActionModalDescription = $filtersTriggerAction->getModalDescription();
+                                                $filtersTriggerActionExtraModalWindowAttributeBag = $filtersTriggerAction->getExtraModalWindowAttributeBag();
+                                                $filtersTriggerActionExtraModalOverlayAttributeBag = $filtersTriggerAction->getExtraModalOverlayAttributeBag();
+                                                $filtersTriggerActionVisibleModalFooterActions = $filtersTriggerAction->getVisibleModalFooterActions();
+                                                $filtersTriggerActionModalFooterActionsAlignment = $filtersTriggerAction->getModalFooterActionsAlignment();
+                                                $filtersTriggerActionModalHeading = $filtersTriggerAction->getCustomModalHeading() ?? __('filament-tables::table.filters.heading');
+                                                $filtersTriggerActionModalIcon = $filtersTriggerAction->getModalIcon();
+                                                $filtersTriggerActionModalIconColor = $filtersTriggerAction->getModalIconColor();
+                                                $filtersTriggerActionIsModalSlideOver = $filtersTriggerAction->isModalSlideOver();
+                                                $filtersTriggerActionModalSlideOverPosition = $filtersTriggerAction->getModalSlideOverPosition();
+                                                $filtersTriggerActionIsModalFooterSticky = $filtersTriggerAction->isModalFooterSticky();
+                                                $filtersTriggerActionIsModalHeaderSticky = $filtersTriggerAction->isModalHeaderSticky();
+                                            @endphp
 
-                                        <x-filament::modal
-                                            :alignment="$filtersTriggerActionModalAlignment"
-                                            :autofocus="$filtersTriggerActionIsModalAutofocused"
-                                            :close-button="$filtersTriggerActionHasModalCloseButton"
-                                            :close-by-clicking-away="$filtersTriggerActionIsModalClosedByClickingAway"
-                                            :close-by-escaping="$filtersTriggerActionIsModalClosedByEscaping"
-                                            :description="$filtersTriggerActionModalDescription"
-                                            :extra-modal-window-attribute-bag="$filtersTriggerActionExtraModalWindowAttributeBag"
-                                            :extra-modal-overlay-attribute-bag="$filtersTriggerActionExtraModalOverlayAttributeBag"
-                                            :footer-actions="$filtersTriggerActionVisibleModalFooterActions"
-                                            :footer-actions-alignment="$filtersTriggerActionModalFooterActionsAlignment"
-                                            :heading="$filtersTriggerActionModalHeading"
-                                            :icon="$filtersTriggerActionModalIcon"
-                                            :icon-color="$filtersTriggerActionModalIconColor"
-                                            :slide-over="$filtersTriggerActionIsModalSlideOver"
-                                            :slide-over-position="$filtersTriggerActionModalSlideOverPosition"
-                                            :sticky-footer="$filtersTriggerActionIsModalFooterSticky"
-                                            :sticky-header="$filtersTriggerActionIsModalHeaderSticky"
-                                            :width="$dialogFiltersFormWidth"
-                                            :wire:key="$dialogWireKey"
-                                            class="fi-ta-filters-modal"
-                                        >
-                                            <x-slot name="trigger">
-                                                {{ $filtersTriggerAction->badge($dialogActiveFiltersCount) }}
-                                            </x-slot>
+                                            <x-filament::modal
+                                                :alignment="$filtersTriggerActionModalAlignment"
+                                                :autofocus="$filtersTriggerActionIsModalAutofocused"
+                                                :close-button="$filtersTriggerActionHasModalCloseButton"
+                                                :close-by-clicking-away="$filtersTriggerActionIsModalClosedByClickingAway"
+                                                :close-by-escaping="$filtersTriggerActionIsModalClosedByEscaping"
+                                                :description="$filtersTriggerActionModalDescription"
+                                                :extra-modal-window-attribute-bag="$filtersTriggerActionExtraModalWindowAttributeBag"
+                                                :extra-modal-overlay-attribute-bag="$filtersTriggerActionExtraModalOverlayAttributeBag"
+                                                :footer-actions="$filtersTriggerActionVisibleModalFooterActions"
+                                                :footer-actions-alignment="$filtersTriggerActionModalFooterActionsAlignment"
+                                                :heading="$filtersTriggerActionModalHeading"
+                                                :icon="$filtersTriggerActionModalIcon"
+                                                :icon-color="$filtersTriggerActionModalIconColor"
+                                                :slide-over="$filtersTriggerActionIsModalSlideOver"
+                                                :slide-over-position="$filtersTriggerActionModalSlideOverPosition"
+                                                :sticky-footer="$filtersTriggerActionIsModalFooterSticky"
+                                                :sticky-header="$filtersTriggerActionIsModalHeaderSticky"
+                                                :width="$dialogFiltersFormWidth"
+                                                :wire:key="$dialogWireKey"
+                                                class="fi-ta-filters-modal"
+                                            >
+                                                <x-slot name="trigger">
+                                                    {{ $filtersTriggerAction->badge($dialogActiveFiltersCount) }}
+                                                </x-slot>
 
-                                            {{ $filtersTriggerAction->getModalContent() }}
+                                                {{ $filtersTriggerAction->getModalContent() }}
 
-                                            {{ $dialogFiltersForm }}
+                                                {{ $dialogFiltersForm }}
 
-                                            {{ $filtersTriggerAction->getModalContentFooter() }}
-                                        </x-filament::modal>
-                                    @else
-                                        <x-filament::dropdown
-                                            :max-height="$dialogFiltersFormMaxHeight"
-                                            placement="bottom-end"
-                                            shift
-                                            :flip="false"
-                                            :width="$dialogFiltersFormWidth ?? Width::ExtraSmall"
-                                            :wire:key="$dialogWireKey"
-                                            class="fi-ta-filters-dropdown"
-                                        >
-                                            <x-slot name="trigger">
-                                                {{ $filtersTriggerAction->badge($dialogActiveFiltersCount) }}
-                                            </x-slot>
+                                                {{ $filtersTriggerAction->getModalContentFooter() }}
+                                            </x-filament::modal>
+                                        @else
+                                            <x-filament::dropdown
+                                                :max-height="$dialogFiltersFormMaxHeight"
+                                                placement="bottom-end"
+                                                shift
+                                                :flip="false"
+                                                :width="$dialogFiltersFormWidth ?? Width::ExtraSmall"
+                                                :wire:key="$dialogWireKey"
+                                                class="fi-ta-filters-dropdown"
+                                            >
+                                                <x-slot name="trigger">
+                                                    {{ $filtersTriggerAction->badge($dialogActiveFiltersCount) }}
+                                                </x-slot>
 
-                                            <x-filament-tables::filters
-                                                :apply-action="$filtersApplyAction"
-                                                :form="$dialogFiltersForm"
-                                                :location="(count($filterPanels) > 1) ? $dialogPanel->getLocation()->name : null"
-                                                :heading-tag="$secondLevelHeadingTag"
-                                                :reset-action-position="$filtersResetActionPosition"
-                                            />
-                                        </x-filament::dropdown>
-                                    @endif
+                                                <x-filament-tables::filters
+                                                    :apply-action="$filtersApplyAction"
+                                                    :form="$dialogFiltersForm"
+                                                    :location="(count($filterPanels) > 1) ? $dialogPanel->getLocation()->name : null"
+                                                    :heading-tag="$secondLevelHeadingTag"
+                                                    :reset-action-position="$filtersResetActionPosition"
+                                                />
+                                            </x-filament::dropdown>
+                                        @endif
                                     @endforeach
                                 @elseif ($hasFiltersBeforeContent || $hasFiltersAfterContent)
                                     <span

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -6,7 +6,6 @@ use Filament\Facades\Filament;
 use Filament\QueryBuilder\Forms\Components\RuleBuilder;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Schema;
-use Filament\Tables\Enums\FiltersLayout;
 use Filament\Tables\Filters\BaseFilter;
 use Filament\Tables\Filters\Indicator;
 use Filament\Tables\Filters\QueryBuilder;
@@ -149,20 +148,38 @@ trait HasFilters
 
     public function resetTableFiltersForm(?string $location = null): void
     {
-        $locationCase = filled($location)
-            ? constant(FiltersLayout::class . '::' . $location)
+        $table = $this->getTable();
+
+        $panel = filled($location)
+            ? $table->getFilterPanel($location)
             : null;
 
-        $form = $locationCase
-            ? ($this->getTable()->getFiltersFormForLocation($locationCase) ?? $this->getTableFiltersForm())
-            : $this->getTableFiltersForm();
+        if (! $panel) {
+            $this->getTableFiltersForm()->fill();
 
-        $form->fill();
+            if ($table->hasDeferredFilters()) {
+                $this->applyTableFilters();
 
-        if ($this->getTable()->hasDeferredFilters()) {
-            $this->applyTableFilters();
+                return;
+            }
+
+            $this->handleTableFilterUpdates();
 
             return;
+        }
+
+        ($table->getFiltersFormForPanel($panel) ?? $this->getTableFiltersForm())->fill();
+
+        if ($table->hasDeferredFilters()) {
+            // Only this panel's filters are applied, so that pending changes made in
+            // another panel are not committed by resetting this one.
+            $this->tableFilters ??= [];
+
+            foreach ($panel->getVisibleFilters() as $filter) {
+                $filterName = $filter->getName();
+
+                $this->tableFilters[$filterName] = Arr::get($this->tableDeferredFilters, $filterName);
+            }
         }
 
         $this->handleTableFilterUpdates();

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -6,6 +6,7 @@ use Filament\Facades\Filament;
 use Filament\QueryBuilder\Forms\Components\RuleBuilder;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Schema;
+use Filament\Tables\Enums\FiltersLayout;
 use Filament\Tables\Filters\BaseFilter;
 use Filament\Tables\Filters\Indicator;
 use Filament\Tables\Filters\QueryBuilder;
@@ -146,9 +147,17 @@ trait HasFilters
         $this->handleTableFilterUpdates();
     }
 
-    public function resetTableFiltersForm(): void
+    public function resetTableFiltersForm(?string $location = null): void
     {
-        $this->getTableFiltersForm()->fill();
+        $locationCase = filled($location)
+            ? constant(FiltersLayout::class . '::' . $location)
+            : null;
+
+        $form = $locationCase
+            ? ($this->getTable()->getFiltersFormForLocation($locationCase) ?? $this->getTableFiltersForm())
+            : $this->getTableFiltersForm();
+
+        $form->fill();
 
         if ($this->getTable()->hasDeferredFilters()) {
             $this->applyTableFilters();

--- a/packages/tables/src/Filters/FilterPanel.php
+++ b/packages/tables/src/Filters/FilterPanel.php
@@ -46,6 +46,19 @@ class FilterPanel extends Component
         return $static;
     }
 
+    /**
+     * @param  array<BaseFilter>  $filters
+     */
+    public function pushFilters(array $filters): static
+    {
+        $this->filters = [
+            ...$this->filters,
+            ...$filters,
+        ];
+
+        return $this;
+    }
+
     public function columns(int | array | Closure | null $columns): static
     {
         $this->columns = $columns;

--- a/packages/tables/src/Filters/FilterPanel.php
+++ b/packages/tables/src/Filters/FilterPanel.php
@@ -17,6 +17,9 @@ class FilterPanel extends Component
      */
     protected array $filters = [];
 
+    /**
+     * @var int | array<string, int | null> | Closure | null
+     */
     protected int | array | Closure | null $columns = null;
 
     protected Width | string | Closure | null $width = null;
@@ -59,6 +62,9 @@ class FilterPanel extends Component
         return $this;
     }
 
+    /**
+     * @param  int | array<string, int | null> | Closure | null  $columns
+     */
     public function columns(int | array | Closure | null $columns): static
     {
         $this->columns = $columns;

--- a/packages/tables/src/Filters/FilterPanel.php
+++ b/packages/tables/src/Filters/FilterPanel.php
@@ -5,12 +5,16 @@ namespace Filament\Tables\Filters;
 use Closure;
 use Filament\Support\Components\Component;
 use Filament\Support\Enums\Width;
+use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Enums\FiltersLayout;
 use Filament\Tables\Enums\FiltersResetActionPosition;
+use Filament\Tables\Table;
 
 class FilterPanel extends Component
 {
     protected string $evaluationIdentifier = 'filterPanel';
+
+    protected Table $table;
 
     /**
      * @var array<BaseFilter>
@@ -33,7 +37,7 @@ class FilterPanel extends Component
     /**
      * @param  array<BaseFilter>  $filters
      */
-    final public function __construct(protected FiltersLayout $location, array $filters = [])
+    final public function __construct(protected FiltersLayout $location, array $filters)
     {
         $this->filters = $filters;
     }
@@ -41,7 +45,7 @@ class FilterPanel extends Component
     /**
      * @param  array<BaseFilter>  $filters
      */
-    public static function make(FiltersLayout $location, array $filters = []): static
+    public static function make(FiltersLayout $location, array $filters): static
     {
         $static = app(static::class, ['location' => $location, 'filters' => $filters]);
         $static->configure();
@@ -58,6 +62,13 @@ class FilterPanel extends Component
             ...$this->filters,
             ...$filters,
         ];
+
+        return $this;
+    }
+
+    public function table(Table $table): static
+    {
+        $this->table = $table;
 
         return $this;
     }
@@ -100,6 +111,16 @@ class FilterPanel extends Component
         return $this;
     }
 
+    public function getTable(): Table
+    {
+        return $this->table;
+    }
+
+    public function getLivewire(): HasTable
+    {
+        return $this->getTable()->getLivewire();
+    }
+
     public function getLocation(): FiltersLayout
     {
         return $this->location;
@@ -111,6 +132,44 @@ class FilterPanel extends Component
     public function getFilters(): array
     {
         return $this->filters;
+    }
+
+    /**
+     * @return array<BaseFilter>
+     */
+    public function getVisibleFilters(): array
+    {
+        return array_values(array_filter(
+            $this->filters,
+            fn (BaseFilter $filter): bool => $filter->isVisible(),
+        ));
+    }
+
+    /**
+     * An interactive panel owns a trigger that opens it, so a table may only have one of them.
+     * The non-collapsible before/after locations count too, as they open from the filter trigger
+     * as floating panels on mobile.
+     */
+    public function isInteractive(): bool
+    {
+        return in_array($this->location, [
+            FiltersLayout::Dropdown,
+            FiltersLayout::Modal,
+            FiltersLayout::AboveContentCollapsible,
+            FiltersLayout::BeforeContent,
+            FiltersLayout::BeforeContentCollapsible,
+            FiltersLayout::AfterContent,
+            FiltersLayout::AfterContentCollapsible,
+        ], strict: true);
+    }
+
+    public function isCollapsible(): bool
+    {
+        return in_array($this->location, [
+            FiltersLayout::AboveContentCollapsible,
+            FiltersLayout::BeforeContentCollapsible,
+            FiltersLayout::AfterContentCollapsible,
+        ], strict: true);
     }
 
     /**
@@ -139,5 +198,17 @@ class FilterPanel extends Component
     public function getModifyTriggerActionUsing(): ?Closure
     {
         return $this->modifyTriggerActionUsing;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    protected function resolveDefaultClosureDependencyForEvaluationByName(string $parameterName): array
+    {
+        return match ($parameterName) {
+            'livewire' => [$this->getLivewire()],
+            'table' => [$this->getTable()],
+            default => parent::resolveDefaultClosureDependencyForEvaluationByName($parameterName),
+        };
     }
 }

--- a/packages/tables/src/Filters/FilterPanel.php
+++ b/packages/tables/src/Filters/FilterPanel.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Filament\Tables\Filters;
+
+use Closure;
+use Filament\Support\Components\Component;
+use Filament\Support\Enums\Width;
+use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Enums\FiltersResetActionPosition;
+
+class FilterPanel extends Component
+{
+    protected string $evaluationIdentifier = 'filterPanel';
+
+    /**
+     * @var array<BaseFilter>
+     */
+    protected array $filters = [];
+
+    protected int | array | Closure | null $columns = null;
+
+    protected Width | string | Closure | null $width = null;
+
+    protected string | Closure | null $maxHeight = null;
+
+    protected FiltersResetActionPosition | Closure | null $resetActionPosition = null;
+
+    protected ?Closure $modifyTriggerActionUsing = null;
+
+    /**
+     * @param  array<BaseFilter>  $filters
+     */
+    final public function __construct(protected FiltersLayout $location, array $filters = [])
+    {
+        $this->filters = $filters;
+    }
+
+    /**
+     * @param  array<BaseFilter>  $filters
+     */
+    public static function make(FiltersLayout $location, array $filters = []): static
+    {
+        $static = app(static::class, ['location' => $location, 'filters' => $filters]);
+        $static->configure();
+
+        return $static;
+    }
+
+    public function columns(int | array | Closure | null $columns): static
+    {
+        $this->columns = $columns;
+
+        return $this;
+    }
+
+    public function width(Width | string | Closure | null $width): static
+    {
+        $this->width = $width;
+
+        return $this;
+    }
+
+    public function maxHeight(string | Closure | null $maxHeight): static
+    {
+        $this->maxHeight = $maxHeight;
+
+        return $this;
+    }
+
+    public function resetActionPosition(FiltersResetActionPosition | Closure | null $position): static
+    {
+        $this->resetActionPosition = $position;
+
+        return $this;
+    }
+
+    public function triggerAction(?Closure $callback): static
+    {
+        $this->modifyTriggerActionUsing = $callback;
+
+        return $this;
+    }
+
+    public function getLocation(): FiltersLayout
+    {
+        return $this->location;
+    }
+
+    /**
+     * @return array<BaseFilter>
+     */
+    public function getFilters(): array
+    {
+        return $this->filters;
+    }
+
+    /**
+     * @return int | array<string, int | null> | null
+     */
+    public function getColumns(): int | array | null
+    {
+        return $this->evaluate($this->columns);
+    }
+
+    public function getWidth(): Width | string | null
+    {
+        return $this->evaluate($this->width);
+    }
+
+    public function getMaxHeight(): ?string
+    {
+        return $this->evaluate($this->maxHeight);
+    }
+
+    public function getResetActionPosition(): ?FiltersResetActionPosition
+    {
+        return $this->evaluate($this->resetActionPosition);
+    }
+
+    public function getModifyTriggerActionUsing(): ?Closure
+    {
+        return $this->modifyTriggerActionUsing;
+    }
+}

--- a/packages/tables/src/Table/Concerns/HasFilters.php
+++ b/packages/tables/src/Table/Concerns/HasFilters.php
@@ -13,7 +13,9 @@ use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Enums\FiltersLayout;
 use Filament\Tables\Enums\FiltersResetActionPosition;
 use Filament\Tables\Filters\BaseFilter;
+use Filament\Tables\Filters\FilterPanel;
 use Filament\Tables\View\TablesIconAlias;
+use LogicException;
 
 trait HasFilters
 {
@@ -21,6 +23,13 @@ trait HasFilters
      * @var array<string, BaseFilter>
      */
     protected array $filters = [];
+
+    /**
+     * @var array<string, FilterPanel>
+     */
+    protected array $filterPanels = [];
+
+    protected bool $hasFilterPanels = false;
 
     protected ?Closure $filtersFormSchema = null;
 
@@ -83,11 +92,13 @@ trait HasFilters
     }
 
     /**
-     * @param  array<BaseFilter>  $filters
+     * @param  array<BaseFilter | FilterPanel>  $filters
      */
     public function filters(array $filters, FiltersLayout | string | Closure | null $layout = null): static
     {
         $this->filters = [];
+        $this->filterPanels = [];
+        $this->hasFilterPanels = false;
         $this->pushFilters($filters);
 
         if ($layout) {
@@ -98,17 +109,84 @@ trait HasFilters
     }
 
     /**
-     * @param  array<BaseFilter>  $filters
+     * @param  array<BaseFilter | FilterPanel>  $filters
      */
     public function pushFilters(array $filters): static
     {
-        foreach ($filters as $filter) {
-            $filter->table($this);
+        $incomingArePanels = null;
 
-            $this->filters[$filter->getName()] = $filter;
+        foreach ($filters as $filter) {
+            $isPanel = $filter instanceof FilterPanel;
+
+            $incomingArePanels ??= $isPanel;
+
+            if ($isPanel !== $incomingArePanels) {
+                throw new LogicException('A table\'s [filters()] must be either all [FilterPanel] instances or all filters, not a mix.');
+            }
+        }
+
+        if ($incomingArePanels === null) {
+            return $this;
+        }
+
+        if ((filled($this->filters) || filled($this->filterPanels)) && ($this->hasFilterPanels !== $incomingArePanels)) {
+            throw new LogicException('A table cannot mix [FilterPanel] instances with loose filters, including across [pushFilters()] calls.');
+        }
+
+        $this->hasFilterPanels = $incomingArePanels;
+
+        if (! $incomingArePanels) {
+            foreach ($filters as $filter) {
+                $filter->table($this);
+
+                $this->filters[$filter->getName()] = $filter;
+            }
+
+            return $this;
+        }
+
+        foreach ($filters as $panel) {
+            $locationName = $panel->getLocation()->name;
+
+            if (array_key_exists($locationName, $this->filterPanels)) {
+                throw new LogicException("A table can only have one filter panel per location; [{$locationName}] is used more than once.");
+            }
+
+            $this->filterPanels[$locationName] = $panel;
+
+            foreach ($panel->getFilters() as $filter) {
+                $filter->table($this);
+
+                $this->filters[$filter->getName()] = $filter;
+            }
         }
 
         return $this;
+    }
+
+    public function hasFilterPanels(): bool
+    {
+        return $this->hasFilterPanels;
+    }
+
+    /**
+     * @return array<FilterPanel>
+     */
+    public function getFilterPanels(): array
+    {
+        if (! $this->hasFilterPanels) {
+            return [
+                FilterPanel::make($this->getFiltersLayout(), array_values($this->getFilters())),
+            ];
+        }
+
+        return array_values(array_filter(
+            $this->filterPanels,
+            fn (FilterPanel $panel): bool => (bool) array_filter(
+                $panel->getFilters(),
+                fn (BaseFilter $filter): bool => $filter->isVisible(),
+            ),
+        ));
     }
 
     /**

--- a/packages/tables/src/Table/Concerns/HasFilters.php
+++ b/packages/tables/src/Table/Concerns/HasFilters.php
@@ -149,10 +149,10 @@ trait HasFilters
             $locationName = $panel->getLocation()->name;
 
             if (array_key_exists($locationName, $this->filterPanels)) {
-                throw new LogicException("A table can only have one filter panel per location; [{$locationName}] is used more than once.");
+                $this->filterPanels[$locationName]->pushFilters($panel->getFilters());
+            } else {
+                $this->filterPanels[$locationName] = $panel;
             }
-
-            $this->filterPanels[$locationName] = $panel;
 
             foreach ($panel->getFilters() as $filter) {
                 $filter->table($this);

--- a/packages/tables/src/Table/Concerns/HasFilters.php
+++ b/packages/tables/src/Table/Concerns/HasFilters.php
@@ -307,7 +307,7 @@ trait HasFilters
     }
 
     /**
-     * @return array<string, Group>
+     * @return array<Group>
      */
     public function getFiltersFormSchema(): array
     {

--- a/packages/tables/src/Table/Concerns/HasFilters.php
+++ b/packages/tables/src/Table/Concerns/HasFilters.php
@@ -225,6 +225,11 @@ trait HasFilters
         return $this->evaluate($this->filtersResetActionPosition) ?? FiltersResetActionPosition::Header;
     }
 
+    public function getResetActionPositionForPanel(FilterPanel $panel): FiltersResetActionPosition
+    {
+        return $panel->getResetActionPosition() ?? $this->getFiltersResetActionPosition();
+    }
+
     public function filtersLayout(FiltersLayout | Closure | null $filtersLayout): static
     {
         $this->filtersLayout = $filtersLayout;
@@ -271,6 +276,24 @@ trait HasFilters
         return $this->getLivewire()->getTableFiltersForm();
     }
 
+    public function getFiltersFormForPanel(FilterPanel $panel): ?Schema
+    {
+        $form = $this->getFiltersForm();
+
+        // Single panel => the whole flat form renders as one.
+        if (count($this->getFilterPanels()) <= 1) {
+            return $form;
+        }
+
+        foreach ($form->getComponents(withHidden: true) as $component) {
+            if ($component->getKey(isAbsolute: false) === 'filterPanel::' . $panel->getLocation()->name) {
+                return $component->getChildSchema();
+            }
+        }
+
+        return null;
+    }
+
     public function filtersFormSchema(?Closure $schema): static
     {
         $this->filtersFormSchema = $schema;
@@ -283,10 +306,14 @@ trait HasFilters
      */
     public function getFiltersFormSchema(): array
     {
-        $filters = [];
+        if ($this->filtersFormSchema && $this->hasFilterPanels) {
+            throw new LogicException('[filtersFormSchema()] cannot be combined with [FilterPanel] instances; use a flat filters array to customize the whole schema, or lay filters out within each panel.');
+        }
+
+        $filterGroups = [];
 
         foreach ($this->getFilters() as $filterName => $filter) {
-            $filters[$filterName] = Group::make()
+            $filterGroups[$filterName] = Group::make()
                 ->schema($filter->getSchemaComponents())
                 ->statePath($filterName)
                 ->key($filterName)
@@ -295,7 +322,36 @@ trait HasFilters
                 ->columns($filter->getColumns());
         }
 
-        return $this->evaluate($this->filtersFormSchema, ['filters' => $filters]) ?? array_values($filters);
+        if ($this->filtersFormSchema) {
+            return $this->evaluate($this->filtersFormSchema, ['filters' => $filterGroups]) ?? array_values($filterGroups);
+        }
+
+        $panels = $this->getFilterPanels();
+
+        // A single panel (including the normalised implicit one for flat `filters()`) renders as a flat schema, identical to before.
+        if (count($panels) <= 1) {
+            return array_values($filterGroups);
+        }
+
+        $containers = [];
+
+        foreach ($panels as $panel) {
+            $panelFilterGroups = array_values(array_intersect_key(
+                $filterGroups,
+                array_flip(array_map(fn (BaseFilter $filter): string => $filter->getName(), $panel->getFilters())),
+            ));
+
+            if ($panelFilterGroups === []) {
+                continue;
+            }
+
+            $containers[] = Group::make()
+                ->schema($panelFilterGroups)
+                ->key('filterPanel::' . $panel->getLocation()->name)
+                ->columns($this->getFiltersFormColumnsForPanel($panel));
+        }
+
+        return $containers;
     }
 
     public function getFiltersTriggerAction(): Action
@@ -376,9 +432,28 @@ trait HasFilters
     /**
      * @return int | array<string, int | null>
      */
+    /**
+     * @return int | array<string, int | null>
+     */
     public function getFiltersFormColumns(): int | array
     {
-        return $this->evaluate($this->filtersFormColumns) ?? match ($this->getFiltersLayout()) {
+        return $this->getFiltersFormColumnsForPanel($this->getFilterPanels()[0]);
+    }
+
+    /**
+     * @return int | array<string, int | null>
+     */
+    public function getFiltersFormColumnsForPanel(FilterPanel $panel): int | array
+    {
+        return $panel->getColumns() ?? $this->getFiltersFormColumnsForLocation($panel->getLocation());
+    }
+
+    /**
+     * @return int | array<string, int | null>
+     */
+    protected function getFiltersFormColumnsForLocation(FiltersLayout $location): int | array
+    {
+        return $this->evaluate($this->filtersFormColumns) ?? match ($location) {
             FiltersLayout::AboveContent, FiltersLayout::AboveContentCollapsible, FiltersLayout::BelowContent => [
                 'sm' => 2,
                 'lg' => 3,
@@ -394,9 +469,19 @@ trait HasFilters
         return $this->evaluate($this->filtersFormMaxHeight);
     }
 
+    public function getFiltersFormMaxHeightForPanel(FilterPanel $panel): ?string
+    {
+        return $panel->getMaxHeight() ?? $this->evaluate($this->filtersFormMaxHeight);
+    }
+
     public function getFiltersFormWidth(): Width | string | null
     {
-        return $this->evaluate($this->filtersFormWidth) ?? match ($this->getFiltersFormColumns()) {
+        return $this->getFiltersFormWidthForPanel($this->getFilterPanels()[0]);
+    }
+
+    public function getFiltersFormWidthForPanel(FilterPanel $panel): Width | string | null
+    {
+        return $panel->getWidth() ?? $this->evaluate($this->filtersFormWidth) ?? match ($this->getFiltersFormColumnsForPanel($panel)) {
             2 => Width::TwoExtraLarge,
             3 => Width::FourExtraLarge,
             4 => Width::SixExtraLarge,
@@ -428,6 +513,15 @@ trait HasFilters
     {
         return array_reduce(
             $this->getFilters(),
+            fn (int $carry, BaseFilter $filter): int => $carry + $filter->getActiveCount(),
+            0,
+        );
+    }
+
+    public function getActiveFiltersCountForPanel(FilterPanel $panel): int
+    {
+        return array_reduce(
+            $panel->getFilters(),
             fn (int $carry, BaseFilter $filter): int => $carry + $filter->getActiveCount(),
             0,
         );

--- a/packages/tables/src/Table/Concerns/HasFilters.php
+++ b/packages/tables/src/Table/Concerns/HasFilters.php
@@ -278,6 +278,11 @@ trait HasFilters
 
     public function getFiltersFormForPanel(FilterPanel $panel): ?Schema
     {
+        return $this->getFiltersFormForLocation($panel->getLocation());
+    }
+
+    public function getFiltersFormForLocation(FiltersLayout $location): ?Schema
+    {
         $form = $this->getFiltersForm();
 
         // Single panel => the whole flat form renders as one.
@@ -286,7 +291,7 @@ trait HasFilters
         }
 
         foreach ($form->getComponents(withHidden: true) as $component) {
-            if ($component->getKey(isAbsolute: false) === 'filterPanel::' . $panel->getLocation()->name) {
+            if ($component->getKey(isAbsolute: false) === 'filterPanel::' . $location->name) {
                 return $component->getChildSchema();
             }
         }
@@ -354,7 +359,7 @@ trait HasFilters
         return $containers;
     }
 
-    public function getFiltersTriggerAction(): Action
+    public function getFiltersTriggerAction(?FiltersLayout $location = null): Action
     {
         $action = Action::make('openFilters')
             ->label(__('filament-tables::table.actions.filter.label'))
@@ -369,7 +374,11 @@ trait HasFilters
                 Action::make('resetFilters')
                     ->label(__('filament-tables::table.filters.actions.reset.label'))
                     ->color('danger')
-                    ->action('resetTableFiltersForm')
+                    ->action(
+                        $location
+                            ? "resetTableFiltersForm('{$location->name}')"
+                            : 'resetTableFiltersForm',
+                    )
                     ->button(),
             ])
             ->modalCancelActionLabel(__('filament::components/modal.actions.close.label'))

--- a/packages/tables/src/Table/Concerns/HasFilters.php
+++ b/packages/tables/src/Table/Concerns/HasFilters.php
@@ -148,6 +148,8 @@ trait HasFilters
         foreach ($filters as $panel) {
             $locationName = $panel->getLocation()->name;
 
+            $panel->table($this);
+
             if (array_key_exists($locationName, $this->filterPanels)) {
                 $this->filterPanels[$locationName]->pushFilters($panel->getFilters());
             } else {
@@ -161,12 +163,55 @@ trait HasFilters
             }
         }
 
+        $this->validateFilterPanelLocations();
+
         return $this;
+    }
+
+    /**
+     * A table may only have one panel that owns a trigger, since there is a single filter trigger
+     * to open it. `AboveContent`, `BelowContent` and `Hidden` have no trigger of their own, so they
+     * may accompany it - except that `AboveContent` and `AboveContentCollapsible` occupy the same
+     * physical location and cannot both be used.
+     */
+    protected function validateFilterPanelLocations(): void
+    {
+        $interactiveLocationNames = [];
+
+        foreach ($this->filterPanels as $locationName => $panel) {
+            if (! $panel->isInteractive()) {
+                continue;
+            }
+
+            $interactiveLocationNames[] = $locationName;
+        }
+
+        if (count($interactiveLocationNames) > 1) {
+            throw new LogicException('A table may only have one interactive filter panel, but [' . implode('] and [', $interactiveLocationNames) . '] were used together. Only one of [Dropdown], [Modal], [AboveContentCollapsible], [BeforeContent], [BeforeContentCollapsible], [AfterContent] or [AfterContentCollapsible] may be used at a time, optionally alongside [AboveContent], [BelowContent] and [Hidden].');
+        }
+
+        if (
+            array_key_exists(FiltersLayout::AboveContent->name, $this->filterPanels) &&
+            array_key_exists(FiltersLayout::AboveContentCollapsible->name, $this->filterPanels)
+        ) {
+            throw new LogicException('A table cannot use [AboveContent] and [AboveContentCollapsible] filter panels together, as they occupy the same location above the table.');
+        }
     }
 
     public function hasFilterPanels(): bool
     {
         return $this->hasFilterPanels;
+    }
+
+    public function getFilterPanel(string $locationName): ?FilterPanel
+    {
+        foreach ($this->getFilterPanels() as $panel) {
+            if ($panel->getLocation()->name === $locationName) {
+                return $panel;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -176,7 +221,8 @@ trait HasFilters
     {
         if (! $this->hasFilterPanels) {
             return [
-                FilterPanel::make($this->getFiltersLayout(), array_values($this->getFilters())),
+                FilterPanel::make($this->getFiltersLayout(), array_values($this->getFilters()))
+                    ->table($this),
             ];
         }
 
@@ -359,8 +405,10 @@ trait HasFilters
         return $containers;
     }
 
-    public function getFiltersTriggerAction(?FiltersLayout $location = null): Action
+    public function getFiltersTriggerAction(?FilterPanel $panel = null): Action
     {
+        $location = $panel?->getLocation();
+
         $action = Action::make('openFilters')
             ->label(__('filament-tables::table.actions.filter.label'))
             ->iconButton()
@@ -387,6 +435,12 @@ trait HasFilters
 
         if ($this->modifyFiltersTriggerActionUsing) {
             $action = $this->evaluate($this->modifyFiltersTriggerActionUsing, [
+                'action' => $action,
+            ]) ?? $action;
+        }
+
+        if ($modifyTriggerActionUsing = $panel?->getModifyTriggerActionUsing()) {
+            $action = $panel->evaluate($modifyTriggerActionUsing, [
                 'action' => $action,
             ]) ?? $action;
         }
@@ -441,12 +495,15 @@ trait HasFilters
     /**
      * @return int | array<string, int | null>
      */
-    /**
-     * @return int | array<string, int | null>
-     */
     public function getFiltersFormColumns(): int | array
     {
-        return $this->getFiltersFormColumnsForPanel($this->getFilterPanels()[0]);
+        $panel = $this->getFilterPanels()[0] ?? null;
+
+        if (! $panel) {
+            return $this->getFiltersFormColumnsForLocation($this->getFiltersLayout());
+        }
+
+        return $this->getFiltersFormColumnsForPanel($panel);
     }
 
     /**
@@ -485,12 +542,26 @@ trait HasFilters
 
     public function getFiltersFormWidth(): Width | string | null
     {
-        return $this->getFiltersFormWidthForPanel($this->getFilterPanels()[0]);
+        $panel = $this->getFilterPanels()[0] ?? null;
+
+        if (! $panel) {
+            return $this->getFiltersFormWidthForColumns($this->getFiltersFormColumns());
+        }
+
+        return $this->getFiltersFormWidthForPanel($panel);
     }
 
     public function getFiltersFormWidthForPanel(FilterPanel $panel): Width | string | null
     {
-        return $panel->getWidth() ?? $this->evaluate($this->filtersFormWidth) ?? match ($this->getFiltersFormColumnsForPanel($panel)) {
+        return $panel->getWidth() ?? $this->getFiltersFormWidthForColumns($this->getFiltersFormColumnsForPanel($panel));
+    }
+
+    /**
+     * @param  int | array<string, int | null>  $columns
+     */
+    protected function getFiltersFormWidthForColumns(int | array $columns): Width | string | null
+    {
+        return $this->evaluate($this->filtersFormWidth) ?? match ($columns) {
             2 => Width::TwoExtraLarge,
             3 => Width::FourExtraLarge,
             4 => Width::SixExtraLarge,
@@ -530,7 +601,7 @@ trait HasFilters
     public function getActiveFiltersCountForPanel(FilterPanel $panel): int
     {
         return array_reduce(
-            $panel->getFilters(),
+            $panel->getVisibleFilters(),
             fn (int $carry, BaseFilter $filter): int => $carry + $filter->getActiveCount(),
             0,
         );

--- a/tests/src/Fixtures/Livewire/PostsTableWithConfigurableFilterPanels.php
+++ b/tests/src/Fixtures/Livewire/PostsTableWithConfigurableFilterPanels.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Livewire;
+
+use Closure;
+use Filament\Tables\Table;
+
+class PostsTableWithConfigurableFilterPanels extends PostsTable
+{
+    public static ?Closure $configureUsing = null;
+
+    public function table(Table $table): Table
+    {
+        $table = parent::table($table);
+
+        if (static::$configureUsing) {
+            $table = (static::$configureUsing)($table);
+        }
+
+        return $table;
+    }
+}

--- a/tests/src/Fixtures/Livewire/PostsTableWithFilterPanels.php
+++ b/tests/src/Fixtures/Livewire/PostsTableWithFilterPanels.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Livewire;
+
+use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\FilterPanel;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+
+class PostsTableWithFilterPanels extends PostsTable
+{
+    public function table(Table $table): Table
+    {
+        return parent::table($table)
+            ->filters([
+                FilterPanel::make(FiltersLayout::AboveContent, [
+                    Filter::make('is_published')
+                        ->query(fn (EloquentBuilder $query) => $query->where('is_published', true)),
+                ])->columns(4),
+                FilterPanel::make(FiltersLayout::Dropdown, [
+                    SelectFilter::make('author')->relationship('author', 'name'),
+                ]),
+            ]);
+    }
+}

--- a/tests/src/Fixtures/Pages/FilterPanelBrowserTest.php
+++ b/tests/src/Fixtures/Pages/FilterPanelBrowserTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Pages;
+
+use BackedEnum;
+use Filament\Pages\Page;
+use Filament\Schemas\Components\EmbeddedTable;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\FilterPanel;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Filament\Tests\Fixtures\Models\Post;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+
+class FilterPanelBrowserTest extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedFunnel;
+
+    protected static ?int $navigationSort = 10;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(Post::query())
+            ->columns([
+                TextColumn::make('title'),
+            ])
+            ->filters([
+                FilterPanel::make(FiltersLayout::AboveContent, [
+                    Filter::make('is_published')
+                        ->query(fn (EloquentBuilder $query) => $query->where('is_published', true)),
+                ])->columns(2),
+                FilterPanel::make(FiltersLayout::Dropdown, [
+                    SelectFilter::make('author')->relationship('author', 'name'),
+                ]),
+                FilterPanel::make(FiltersLayout::Modal, [
+                    Filter::make('recent')
+                        ->query(fn (EloquentBuilder $query) => $query->where('created_at', '>=', now()->subYear())),
+                ]),
+            ]);
+    }
+
+    public function content(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                EmbeddedTable::make(),
+            ]);
+    }
+}

--- a/tests/src/Fixtures/Pages/FilterPanelBrowserTest.php
+++ b/tests/src/Fixtures/Pages/FilterPanelBrowserTest.php
@@ -38,12 +38,12 @@ class FilterPanelBrowserTest extends Page implements HasTable
                     Filter::make('is_published')
                         ->query(fn (EloquentBuilder $query) => $query->where('is_published', true)),
                 ])->columns(2),
-                FilterPanel::make(FiltersLayout::Dropdown, [
-                    SelectFilter::make('author')->relationship('author', 'name'),
-                ]),
-                FilterPanel::make(FiltersLayout::Modal, [
+                FilterPanel::make(FiltersLayout::BelowContent, [
                     Filter::make('recent')
                         ->query(fn (EloquentBuilder $query) => $query->where('created_at', '>=', now()->subYear())),
+                ]),
+                FilterPanel::make(FiltersLayout::Dropdown, [
+                    SelectFilter::make('author')->relationship('author', 'name'),
                 ]),
             ]);
     }

--- a/tests/src/Fixtures/Providers/AdminPanelProvider.php
+++ b/tests/src/Fixtures/Providers/AdminPanelProvider.php
@@ -37,6 +37,7 @@ use Filament\Tests\Fixtures\Pages\DatabaseNotificationsBrowserTest;
 use Filament\Tests\Fixtures\Pages\DatePickerBrowserTest;
 use Filament\Tests\Fixtures\Pages\DateTimePickerTest;
 use Filament\Tests\Fixtures\Pages\FileUploadBrowserTest;
+use Filament\Tests\Fixtures\Pages\FilterPanelBrowserTest;
 use Filament\Tests\Fixtures\Pages\IndividualColumnSearchBrowserTest;
 use Filament\Tests\Fixtures\Pages\InfolistEntriesBrowserTest;
 use Filament\Tests\Fixtures\Pages\KeyValueTest;
@@ -128,6 +129,7 @@ class AdminPanelProvider extends PanelProvider
                 DatePickerBrowserTest::class,
                 DateTimePickerTest::class,
                 FileUploadBrowserTest::class,
+                FilterPanelBrowserTest::class,
                 IndividualColumnSearchBrowserTest::class,
                 InfolistEntriesBrowserTest::class,
                 KeyValueTest::class,

--- a/tests/src/Tables/Filters/FilterPanelBrowserTest.php
+++ b/tests/src/Tables/Filters/FilterPanelBrowserTest.php
@@ -16,9 +16,10 @@ it('renders filter panels in the browser with dialog triggers and no accessibili
         Post::factory()->count(3)->create();
 
         visit('/filter-panel-browser-test')
-            // The AboveContent panel renders above the table...
+            // The AboveContent panel renders above the table, the BelowContent panel below it...
             ->assertPresent('.fi-ta-filters-above-content-ctn')
-            // ...and the Dropdown + Modal panels render as toolbar triggers.
+            ->assertPresent('.fi-ta-filters-below-content')
+            // ...and the Dropdown panel renders as a toolbar trigger.
             ->assertPresent('button[title="Filter"]')
             ->assertNoSmoke()
             ->assertNoAccessibilityIssues();

--- a/tests/src/Tables/Filters/FilterPanelBrowserTest.php
+++ b/tests/src/Tables/Filters/FilterPanelBrowserTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use Filament\Tests\Fixtures\Models\Post;
+use Filament\Tests\Fixtures\Models\User;
+use Filament\Tests\Tables\TestCase;
+use Illuminate\Support\Facades\Artisan;
+
+uses(TestCase::class);
+
+it('renders filter panels in the browser with dialog triggers and no accessibility issues', function (): void {
+    retry(10, function (): void {
+        Artisan::call('filament:assets');
+
+        $this->actingAs(User::factory()->create());
+
+        Post::factory()->count(3)->create();
+
+        visit('/filter-panel-browser-test')
+            // The AboveContent panel renders above the table...
+            ->assertPresent('.fi-ta-filters-above-content-ctn')
+            // ...and the Dropdown + Modal panels render as toolbar triggers.
+            ->assertPresent('button[title="Filter"]')
+            ->assertNoSmoke()
+            ->assertNoAccessibilityIssues();
+
+        visit('/filter-panel-browser-test')
+            ->inDarkMode()
+            ->assertNoAccessibilityIssues();
+    });
+})->group('browser');

--- a/tests/src/Tables/Filters/FilterPanelRenderTest.php
+++ b/tests/src/Tables/Filters/FilterPanelRenderTest.php
@@ -1,6 +1,14 @@
 <?php
 
+use Filament\Actions\Action;
+use Filament\Support\Enums\Width;
+use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Enums\FiltersResetActionPosition;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\FilterPanel;
+use Filament\Tables\Table;
 use Filament\Tests\Fixtures\Livewire\PostsTable;
+use Filament\Tests\Fixtures\Livewire\PostsTableWithConfigurableFilterPanels as Fixture;
 use Filament\Tests\Fixtures\Livewire\PostsTableWithFilterPanels;
 use Filament\Tests\Fixtures\Models\Post;
 use Filament\Tests\Tables\TestCase;
@@ -8,6 +16,10 @@ use Filament\Tests\Tables\TestCase;
 use function Filament\Tests\livewire;
 
 uses(TestCase::class);
+
+beforeEach(function (): void {
+    Fixture::$configureUsing = null;
+});
 
 it('renders each panel in its location and both drive the table', function (): void {
     $posts = Post::factory()->count(10)->create();
@@ -28,4 +40,109 @@ it('renders a flat table in the dropdown only, not above content', function (): 
     livewire(PostsTable::class)
         ->assertDontSeeHtml('fi-ta-filters-above-content-ctn')
         ->assertSeeHtml('fi-ta-filters-dropdown');
+});
+
+it('applies a panel\'s own `width()` to the rendered side panel', function (): void {
+    // The side panel is registered second, so a width taken from the first panel would be wrong.
+    Fixture::$configureUsing = fn (Table $table): Table => $table->filters([
+        FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('is_published')]),
+        FilterPanel::make(FiltersLayout::BeforeContent, [Filter::make('is_recent')])
+            ->width(Width::Medium),
+    ]);
+
+    expect(livewire(Fixture::class)->html())
+        ->toContain('fi-ta-filters-before-content-ctn lg:fi-open fi-width-md');
+
+    Fixture::$configureUsing = fn (Table $table): Table => $table->filters([
+        FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('is_published')]),
+        FilterPanel::make(FiltersLayout::BeforeContent, [Filter::make('is_recent')]),
+    ]);
+
+    expect(livewire(Fixture::class)->html())
+        ->toContain('fi-ta-filters-before-content-ctn lg:fi-open fi-width-xs');
+});
+
+it('applies a panel\'s `maxHeight()` to the rendered dropdown', function (): void {
+    Fixture::$configureUsing = fn (Table $table): Table => $table->filters([
+        FilterPanel::make(FiltersLayout::Dropdown, [Filter::make('is_published')])
+            ->maxHeight('400px'),
+    ]);
+
+    expect(livewire(Fixture::class)->html())->toContain('max-height: 400px;');
+});
+
+it('applies a panel\'s `triggerAction()` to the rendered trigger', function (): void {
+    Fixture::$configureUsing = fn (Table $table): Table => $table->filters([
+        FilterPanel::make(FiltersLayout::Dropdown, [Filter::make('is_published')])
+            ->triggerAction(fn (Action $action): Action => $action->label('Narrow these down')),
+    ]);
+
+    expect(livewire(Fixture::class)->html())->toContain('Narrow these down');
+});
+
+it('renders a panel\'s reset action in the position the panel asks for', function (): void {
+    Fixture::$configureUsing = fn (Table $table): Table => $table->filters([
+        FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('is_published')])
+            ->resetActionPosition(FiltersResetActionPosition::Footer),
+    ]);
+
+    $footerHtml = livewire(Fixture::class)->html();
+
+    // In the footer the reset renders as a button, in the header as a link.
+    expect($footerHtml)->toMatch('/<button[^>]*\bfi-btn\b[^>]*wire:click="resetTableFiltersForm/');
+    expect($footerHtml)->not->toMatch('/<button[^>]*\bfi-link\b[^>]*wire:click="resetTableFiltersForm/');
+
+    Fixture::$configureUsing = fn (Table $table): Table => $table->filters([
+        FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('is_published')])
+            ->resetActionPosition(FiltersResetActionPosition::Header),
+    ]);
+
+    $headerHtml = livewire(Fixture::class)->html();
+
+    expect($headerHtml)->toMatch('/<button[^>]*\bfi-link\b[^>]*wire:click="resetTableFiltersForm/');
+    expect($headerHtml)->not->toMatch('/<button[^>]*\bfi-btn\b[^>]*wire:click="resetTableFiltersForm/');
+});
+
+it('opens a non-collapsible side panel from the filter trigger on mobile only', function (): void {
+    Fixture::$configureUsing = fn (Table $table): Table => $table->filters([
+        FilterPanel::make(FiltersLayout::BeforeContent, [Filter::make('is_published')]),
+    ]);
+
+    $html = livewire(Fixture::class)->html();
+
+    // The panel is laid out beside the table from `lg` up...
+    expect($html)->toContain('fi-ta-filters-before-content-ctn lg:fi-open');
+    // ...so its trigger is only needed below that breakpoint, where it floats open instead.
+    expect($html)->toContain('fi-ta-filters-trigger-action-ctn lg:fi-hidden');
+});
+
+it('keeps the filter trigger at every breakpoint for a collapsible side panel', function (): void {
+    Fixture::$configureUsing = fn (Table $table): Table => $table->filters([
+        FilterPanel::make(FiltersLayout::BeforeContentCollapsible, [Filter::make('is_published')]),
+    ]);
+
+    $html = livewire(Fixture::class)->html();
+
+    expect($html)->not->toContain('fi-ta-filters-before-content-ctn lg:fi-open');
+    expect($html)->toContain('class="fi-ta-filters-trigger-action-ctn"');
+});
+
+it('resolves collapsibility from the relevant panel rather than the whole table', function (): void {
+    Fixture::$configureUsing = fn (Table $table): Table => $table->filters([
+        FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('is_published')]),
+        FilterPanel::make(FiltersLayout::BeforeContentCollapsible, [Filter::make('is_recent')]),
+    ]);
+
+    $html = livewire(Fixture::class)->html();
+
+    // The above-content panel is always visible, so a collapsible side panel alongside it
+    // must not make it collapse too.
+    expect($html)->toContain('fi-ta-filters-above-content-ctn');
+    expect($html)->not->toContain('x-show="areFiltersOpen"');
+
+    Fixture::$configureUsing = fn (Table $table): Table => $table->filters([
+        FilterPanel::make(FiltersLayout::AboveContentCollapsible, [Filter::make('is_published')]),
+    ]);
+
+    expect(livewire(Fixture::class)->html())->toContain('x-show="areFiltersOpen"');
 });

--- a/tests/src/Tables/Filters/FilterPanelRenderTest.php
+++ b/tests/src/Tables/Filters/FilterPanelRenderTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Filament\Tests\Fixtures\Livewire\PostsTable;
+use Filament\Tests\Fixtures\Livewire\PostsTableWithFilterPanels;
+use Filament\Tests\Fixtures\Models\Post;
+use Filament\Tests\Tables\TestCase;
+
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+it('renders each panel in its location and both drive the table', function (): void {
+    $posts = Post::factory()->count(10)->create();
+
+    // `is_published` is in the AboveContent panel; `author` in the Dropdown panel.
+    livewire(PostsTableWithFilterPanels::class)
+        ->assertSeeHtml('fi-ta-filters-above-content-ctn')
+        ->assertSeeHtml('fi-ta-filters-dropdown')
+        ->assertCanSeeTableRecords($posts)
+        ->filterTable('is_published')
+        ->assertCanSeeTableRecords($posts->where('is_published', true))
+        ->assertCanNotSeeTableRecords($posts->where('is_published', false));
+});
+
+it('renders a flat table in the dropdown only, not above content', function (): void {
+    Post::factory()->count(3)->create();
+
+    livewire(PostsTable::class)
+        ->assertDontSeeHtml('fi-ta-filters-above-content-ctn')
+        ->assertSeeHtml('fi-ta-filters-dropdown');
+});

--- a/tests/src/Tables/Filters/FilterPanelTest.php
+++ b/tests/src/Tables/Filters/FilterPanelTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\FilterPanel;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Filament\Tests\Fixtures\Livewire\PostsTable;
+use Filament\Tests\Fixtures\Livewire\PostsTableWithFilterPanels;
+use Filament\Tests\Tables\TestCase;
+
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+it('holds a location and its filters', function (): void {
+    $panel = FilterPanel::make(FiltersLayout::AboveContent, [
+        Filter::make('is_published'),
+        Filter::make('is_featured'),
+    ]);
+
+    expect($panel->getLocation())->toBe(FiltersLayout::AboveContent);
+    expect(array_map(fn ($filter): string => $filter->getName(), $panel->getFilters()))
+        ->toBe(['is_published', 'is_featured']);
+});
+
+it('returns `null` for unset panel config by default', function (): void {
+    $panel = FilterPanel::make(FiltersLayout::Dropdown, [Filter::make('a')]);
+
+    expect($panel->getColumns())->toBeNull();
+    expect($panel->getWidth())->toBeNull();
+    expect($panel->getMaxHeight())->toBeNull();
+    expect($panel->getResetActionPosition())->toBeNull();
+});
+
+it('stores per-panel `columns()`', function (): void {
+    $panel = FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('a')])->columns(4);
+
+    expect($panel->getColumns())->toBe(4);
+});
+
+it('flattens panel filters into the name-keyed map so `getFilters()` is unchanged in shape', function (): void {
+    $table = livewire(PostsTableWithFilterPanels::class)->instance()->getTable();
+
+    expect(array_keys($table->getFilters()))->toContain('is_published', 'author');
+    expect($table->getFilter('author'))->toBeInstanceOf(SelectFilter::class);
+});
+
+it('exposes the panels via `getFilterPanels()`', function (): void {
+    $table = livewire(PostsTableWithFilterPanels::class)->instance()->getTable();
+
+    $panels = $table->getFilterPanels();
+
+    expect($panels)->toHaveCount(2);
+    expect($panels[0]->getLocation())->toBe(FiltersLayout::AboveContent);
+    expect($panels[1]->getLocation())->toBe(FiltersLayout::Dropdown);
+});
+
+it('normalises a flat `filters()` array into one implicit panel at the table layout', function (): void {
+    // `PostsTable` uses a flat filters array and no `filtersLayout()`, so the default is `Dropdown`.
+    $table = livewire(PostsTable::class)->instance()->getTable();
+
+    $panels = $table->getFilterPanels();
+
+    expect($panels)->toHaveCount(1);
+    expect($panels[0]->getLocation())->toBe(FiltersLayout::Dropdown);
+    expect(count($panels[0]->getFilters()))->toBe(count($table->getFilters()));
+});
+
+it('throws when mixing a `FilterPanel` and a loose filter in `filters()`', function (): void {
+    $table = Table::make(livewire(PostsTable::class)->instance());
+
+    expect(fn () => $table->filters([
+        FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('a')]),
+        Filter::make('b'),
+    ]))->toThrow(LogicException::class);
+});
+
+it('throws when two panels target the same location', function (): void {
+    $table = Table::make(livewire(PostsTable::class)->instance());
+
+    expect(fn () => $table->filters([
+        FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('a')]),
+        FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('b')]),
+    ]))->toThrow(LogicException::class);
+});

--- a/tests/src/Tables/Filters/FilterPanelTest.php
+++ b/tests/src/Tables/Filters/FilterPanelTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Filament\Schemas\Schema;
+use Filament\Support\Enums\Width;
 use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Enums\FiltersResetActionPosition;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\FilterPanel;
 use Filament\Tables\Filters\SelectFilter;
@@ -187,4 +189,70 @@ it('keeps the filter trigger reset action global when no location is given', fun
         ->first(fn ($action): bool => $action->getName() === 'resetFilters');
 
     expect($resetAction?->getLivewireClickHandler())->toBe('resetTableFiltersForm');
+});
+
+it('normalises a flat `filters($filters, layout:)` array to an implicit panel at that layout', function (): void {
+    $table = Table::make(livewire(PostsTable::class)->instance())
+        ->filters([Filter::make('a'), Filter::make('b')], layout: FiltersLayout::AboveContent);
+
+    $panels = $table->getFilterPanels();
+
+    expect($panels)->toHaveCount(1);
+    expect($panels[0]->getLocation())->toBe(FiltersLayout::AboveContent);
+    expect(count($panels[0]->getFilters()))->toBe(2);
+});
+
+it('removes filters from every panel with the global "remove all"', function (): void {
+    $posts = Post::factory()->count(10)->create();
+
+    $author = $posts->first()->author;
+
+    $livewire = livewire(PostsTableWithFilterPanels::class)
+        ->filterTable('is_published')      // AboveContent panel
+        ->filterTable('author', $author);  // Dropdown panel
+
+    expect($livewire->instance()->getTable()->getActiveFiltersCount())->toBe(2);
+
+    $livewire->call('removeTableFilters');
+
+    expect($livewire->instance()->getTable()->getActiveFiltersCount())->toBe(0);
+});
+
+it('throws when `pushFilters()` adds a loose filter to a panel-mode table', function (): void {
+    $table = Table::make(livewire(PostsTable::class)->instance())
+        ->filters([FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('a')])]);
+
+    expect(fn () => $table->pushFilters([Filter::make('b')]))->toThrow(LogicException::class);
+});
+
+it('throws when `pushFilters()` adds a panel to a flat-mode table', function (): void {
+    $table = Table::make(livewire(PostsTable::class)->instance())
+        ->filters([Filter::make('a')]);
+
+    expect(fn () => $table->pushFilters([
+        FilterPanel::make(FiltersLayout::Dropdown, [Filter::make('b')]),
+    ]))->toThrow(LogicException::class);
+});
+
+it('resolves per-panel `width()`, `maxHeight()` and `resetActionPosition()` with fallthrough', function (): void {
+    $table = Table::make(livewire(PostsTable::class)->instance())
+        ->filtersFormMaxHeight('300px')
+        ->filters([
+            FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('a')])
+                ->width(Width::Large)
+                ->maxHeight('500px')
+                ->resetActionPosition(FiltersResetActionPosition::Footer),
+            FilterPanel::make(FiltersLayout::Dropdown, [Filter::make('b')]),
+        ]);
+
+    [$abovePanel, $dropdownPanel] = $table->getFilterPanels();
+
+    // Panel overrides win.
+    expect($table->getFiltersFormWidthForPanel($abovePanel))->toBe(Width::Large);
+    expect($table->getFiltersFormMaxHeightForPanel($abovePanel))->toBe('500px');
+    expect($table->getResetActionPositionForPanel($abovePanel))->toBe(FiltersResetActionPosition::Footer);
+
+    // Unset falls through to the table-level default, then the per-layout default.
+    expect($table->getFiltersFormMaxHeightForPanel($dropdownPanel))->toBe('300px');
+    expect($table->getResetActionPositionForPanel($dropdownPanel))->toBe(FiltersResetActionPosition::Header);
 });

--- a/tests/src/Tables/Filters/FilterPanelTest.php
+++ b/tests/src/Tables/Filters/FilterPanelTest.php
@@ -9,13 +9,19 @@ use Filament\Tables\Filters\FilterPanel;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Filament\Tests\Fixtures\Livewire\PostsTable;
+use Filament\Tests\Fixtures\Livewire\PostsTableWithConfigurableFilterPanels;
 use Filament\Tests\Fixtures\Livewire\PostsTableWithFilterPanels;
 use Filament\Tests\Fixtures\Models\Post;
 use Filament\Tests\Tables\TestCase;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 use function Filament\Tests\livewire;
 
 uses(TestCase::class);
+
+beforeEach(function (): void {
+    PostsTableWithConfigurableFilterPanels::$configureUsing = null;
+});
 
 it('holds a location and its filters', function (): void {
     $panel = FilterPanel::make(FiltersLayout::AboveContent, [
@@ -202,7 +208,7 @@ it('resets only the filters belonging to the given panel', function (): void {
 it('scopes the filter trigger reset action to its panel location', function (): void {
     $table = livewire(PostsTableWithFilterPanels::class)->instance()->getTable();
 
-    $resetAction = collect($table->getFiltersTriggerAction(FiltersLayout::Dropdown)->getExtraModalFooterActions())
+    $resetAction = collect($table->getFiltersTriggerAction($table->getFilterPanel('Dropdown'))->getExtraModalFooterActions())
         ->first(fn ($action): bool => $action->getName() === 'resetFilters');
 
     expect($resetAction?->getLivewireClickHandler())->toBe("resetTableFiltersForm('Dropdown')");
@@ -281,4 +287,154 @@ it('resolves per-panel `width()`, `maxHeight()` and `resetActionPosition()` with
     // Unset falls through to the table-level default, then the per-layout default.
     expect($table->getFiltersFormMaxHeightForPanel($dropdownPanel))->toBe('300px');
     expect($table->getResetActionPositionForPanel($dropdownPanel))->toBe(FiltersResetActionPosition::Header);
+});
+
+it('accepts a supported filter panel layout combination', function (array $locations): void {
+    $table = Table::make(livewire(PostsTable::class)->instance())
+        ->filters(array_map(
+            fn (FiltersLayout $location, int $index): FilterPanel => FilterPanel::make($location, [Filter::make("filter{$index}")]),
+            $locations,
+            array_keys($locations),
+        ));
+
+    expect($table->getFilterPanels())->toHaveCount(count($locations));
+})->with([
+    'an interactive panel on its own' => [[FiltersLayout::Dropdown]],
+    '`Dropdown` with `AboveContent`' => [[FiltersLayout::AboveContent, FiltersLayout::Dropdown]],
+    '`Modal` with `AboveContent`, `BelowContent` and `Hidden`' => [[FiltersLayout::AboveContent, FiltersLayout::Modal, FiltersLayout::BelowContent, FiltersLayout::Hidden]],
+    '`AboveContentCollapsible` with `BelowContent`' => [[FiltersLayout::AboveContentCollapsible, FiltersLayout::BelowContent]],
+    '`BeforeContent` with `AboveContent`' => [[FiltersLayout::BeforeContent, FiltersLayout::AboveContent]],
+    '`AfterContentCollapsible` with `BelowContent`' => [[FiltersLayout::AfterContentCollapsible, FiltersLayout::BelowContent]],
+    'no interactive panel at all' => [[FiltersLayout::AboveContent, FiltersLayout::BelowContent]],
+]);
+
+it('rejects an unsupported filter panel layout combination', function (array $locations): void {
+    $panels = array_map(
+        fn (FiltersLayout $location, int $index): FilterPanel => FilterPanel::make($location, [Filter::make("filter{$index}")]),
+        $locations,
+        array_keys($locations),
+    );
+
+    expect(fn (): Table => Table::make(livewire(PostsTable::class)->instance())->filters($panels))
+        ->toThrow(LogicException::class);
+})->with([
+    '`Dropdown` and `Modal`' => [[FiltersLayout::Dropdown, FiltersLayout::Modal]],
+    '`BeforeContent` and `AfterContent`' => [[FiltersLayout::BeforeContent, FiltersLayout::AfterContent]],
+    '`BeforeContentCollapsible` and `AfterContentCollapsible`' => [[FiltersLayout::BeforeContentCollapsible, FiltersLayout::AfterContentCollapsible]],
+    '`Dropdown` and `BeforeContent`' => [[FiltersLayout::Dropdown, FiltersLayout::BeforeContent]],
+    '`Modal` and `AfterContentCollapsible`' => [[FiltersLayout::Modal, FiltersLayout::AfterContentCollapsible]],
+    '`Dropdown` and `AboveContentCollapsible`' => [[FiltersLayout::Dropdown, FiltersLayout::AboveContentCollapsible]],
+    '`AboveContent` and `AboveContentCollapsible`' => [[FiltersLayout::AboveContent, FiltersLayout::AboveContentCollapsible]],
+]);
+
+it('rejects an unsupported combination introduced by `pushFilters()`', function (): void {
+    $table = Table::make(livewire(PostsTable::class)->instance())
+        ->filters([FilterPanel::make(FiltersLayout::Dropdown, [Filter::make('a')])]);
+
+    expect(fn (): Table => $table->pushFilters([FilterPanel::make(FiltersLayout::Modal, [Filter::make('b')])]))
+        ->toThrow(LogicException::class);
+});
+
+it('names the conflicting locations in the `LogicException`', function (): void {
+    expect(fn (): Table => Table::make(livewire(PostsTable::class)->instance())->filters([
+        FilterPanel::make(FiltersLayout::Dropdown, [Filter::make('a')]),
+        FilterPanel::make(FiltersLayout::Modal, [Filter::make('b')]),
+    ]))->toThrow(LogicException::class, 'but [Dropdown] and [Modal] were used together');
+
+    expect(fn (): Table => Table::make(livewire(PostsTable::class)->instance())->filters([
+        FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('a')]),
+        FilterPanel::make(FiltersLayout::AboveContentCollapsible, [Filter::make('b')]),
+    ]))->toThrow(LogicException::class, 'occupy the same location above the table');
+});
+
+it('still merges panels that share a location without tripping the layout contract', function (): void {
+    $table = Table::make(livewire(PostsTable::class)->instance())
+        ->filters([
+            FilterPanel::make(FiltersLayout::Dropdown, [Filter::make('a')]),
+            FilterPanel::make(FiltersLayout::Dropdown, [Filter::make('b')]),
+        ]);
+
+    expect($table->getFilterPanels())->toHaveCount(1);
+    expect($table->getFilterPanels()[0]->getFilters())->toHaveCount(2);
+});
+
+it('renders a table whose panel filters are all hidden', function (): void {
+    $posts = Post::factory()->count(3)->create();
+
+    PostsTableWithConfigurableFilterPanels::$configureUsing = fn (Table $table): Table => $table
+        ->filters([
+            FilterPanel::make(FiltersLayout::AboveContent, [
+                Filter::make('is_published')->hidden(),
+            ]),
+            FilterPanel::make(FiltersLayout::Dropdown, [
+                Filter::make('is_recent')->hidden(),
+            ]),
+        ]);
+
+    $livewire = livewire(PostsTableWithConfigurableFilterPanels::class)
+        ->assertCanSeeTableRecords($posts);
+
+    $table = $livewire->instance()->getTable();
+
+    // Every panel drops out once its filters are hidden, so the form configuration must not
+    // assume that a first panel exists.
+    expect($table->getFilterPanels())->toBeEmpty();
+    expect($table->getFiltersFormColumns())->not->toBeNull();
+    expect(fn (): mixed => $table->getFiltersFormWidth())->not->toThrow(Throwable::class);
+});
+
+it('excludes hidden filters from a panel\'s active filter count', function (): void {
+    Post::factory()->count(3)->create();
+
+    PostsTableWithConfigurableFilterPanels::$configureUsing = fn (Table $table): Table => $table
+        ->filters([
+            FilterPanel::make(FiltersLayout::AboveContent, [
+                Filter::make('is_published'),
+                Filter::make('is_recent')->hidden(),
+            ]),
+        ]);
+
+    $livewire = livewire(PostsTableWithConfigurableFilterPanels::class)
+        ->set('tableFilters.is_published', ['isActive' => true])
+        ->set('tableFilters.is_recent', ['isActive' => true]);
+
+    $table = $livewire->instance()->getTable();
+
+    // The table never applies `is_recent`, so the panel badge must not advertise it.
+    expect($table->getActiveFiltersCountForPanel($table->getFilterPanels()[0]))->toBe(1);
+});
+
+it('resets one deferred panel without applying another panel\'s pending changes', function (): void {
+    $posts = Post::factory()->count(5)->create();
+
+    PostsTableWithConfigurableFilterPanels::$configureUsing = fn (Table $table): Table => $table
+        ->filters([
+            FilterPanel::make(FiltersLayout::AboveContent, [
+                Filter::make('is_published')
+                    ->query(fn (EloquentBuilder $query): EloquentBuilder => $query->where('is_published', true)),
+            ]),
+            FilterPanel::make(FiltersLayout::Dropdown, [
+                Filter::make('hides_everything')
+                    ->query(fn (EloquentBuilder $query): EloquentBuilder => $query->whereRaw('1 = 0')),
+            ]),
+        ]);
+
+    $livewire = livewire(PostsTableWithConfigurableFilterPanels::class)
+        // Applied in the above-content panel...
+        ->set('tableFilters.is_published', ['isActive' => true])
+        // ...while the dropdown panel only holds a pending change, as a deferred filters form
+        // writes to `tableDeferredFilters` until its apply action is used.
+        ->set('tableDeferredFilters.hides_everything', ['isActive' => true]);
+
+    $livewire->call('resetTableFiltersForm', 'AboveContent');
+
+    // The reset panel is cleared...
+    expect($livewire->get('tableFilters.is_published.isActive'))->toBeFalsy();
+    // ...the other panel's pending change is neither applied...
+    expect($livewire->get('tableFilters.hides_everything.isActive'))->toBeFalsy();
+    // ...nor discarded.
+    expect($livewire->get('tableDeferredFilters.hides_everything.isActive'))->toBeTrue();
+
+    // Had the pending change been applied, no records would remain.
+    $livewire->assertCanSeeTableRecords($posts);
 });

--- a/tests/src/Tables/Filters/FilterPanelTest.php
+++ b/tests/src/Tables/Filters/FilterPanelTest.php
@@ -149,3 +149,42 @@ it('throws when `filtersFormSchema()` is combined with panels', function (): voi
 
     expect(fn () => $table->getFiltersFormSchema())->toThrow(LogicException::class);
 });
+
+it('resets only the filters belonging to the given panel', function (): void {
+    $posts = Post::factory()->count(10)->create();
+
+    $author = $posts->first()->author;
+
+    $livewire = livewire(PostsTableWithFilterPanels::class)
+        ->filterTable('is_published')      // AboveContent panel
+        ->filterTable('author', $author);  // Dropdown panel
+
+    expect($livewire->instance()->getTable()->getActiveFiltersCount())->toBe(2);
+
+    $livewire->call('resetTableFiltersForm', 'AboveContent');
+
+    $table = $livewire->instance()->getTable();
+
+    [$abovePanel, $dropdownPanel] = $table->getFilterPanels();
+
+    expect($table->getActiveFiltersCountForPanel($abovePanel))->toBe(0);
+    expect($table->getActiveFiltersCountForPanel($dropdownPanel))->toBe(1);
+});
+
+it('scopes the filter trigger reset action to its panel location', function (): void {
+    $table = livewire(PostsTableWithFilterPanels::class)->instance()->getTable();
+
+    $resetAction = collect($table->getFiltersTriggerAction(FiltersLayout::Dropdown)->getExtraModalFooterActions())
+        ->first(fn ($action): bool => $action->getName() === 'resetFilters');
+
+    expect($resetAction?->getLivewireClickHandler())->toBe("resetTableFiltersForm('Dropdown')");
+});
+
+it('keeps the filter trigger reset action global when no location is given', function (): void {
+    $table = livewire(PostsTableWithFilterPanels::class)->instance()->getTable();
+
+    $resetAction = collect($table->getFiltersTriggerAction()->getExtraModalFooterActions())
+        ->first(fn ($action): bool => $action->getName() === 'resetFilters');
+
+    expect($resetAction?->getLivewireClickHandler())->toBe('resetTableFiltersForm');
+});

--- a/tests/src/Tables/Filters/FilterPanelTest.php
+++ b/tests/src/Tables/Filters/FilterPanelTest.php
@@ -80,13 +80,39 @@ it('throws when mixing a `FilterPanel` and a loose filter in `filters()`', funct
     ]))->toThrow(LogicException::class);
 });
 
-it('throws when two panels target the same location', function (): void {
-    $table = Table::make(livewire(PostsTable::class)->instance());
+it('merges panels that share a location, keeping the first panel\'s configuration', function (): void {
+    $table = Table::make(livewire(PostsTable::class)->instance())
+        ->filters([
+            FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('a')])->columns(4),
+            FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('b')]),
+        ]);
 
-    expect(fn () => $table->filters([
-        FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('a')]),
-        FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('b')]),
-    ]))->toThrow(LogicException::class);
+    $panels = $table->getFilterPanels();
+
+    expect($panels)->toHaveCount(1);
+    expect($panels[0]->getColumns())->toBe(4); // The first panel's config wins.
+    expect(array_map(fn ($filter): string => $filter->getName(), $panels[0]->getFilters()))->toBe(['a', 'b']);
+    expect(array_keys($table->getFilters()))->toContain('a', 'b');
+});
+
+it('merges a pushed panel into the existing panel at the same location', function (): void {
+    $table = Table::make(livewire(PostsTable::class)->instance())
+        ->filters([
+            FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('a')])->columns(3),
+            FilterPanel::make(FiltersLayout::Dropdown, [Filter::make('b')]),
+        ]);
+
+    // A plugin appends another panel at an already-occupied location.
+    $table->pushFilters([
+        FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('c')])->columns(1),
+    ]);
+
+    $abovePanel = collect($table->getFilterPanels())
+        ->first(fn ($panel): bool => $panel->getLocation() === FiltersLayout::AboveContent);
+
+    expect($abovePanel->getColumns())->toBe(3); // The existing panel's config wins.
+    expect(array_map(fn ($filter): string => $filter->getName(), $abovePanel->getFilters()))->toBe(['a', 'c']);
+    expect(array_keys($table->getFilters()))->toContain('a', 'b', 'c');
 });
 
 it('builds one container per panel keyed by location', function (): void {

--- a/tests/src/Tables/Filters/FilterPanelTest.php
+++ b/tests/src/Tables/Filters/FilterPanelTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Filament\Schemas\Schema;
 use Filament\Tables\Enums\FiltersLayout;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\FilterPanel;
@@ -7,6 +8,7 @@ use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Filament\Tests\Fixtures\Livewire\PostsTable;
 use Filament\Tests\Fixtures\Livewire\PostsTableWithFilterPanels;
+use Filament\Tests\Fixtures\Models\Post;
 use Filament\Tests\Tables\TestCase;
 
 use function Filament\Tests\livewire;
@@ -83,4 +85,67 @@ it('throws when two panels target the same location', function (): void {
         FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('a')]),
         FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('b')]),
     ]))->toThrow(LogicException::class);
+});
+
+it('builds one container per panel keyed by location', function (): void {
+    $keys = collect(livewire(PostsTableWithFilterPanels::class)->instance()->getTableFiltersForm()->getComponents(withHidden: true))
+        ->map(fn ($component): ?string => $component->getKey(isAbsolute: false))
+        ->all();
+
+    expect($keys)->toContain('filterPanel::AboveContent')->toContain('filterPanel::Dropdown');
+});
+
+it('builds a flat schema for a flat, single-panel table', function (): void {
+    $keys = collect(livewire(PostsTable::class)->instance()->getTableFiltersForm()->getComponents(withHidden: true))
+        ->map(fn ($component): ?string => $component->getKey(isAbsolute: false))
+        ->all();
+
+    expect($keys)->not->toContain('filterPanel::Dropdown')->toContain('is_published');
+});
+
+it('resolves per-panel `columns()` with fallthrough', function (): void {
+    $table = livewire(PostsTableWithFilterPanels::class)->instance()->getTable();
+
+    [$abovePanel, $dropdownPanel] = $table->getFilterPanels();
+
+    // `AboveContent` panel sets `columns(4)` explicitly.
+    expect($table->getFiltersFormColumnsForPanel($abovePanel))->toBe(4);
+    // `Dropdown` panel sets nothing => falls through to the per-layout default (1 for a dialog).
+    expect($table->getFiltersFormColumnsForPanel($dropdownPanel))->toBe(1);
+});
+
+it('counts active filters per panel', function (): void {
+    Post::factory()->count(5)->create();
+
+    $table = livewire(PostsTableWithFilterPanels::class)
+        ->filterTable('is_published')
+        ->instance()
+        ->getTable();
+
+    [$abovePanel, $dropdownPanel] = $table->getFilterPanels();
+
+    expect($table->getActiveFiltersCountForPanel($abovePanel))->toBe(1);
+    expect($table->getActiveFiltersCountForPanel($dropdownPanel))->toBe(0);
+});
+
+it('returns a scoped child schema per panel', function (): void {
+    $table = livewire(PostsTableWithFilterPanels::class)->instance()->getTable();
+
+    $aboveContent = $table->getFiltersFormForPanel($table->getFilterPanels()[0]);
+
+    expect($aboveContent)->toBeInstanceOf(Schema::class);
+    expect($aboveContent->toHtml())
+        ->toContain('is_published')
+        ->not->toContain('tableFilters.author');
+});
+
+it('throws when `filtersFormSchema()` is combined with panels', function (): void {
+    $table = Table::make(livewire(PostsTable::class)->instance())
+        ->filters([
+            FilterPanel::make(FiltersLayout::AboveContent, [Filter::make('a')]),
+            FilterPanel::make(FiltersLayout::Dropdown, [Filter::make('b')]),
+        ])
+        ->filtersFormSchema(fn (array $filters): array => array_values($filters));
+
+    expect(fn () => $table->getFiltersFormSchema())->toThrow(LogicException::class);
 });


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This Pull Request introduces the ability to place filters in multiple locations and closes #14956.

It is a rework of the original Pull Request #20139. Thanks @danharrin for taking the time to think through the API properly.

The PR introduces a new `FilterPanel` component. Its first argument accepts a `FiltersLayout`, and the second argument is an array of filters that should be displayed in that location:

```php
$table
    ->filters([
        FilterPanel::make(FiltersLayout::AboveContent, [
            SelectFilter::make('status'),
            SelectFilter::make('category'),
        ])->columns(2),

        FilterPanel::make(FiltersLayout::Dropdown, [
            SelectFilter::make('author'),
        ]),
    ]);
```

FilterPanel exposes the same configuration methods that are currently available on the table via the `filtersForm*` / `filters*` methods:

- `columns()`
- `width()`
- `maxHeight()`
- `resetActionPosition()`
- `triggerAction()`

`filtersApplyAction()` was intentionally not included, as the Apply action behaves globally regardless of which filter panel it is triggered from.

If a setting is not explicitly overridden, it falls back to the global table configuration.

**Intentional design decisions**
- `Apply filters` button applies filters from all panels, regardless of which panel’s button is clicked.
- Reset filters within a panel resets only the filters belonging to that panel (this behavior has been preserved from the first version).
- The Reset filters button (the “X” button above the table) resets all filters across all panels.
- `Modal` and `Dropdown` panels display two filter icons. I believe this is acceptable, as developers can assign different icons to each panel or simply use only one of them.
- The badge displayed on the filter icons for `Modal` and `Dropdown` panels shows only the number of active filters within that panel.
- Creating multiple `FilterPanel` instances for the same `FiltersLayout` automatically merges their filters.
- `pushFilters()` also merges filters into the specified panel.
- Mixing `FilterPanel` instances with standard filters is intentionally not supported. The following code will throw `LogicException`:
```php
$table
    ->filters([
        FilterPanel::make(FiltersLayout::AboveContent, [
            SelectFilter::make('status'),
            SelectFilter::make('category'),
        ])->columns(2),

        SelectFilter::make('author'),
    ]);
```

Tested and verified - everything works as expected. Backward compatibility is preserved.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
