### PR TITLE
fix: Qualify column names for joins on `MorphToSelect` / `Repeater`

### DIFF
--- a/packages/forms/src/Components/MorphToSelect/Type.php
+++ b/packages/forms/src/Components/MorphToSelect/Type.php
@@ -109,6 +109,7 @@ class Type
             }
 
             $keyName = $query->getModel()->getKeyName();
+            $qualifiedKeyName = $query->getModel()->getQualifiedKeyName();
 
             if ($this->hasOptionLabelFromRecordUsingCallback()) {
                 return $query
@@ -121,12 +122,18 @@ class Type
 
             $titleAttribute = $this->getTitleAttribute();
 
+            // Qualify the column names so they are not ambiguous when the query has been
+            // modified to include a join (for example, through `modifyOptionsQueryUsing()`).
+            $qualifiedTitleAttribute = str_contains($titleAttribute, '->')
+                ? $titleAttribute
+                : $query->qualifyColumn($titleAttribute);
+
             if (empty($query->getQuery()->orders)) {
-                $query->orderBy($titleAttribute);
+                $query->orderBy($qualifiedTitleAttribute);
             }
 
             return $query
-                ->pluck($titleAttribute, $keyName)
+                ->pluck($qualifiedTitleAttribute, $qualifiedKeyName)
                 ->toArray();
         });
 
@@ -152,6 +159,7 @@ class Type
             }
 
             $keyName = $query->getModel()->getKeyName();
+            $qualifiedKeyName = $query->getModel()->getQualifiedKeyName();
 
             if ($this->hasOptionLabelFromRecordUsingCallback()) {
                 return $query
@@ -164,19 +172,27 @@ class Type
 
             $titleAttribute = $this->getTitleAttribute();
 
+            // Qualify the column names so they are not ambiguous when the query has been
+            // modified to include a join (for example, through `modifyOptionsQueryUsing()`).
+            $qualifiedTitleAttribute = str_contains($titleAttribute, '->')
+                ? $titleAttribute
+                : $query->qualifyColumn($titleAttribute);
+
             if (empty($query->getQuery()->orders)) {
-                $query->orderBy($titleAttribute);
+                $query->orderBy($qualifiedTitleAttribute);
             }
 
             return $query
-                ->pluck($titleAttribute, $keyName)
+                ->pluck($qualifiedTitleAttribute, $qualifiedKeyName)
                 ->toArray();
         });
 
         $this->getOptionLabelUsing(function (Select $component, $value) {
             $query = $this->getModel()::query();
 
-            $query->where($query->getModel()->getKeyName(), $value);
+            // Qualify the key name so it is not ambiguous when the query has been modified to
+            // include a join (for example, through `modifyOptionsQueryUsing()`).
+            $query->where($query->getModel()->getQualifiedKeyName(), $value);
 
             if ($this->modifyOptionsQueryUsing) {
                 $query = $component->evaluate($this->modifyOptionsQueryUsing, [

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1224,11 +1224,16 @@ class Repeater extends Field implements CanConcealComponents, HasEmbeddedView, H
 
         $relationshipQuery = $relationship->getQuery();
 
+        // Explicitly select the related table's columns so the query is not ambiguous if it is
+        // later modified to include a join (for example, through `modifyRelationshipQueryUsing()`).
+        // Without this, `select *` across a join can hydrate the key from the wrong table.
         if ($relationship instanceof BelongsToMany) {
             $relationshipQuery->select([
                 $relationship->getTable() . '.*',
                 $relationshipQuery->getModel()->getTable() . '.*',
             ]);
+        } else {
+            $relationshipQuery->select($relationshipQuery->getModel()->getTable() . '.*');
         }
 
         if ($this->modifyRelationshipQueryUsing) {
@@ -1238,7 +1243,8 @@ class Repeater extends Field implements CanConcealComponents, HasEmbeddedView, H
         }
 
         if (filled($orderColumn)) {
-            $relationshipQuery->orderBy($orderColumn);
+            // Qualify the order column so it is not ambiguous when the query includes a join.
+            $relationshipQuery->orderBy($relationshipQuery->qualifyColumn($orderColumn));
         }
 
         return $this->cachedExistingRecords = $this->modifyRelationshipRecords($relationshipQuery->get()->mapWithKeys(

--- a/tests/src/Forms/Components/MorphToSelectTest.php
+++ b/tests/src/Forms/Components/MorphToSelectTest.php
@@ -149,6 +149,19 @@ describe('validation', function (): void {
             ->call('save')
             ->assertHasFormErrors(['imageable_id' => ['in']]);
     });
+
+    it('validates against a `modifyOptionsQueryUsing` query that adds a join without an ambiguous column error', function (): void {
+        $author = User::factory()->create();
+        $post = Post::factory()->create(['title' => 'Alpha Article', 'author_id' => $author->getKey()]);
+
+        livewire(TestComponentWithMorphToSelectAndJoinQuery::class)
+            ->fillForm([
+                'imageable_type' => Post::class,
+                'imageable_id' => (string) $post->id,
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+    });
 });
 
 describe('modifier callback clearing', function (): void {
@@ -168,6 +181,46 @@ describe('modifier callback clearing', function (): void {
         expect($component->getModifyKeySelectUsingCallback())->toBeNull();
     });
 });
+
+class TestComponentWithMorphToSelectAndJoinQuery extends Component implements HasActions, HasSchemas
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+
+    public $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->schema([
+                MorphToSelect::make('imageable')
+                    ->types([
+                        MorphToSelect\Type::make(Post::class)
+                            ->titleAttribute('title')
+                            // The join brings in a second `id` column, so any unqualified
+                            // reference to the key must be qualified to avoid an ambiguous column error.
+                            ->modifyOptionsQueryUsing(fn ($query) => $query->join('users', 'users.id', '=', 'posts.author_id')),
+                    ]),
+            ])
+            ->model(Image::class)
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
+    }
+
+    public function render(): View
+    {
+        return view('livewire.form');
+    }
+}
 
 class TestComponentWithMorphToSelectAndModifyQuery extends Component implements HasActions, HasSchemas
 {

--- a/tests/src/Forms/Components/RepeaterTest.php
+++ b/tests/src/Forms/Components/RepeaterTest.php
@@ -452,6 +452,22 @@ describe('relationships', function (): void {
         $undoRepeaterFake();
     });
 
+    it('loads existing records when `modifyQueryUsing()` adds a join and `orderColumn()` is set, without an ambiguous column error', function (): void {
+        $undoRepeaterFake = Repeater::fake();
+
+        $user = User::factory()->create();
+        Post::factory()->count(3)->create(['author_id' => $user->id]);
+
+        livewire(RepeaterWithHasManyRelationshipJoinAndOrderColumn::class, ['record' => $user])
+            ->assertSchemaStateSet(function (array $state) {
+                expect($state['posts'])->toHaveCount(3);
+
+                return [];
+            });
+
+        $undoRepeaterFake();
+    });
+
     it('does not delete out-of-scope records when clearing a Repeater bound to a scoped relationship', function (): void {
         $undoRepeaterFake = Repeater::fake();
 
@@ -1265,6 +1281,51 @@ class RepeaterWithHasManyRelationshipAndModifyQuery extends Component implements
     {
         $this->form->getState();
         $this->form->saveRelationships();
+    }
+
+    public function render(): View
+    {
+        return view('livewire.form');
+    }
+}
+
+class RepeaterWithHasManyRelationshipJoinAndOrderColumn extends Component implements HasActions, HasSchemas
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+
+    public $data = [];
+
+    public User $record;
+
+    public function mount(): void
+    {
+        $this->form->fill([]);
+    }
+
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->schema([
+                Repeater::make('posts')
+                    ->relationship(
+                        'posts',
+                        // The join brings in a second `created_at` column, so the order column must be
+                        // qualified to avoid an ambiguous column error when existing records are loaded.
+                        modifyQueryUsing: fn ($query) => $query->join('users', 'users.id', '=', 'posts.author_id'),
+                    )
+                    ->orderColumn('created_at')
+                    ->schema([
+                        TextInput::make('title'),
+                    ]),
+            ])
+            ->model($this->record)
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
     }
 
     public function render(): View


### PR DESCRIPTION
Fixes #20179.