### PR TITLE
Use Str::counted() in generated exporter notification body on Laravel 13.19+

### DIFF
--- a/packages/actions/src/Commands/FileGenerators/ExporterClassGenerator.php
+++ b/packages/actions/src/Commands/FileGenerators/ExporterClassGenerator.php
@@ -9,6 +9,7 @@ use Filament\Support\Commands\Concerns\CanReadModelSchemas;
 use Filament\Support\Commands\FileGenerators\ClassGenerator;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Application;
+use Illuminate\Support\Number;
 use Illuminate\Support\Str;
 use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Literal;
@@ -44,7 +45,7 @@ class ExporterClassGenerator extends ClassGenerator
             $this->getExtends(),
             Export::class,
             ExportColumn::class,
-            Str::class,
+            version_compare(Application::VERSION, '13.19.0', '>=') ? Str::class : Number::class,
             $this->getModelFqn(),
         ];
     }
@@ -188,17 +189,17 @@ class ExporterClassGenerator extends ClassGenerator
 
     protected function addGetCompletedNotificationBodyMethodToClass(ClassType $class): void
     {
-        $str = $this->simplifyFqn(Str::class);
+        if (version_compare(Application::VERSION, '13.19.0', '>=')) {
+            $str = $this->simplifyFqn(Str::class);
 
-        $useCounted = version_compare(Application::VERSION, '13.19.0', '>=');
+            $completedSegment = "{$str}::of('row')->counted(\$export->successful_rows)";
+            $failedSegment = "{$str}::of('row')->counted(\$failedRowsCount)";
+        } else {
+            $number = $this->simplifyFqn(Number::class);
 
-        $completedSegment = $useCounted
-            ? "{$str}::of('row')->counted(\$export->successful_rows)"
-            : "{$str}::of('row')->plural(\$export->successful_rows, prependCount: true)";
-
-        $failedSegment = $useCounted
-            ? "{$str}::of('row')->counted(\$failedRowsCount)"
-            : "{$str}::of('row')->plural(\$failedRowsCount, prependCount: true)";
+            $completedSegment = "{$number}::format(\$export->successful_rows) . ' ' . str('row')->plural(\$export->successful_rows)";
+            $failedSegment = "{$number}::format(\$failedRowsCount) . ' ' . str('row')->plural(\$failedRowsCount)";
+        }
 
         $method = $class->addMethod('getCompletedNotificationBody')
             ->setPublic()

--- a/packages/actions/src/Commands/FileGenerators/ExporterClassGenerator.php
+++ b/packages/actions/src/Commands/FileGenerators/ExporterClassGenerator.php
@@ -214,7 +214,6 @@ class ExporterClassGenerator extends ClassGenerator
 
                 return \$body;
                 PHP);
-
         $method->addParameter('export')
             ->setType(Export::class);
 

--- a/packages/actions/src/Commands/FileGenerators/ExporterClassGenerator.php
+++ b/packages/actions/src/Commands/FileGenerators/ExporterClassGenerator.php
@@ -188,19 +188,32 @@ class ExporterClassGenerator extends ClassGenerator
 
     protected function addGetCompletedNotificationBodyMethodToClass(ClassType $class): void
     {
+        $str = $this->simplifyFqn(Str::class);
+
+        $useCounted = version_compare(app()->version(), '13.19.0', '>=');
+
+        $completedSegment = $useCounted
+            ? "{$str}::of('row')->counted(\$export->successful_rows)"
+            : "{$str}::of('row')->plural(\$export->successful_rows, prependCount: true)";
+
+        $failedSegment = $useCounted
+            ? "{$str}::of('row')->counted(\$failedRowsCount)"
+            : "{$str}::of('row')->plural(\$failedRowsCount, prependCount: true)";
+
         $method = $class->addMethod('getCompletedNotificationBody')
             ->setPublic()
             ->setStatic()
             ->setReturnType('string')
             ->setBody(<<<PHP
-                \$body = 'Your {$this->getModelLabel()} export has completed and ' . {$this->simplifyFqn(Number::class)}::format(\$export->successful_rows) . ' ' . str('row')->plural(\$export->successful_rows) . ' exported.';
+            \$body = 'Your {$this->getModelLabel()} export has completed and ' . {$completedSegment} . ' exported.';
 
-                if (\$failedRowsCount = \$export->getFailedRowsCount()) {
-                    \$body .= ' ' . {$this->simplifyFqn(Number::class)}::format(\$failedRowsCount) . ' ' . str('row')->plural(\$failedRowsCount) . ' failed to export.';
-                }
+            if (\$failedRowsCount = \$export->getFailedRowsCount()) {
+                \$body .= ' ' . {$failedSegment} . ' failed to export.';
+            }
 
-                return \$body;
-                PHP);
+            return \$body;
+            PHP);
+
         $method->addParameter('export')
             ->setType(Export::class);
 

--- a/packages/actions/src/Commands/FileGenerators/ExporterClassGenerator.php
+++ b/packages/actions/src/Commands/FileGenerators/ExporterClassGenerator.php
@@ -8,7 +8,7 @@ use Filament\Actions\Exports\Models\Export;
 use Filament\Support\Commands\Concerns\CanReadModelSchemas;
 use Filament\Support\Commands\FileGenerators\ClassGenerator;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Number;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Str;
 use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Literal;
@@ -44,7 +44,7 @@ class ExporterClassGenerator extends ClassGenerator
             $this->getExtends(),
             Export::class,
             ExportColumn::class,
-            Number::class,
+            Str::class,
             $this->getModelFqn(),
         ];
     }
@@ -190,7 +190,7 @@ class ExporterClassGenerator extends ClassGenerator
     {
         $str = $this->simplifyFqn(Str::class);
 
-        $useCounted = version_compare(app()->version(), '13.19.0', '>=');
+        $useCounted = version_compare(Application::VERSION, '13.19.0', '>=');
 
         $completedSegment = $useCounted
             ? "{$str}::of('row')->counted(\$export->successful_rows)"
@@ -205,14 +205,14 @@ class ExporterClassGenerator extends ClassGenerator
             ->setStatic()
             ->setReturnType('string')
             ->setBody(<<<PHP
-            \$body = 'Your {$this->getModelLabel()} export has completed and ' . {$completedSegment} . ' exported.';
+                \$body = 'Your {$this->getModelLabel()} export has completed and ' . {$completedSegment} . ' exported.';
 
-            if (\$failedRowsCount = \$export->getFailedRowsCount()) {
-                \$body .= ' ' . {$failedSegment} . ' failed to export.';
-            }
+                if (\$failedRowsCount = \$export->getFailedRowsCount()) {
+                    \$body .= ' ' . {$failedSegment} . ' failed to export.';
+                }
 
-            return \$body;
-            PHP);
+                return \$body;
+                PHP);
 
         $method->addParameter('export')
             ->setType(Export::class);


### PR DESCRIPTION
## Description

Laravel 13.19.0 added `Str::counted()` — a shorthand for `plural($count, prependCount: true)` that pluralizes a word and prepends the count in one call.

This updates `ExporterClassGenerator` so the generated `getCompletedNotificationBody()` uses `Str::of('row')->counted(...)` when the app runs Laravel 13.19+, falling back to `plural(..., prependCount: true)` on older versions. The version check uses `app()->version()`, so no extra import is added.

Both paths still run the count through `Number::format()` internally (via `plural(prependCount: true)`), so thousands separators are preserved — no behavior change to the output.

Result: cleaner generated code on the latest Laravel, with full backward compatibility.

Ref: laravel/framework#60649

## Visual changes

N/A — this only affects generated PHP code, no UI changes.

**Before PR** (current Filament code):
```php
$body = 'Your ... export has completed and ' . Number::format($export->successful_rows) . ' ' . str('row')->plural($export->successful_rows) . ' exported.';
// → "Your ... export has completed and 1,000 rows exported."
```

**New PR — Laravel < 13.19** (fallback):
```php
$body = 'Your ... export has completed and ' . Str::of('row')->plural($export->successful_rows, prependCount: true) . ' exported.';
// → "Your ... export has completed and 1,000 rows exported."
```

**New PR — Laravel >= 13.19** (the reason for this PR):
```php
$body = 'Your ... export has completed and ' . Str::of('row')->counted($export->successful_rows) . ' exported.';
// → "Your ... export has completed and 1,000 rows exported."
```

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.