### PR TITLE
Fix stale repeatable entry items after relationship refresh

### DIFF
--- a/packages/infolists/src/Components/RepeatableEntry.php
+++ b/packages/infolists/src/Components/RepeatableEntry.php
@@ -31,6 +31,8 @@ class RepeatableEntry extends Entry implements HasEmbeddedView
      */
     protected ?array $cachedItems = null;
 
+    protected mixed $cachedItemsState = null;
+
     /**
      * Configure table columns for display
      *
@@ -66,13 +68,15 @@ class RepeatableEntry extends Entry implements HasEmbeddedView
      */
     public function getItems(): array
     {
-        if ($this->cachedItems !== null) {
+        $state = $this->getState() ?? [];
+
+        if (($this->cachedItems !== null) && ($this->cachedItemsState === $state)) {
             return $this->cachedItems;
         }
 
         $containers = [];
 
-        foreach ($this->getState() ?? [] as $itemKey => $itemData) {
+        foreach ($state as $itemKey => $itemData) {
             $container = $this
                 ->getChildSchema()
                 ->getClone()
@@ -87,6 +91,8 @@ class RepeatableEntry extends Entry implements HasEmbeddedView
 
             $containers[$itemKey] = $container;
         }
+
+        $this->cachedItemsState = $state;
 
         return $this->cachedItems = $containers;
     }
@@ -104,6 +110,7 @@ class RepeatableEntry extends Entry implements HasEmbeddedView
         parent::clearCachedChildSchemas();
 
         $this->cachedItems = null;
+        $this->cachedItemsState = null;
     }
 
     public function toEmbeddedHtml(): string

--- a/tests/src/Infolists/Components/RepeatableEntryTest.php
+++ b/tests/src/Infolists/Components/RepeatableEntryTest.php
@@ -421,6 +421,31 @@ describe('nested state resolution', function (): void {
 });
 
 describe('relationships', function (): void {
+    it('rebuilds items when a loaded relationship changes', function (): void {
+        $user = User::factory()
+            ->has(Post::factory()->count(2), 'posts')
+            ->create()
+            ->load('posts');
+
+        $schema = Schema::make(Livewire::make())
+            ->record($user)
+            ->components([
+                RepeatableEntry::make('posts')
+                    ->schema([
+                        TextEntry::make('title'),
+                    ]),
+            ]);
+
+        $entry = $schema->getComponents()[0];
+
+        expect($entry->getItems())->toHaveCount(2);
+
+        $user->posts()->firstOrFail()->delete();
+        $user->refresh();
+
+        expect($entry->getItems())->toHaveCount(1);
+    });
+
     it('can resolve state for relationship-based `RepeatableEntry`', function (): void {
         $user = User::factory()
             ->has(Post::factory()->count(2)->sequence(


### PR DESCRIPTION
## Description

Fixes #20222.

`RepeatableEntry::getItems()` now compares the current state with the state used to build its memoized item schemas. This keeps the 5.7 memoization optimization for unchanged state while rebuilding the schemas when a loaded Eloquent relationship is refreshed after an action.

A regression test deletes a related record, refreshes the parent model, and verifies that the repeatable entry immediately reflects the remaining relationship items.

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed with Pint and verified with Rector.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date (no documentation changes are required).

## Tests

- `vendor/bin/pest --configuration=phpunit.sqlite.xml tests/src/Infolists/Components/RepeatableEntryTest.php --compact`
- `php -d memory_limit=1G vendor/bin/phpstan analyse packages/infolists/src/Components/RepeatableEntry.php --no-progress`
