### PR TITLE
feat:Add HasRenderHooks concern, enabling Pages, Widgets, RelationManagers, and Resources to declare their own render hooks

### DIFF
--- a/docs/09-advanced/01-render-hooks.md
+++ b/docs/09-advanced/01-render-hooks.md
@@ -257,6 +257,76 @@ FilamentView::registerRenderHook(
 );
 ```
 
+## Registering render hooks from within a class
+
+Instead of registering a scoped render hook from a service provider, you can
+declare it directly on the class it belongs to, using the
+`Filament\Livewire\Concerns\HasRenderHooks` trait. This trait is already
+included by default on:
+
+- Pages
+- Table widgets
+- Relation managers
+
+To use it, override `getRenderHooks()`, returning an array that maps render
+hook names to their callbacks:
+
+```php
+use Filament\View\PanelsRenderHook;
+use Illuminate\Contracts\View\View;
+
+class EditUser extends EditRecord
+{
+    protected function getRenderHooks(): array
+    {
+        return [
+            PanelsRenderHook::PAGE_START => fn (): View => view('warning-banner'),
+        ];
+    }
+}
+```
+
+Each hook registered this way is automatically [scoped](#scoping-render-hooks)
+to the declaring class, so you don't need to pass a `scopes` argument
+yourself. This is functionally equivalent to calling:
+
+```php
+FilamentView::registerRenderHook(
+    PanelsRenderHook::PAGE_START,
+    fn (): View => view('warning-banner'),
+    scopes: EditUser::class,
+);
+```
+
+### Registering render hooks on a resource
+
+`Filament\Resources\Resource` is not a Livewire component, so instead it uses
+`Filament\Resources\Resource\Concerns\HasRenderHooks`, which exposes a
+static `getRenderHooks()` method:
+
+```php
+use Filament\Resources\Resource;
+use Filament\View\PanelsRenderHook;
+use Illuminate\Contracts\View\View;
+
+class UserResource extends Resource
+{
+    public static function getRenderHooks(): array
+    {
+        return [
+            PanelsRenderHook::PAGE_START => fn (): View => view('resource-banner'),
+        ];
+    }
+}
+```
+
+Any hooks declared this way are automatically picked up by every page
+belonging to the resource, and registered scoped to each individual page
+class — so you don't need to repeat the hook on every page.
+
+If a page and its resource both declare a hook under the same name, the
+page's hook takes precedence for that page.
+
 ## Rendering hooks
 
 Plugin developers might find it useful to expose render hooks to their users. You do not need to register them anywhere, simply output them in Blade like so:

--- a/packages/panels/src/Livewire/Concerns/HasRenderHooks.php
+++ b/packages/panels/src/Livewire/Concerns/HasRenderHooks.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Filament\Livewire\Concerns;
+
+use Filament\Support\Facades\FilamentView;
+
+trait HasRenderHooks
+{
+    public function bootHasRenderHooks(): void
+    {
+        foreach ($this->getRenderHooks() as $name => $hook) {
+            FilamentView::registerRenderHook($name, $hook, static::class);
+        }
+    }
+
+    /**
+     * @return array<string, callable(): \Illuminate\Contracts\View\View|string>
+     */
+    protected function getRenderHooks(): array
+    {
+        return [];
+    }
+}

--- a/packages/panels/src/Pages/BasePage.php
+++ b/packages/panels/src/Pages/BasePage.php
@@ -5,6 +5,7 @@ namespace Filament\Pages;
 use Closure;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Livewire\Concerns\HasRenderHooks;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasRenderHookScopes;
 use Filament\Schemas\Contracts\HasSchemas;
@@ -19,6 +20,7 @@ use Livewire\Component;
 
 abstract class BasePage extends Component implements HasActions, HasRenderHookScopes, HasSchemas
 {
+    use HasRenderHooks;
     use InteractsWithActions;
     use InteractsWithSchemas;
 

--- a/packages/panels/src/Resources/Pages/Page.php
+++ b/packages/panels/src/Resources/Pages/Page.php
@@ -25,6 +25,7 @@ use Filament\Resources\Events\RecordSaved;
 use Filament\Resources\Events\RecordUpdated;
 use Filament\Resources\Pages\Concerns\CanAuthorizeResourceAccess;
 use Filament\Resources\Pages\Concerns\InteractsWithParentRecord;
+use Filament\Support\Facades\FilamentView;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -277,15 +278,13 @@ abstract class Page extends BasePage
         return static::$resource;
     }
 
-    /**
-     * @return array<string, callable(): \Illuminate\Contracts\View\View|string>
-     */
-    protected function getRenderHooks(): array
+    public function bootHasRenderHooks(): void
     {
-        return [
-            ...parent::getRenderHooks(),
-            ...static::getResource()::getRenderHooks(),
-        ];
+        $renderHooks = array_merge(static::getResource()::getRenderHooks(), $this->getRenderHooks());
+
+        foreach ($renderHooks as $name => $hook) {
+            FilamentView::registerRenderHook($name, $hook, static::class);
+        }
     }
 
     /**

--- a/packages/panels/src/Resources/Pages/Page.php
+++ b/packages/panels/src/Resources/Pages/Page.php
@@ -278,6 +278,17 @@ abstract class Page extends BasePage
     }
 
     /**
+     * @return array<string, callable(): \Illuminate\Contracts\View\View|string>
+     */
+    protected function getRenderHooks(): array
+    {
+        return [
+            ...parent::getRenderHooks(),
+            ...static::getResource()::getRenderHooks(),
+        ];
+    }
+
+    /**
      * @return array<string>
      */
     public function getRenderHookScopes(): array

--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -25,6 +25,7 @@ use Filament\Actions\RestoreAction;
 use Filament\Actions\RestoreBulkAction;
 use Filament\Actions\ViewAction;
 use Filament\Facades\Filament;
+use Filament\Livewire\Concerns\HasRenderHooks;
 use Filament\Pages\Page;
 use Filament\Resources\Concerns\InteractsWithRelationshipTable;
 use Filament\Resources\Pages\ViewRecord;
@@ -55,6 +56,7 @@ class RelationManager extends Component implements HasActions, HasRenderHookScop
 {
     use CanAuthorizeAccess;
     use CanBeLazy;
+    use HasRenderHooks;
     use InteractsWithActions;
     use InteractsWithRelationshipTable {
         InteractsWithRelationshipTable::makeTable as makeBaseRelationshipTable;

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -3,7 +3,6 @@
 namespace Filament\Resources;
 
 use Filament\Facades\Filament;
-use Filament\Livewire\Concerns\HasRenderHooks;
 use Filament\Panel;
 use Filament\Resources\RelationManagers\RelationGroup;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -21,8 +20,6 @@ use Illuminate\Support\Traits\Macroable;
  */
 abstract class Resource
 {
-    use HasRenderHooks;
-
     use Macroable {
         Macroable::__call as dynamicMacroCall;
     }
@@ -47,6 +44,8 @@ abstract class Resource
 
     use Resource\Concerns\HasNavigation;
     use Resource\Concerns\HasPages;
+
+    use Resource\Concerns\HasRenderHooks;
 
     /** @use Resource\Concerns\HasRoutes<TModel> */
     use Resource\Concerns\HasRoutes;

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -3,6 +3,7 @@
 namespace Filament\Resources;
 
 use Filament\Facades\Filament;
+use Filament\Livewire\Concerns\HasRenderHooks;
 use Filament\Panel;
 use Filament\Resources\RelationManagers\RelationGroup;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -20,6 +21,8 @@ use Illuminate\Support\Traits\Macroable;
  */
 abstract class Resource
 {
+    use HasRenderHooks;
+
     use Macroable {
         Macroable::__call as dynamicMacroCall;
     }

--- a/packages/panels/src/Resources/Resource/Concerns/HasRenderHooks.php
+++ b/packages/panels/src/Resources/Resource/Concerns/HasRenderHooks.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Filament\Resources\Resource\Concerns;
+
+trait HasRenderHooks
+{
+    /**
+     * @return array<string, callable(): \Illuminate\Contracts\View\View|string>
+     */
+    public static function getRenderHooks(): array
+    {
+        return [];
+    }
+}

--- a/packages/widgets/src/TableWidget.php
+++ b/packages/widgets/src/TableWidget.php
@@ -4,6 +4,7 @@ namespace Filament\Widgets;
 
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Livewire\Concerns\HasRenderHooks;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Tables\Concerns\InteractsWithTable;
@@ -14,6 +15,7 @@ use Illuminate\Contracts\Support\Htmlable;
 
 class TableWidget extends Widget implements HasActions, HasSchemas, HasTable
 {
+    use HasRenderHooks;
     use InteractsWithActions;
     use InteractsWithSchemas;
     use InteractsWithTable {


### PR DESCRIPTION
## Summary

Adds a `Filament\Livewire\Concerns\HasRenderHooks` trait that lets a Filament
Livewire component declare its own render hooks directly on the class,
automatically scoped to itself, instead of registering them externally from
a service provider or middleware.

- `Filament\Pages\BasePage` uses it directly.
- `Filament\Widgets\TableWidget` uses it directly.
- `Filament\Resources\RelationManagers\RelationManager` uses it directly.
- `Filament\Resources\Resource` is not a Livewire component, so it gets a
  separate, static-only counterpart:
  `Filament\Resources\Resource\Concerns\HasRenderHooks`, exposing a static
  `getRenderHooks()` with no booting logic.
- `Filament\Resources\Pages\Page` bridges the two by overriding
  `bootHasRenderHooks()` to merge its resource's static hooks with its own
  instance hooks before registering them, all scoped to the page class:

  ```php
  public function bootHasRenderHooks(): void
  {
      $renderHooks = array_merge(static::getResource()::getRenderHooks(), $this->getRenderHooks());

      foreach ($renderHooks as $name => $hook) {
          FilamentView::registerRenderHook($name, $hook, static::class);
      }
  }
  ```

  Because the page's own hooks are merged in second, a hook name declared on
  both the resource and the page resolves in favor of the page — the more
  specific declaration wins.

## Motivation

Registering a render hook scoped to a specific page, widget, relation
manager, or resource currently requires a service provider call:

```php
FilamentView::registerRenderHook(
    PanelsRenderHook::PAGE_START,
    fn (): View => view('warning-banner'),
    scopes: EditUser::class,
);
```

This works, but separates the hook from the class it belongs to. Plugin
authors and anyone shipping reusable pages, widgets, relation managers, or
resources benefit from declaring hooks alongside the class itself, the same
way `getHeaderActions()` or `getHeaderWidgets()` already work.

## Usage

On a page, table widget, or relation manager:

```php
use Filament\View\PanelsRenderHook;
use Illuminate\Contracts\View\View;

class EditUser extends EditRecord
{
    protected function getRenderHooks(): array
    {
        return [
            PanelsRenderHook::PAGE_START => fn (): View => view('warning-banner'),
        ];
    }
}
```

On a resource:

```php
use Filament\Resources\Resource;
use Filament\View\PanelsRenderHook;
use Illuminate\Contracts\View\View;

class UserResource extends Resource
{
    public static function getRenderHooks(): array
    {
        return [
            PanelsRenderHook::PAGE_START => fn (): View => view('resource-banner'),
        ];
    }
}
```

Hooks declared on `UserResource` are automatically picked up by every page
belonging to that resource, and registered scoped to each individual page
class. If a page declares a hook under the same name, the page's hook takes
precedence over the resource's for that page.