### PR TITLE
fix: Evaluate stat value

### DIFF
--- a/packages/widgets/src/StatsOverviewWidget/Stat.php
+++ b/packages/widgets/src/StatsOverviewWidget/Stat.php
@@ -168,11 +168,11 @@ class Stat extends Component
     }
 
     /**
-     * @return scalar | Htmlable | Closure
+     * @return scalar | Htmlable
      */
     public function getValue(): mixed
     {
-        return value($this->value);
+        return $this->evaluate($this->value);
     }
 
     public function generateChartDataChecksum(): string


### PR DESCRIPTION
## Summary

Changes `Stat::getValue()` to resolve the stat's value using `$this->evaluate()` instead of the global `value()` helper.

```php
public function getValue(): mixed
{
    return $this->evaluate($this->value);
}
```

## Fix or Feature?

I wasn't able to cleanly classify this as a feature or a bug fix — no existing behavior is broken, but the current implementation is inconsistent with how closures are resolved everywhere else in Filament. Given that, I'm leaning towards **fix**, since it corrects an inconsistency rather than adding new capability.

## Motivation

I ran into this while building a stat whose value needed to render as a `Text` component, which required access to the parent `Stat` instance itself (`$stat->getContainer()`) inside the value closure — something `value()` can't provide.

Since `getValue()` didn't resolve closures through `evaluate()`, I had to wrap the whole thing in `->when(true, fn (Stat $stat) => ...)` just to get a reference to `$stat` in scope, then close over it manually inside the value closure, purely to compensate for the missing injection support:

```php
Stat::make($label, null)
    ->when(true, fn (Stat $stat): Stat => $stat
        ->value(fn (): Text => Text::make($value)
            ->container($stat->getContainer())
            ->color('neutral')
            // ...conditional icon/tooltip/color logic
        )
    ),
```

With `$this->evaluate($this->value)` in place, the value closure itself can type-hint `Stat $component` directly, and this workaround is no longer necessary:

```php
Stat::make($label, value: fn (Stat $component): Text => Text::make($value)
    ->container($component->getContainer())
    ->color('neutral')
    // ...conditional icon/tooltip/color logic
),
```