### PR TITLE
fix: Make table action buttons same height as search bar

### DIFF
--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -4,7 +4,6 @@ namespace Filament\Tables\Table\Concerns;
 
 use Closure;
 use Filament\Actions\Action;
-use Filament\Support\Enums\Size;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Grouping\Group;
@@ -123,10 +122,6 @@ trait CanGroupRecords
         }
 
         $action->extraAttributes(['class' => 'fi-force-enabled'], merge: true);
-
-        if ($action->getView() === Action::BUTTON_VIEW) {
-            $action->defaultSize(Size::Small);
-        }
 
         return $action;
     }

--- a/packages/tables/src/Table/Concerns/HasColumnManager.php
+++ b/packages/tables/src/Table/Concerns/HasColumnManager.php
@@ -4,7 +4,6 @@ namespace Filament\Tables\Table\Concerns;
 
 use Closure;
 use Filament\Actions\Action;
-use Filament\Support\Enums\Size;
 use Filament\Support\Enums\Width;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Support\Icons\Heroicon;
@@ -275,10 +274,6 @@ trait HasColumnManager
         }
 
         $action->extraAttributes(['class' => 'fi-force-enabled'], merge: true);
-
-        if ($action->getView() === Action::BUTTON_VIEW) {
-            $action->defaultSize(Size::Small);
-        }
 
         return $action;
     }

--- a/packages/tables/src/Table/Concerns/HasFilters.php
+++ b/packages/tables/src/Table/Concerns/HasFilters.php
@@ -250,10 +250,6 @@ trait HasFilters
 
         $action->extraAttributes(['class' => 'fi-force-enabled'], merge: true);
 
-        if ($action->getView() === Action::BUTTON_VIEW) {
-            $action->defaultSize(Size::Small);
-        }
-
         return $action;
     }
 


### PR DESCRIPTION
## Description

It looks like this was intentional, but I couldn't find a reason for it. So close this if we need to keep it this way. But, the small buttons do not visually align with the size of the search bar.

### `Size::Small`

<img width="1135" height="336" alt="grafik" src="https://github.com/user-attachments/assets/f2c7838a-124f-4677-b4b7-6b8ea83e7f89" />


### `Size::Medium`

<img width="1086" height="297" alt="grafik" src="https://github.com/user-attachments/assets/6e75ab14-948d-4aec-b2d5-dacbf1d9d2fc" />
