### PR TITLE
Fix action inside livewireProperty tab never running

### DIFF
--- a/packages/schemas/src/Components/Concerns/HasKey.php
+++ b/packages/schemas/src/Components/Concerns/HasKey.php
@@ -23,6 +23,9 @@ trait HasKey
         $this->key = $key;
         $this->isKeyInheritable = $isInheritable;
 
+        $this->flushCachedAbsoluteKey();
+        $this->flushCachedAbsoluteInheritanceKey();
+
         return $this;
     }
 

--- a/packages/schemas/src/Components/Tabs.php
+++ b/packages/schemas/src/Components/Tabs.php
@@ -7,6 +7,7 @@ use Filament\Schemas\Components\Concerns\CanPersistTab;
 use Filament\Schemas\Components\Concerns\HasLabel;
 use Filament\Schemas\Components\Tabs\Tab;
 use Filament\Schemas\Contracts\HasRenderHookScopes;
+use Filament\Schemas\Schema;
 use Filament\Schemas\View\SchemaIconAlias;
 use Filament\Support\Components\Attributes\ExposedLivewireMethod;
 use Filament\Support\Components\Contracts\HasEmbeddedView;
@@ -96,6 +97,23 @@ class Tabs extends Component implements HasEmbeddedView
         $this->components($tabs);
 
         return $this;
+    }
+
+    protected function configureChildSchema(Schema $schema, string $key): Schema
+    {
+        $schema = parent::configureChildSchema($schema, $key);
+
+        if (filled($this->getLivewireProperty())) {
+            foreach ($schema->getComponents(withOriginalKeys: true) as $tabKey => $tab) {
+                if (! $tab instanceof Tab) {
+                    continue;
+                }
+
+                $tab->key(strval($tabKey));
+            }
+        }
+
+        return $schema;
     }
 
     public function activeTab(int | Closure $activeTab): static

--- a/tests/src/Schemas/Components/TabsTest.php
+++ b/tests/src/Schemas/Components/TabsTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\Tabs;
 use Filament\Schemas\Components\Tabs\Tab;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
@@ -192,6 +194,32 @@ it('renders `wire:click="$set(...)"` on each tab when `livewireProperty()` is se
 
     expect($html)->toContain("\$set('activeTab', 'all')");
     expect($html)->toContain("\$set('activeTab', 'active')");
+});
+
+it('can resolve an action inside a tab before rendering when `livewireProperty()` is set', function (): void {
+    $livewire = new class extends Livewire
+    {
+        public string $activeTab = 'first';
+    };
+
+    $schema = Schema::make($livewire)
+        ->components([
+            Tabs::make()
+                ->livewireProperty('activeTab')
+                ->tabs([
+                    'first' => Tab::make('Details')
+                        ->schema([
+                            Actions::make([Action::make('inTabAction')]),
+                        ]),
+                ]),
+        ]);
+
+    // Resolving before the schema is rendered is the condition during
+    // `mountAction()`. Regression: the tab kept its auto-generated key until
+    // render, so this returned `null` and the action was silently skipped.
+    expect($schema->getAction('inTabAction', 'first'))
+        ->not->toBeNull()
+        ->getName()->toBe('inTabAction');
 });
 
 it('returns fluent `$this` from `tabs()`', function (): void {

--- a/tests/src/Schemas/SchemaTest.php
+++ b/tests/src/Schemas/SchemaTest.php
@@ -246,6 +246,25 @@ describe('key', function (): void {
 
         expect($schema->getKey())->toBe('my-form');
     });
+
+    it('reflects a new key on a component after its absolute key was cached', function (): void {
+        $schema = Schema::make(Livewire::make())
+            ->components([
+                Text::make('Example')->key('original'),
+            ]);
+
+        $component = $schema->getComponents()[0];
+
+        // Cache the absolute key...
+        expect($component->getKey())->toBe('original');
+
+        // ...then re-key it; the change must take effect. Regression: the cached
+        // absolute key was returned, so re-keying (as the livewireProperty tabs
+        // renderer does) had no effect and left actions unresolvable.
+        $component->key('renamed');
+
+        expect($component->getKey())->toBe('renamed');
+    });
 });
 
 describe('extra attributes', function (): void {


### PR DESCRIPTION
**DISCLAIMER: As you can see Claude did find this fix. I am not too sure about the internals here, so please check whether it's the best approach.**


## Description

An action placed inside a `Tabs::make()->livewireProperty(...)` tab never executed its `->action()` callback: no modal opened, no download was returned, nothing happened. The same action at the top level worked.

## Changes

Two things combined to cause it:

1. A livewireProperty tab is keyed by its array key only at render time (`toEmbeddedHtmlForLivewireProperty()`). During `mountAction()` — which resolves the action before the schema renders — the tab still carried its auto-generated key, so `Schema::getAction()` could not resolve the nested schemaComponent key (e.g. `content.first`) and returned null.

2. `HasKey::key()` did not flush the cached absolute key, so once a tab's absolute key had been cached, re-keying it had no effect on `getKey(isAbsolute: true)` — the value the action button's schemaComponent is built from. The button then emitted a stale, unresolvable key.

Fix both: key each tab with its array key when the child schema is built (`configureChildSchema()`), so resolution works at mount time as well as at render time; and flush the cached absolute keys in `key()` so a re-key always takes effect.

Fixes https://github.com/filamentphp/filament/issues/20190