### PR TITLE
fix: prevent Builder block picker from using null array keys

### DIFF
--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -1317,7 +1317,7 @@ class Builder extends Field implements CanConcealComponents, HasEmbeddedView, Ha
             ->class([
                 'fi-dropdown',
                 'fi-fo-builder-block-picker',
-                $alignmentClass => filled($alignmentClass),
+                $alignmentClass,
             ]);
 
         $panelAttributes = (new FilamentComponentAttributeBag)
@@ -1330,7 +1330,7 @@ class Builder extends Field implements CanConcealComponents, HasEmbeddedView, Ha
             ], escape: false)
             ->class([
                 'fi-dropdown-panel',
-                $widthClass => filled($widthClass),
+                $widthClass,
             ]);
 
         $loadingDelay = config('filament.livewire_loading_delay', 'default');


### PR DESCRIPTION
## Description

On PHP 8.4+, rendering the Builder block picker (e.g. via the `QueryBuilder` table filter) emits:

```
Using null as an array offset is deprecated, use an empty string instead
```

The deprecation comes from `Builder::generateBlockPickerHtml()`. When the block picker has no explicit alignment or width, `$alignmentClass` and `$widthClass` are `null`, so these class arrays are built with a `null` key:

```php
->class([
    'fi-dropdown',
    'fi-fo-builder-block-picker',
    $alignmentClass => filled($alignmentClass), // [null => false] when no alignment
]);

->class([
    'fi-dropdown-panel',
    $widthClass => filled($widthClass), // [null => false] when no width
]);
```

Building an array literal with a `null` key triggers the PHP 8.4+ deprecation.

This is the same class of bug that was fixed for the block-picker **Blade view** in #19999. The inline `toEmbeddedHtml` path in `generateBlockPickerHtml()` still had it, so panels that use the embedded-HTML render path (the default) continue to emit the notice.

## Fix

Pass the class as a plain array value instead of a `$class => filled($class)` entry. `ComponentAttributeBag::class()` filters out `null`/falsy plain values, so the rendered output is unchanged when alignment/width is set and simply omits the class when it is not — matching the approach already merged in #19999 for the Blade view.

## How to reproduce

Render any resource list page with a `QueryBuilder` filter (or any `Builder` field with a block picker) on PHP 8.4+ with deprecation reporting enabled; the notice fires from `Builder::generateBlockPickerHtml()`.
