### PR TITLE
feat(tables): persist grouping in the user's session

### DIFF
--- a/packages/tables/docs/07-grouping.md
+++ b/packages/tables/docs/07-grouping.md
@@ -60,6 +60,24 @@ public function table(Table $table): Table
 }
 ```
 
+### Persisting the grouping in the user's session
+
+To persist the grouping in the user's session, use the `persistGroupInSession()` method:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->groups([
+            'status',
+            'category',
+        ])
+        ->persistGroupInSession();
+}
+```
+
 ## Grouping by a relationship attribute
 
 You can also group by a relationship attribute using dot-syntax. For example, if you have an `author` relationship which has a `name` attribute, you can use `author.name` as the name of the attribute:

--- a/packages/tables/docs/07-grouping.md
+++ b/packages/tables/docs/07-grouping.md
@@ -60,24 +60,6 @@ public function table(Table $table): Table
 }
 ```
 
-### Persisting the grouping in the user's session
-
-To persist the grouping in the user's session, use the `persistGroupInSession()` method:
-
-```php
-use Filament\Tables\Table;
-
-public function table(Table $table): Table
-{
-    return $table
-        ->groups([
-            'status',
-            'category',
-        ])
-        ->persistGroupInSession();
-}
-```
-
 ## Grouping by a relationship attribute
 
 You can also group by a relationship attribute using dot-syntax. For example, if you have an `author` relationship which has a `name` attribute, you can use `author.name` as the name of the attribute:
@@ -397,5 +379,23 @@ public function table(Table $table): Table
     return $table
 		->defaultGroup('status')
         ->groupingDirectionSettingHidden();
+}
+```
+
+## Persisting the grouping in the user's session
+
+To persist the grouping in the user's session, use the `persistGroupInSession()` method:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->groups([
+            'status',
+            'category',
+        ])
+        ->persistGroupInSession();
 }
 ```

--- a/packages/tables/src/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Concerns/CanGroupRecords.php
@@ -29,8 +29,15 @@ trait CanGroupRecords
         return $this->getTable()->getDefaultGroup();
     }
 
-    public function updatedTableGroupColumn(): void
+    public function updatedTableGrouping(): void
     {
+        if ($this->getTable()->persistsGroupInSession()) {
+            session()->put(
+                $this->getTableGroupingSessionKey(),
+                $this->tableGrouping,
+            );
+        }
+
         $this->resetPage();
     }
 
@@ -64,5 +71,12 @@ trait CanGroupRecords
         $group->orderQuery($query, $this->getTableGroupingDirection() ?? 'asc');
 
         return $query;
+    }
+
+    public function getTableGroupingSessionKey(): string
+    {
+        $table = md5($this::class);
+
+        return "tables.{$table}_grouping";
     }
 }

--- a/packages/tables/src/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Concerns/CanGroupRecords.php
@@ -41,6 +41,14 @@ trait CanGroupRecords
         $this->resetPage();
     }
 
+    /**
+     * @deprecated Use `updatedTableGrouping()` instead.
+     */
+    public function updatedTableGroupColumn(): void
+    {
+        $this->updatedTableGrouping();
+    }
+
     public function getTableGroupingDirection(): ?string
     {
         if (blank($this->tableGrouping)) {

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -91,19 +91,17 @@ trait InteractsWithTable
             );
         }
 
-        if ($this->getTable()->isDefaultGroupSelectable()) {
-            $this->tableGrouping = "{$this->getTable()->getDefaultGroup()->getId()}:asc";
-        }
-
         $shouldPersistGroupInSession = $this->getTable()->persistsGroupInSession();
         $groupingSessionKey = $this->getTableGroupingSessionKey();
+        $hasPersistedGroupInSession = $shouldPersistGroupInSession && session()->exists($groupingSessionKey);
 
-        if (
-            $shouldPersistGroupInSession &&
-            session()->has($groupingSessionKey)
-        ) {
-            $sessionGrouping = session()->get($groupingSessionKey);
-            $this->tableGrouping = is_string($sessionGrouping) ? $sessionGrouping : null;
+        if (blank($this->tableGrouping)) {
+            if ($hasPersistedGroupInSession) {
+                $sessionGrouping = session()->get($groupingSessionKey);
+                $this->tableGrouping = is_string($sessionGrouping) ? $sessionGrouping : null;
+            } elseif ($this->getTable()->isDefaultGroupSelectable()) {
+                $this->tableGrouping = "{$this->getTable()->getDefaultGroup()->getId()}:asc";
+            }
         }
 
         if ($shouldPersistGroupInSession) {

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -95,6 +95,24 @@ trait InteractsWithTable
             $this->tableGrouping = "{$this->getTable()->getDefaultGroup()->getId()}:asc";
         }
 
+        $shouldPersistGroupInSession = $this->getTable()->persistsGroupInSession();
+        $groupingSessionKey = $this->getTableGroupingSessionKey();
+
+        if (
+            $shouldPersistGroupInSession &&
+            session()->has($groupingSessionKey)
+        ) {
+            $sessionGrouping = session()->get($groupingSessionKey);
+            $this->tableGrouping = is_string($sessionGrouping) ? $sessionGrouping : null;
+        }
+
+        if ($shouldPersistGroupInSession) {
+            session()->put(
+                $groupingSessionKey,
+                $this->tableGrouping,
+            );
+        }
+
         $shouldPersistSearchInSession = $this->getTable()->persistsSearchInSession();
         $searchSessionKey = $this->getTableSearchSessionKey();
 

--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -25,6 +25,8 @@ trait CanGroupRecords
 
     protected bool | Closure $isGroupsOnly = false;
 
+    protected bool | Closure | null $persistsGroupInSession = false;
+
     protected bool | Closure $areGroupingSettingsInDropdownOnDesktop = false;
 
     protected bool | Closure $areGroupingSettingsHidden = false;
@@ -100,6 +102,13 @@ trait CanGroupRecords
     public function groupsOnly(bool | Closure $condition = true): static
     {
         $this->isGroupsOnly = $condition;
+
+        return $this;
+    }
+
+    public function persistGroupInSession(bool | Closure $condition = true): static
+    {
+        $this->persistsGroupInSession = $condition;
 
         return $this;
     }
@@ -212,5 +221,10 @@ trait CanGroupRecords
     public function isGroupsOnly(): bool
     {
         return (bool) $this->evaluate($this->isGroupsOnly);
+    }
+
+    public function persistsGroupInSession(): bool
+    {
+        return (bool) $this->evaluate($this->persistsGroupInSession);
     }
 }

--- a/tests/src/Fixtures/Livewire/PostsTableWithGroupPersistedInSession.php
+++ b/tests/src/Fixtures/Livewire/PostsTableWithGroupPersistedInSession.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Livewire;
+
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Tests\Fixtures\Models\Post;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+
+class PostsTableWithGroupPersistedInSession extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use Tables\Concerns\InteractsWithTable;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(Post::query())
+            ->groups(fn () => [
+                Tables\Grouping\Group::make('title'),
+                Tables\Grouping\Group::make('author.name'),
+            ])
+            ->persistGroupInSession()
+            ->columns([
+                Tables\Columns\TextColumn::make('title')->sortable(),
+                Tables\Columns\TextColumn::make('author.name')->sortable(),
+            ]);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.table');
+    }
+}

--- a/tests/src/Fixtures/Livewire/PostsTableWithGroupPersistedInSession.php
+++ b/tests/src/Fixtures/Livewire/PostsTableWithGroupPersistedInSession.php
@@ -10,6 +10,7 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Filament\Tests\Fixtures\Models\Post;
 use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Url;
 use Livewire\Component;
 
 class PostsTableWithGroupPersistedInSession extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
@@ -18,14 +19,18 @@ class PostsTableWithGroupPersistedInSession extends Component implements HasActi
     use InteractsWithSchemas;
     use Tables\Concerns\InteractsWithTable;
 
+    #[Url(as: 'grouping')]
+    public ?string $tableGrouping = null;
+
     public function table(Table $table): Table
     {
         return $table
             ->query(Post::query())
-            ->groups(fn () => [
+            ->groups(static fn () => [
                 Tables\Grouping\Group::make('title'),
                 Tables\Grouping\Group::make('author.name'),
             ])
+            ->defaultGroup('title')
             ->persistGroupInSession()
             ->columns([
                 Tables\Columns\TextColumn::make('title')->sortable(),

--- a/tests/src/Tables/GroupingTest.php
+++ b/tests/src/Tables/GroupingTest.php
@@ -3,6 +3,7 @@
 use Filament\Tables\Grouping\Group;
 use Filament\Tests\Fixtures\Livewire\GroupedCustomDataTable;
 use Filament\Tests\Fixtures\Livewire\PostsTable;
+use Filament\Tests\Fixtures\Livewire\PostsTableWithGroupPersistedInSession;
 use Filament\Tests\Fixtures\Livewire\PostsTableWithoutSummarizers;
 use Filament\Tests\Fixtures\Livewire\TicketMessagesTable;
 use Filament\Tests\Fixtures\Livewire\UsersTable;
@@ -960,4 +961,69 @@ it('can group records by `HasOneThrough` -> `BelongsTo` relationship that uses `
     livewire(UsersTable::class)
         ->set('tableGrouping', 'setting.languageWithTrashed.name')
         ->assertCanSeeTableRecords($sortedUsers, inOrder: true);
+});
+
+describe('session persistence', function (): void {
+    it('defaults `persistsGroupInSession()` to `false`', function (): void {
+        livewire(PostsTable::class)
+            ->tap(function (Testable $testable): void {
+                /** @var PostsTable $livewire */
+                $livewire = $testable->instance();
+
+                expect($livewire->getTable()->persistsGroupInSession())->toBeFalse();
+            });
+    });
+
+    it('can enable grouping persistence with `persistGroupInSession()`', function (): void {
+        livewire(PostsTableWithGroupPersistedInSession::class)
+            ->tap(function (Testable $testable): void {
+                /** @var PostsTableWithGroupPersistedInSession $livewire */
+                $livewire = $testable->instance();
+
+                expect($livewire->getTable()->persistsGroupInSession())->toBeTrue();
+            });
+    });
+
+    it('scopes `getTableGroupingSessionKey()` to the component class', function (): void {
+        /** @var PostsTableWithGroupPersistedInSession $livewire */
+        $livewire = livewire(PostsTableWithGroupPersistedInSession::class)->instance();
+
+        expect($livewire->getTableGroupingSessionKey())
+            ->toBe('tables.' . md5($livewire::class) . '_grouping');
+    });
+
+    it('can persist the grouping in the user\'s session', function (): void {
+        Post::factory()->count(10)->create();
+
+        livewire(PostsTableWithGroupPersistedInSession::class)
+            ->assertSet('tableGrouping', null)
+            ->set('tableGrouping', 'title')
+            ->assertSet('tableGrouping', 'title');
+
+        livewire(PostsTableWithGroupPersistedInSession::class)
+            ->assertSet('tableGrouping', 'title');
+    });
+
+    it('can clear the persisted grouping in the user\'s session', function (): void {
+        Post::factory()->count(10)->create();
+
+        livewire(PostsTableWithGroupPersistedInSession::class)
+            ->set('tableGrouping', 'title')
+            ->set('tableGrouping', null)
+            ->assertSet('tableGrouping', null);
+
+        livewire(PostsTableWithGroupPersistedInSession::class)
+            ->assertSet('tableGrouping', null);
+    });
+
+    it('does not persist the grouping in the user\'s session by default', function (): void {
+        Post::factory()->count(10)->create();
+
+        livewire(PostsTable::class)
+            ->set('tableGrouping', 'title')
+            ->assertSet('tableGrouping', 'title');
+
+        livewire(PostsTable::class)
+            ->assertSet('tableGrouping', null);
+    });
 });

--- a/tests/src/Tables/GroupingTest.php
+++ b/tests/src/Tables/GroupingTest.php
@@ -19,6 +19,7 @@ use Filament\Tests\Fixtures\Models\TicketMessage;
 use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\Tables\TestCase;
 use Livewire\Features\SupportTesting\Testable;
+use Livewire\Livewire;
 
 use function Filament\Tests\livewire;
 
@@ -963,6 +964,16 @@ it('can group records by `HasOneThrough` -> `BelongsTo` relationship that uses `
         ->assertCanSeeTableRecords($sortedUsers, inOrder: true);
 });
 
+it('resets pagination when `$tableGrouping` is updated', function (): void {
+    Post::factory()->count(20)->create();
+
+    livewire(PostsTable::class)
+        ->call('setPage', 2)
+        ->assertSet('paginators.page', 2)
+        ->set('tableGrouping', 'title')
+        ->assertSet('paginators.page', 1);
+});
+
 describe('session persistence', function (): void {
     it('defaults `persistsGroupInSession()` to `false`', function (): void {
         livewire(PostsTable::class)
@@ -996,24 +1007,33 @@ describe('session persistence', function (): void {
         Post::factory()->count(10)->create();
 
         livewire(PostsTableWithGroupPersistedInSession::class)
-            ->assertSet('tableGrouping', null)
-            ->set('tableGrouping', 'title')
-            ->assertSet('tableGrouping', 'title');
+            ->assertSet('tableGrouping', 'title:asc')
+            ->set('tableGrouping', 'author.name:desc')
+            ->assertSet('tableGrouping', 'author.name:desc');
 
         livewire(PostsTableWithGroupPersistedInSession::class)
-            ->assertSet('tableGrouping', 'title');
+            ->assertSet('tableGrouping', 'author.name:desc');
     });
 
     it('can clear the persisted grouping in the user\'s session', function (): void {
         Post::factory()->count(10)->create();
 
         livewire(PostsTableWithGroupPersistedInSession::class)
-            ->set('tableGrouping', 'title')
+            ->assertSet('tableGrouping', 'title:asc')
             ->set('tableGrouping', null)
             ->assertSet('tableGrouping', null);
 
         livewire(PostsTableWithGroupPersistedInSession::class)
             ->assertSet('tableGrouping', null);
+    });
+
+    it('does not override explicit `$tableGrouping` with the persisted grouping', function (): void {
+        livewire(PostsTableWithGroupPersistedInSession::class)
+            ->assertSet('tableGrouping', 'title:asc');
+
+        Livewire::withQueryParams(['grouping' => 'author.name:desc'])
+            ->test(PostsTableWithGroupPersistedInSession::class)
+            ->assertSet('tableGrouping', 'author.name:desc');
     });
 
     it('does not persist the grouping in the user\'s session by default', function (): void {


### PR DESCRIPTION
## Description

Tables can already persist their sort, search, filters and columns in the user's session, but not their grouping. This adds a `persistGroupInSession()` method to the table configuration so a user's selected grouping is restored on their next visit, mirroring the existing `persistSortInSession()`:

```php
public function table(Table $table): Table
{
    return $table
        ->groups([
            'status',
            'category',
        ])
        ->persistGroupInSession();
}
```

While implementing this I found that the `updatedTableGroupColumn()` Livewire hook was dead code: the underlying property is `$tableGrouping`, so Livewire resolves the hook as `updatedTableGrouping()` and the old name never fired. Renaming it fixes that dormant hook (grouping changes now also reset the pagination page correctly) and is what enables writing the grouping to the session.

## Visual changes

None. The behavior is opt-in and there is no UI change.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
