### PR TITLE
fix: use dehydrated settings for query builder constraints

### DIFF
--- a/packages/tables/src/Filters/QueryBuilder.php
+++ b/packages/tables/src/Filters/QueryBuilder.php
@@ -138,6 +138,7 @@ class QueryBuilder extends BaseFilter
                 function (Operator $operator) use ($ruleIndex, &$summaries): void {
                     $summaries[$ruleIndex] = $operator->getSummary();
                 },
+                shouldUseRawSettings: true,
             );
         }
 
@@ -236,7 +237,6 @@ class QueryBuilder extends BaseFilter
                 $rule,
                 $ruleBuilderBlockContainer,
                 fn (Operator $operator) => $operator->applyToBaseQuery($query),
-                shouldUseDehydratedSettings: true,
             );
         }
 
@@ -275,7 +275,6 @@ class QueryBuilder extends BaseFilter
                 $rule,
                 $ruleBuilderBlockContainer,
                 fn (Operator $operator) => $operator->applyToBaseFilterQuery($query),
-                shouldUseDehydratedSettings: true,
             );
         }
 
@@ -443,7 +442,7 @@ class QueryBuilder extends BaseFilter
     /**
      * @param  array<string, mixed>  $rule
      */
-    protected function tapOperatorFromRule(array $rule, Schema $schema, Closure $callback, bool $shouldUseDehydratedSettings = false): void
+    protected function tapOperatorFromRule(array $rule, Schema $schema, Closure $callback, bool $shouldUseRawSettings = false): void
     {
         $constraint = $this->getConstraint($rule['type']);
 
@@ -469,7 +468,7 @@ class QueryBuilder extends BaseFilter
             return;
         }
 
-        $settings = $shouldUseDehydratedSettings ? ($schema->getStateSnapshot()['settings'] ?? []) : $rule['data']['settings'];
+        $settings = $shouldUseRawSettings ? $rule['data']['settings'] : ($schema->getStateSnapshot()['settings'] ?? []);
 
         $constraint
             ->settings($settings)

--- a/packages/tables/src/Filters/QueryBuilder.php
+++ b/packages/tables/src/Filters/QueryBuilder.php
@@ -236,6 +236,7 @@ class QueryBuilder extends BaseFilter
                 $rule,
                 $ruleBuilderBlockContainer,
                 fn (Operator $operator) => $operator->applyToBaseQuery($query),
+                shouldUseDehydratedSettings: true,
             );
         }
 
@@ -274,6 +275,7 @@ class QueryBuilder extends BaseFilter
                 $rule,
                 $ruleBuilderBlockContainer,
                 fn (Operator $operator) => $operator->applyToBaseFilterQuery($query),
+                shouldUseDehydratedSettings: true,
             );
         }
 
@@ -441,7 +443,7 @@ class QueryBuilder extends BaseFilter
     /**
      * @param  array<string, mixed>  $rule
      */
-    protected function tapOperatorFromRule(array $rule, Schema $schema, Closure $callback): void
+    protected function tapOperatorFromRule(array $rule, Schema $schema, Closure $callback, bool $shouldUseDehydratedSettings = false): void
     {
         $constraint = $this->getConstraint($rule['type']);
 
@@ -467,13 +469,15 @@ class QueryBuilder extends BaseFilter
             return;
         }
 
+        $settings = $shouldUseDehydratedSettings ? ($schema->getStateSnapshot()['settings'] ?? []) : $rule['data']['settings'];
+
         $constraint
-            ->settings($rule['data']['settings'])
+            ->settings($settings)
             ->inverse($isInverseOperator);
 
         $operator
             ->constraint($constraint)
-            ->settings($rule['data']['settings'])
+            ->settings($settings)
             ->inverse($isInverseOperator);
 
         $callback($operator);

--- a/tests/src/Tables/Filters/QueryBuilderTest.php
+++ b/tests/src/Tables/Filters/QueryBuilderTest.php
@@ -18,6 +18,7 @@ use Filament\QueryBuilder\Constraints\RelationshipConstraint\Operators\IsRelated
 use Filament\QueryBuilder\Constraints\SelectConstraint;
 use Filament\QueryBuilder\Constraints\SelectConstraint\Operators\IsOperator as SelectIsOperator;
 use Filament\QueryBuilder\Forms\Components\RuleBuilder;
+use Filament\Support\Facades\FilamentTimezone;
 use Filament\Tables\Filters\QueryBuilder;
 use Filament\Tables\Filters\QueryBuilder\Constraints\TextConstraint;
 use Filament\Tests\Fixtures\Livewire\PostsQueryBuilderTable;
@@ -3786,6 +3787,36 @@ describe('absolute and relative date filtering', function (): void {
 
         $afterThresholdPost = Post::factory()->create([
             'published_at' => '2026-07-13 15:00:00',
+        ]);
+
+        livewire(PostsQueryBuilderTable::class)
+            ->assertCanSeeTableRecords([$beforeThresholdPost, $afterThresholdPost])
+            ->tap(applyQueryBuilderFilter([
+                [
+                    'type' => 'published_at',
+                    'data' => [
+                        'operator' => 'isAfter',
+                        'settings' => [
+                            'mode' => 'absolute',
+                            'date' => '2026-07-13 12:00:00',
+                        ],
+                    ],
+                ],
+            ]))
+            ->assertCanSeeTableRecords([$afterThresholdPost])
+            ->assertCanNotSeeTableRecords([$beforeThresholdPost]);
+    });
+
+    it('can filter records using datetime constraint with is after operator when the Filament timezone differs from the app timezone', function (): void {
+        config(['app.timezone' => 'UTC']);
+        FilamentTimezone::set('America/New_York');
+
+        $beforeThresholdPost = Post::factory()->create([
+            'published_at' => '2026-07-13 15:00:00',
+        ]);
+
+        $afterThresholdPost = Post::factory()->create([
+            'published_at' => '2026-07-13 17:00:00',
         ]);
 
         livewire(PostsQueryBuilderTable::class)

--- a/tests/src/Tables/Filters/QueryBuilderTest.php
+++ b/tests/src/Tables/Filters/QueryBuilderTest.php
@@ -3834,7 +3834,8 @@ describe('absolute and relative date filtering', function (): void {
                 ],
             ]))
             ->assertCanSeeTableRecords([$afterThresholdPost])
-            ->assertCanNotSeeTableRecords([$beforeThresholdPost]);
+            ->assertCanNotSeeTableRecords([$beforeThresholdPost])
+            ->assertSee('Published at is after Mon, Jul 13, 2026 12:00:00');
     });
 
     it('can filter records using datetime constraint with is after operator with `this_minute` preset', function (): void {

--- a/tests/src/Tables/Filters/QueryBuilderTest.php
+++ b/tests/src/Tables/Filters/QueryBuilderTest.php
@@ -3838,6 +3838,88 @@ describe('absolute and relative date filtering', function (): void {
             ->assertSee('Published at is after Mon, Jul 13, 2026 12:00:00');
     });
 
+    it('can filter records using datetime constraint with is before operator when the Filament timezone differs from the app timezone', function (): void {
+        config(['app.timezone' => 'UTC']);
+        FilamentTimezone::set('America/New_York');
+
+        // The cutoff of `12:00:00` is entered in the Filament timezone (`America/New_York`), so it
+        // must be dehydrated to `16:00:00` in the app timezone (`UTC`) before querying, while the
+        // summary continues to display the raw `12:00:00` the user entered.
+        $beforeThresholdPost = Post::factory()->create([
+            'published_at' => '2026-07-13 15:00:00',
+        ]);
+
+        $afterThresholdPost = Post::factory()->create([
+            'published_at' => '2026-07-13 17:00:00',
+        ]);
+
+        livewire(PostsQueryBuilderTable::class)
+            ->assertCanSeeTableRecords([$beforeThresholdPost, $afterThresholdPost])
+            ->tap(applyQueryBuilderFilter([
+                [
+                    'type' => 'published_at',
+                    'data' => [
+                        'operator' => 'isBefore',
+                        'settings' => [
+                            'mode' => 'absolute',
+                            'date' => '2026-07-13 12:00:00',
+                        ],
+                    ],
+                ],
+            ]))
+            ->assertCanSeeTableRecords([$beforeThresholdPost])
+            ->assertCanNotSeeTableRecords([$afterThresholdPost])
+            ->assertSee('Published at is before Mon, Jul 13, 2026 12:00:00');
+    });
+
+    it('applies datetime constraints and summaries from the applied state, not unapplied deferred edits', function (): void {
+        $earlyPost = Post::factory()->create([
+            'published_at' => '2026-07-13 10:00:00',
+        ]);
+
+        $latePost = Post::factory()->create([
+            'published_at' => '2026-07-13 20:00:00',
+        ]);
+
+        livewire(PostsQueryBuilderTable::class)
+            ->assertCanSeeTableRecords([$earlyPost, $latePost])
+            // Apply a rule that only matches the late post.
+            ->tap(applyQueryBuilderFilter([
+                [
+                    'type' => 'published_at',
+                    'data' => [
+                        'operator' => 'isAfter',
+                        'settings' => [
+                            'mode' => 'absolute',
+                            'date' => '2026-07-13 15:00:00',
+                        ],
+                    ],
+                ],
+            ]))
+            ->assertCanSeeTableRecords([$latePost])
+            ->assertCanNotSeeTableRecords([$earlyPost])
+            ->assertSee('Published at is after Mon, Jul 13, 2026 15:00:00')
+            // Edit the deferred form to a looser threshold that would match both posts, *without* applying it.
+            ->set('tableDeferredFilters.query_builder.rules', [
+                [
+                    'type' => 'published_at',
+                    'data' => [
+                        'operator' => 'isAfter',
+                        'settings' => [
+                            'mode' => 'absolute',
+                            'date' => '2026-07-13 05:00:00',
+                        ],
+                    ],
+                ],
+            ])
+            // The query and the summary must still reflect the applied threshold (`15:00:00`),
+            // not the unapplied deferred edit (`05:00:00`).
+            ->assertCanSeeTableRecords([$latePost])
+            ->assertCanNotSeeTableRecords([$earlyPost])
+            ->assertSee('Published at is after Mon, Jul 13, 2026 15:00:00')
+            ->assertDontSee('Published at is after Mon, Jul 13, 2026 05:00:00');
+    });
+
     it('can filter records using datetime constraint with is after operator with `this_minute` preset', function (): void {
         $currentMinutePosts = Post::factory()->count(3)->create([
             'published_at' => now()->startOfMinute()->addSeconds(30),


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Query builder constraints bypass schema state casts when applying raw settings, causing incorrect datetime filters when the Filament and app timezones differ.

Use dehydrated settings for queries while retaining raw settings for summaries.

## Visual changes

### Before

<img width="2300" height="650" alt="image" src="https://github.com/user-attachments/assets/03d35c38-4459-45a2-9b0e-ae23f40d6003" />


### After

<img width="2302" height="542" alt="image" src="https://github.com/user-attachments/assets/e9949416-49b5-4c10-b17b-20809794506f" />



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
