### PR TITLE
fix: add missing space before `@deprecated` PHPDoc tags

### DIFF
--- a/packages/actions/src/Concerns/CanOpenModal.php
+++ b/packages/actions/src/Concerns/CanOpenModal.php
@@ -188,7 +188,7 @@ trait CanOpenModal
     /**
      * @param  array<Action> | Closure | null  $actions
      *
-     *@deprecated Use `modalFooterActions()` instead.
+     * @deprecated Use `modalFooterActions()` instead.
      */
     public function modalActions(array | Closure | null $actions = null): static
     {
@@ -217,7 +217,7 @@ trait CanOpenModal
     /**
      * @param  array<Action> | Closure  $actions
      *
-     *@deprecated Use `extraModalFooterActions()` instead.
+     * @deprecated Use `extraModalFooterActions()` instead.
      */
     public function extraModalActions(array | Closure $actions): static
     {

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -120,7 +120,7 @@ trait InteractsWithForms /** @phpstan-ignore trait.unused */
     /**
      * @return array<string, Schema>
      *
-     *@deprecated Use `getCachedSchemas()` instead.
+     * @deprecated Use `getCachedSchemas()` instead.
      */
     public function getCachedForms(): array
     {


### PR DESCRIPTION
## Description

Three `@deprecated` PHPDoc tags were missing a space after the `*`, making them malformed and unrecognisable by IDEs and static analysis tools.

**Before:**
*@deprecated Use modalFooterActions() instead.

**After:**
@deprecated Use modalFooterActions() instead.

Affected:
- `packages/actions/src/Concerns/CanOpenModal.php` — 2 tags
- `packages/forms/src/Concerns/InteractsWithForms.php` — 1 tag

## Visual changes

No visual changes — PHPDoc comments only.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
