### PR TITLE
Fix broken link in container queries documentation

### DIFF
--- a/packages/schemas/docs/02-layouts.md
+++ b/packages/schemas/docs/02-layouts.md
@@ -284,7 +284,7 @@ Fieldset::make('Label')
 
 In addition to traditional breakpoints based on the size of the viewport, you can also use [container queries](https://tailwindcss.com/docs/responsive-design#container-queries) to create responsive layouts based on the size of a parent container. This is particularly useful when the size of the parent container is not directly tied to the size of the viewport. For example, when using a collapsible sidebar alongside the content, the content area dynamically adjusts its size depending on the collapse state of the sidebar.
 
-The foundation of a container query is the container itself. The container is the element whose width determines the layout. To designate an element as a container, use the `gridContainer()` method on it. For instance, if you want to define the number of grid columns in a [`Grid` component] based on its width:
+The foundation of a container query is the container itself. The container is the element whose width determines the layout. To designate an element as a container, use the `gridContainer()` method on it. For instance, if you want to define the number of grid columns in a [Grid component](#grid-component) based on its width:
 
 ```php
 use Filament\Schemas\Components\Grid;

--- a/packages/schemas/docs/02-layouts.md
+++ b/packages/schemas/docs/02-layouts.md
@@ -284,7 +284,7 @@ Fieldset::make('Label')
 
 In addition to traditional breakpoints based on the size of the viewport, you can also use [container queries](https://tailwindcss.com/docs/responsive-design#container-queries) to create responsive layouts based on the size of a parent container. This is particularly useful when the size of the parent container is not directly tied to the size of the viewport. For example, when using a collapsible sidebar alongside the content, the content area dynamically adjusts its size depending on the collapse state of the sidebar.
 
-The foundation of a container query is the container itself. The container is the element whose width determines the layout. To designate an element as a container, use the `gridContainer()` method on it. For instance, if you want to define the number of grid columns in a [Grid component](#grid-component) based on its width:
+The foundation of a container query is the container itself. The container is the element whose width determines the layout. To designate an element as a container, use the `gridContainer()` method on it. For instance, if you want to define the number of grid columns in a [`Grid` component](#grid-component) based on its width:
 
 ```php
 use Filament\Schemas\Components\Grid;


### PR DESCRIPTION
## Description

Updated link formatting for `Grid component` reference in **Using container queries** section.

## Visual changes

This is how it is current looking:

<img width="675" height="383" alt="container_queries" src="https://github.com/user-attachments/assets/7bc24da3-69bc-4b5f-8b91-aa6bdb2c1f31" />

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
