### PR TITLE
Fix: helperText is hidden when the Toggle has inlineLabel(), is live(), and its value is false.

### DIFF
--- a/packages/forms/src/Components/Toggle.php
+++ b/packages/forms/src/Components/Toggle.php
@@ -99,7 +99,7 @@ class Toggle extends Field implements HasEmbeddedView
             <div
                 x-cloak="inline-flex"
                 wire:ignore
-                wire:key="<?= e($livewireKey) ?>.on-state-fallback"
+                wire:key="<?= e($livewireKey) ?>.placeholder"
                 <?= (new FilamentComponentAttributeBag)->class([
                     'fi-toggle fi-toggle-on fi-hidden',
                     ...get_component_color_classes(ToggleComponent::class, $onColor),

--- a/packages/forms/src/Components/Toggle.php
+++ b/packages/forms/src/Components/Toggle.php
@@ -45,6 +45,7 @@ class Toggle extends Field implements HasEmbeddedView
         $onColor = $this->getOnColor() ?? 'primary';
         $onIcon = $this->getOnIcon();
         $isOn = (bool) $this->getState();
+        $livewireKey = $this->getLivewireKey();
 
         $stateExpression = '$wire.' . $this->applyStateBindingModifiers("\$entangle('{$statePath}')");
 
@@ -98,7 +99,7 @@ class Toggle extends Field implements HasEmbeddedView
             <div
                 x-cloak="inline-flex"
                 wire:ignore
-                wire:key="<?= e($this->getId()) ?>.on-fallback"
+                wire:key="<?= e($livewireKey) ?>.on-state-fallback"
                 <?= (new FilamentComponentAttributeBag)->class([
                     'fi-toggle fi-toggle-on fi-hidden',
                     ...get_component_color_classes(ToggleComponent::class, $onColor),

--- a/packages/forms/src/Components/Toggle.php
+++ b/packages/forms/src/Components/Toggle.php
@@ -98,6 +98,7 @@ class Toggle extends Field implements HasEmbeddedView
             <div
                 x-cloak="inline-flex"
                 wire:ignore
+                wire:key="<?= e($this->getId()) ?>.on-fallback"
                 <?= (new FilamentComponentAttributeBag)->class([
                     'fi-toggle fi-toggle-on fi-hidden',
                     ...get_component_color_classes(ToggleComponent::class, $onColor),

--- a/tests/src/Fixtures/Pages/ToggleTest.php
+++ b/tests/src/Fixtures/Pages/ToggleTest.php
@@ -30,6 +30,12 @@ class ToggleTest extends Page
                 Toggle::make('toggle')
                     ->label('Basic Toggle')
                     ->extraAttributes(['data-testid' => 'toggle']),
+                Toggle::make('liveInlineLabelToggle')
+                    ->label('Live Inline Label Toggle')
+                    ->inlineLabel()
+                    ->helperText('Live inline label helper text')
+                    ->live()
+                    ->extraAttributes(['data-testid' => 'live-inline-label-toggle']),
             ])
             ->statePath('data');
     }

--- a/tests/src/Forms/Components/ToggleTest.php
+++ b/tests/src/Forms/Components/ToggleTest.php
@@ -37,6 +37,23 @@ it('can toggle state by clicking in the browser', function (): void {
     });
 });
 
+it('keeps `helperText()` visible after toggling off when `inlineLabel()` and `live()` are used', function (): void {
+    retry(10, function (): void {
+        $this->actingAs(User::factory()->create());
+
+        visit('/toggle-test')
+            ->assertSee('Live inline label helper text')
+            ->click('[data-testid="live-inline-label-toggle"]')
+            ->assertAttribute('[data-testid="live-inline-label-toggle"]', 'aria-checked', 'true')
+            ->assertSee('Live inline label helper text')
+            ->click('[data-testid="live-inline-label-toggle"]')
+            ->wait(1)
+            ->assertAttribute('[data-testid="live-inline-label-toggle"]', 'aria-checked', 'false')
+            ->assertSee('Live inline label helper text')
+            ->assertNoSmoke();
+    });
+});
+
 it('can set and get `onColor()`', function (): void {
     $toggle = Toggle::make('active');
     expect($toggle->getOnColor())->toBeNull();


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

```php
Toggle::make('is_admin')
    ->label('Is Admin')
    ->inlineLabel()
    ->helperText('If enabled, this role will have administrative privileges.')
    ->live()
```

In this case, the `helperText` is hidden when the value is `false` (when the state is off).

## Visual changes

Before:

https://github.com/user-attachments/assets/251c6f61-f8f6-48f1-aea8-879b8d4be37c

After:


https://github.com/user-attachments/assets/d7585106-22b2-45d4-9c0c-da4709f2b3cc


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
