### PR TITLE
fix: respect time in absolute date constraints

### DIFF
--- a/packages/query-builder/src/Constraints/DateConstraint/Operators/IsAfterOperator.php
+++ b/packages/query-builder/src/Constraints/DateConstraint/Operators/IsAfterOperator.php
@@ -210,6 +210,10 @@ class IsAfterOperator extends Operator
             return $query;
         }
 
+        if ($hasTime) {
+            return $query->where($qualifiedColumn, $this->isInverse() ? '<' : '>=', $date);
+        }
+
         return $query->whereDate($qualifiedColumn, $this->isInverse() ? '<' : '>=', $date);
     }
 

--- a/packages/query-builder/src/Constraints/DateConstraint/Operators/IsBeforeOperator.php
+++ b/packages/query-builder/src/Constraints/DateConstraint/Operators/IsBeforeOperator.php
@@ -210,6 +210,10 @@ class IsBeforeOperator extends Operator
             return $query;
         }
 
+        if ($hasTime) {
+            return $query->where($qualifiedColumn, $this->isInverse() ? '>' : '<=', $date);
+        }
+
         return $query->whereDate($qualifiedColumn, $this->isInverse() ? '>' : '<=', $date);
     }
 

--- a/tests/src/Tables/Filters/QueryBuilderTest.php
+++ b/tests/src/Tables/Filters/QueryBuilderTest.php
@@ -3779,6 +3779,33 @@ describe('absolute and relative date filtering', function (): void {
 
     // Time-Based Date Filtering Tests
 
+    it('can filter records using datetime constraint with is after operator in `absolute` mode', function (): void {
+        $beforeThresholdPost = Post::factory()->create([
+            'published_at' => '2026-07-13 09:00:00',
+        ]);
+
+        $afterThresholdPost = Post::factory()->create([
+            'published_at' => '2026-07-13 15:00:00',
+        ]);
+
+        livewire(PostsQueryBuilderTable::class)
+            ->assertCanSeeTableRecords([$beforeThresholdPost, $afterThresholdPost])
+            ->tap(applyQueryBuilderFilter([
+                [
+                    'type' => 'published_at',
+                    'data' => [
+                        'operator' => 'isAfter',
+                        'settings' => [
+                            'mode' => 'absolute',
+                            'date' => '2026-07-13 12:00:00',
+                        ],
+                    ],
+                ],
+            ]))
+            ->assertCanSeeTableRecords([$afterThresholdPost])
+            ->assertCanNotSeeTableRecords([$beforeThresholdPost]);
+    });
+
     it('can filter records using datetime constraint with is after operator with `this_minute` preset', function (): void {
         $currentMinutePosts = Post::factory()->count(3)->create([
             'published_at' => now()->startOfMinute()->addSeconds(30),
@@ -4130,6 +4157,33 @@ describe('absolute and relative date filtering', function (): void {
     });
 
     // IsBeforeOperator Time-Based Tests
+
+    it('can filter records using datetime constraint with is before operator in `absolute` mode', function (): void {
+        $beforeThresholdPost = Post::factory()->create([
+            'published_at' => '2026-07-13 09:00:00',
+        ]);
+
+        $afterThresholdPost = Post::factory()->create([
+            'published_at' => '2026-07-13 15:00:00',
+        ]);
+
+        livewire(PostsQueryBuilderTable::class)
+            ->assertCanSeeTableRecords([$beforeThresholdPost, $afterThresholdPost])
+            ->tap(applyQueryBuilderFilter([
+                [
+                    'type' => 'published_at',
+                    'data' => [
+                        'operator' => 'isBefore',
+                        'settings' => [
+                            'mode' => 'absolute',
+                            'date' => '2026-07-13 12:00:00',
+                        ],
+                    ],
+                ],
+            ]))
+            ->assertCanSeeTableRecords([$beforeThresholdPost])
+            ->assertCanNotSeeTableRecords([$afterThresholdPost]);
+    });
 
     it('can filter records using datetime constraint with is before operator with `this_minute` preset', function (): void {
         $oldPosts = Post::factory()->count(5)->create([


### PR DESCRIPTION

## Description

When `DateConstraint::time()` is enabled, the absolute `isAfter` and `isBefore` operators still use `whereDate()`, so the selected time is ignored.

Use `where()` for absolute datetime constraints while keeping `whereDate()` for date-only constraints. Add regression tests for both operators.


## Visual changes

### Before
<img width="2280" height="984" alt="image" src="https://github.com/user-attachments/assets/4f96061c-7d9e-4c30-9d42-2bf0cae16a4c" />



### After

<img width="2328" height="964" alt="image" src="https://github.com/user-attachments/assets/bdb6ac31-86b7-4fda-8c5a-47e314ad60fe" />



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
