### PR TITLE
Allow OptionState to use a Stringable

### DIFF
--- a/packages/schemas/src/Components/StateCasts/OptionStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/OptionStateCast.php
@@ -4,6 +4,7 @@ namespace Filament\Schemas\Components\StateCasts;
 
 use BackedEnum;
 use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
+use Stringable;
 
 class OptionStateCast implements StateCast
 {
@@ -21,12 +22,16 @@ class OptionStateCast implements StateCast
         // always a scalar or `null`. A tampered request payload can deliver an array (or
         // other non-scalar), which would throw a `TypeError` at the `strval()` below and
         // crash the request. Fail closed by treating it as no selection instead.
-        if (! is_scalar($state) && (! $state instanceof BackedEnum)) {
+        if (! is_scalar($state) && (! $state instanceof BackedEnum) && (! $state instanceof Stringable)) {
             return null;
         }
 
         if ($state instanceof BackedEnum) {
             $state = $state->value;
+        }
+
+        if ($state instanceof Stringable) {
+            $state = (string) $state;
         }
 
         if (

--- a/packages/schemas/src/Components/StateCasts/OptionStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/OptionStateCast.php
@@ -65,7 +65,7 @@ class OptionStateCast implements StateCast
 
         // Security: mirror `get()` and fail closed on a tampered non-scalar value so a
         // malformed array cannot reach `strval()` and crash the request.
-        if (! is_scalar($state) && (! $state instanceof BackedEnum)) {
+        if (! is_scalar($state) && (! $state instanceof BackedEnum) && (! $state instanceof Stringable)) {
             return null;
         }
 

--- a/packages/schemas/src/Components/StateCasts/OptionsArrayStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/OptionsArrayStateCast.php
@@ -5,6 +5,7 @@ namespace Filament\Schemas\Components\StateCasts;
 use BackedEnum;
 use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
 use Illuminate\Support\Arr;
+use Stringable;
 
 class OptionsArrayStateCast implements StateCast
 {
@@ -34,12 +35,16 @@ class OptionsArrayStateCast implements StateCast
                 // Security: each option must be a scalar or `BackedEnum`, but a tampered
                 // request payload can deliver a nested array, which would throw a `TypeError`
                 // at the `strval()` below and crash the request. Fail closed by skipping it.
-                if ((! is_scalar($stateItem)) && (! $stateItem instanceof BackedEnum)) {
+                if ((! is_scalar($stateItem)) && (! $stateItem instanceof BackedEnum) && (! $stateItem instanceof Stringable)) {
                     return $carry;
                 }
 
                 if ($stateItem instanceof BackedEnum) {
                     $stateItem = $stateItem->value;
+                }
+
+                if ($stateItem instanceof Stringable) {
+                    $stateItem = (string) $stateItem;
                 }
 
                 if (
@@ -96,7 +101,7 @@ class OptionsArrayStateCast implements StateCast
                 // Security: each option must be a scalar or `BackedEnum`, but a tampered
                 // request payload can deliver a nested array, which would throw a `TypeError`
                 // at the `strval()` below and crash the request. Fail closed by skipping it.
-                if ((! is_scalar($stateItem)) && (! $stateItem instanceof BackedEnum)) {
+                if ((! is_scalar($stateItem)) && (! $stateItem instanceof BackedEnum) && (! $stateItem instanceof Stringable)) {
                     return $carry;
                 }
 

--- a/tests/src/Schemas/Components/StateCasts/OptionStateCastTest.php
+++ b/tests/src/Schemas/Components/StateCasts/OptionStateCastTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use Filament\Schemas\Components\StateCasts\OptionStateCast;
+use Filament\Tests\Fixtures\Enums\StringBackedEnum;
+use Filament\Tests\TestCase;
+
+uses(TestCase::class);
+
+it('casts digit strings to integers and keeps other strings in `get()`', function (): void {
+    $cast = app(OptionStateCast::class);
+
+    expect($cast->get('1'))->toBe(1)
+        ->and($cast->get('active'))->toBe('active');
+});
+
+it('resolves a `BackedEnum` option to its value in `get()`', function (): void {
+    $cast = app(OptionStateCast::class);
+
+    expect($cast->get(StringBackedEnum::One))
+        ->toBe(StringBackedEnum::One->value);
+});
+
+it('casts a `Stringable` option to a string in `get()`', function (): void {
+    $cast = app(OptionStateCast::class);
+
+    expect($cast->get(str('active')))->toBe('active')
+        ->and($cast->get(str('1')))->toBe(1);
+});
+
+it('returns `null` for blank state in `get()`', function (): void {
+    $cast = app(OptionStateCast::class);
+
+    expect($cast->get(null))->toBeNull()
+        ->and($cast->get(''))->toBeNull();
+});
+
+it('returns `null` for a tampered non-scalar value in `get()` instead of throwing', function (): void {
+    $cast = app(OptionStateCast::class);
+
+    // Security: a tampered request can deliver an array, which would reach `strval()` and
+    // throw an `Array to string conversion` error. It must be treated as no selection.
+    expect($cast->get(['tampered']))->toBeNull();
+});
+
+it('casts the option to a string in `set()`', function (): void {
+    $cast = app(OptionStateCast::class);
+
+    expect($cast->set(1))->toBe('1')
+        ->and($cast->set('active'))->toBe('active');
+});
+
+it('resolves a `BackedEnum` option to its value in `set()`', function (): void {
+    $cast = app(OptionStateCast::class);
+
+    expect($cast->set(StringBackedEnum::One))
+        ->toBe(StringBackedEnum::One->value);
+});
+
+it('casts a `Stringable` option to a string in `set()`', function (): void {
+    $cast = app(OptionStateCast::class);
+
+    expect($cast->set(str('active')))->toBe('active');
+});
+
+it('returns `null` for a tampered non-scalar value in `set()` instead of throwing', function (): void {
+    $cast = app(OptionStateCast::class);
+
+    // Security: mirror `get()` and fail closed on a tampered array so `strval()` cannot crash.
+    expect($cast->set(['tampered']))->toBeNull();
+});

--- a/tests/src/Schemas/Components/StateCasts/OptionsArrayStateCastTest.php
+++ b/tests/src/Schemas/Components/StateCasts/OptionsArrayStateCastTest.php
@@ -36,11 +36,25 @@ it('drops a tampered non-scalar array element in `get()` instead of throwing', f
         ->toBe([1, 2]);
 });
 
+it('casts `Stringable` options to strings in `get()`', function (): void {
+    $cast = app(OptionsArrayStateCast::class);
+
+    expect($cast->get([str('active'), str('1')]))
+        ->toBe(['active', 1]);
+});
+
 it('casts every option to a string in `set()`', function (): void {
     $cast = app(OptionsArrayStateCast::class);
 
     expect($cast->set([1, 'active']))
         ->toBe(['1', 'active']);
+});
+
+it('casts `Stringable` options to strings in `set()`', function (): void {
+    $cast = app(OptionsArrayStateCast::class);
+
+    expect($cast->set([str('active'), str('1')]))
+        ->toBe(['active', '1']);
 });
 
 it('drops a tampered non-scalar array element in `set()` instead of throwing', function (): void {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Filament 5.7.0 via https://github.com/filamentphp/filament/pull/20151 modified the `OptionStateCast` to check if the state was a scalar or a `BackedEnum`. Previously you could pass in any `Stringable` as well here and it would be correctly handled by `strval`. This adds back the ability to use a `Stringable`.

## Visual changes

None

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
