### PR TITLE
feat: Add strict hierarchical breadcrumbs option

### DIFF
--- a/docs/06-navigation/01-overview.md
+++ b/docs/06-navigation/01-overview.md
@@ -639,6 +639,25 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+## Strict hierarchical breadcrumbs
+
+By default, breadcrumbs for a page are built from its resource and parent record relationships - for example, an `EditRecord` page's breadcrumbs are derived from its resource's list and view pages, and any parent resources in the case of nested resources.
+
+If you'd prefer breadcrumbs to reflect the full navigational hierarchy of a page instead - including its [cluster](clusters), [navigation group](#grouping-navigation-items), and [navigation parent item](#grouping-navigation-items-under-other-items) - you can enable strict hierarchical breadcrumbs in your [configuration](../05-panel-configuration):
+
+```php
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->breadcrumbs(strictHierarchical: true);
+}
+```
+
+When enabled, a page's breadcrumbs will be built by walking up through its cluster, its navigation group, and its navigation parent item, before falling back to the page's own breadcrumb. This is particularly useful if you rely heavily on [navigation parent items](#grouping-navigation-items-under-other-items) to create deep, third-level navigation, and want the breadcrumb trail to mirror that structure exactly.
+
 ## Reloading the sidebar and topbar
 
 Once a page in the panel is loaded, the sidebar and topbar are not reloaded until you navigate away from the page, or until a menu item is clicked to trigger an action. You can manually reload these components to update them by dispatching a `refresh-sidebar` or `refresh-topbar` browser event.

--- a/packages/panels/src/Clusters/Cluster.php
+++ b/packages/panels/src/Clusters/Cluster.php
@@ -3,6 +3,7 @@
 namespace Filament\Clusters;
 
 use Filament\Facades\Filament;
+use Filament\Navigation\NavigationItem;
 use Filament\Pages\Page;
 use Filament\Pages\PageConfiguration;
 use Filament\Panel;
@@ -36,6 +37,34 @@ class Cluster extends Page
     public static function shouldRegisterNavigation(): bool
     {
         return parent::shouldRegisterNavigation() && static::canAccessClusteredComponents();
+    }
+
+    public static function getClusterHierarchicalBreadcrumbs(): array
+    {
+        $breadcrumbs = [];
+
+        $navigationGroupKey = static::getNavigationGroup();
+        $navigationParentItemKey = static::getNavigationParentItem();
+
+        $panelNavigation = Filament::getCurrentOrDefaultPanel()->getNavigation();
+
+        $navigationGroup = $panelNavigation[serialize($navigationGroupKey)];
+        $navigationParentItem = collect($navigationGroup?->getItems() ?? [])
+            ->first(fn (NavigationItem $item): bool => $item->getKey() === $navigationParentItemKey || $item->getLabel() === $navigationParentItemKey);
+
+        if (filled($navigationGroup) && filled($navigationGroup->getLabel())) {
+            $breadcrumbs[] = $navigationGroup->getLabel();
+        }
+
+        if (filled($navigationParentItem)) {
+            $navigationParentItemUrl = $navigationParentItem->getUrl();
+
+            filled($navigationParentItemUrl)
+                ? $breadcrumbs[$navigationParentItemUrl] = $navigationParentItem->getLabel()
+                : $breadcrumbs[] = $navigationParentItem->getLabel();
+        }
+
+        return $breadcrumbs;
     }
 
     public function mount(): void

--- a/packages/panels/src/Pages/Page.php
+++ b/packages/panels/src/Pages/Page.php
@@ -16,7 +16,6 @@ use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Livewire;
 use Filament\Schemas\Components\RenderHook;
 use Filament\Schemas\Schema;
-use Filament\Support\Contracts\HasLabel;
 use Filament\View\PanelsRenderHook;
 use Filament\Widgets\Widget;
 use Filament\Widgets\WidgetConfiguration;
@@ -191,7 +190,7 @@ abstract class Page extends BasePage
     {
         if (Filament::getCurrentOrDefaultPanel()->hasStrictHierarchicalBreadcrumbs()) {
             return [
-                ...static::getHierarchicalBreadcrumbs(),
+                ...$this->getHierarchicalBreadcrumbs(),
                 $this->getBreadcrumb(),
             ];
         }
@@ -203,39 +202,44 @@ abstract class Page extends BasePage
         return [];
     }
 
-    public static function getHierarchicalBreadcrumbs(): array
+    public function getHierarchicalBreadcrumbs(): array
     {
         $breadcrumbs = [];
 
         $cluster = static::getCluster();
-        $navigationGroup = static::getNavigationGroup();
-        $navigationParentItem = static::getNavigationParentItem();
+        $navigationGroupKey = static::getNavigationGroup();
+        $navigationParentItemKey = static::getNavigationParentItem();
 
         if (filled($cluster)) {
-            $breadcrumbs = $cluster::getHierarchicalBreadcrumbs();
+            $breadcrumbs = $cluster::getClusterHierarchicalBreadcrumbs();
             $breadcrumbs[$cluster::getUrl()] = $cluster::getClusterBreadcrumb();
+
+            $subNavigation = $this->getCachedSubNavigation();
+
+            if ($navigationGroupKey instanceof UnitEnum) {
+                $navigationGroupKey = $navigationGroupKey->name;
+            }
+
+            $navigationGroup = $subNavigation[$navigationGroupKey ?? 0];
+        } else {
+            $panelNavigation = Filament::getCurrentOrDefaultPanel()->getNavigation();
+
+            $navigationGroup = $panelNavigation[serialize($navigationGroupKey)];
         }
 
-        if (filled($navigationGroup)) {
-            $breadcrumbs[] = $navigationGroup instanceof HasLabel
-                ? $navigationGroup->getLabel()
-                : enum_value($navigationGroup);
+        $navigationParentItem = collect($navigationGroup?->getItems() ?? [])
+            ->first(fn (NavigationItem $item): bool => $item->getKey() === $navigationParentItemKey || $item->getLabel() === $navigationParentItemKey);
+
+        if (filled($navigationGroup) && filled($navigationGroup->getLabel())) {
+            $breadcrumbs[] = $navigationGroup->getLabel();
         }
 
         if (filled($navigationParentItem)) {
-            $parentItem = collect(Filament::getCurrentOrDefaultPanel()
-                ->getNavigation()[serialize($navigationGroup)]
-                ->getItems())
-                ->first(fn (NavigationItem $item): bool =>
-                    $item->getKey() === $navigationParentItem || $item->getLabel() === $navigationParentItem);
+            $navigationParentItemUrl = $navigationParentItem->getUrl();
 
-            if (filled($parentItem)) {
-                $navigationParentItemUrl = $parentItem->getUrl();
-
-                filled($navigationParentItemUrl)
-                    ? $breadcrumbs[$navigationParentItemUrl] = $parentItem->getLabel()
-                    : $breadcrumbs[] = $parentItem->getLabel();
-            }
+            filled($navigationParentItemUrl)
+                ? $breadcrumbs[$navigationParentItemUrl] = $navigationParentItem->getLabel()
+                : $breadcrumbs[] = $navigationParentItem->getLabel();
         }
 
         return $breadcrumbs;

--- a/packages/panels/src/Pages/Page.php
+++ b/packages/panels/src/Pages/Page.php
@@ -16,6 +16,7 @@ use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Livewire;
 use Filament\Schemas\Components\RenderHook;
 use Filament\Schemas\Schema;
+use Filament\Support\Contracts\HasLabel;
 use Filament\View\PanelsRenderHook;
 use Filament\Widgets\Widget;
 use Filament\Widgets\WidgetConfiguration;
@@ -44,6 +45,8 @@ abstract class Page extends BasePage
      * @var class-string<Cluster> | null
      */
     protected static ?string $cluster = null;
+
+    protected static ?string $breadcrumb = null;
 
     protected static bool $isDiscovered = true;
 
@@ -179,16 +182,63 @@ abstract class Page extends BasePage
         return $panel->generateRouteName($routeName);
     }
 
-    /**
-     * @return array<string>
-     */
+    public function getBreadcrumb(): ?string
+    {
+        return static::$breadcrumb ?? static::getTitle();
+    }
+
     public function getBreadcrumbs(): array
     {
+        if (Filament::getCurrentOrDefaultPanel()->hasStrictHierarchicalBreadcrumbs()) {
+            return [
+                ...static::getHierarchicalBreadcrumbs(),
+                $this->getBreadcrumb(),
+            ];
+        }
+
         if (filled($cluster = static::getCluster())) {
             return $cluster::unshiftClusterBreadcrumbs([]);
         }
 
         return [];
+    }
+
+    public static function getHierarchicalBreadcrumbs(): array
+    {
+        $breadcrumbs = [];
+
+        $cluster = static::getCluster();
+        $navigationGroup = static::getNavigationGroup();
+        $navigationParentItem = static::getNavigationParentItem();
+
+        if (filled($cluster)) {
+            $breadcrumbs = $cluster::getHierarchicalBreadcrumbs();
+            $breadcrumbs[$cluster::getUrl()] = $cluster::getClusterBreadcrumb();
+        }
+
+        if (filled($navigationGroup)) {
+            $breadcrumbs[] = $navigationGroup instanceof HasLabel
+                ? $navigationGroup->getLabel()
+                : enum_value($navigationGroup);
+        }
+
+        if (filled($navigationParentItem)) {
+            $parentItem = collect(Filament::getCurrentOrDefaultPanel()
+                ->getNavigation()[serialize($navigationGroup)]
+                ->getItems())
+                ->first(fn (NavigationItem $item): bool =>
+                    $item->getKey() === $navigationParentItem || $item->getLabel() === $navigationParentItem);
+
+            if (filled($parentItem)) {
+                $navigationParentItemUrl = $parentItem->getUrl();
+
+                filled($navigationParentItemUrl)
+                    ? $breadcrumbs[$navigationParentItemUrl] = $parentItem->getLabel()
+                    : $breadcrumbs[] = $parentItem->getLabel();
+            }
+        }
+
+        return $breadcrumbs;
     }
 
     public static function getNavigationGroup(): string | UnitEnum | null

--- a/packages/panels/src/Panel/Concerns/HasBreadcrumbs.php
+++ b/packages/panels/src/Panel/Concerns/HasBreadcrumbs.php
@@ -8,9 +8,12 @@ trait HasBreadcrumbs
 {
     protected bool | Closure $hasBreadcrumbs = true;
 
-    public function breadcrumbs(bool | Closure $condition = true): static
+    protected bool | Closure $hasStrictHierarchicalBreadcrumbs = false;
+
+    public function breadcrumbs(bool | Closure $condition = true, bool | Closure $strictHierarchical = false): static
     {
         $this->hasBreadcrumbs = $condition;
+        $this->hasStrictHierarchicalBreadcrumbs = $strictHierarchical;
 
         return $this;
     }
@@ -18,5 +21,10 @@ trait HasBreadcrumbs
     public function hasBreadcrumbs(): bool
     {
         return (bool) $this->evaluate($this->hasBreadcrumbs);
+    }
+
+    public function hasStrictHierarchicalBreadcrumbs(): bool
+    {
+        return (bool) $this->evaluate($this->hasStrictHierarchicalBreadcrumbs);
     }
 }

--- a/packages/panels/src/Resources/Pages/Page.php
+++ b/packages/panels/src/Resources/Pages/Page.php
@@ -161,11 +161,6 @@ abstract class Page extends BasePage
         return static::getResource()::isTenantSubscriptionRequired($panel);
     }
 
-    public function getBreadcrumb(): ?string
-    {
-        return static::$breadcrumb ?? static::getTitle();
-    }
-
     public function hasResourceBreadcrumbs(): bool
     {
         return true;

--- a/packages/panels/src/Resources/Pages/Page.php
+++ b/packages/panels/src/Resources/Pages/Page.php
@@ -40,8 +40,6 @@ abstract class Page extends BasePage
     use CanAuthorizeResourceAccess;
     use InteractsWithParentRecord;
 
-    protected static ?string $breadcrumb = null;
-
     protected static string $resource;
 
     protected static bool $isDiscovered = false;
@@ -173,9 +171,6 @@ abstract class Page extends BasePage
         return true;
     }
 
-    /**
-     * @return array<string>
-     */
     public function getResourceBreadcrumbs(): array
     {
         $breadcrumbs = [];
@@ -227,16 +222,18 @@ abstract class Page extends BasePage
             }
         }
 
-        if (filled($cluster = static::getCluster())) {
+        if (Filament::getCurrentOrDefaultPanel()->hasStrictHierarchicalBreadcrumbs()) {
+            return [
+                ...static::getHierarchicalBreadcrumbs(),
+                ...$breadcrumbs,
+            ];
+        } elseif (filled($cluster = static::getCluster())) {
             return $cluster::unshiftClusterBreadcrumbs($breadcrumbs);
         }
 
         return $breadcrumbs;
     }
 
-    /**
-     * @return array<string>
-     */
     public function getBreadcrumbs(): array
     {
         return [

--- a/packages/panels/src/Resources/Pages/Page.php
+++ b/packages/panels/src/Resources/Pages/Page.php
@@ -32,6 +32,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route as RouteFacade;
 use LogicException;
+use UnitEnum;
 
 use function Filament\Support\original_request;
 
@@ -219,7 +220,7 @@ abstract class Page extends BasePage
 
         if (Filament::getCurrentOrDefaultPanel()->hasStrictHierarchicalBreadcrumbs()) {
             return [
-                ...static::getHierarchicalBreadcrumbs(),
+                ...$this->getHierarchicalBreadcrumbs(),
                 ...$breadcrumbs,
             ];
         } elseif (filled($cluster = static::getCluster())) {
@@ -235,6 +236,49 @@ abstract class Page extends BasePage
             ...$this->getResourceBreadcrumbs(),
             $this->getBreadcrumb(),
         ];
+    }
+
+    public function getHierarchicalBreadcrumbs(): array
+    {
+        $breadcrumbs = [];
+
+        $cluster = static::getCluster();
+        $navigationGroupKey = static::getResource()::getNavigationGroup();
+        $navigationParentItemKey = static::getResource()::getNavigationParentItem();
+
+        if (filled($cluster)) {
+            $breadcrumbs = $cluster::getClusterHierarchicalBreadcrumbs();
+            $breadcrumbs[$cluster::getUrl()] = $cluster::getClusterBreadcrumb();
+
+            $subNavigation = $this->getCachedSubNavigation();
+
+            if ($navigationGroupKey instanceof UnitEnum) {
+                $navigationGroupKey = $navigationGroupKey->name;
+            }
+
+            $navigationGroup = $subNavigation[$navigationGroupKey ?? 0];
+        } else {
+            $panelNavigation = Filament::getCurrentOrDefaultPanel()->getNavigation();
+
+            $navigationGroup = $panelNavigation[serialize($navigationGroupKey)];
+        }
+
+        $navigationParentItem = collect($navigationGroup?->getItems() ?? [])
+            ->first(fn (NavigationItem $item): bool => $item->getKey() === $navigationParentItemKey || $item->getLabel() === $navigationParentItemKey);
+
+        if (filled($navigationGroup) && filled($navigationGroup->getLabel())) {
+            $breadcrumbs[] = $navigationGroup->getLabel();
+        }
+
+        if (filled($navigationParentItem)) {
+            $navigationParentItemUrl = $navigationParentItem->getUrl();
+
+            filled($navigationParentItemUrl)
+                ? $breadcrumbs[$navigationParentItemUrl] = $navigationParentItem->getLabel()
+                : $breadcrumbs[] = $navigationParentItem->getLabel();
+        }
+
+        return $breadcrumbs;
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes discussion #19515.

Adds an opt-in **strict hierarchical breadcrumbs** mode, configurable per-panel via `Panel::breadcrumbs()`:

```php
$panel->breadcrumbs(strictHierarchical: true);
```

By default, breadcrumbs for a page are built from its resource and parent record relationships (e.g. an `EditRecord` page's breadcrumbs come from its resource's list/view pages, plus any parent resources for nested resources). When strict hierarchical mode is enabled, breadcrumbs are instead (additionally) built by walking the page's full navigational hierarchy — cluster ancestry, navigation group, and navigation parent item — and combining that chain with the existing resource/parent-record breadcrumbs.

## Changes

- **`Filament\Panel\Concerns\HasBreadcrumbs`**: extended `breadcrumbs()` with a second `bool|Closure $strictHierarchical = false` parameter, and added `hasStrictHierarchicalBreadcrumbs()` alongside the existing `hasBreadcrumbs()`.
- **`Filament\Pages\Page`**: added `$breadcrumb` property, `getBreadcrumb()`, and `getHierarchicalBreadcrumbs()`, which recursively resolves cluster, navigation group, and navigation parent item breadcrumbs for a page. `getBreadcrumbs()` now checks `Filament::getCurrentOrDefaultPanel()->hasStrictHierarchicalBreadcrumbs()` and prepends the hierarchical chain when enabled.
- **`Filament\Resources\Pages\Page`**: `getResourceBreadcrumbs()` now checks strict mode first and, when enabled, prepends `static::getHierarchicalBreadcrumbs()` ahead of the existing resource/parent-record breadcrumbs; falls back to the previous cluster-only behavior otherwise.

## Behavior

- **Strict mode disabled (default):** unchanged — breadcrumbs resolve exactly as before, via cluster + resource/parent-record relationships.
- **Strict mode enabled:** breadcrumbs are `[...hierarchical chain, ...resource/parent-record breadcrumbs, page's own breadcrumb]`. The hierarchical chain and resource/record breadcrumbs are combined, not one replacing the other.