### PR TITLE
feat(tables): allow summaries to be positioned at the top of the table

### DIFF
--- a/packages/tables/docs/06-summaries.md
+++ b/packages/tables/docs/06-summaries.md
@@ -424,6 +424,24 @@ public function table(Table $table): Table
 }
 ```
 
+## Positioning summaries
+
+By default, summaries are displayed at the bottom of the table. You may render a summarizer above the records instead, using the `position()` method with the `SummarizerPosition` enum:
+
+```php
+use Filament\Tables\Columns\Summarizers\Sum;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\SummarizerPosition;
+
+TextColumn::make('views_count')
+    ->summarize(
+        Sum::make()
+            ->position(SummarizerPosition::Top),
+    )
+```
+
+Each summarizer decides individually where it is rendered, so you can display some summaries at the top of the table and others at the bottom of it. Summaries of [groups of rows](#summarising-groups-of-rows) are not affected by the `position()` method.
+
 ## Hiding summary rows
 
 By default, both the page summary and total summary rows are displayed when columns have summarizers. You can control which summary rows appear using the `summaries()` method on the table:

--- a/packages/tables/resources/views/components/summary/index.blade.php
+++ b/packages/tables/resources/views/components/summary/index.blade.php
@@ -9,6 +9,7 @@
     'pageSummary' => true,
     'placeholderColumns' => true,
     'pluralModelLabel',
+    'position' => null,
     'recordCheckboxPosition' => null,
     'records',
     'selectionEnabled' => false,
@@ -53,7 +54,7 @@
 
         @foreach ($columns as $column)
             @php
-                $columnHasSummary = ($pageTableSummaryQuery && $column->hasSummary($pageTableSummaryQuery)) || $column->hasSummary($allTableSummaryQuery);
+                $columnHasSummary = ($pageTableSummaryQuery && $column->hasSummary($pageTableSummaryQuery, $position)) || $column->hasSummary($allTableSummaryQuery, $position);
             @endphp
 
             @if ($placeholderColumns || $columnHasSummary)
@@ -116,6 +117,7 @@
         :extra-heading-column="$extraHeadingColumn"
         :heading="__('filament-tables::table.summary.subheadings.page', ['label' => $pluralModelLabel])"
         :placeholder-columns="$placeholderColumns"
+        :position="$position"
         :query="$pageTableSummaryQuery"
         :record-checkbox-position="$recordCheckboxPosition"
         :selected-state="$selectedState"
@@ -136,6 +138,7 @@
         :groups-only="$groupsOnly"
         :heading="__(($hasPageSummary ? 'filament-tables::table.summary.subheadings.all' : 'filament-tables::table.summary.heading'), ['label' => $pluralModelLabel])"
         :placeholder-columns="$placeholderColumns"
+        :position="$position"
         :query="$allTableSummaryQuery"
         :record-checkbox-position="$recordCheckboxPosition"
         :selected-state="$selectedState"

--- a/packages/tables/resources/views/components/summary/row.blade.php
+++ b/packages/tables/resources/views/components/summary/row.blade.php
@@ -7,6 +7,7 @@
     'groupsOnly' => false,
     'heading',
     'placeholderColumns' => true,
+    'position' => null,
     'query',
     'selectionEnabled' => false,
     'selectedState',
@@ -32,7 +33,7 @@
     $columnsWithSummary = [];
 
     foreach ($columns as $summaryColumnKey => $summaryColumn) {
-        $summaryColumnSummarizers = $summaryColumn->getSummarizers($query);
+        $summaryColumnSummarizers = $summaryColumn->getSummarizers($query, $position);
 
         $columnsWithSummary[$summaryColumnKey] = [
             'summarizers' => $summaryColumnSummarizers,

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -13,6 +13,7 @@
     use Filament\Tables\Enums\FiltersResetActionPosition;
     use Filament\Tables\Enums\RecordActionsPosition;
     use Filament\Tables\Enums\RecordCheckboxPosition;
+    use Filament\Tables\Enums\SummarizerPosition;
     use Filament\Tables\View\TablesRenderHook;
     use Illuminate\Support\Str;
     use Illuminate\View\ComponentAttributeBag;
@@ -46,8 +47,12 @@
     $hasColumnsLayout = $hasColumnsLayout();
     $hasPageSummary = $hasPageSummary();
     $hasAllTableSummary = $hasAllTableSummary();
+    $hasTopPositionedSummarizers = $hasSummary($this->getAllTableSummaryQuery(), SummarizerPosition::Top);
+    $hasBottomPositionedSummarizers = $hasSummary($this->getAllTableSummaryQuery(), SummarizerPosition::Bottom);
     $hasSummary = $hasSummary($this->getAllTableSummaryQuery());
     $hasTopLevelSummary = $hasSummary && ($hasPageSummary || $hasAllTableSummary);
+    $hasTopLevelTopPositionedSummary = $hasTopPositionedSummarizers && ($hasPageSummary || $hasAllTableSummary);
+    $hasTopLevelBottomPositionedSummary = $hasBottomPositionedSummarizers && ($hasPageSummary || $hasAllTableSummary);
     $header = $getHeader();
     $headerActions = array_filter(
         $getHeaderActions(),
@@ -1048,6 +1053,23 @@
                         @if ($content)
                             {{ $content->with(['records' => $records]) }}
                         @else
+                            @if ($hasTopLevelTopPositionedSummary && (! $isReordering))
+                                <table class="fi-ta-table">
+                                    <tbody>
+                                        <x-filament-tables::summary
+                                            :all-table-summary="$hasAllTableSummary"
+                                            :columns="$columns"
+                                            extra-heading-column
+                                            :page-summary="$hasPageSummary"
+                                            :placeholder-columns="false"
+                                            :plural-model-label="$pluralModelLabel"
+                                            :position="\Filament\Tables\Enums\SummarizerPosition::Top"
+                                            :records="$records"
+                                        />
+                                    </tbody>
+                                </table>
+                            @endif
+
                             <div
                                 @if ($isReorderable)
                                     x-on:end.stop="
@@ -1406,7 +1428,7 @@
                             }}
                         @endif
 
-                        @if ($hasTopLevelSummary && (! $isReordering))
+                        @if ($hasTopLevelBottomPositionedSummary && (! $isReordering))
                             <table class="fi-ta-table">
                                 <tbody>
                                     <x-filament-tables::summary
@@ -1416,6 +1438,7 @@
                                         :page-summary="$hasPageSummary"
                                         :placeholder-columns="false"
                                         :plural-model-label="$pluralModelLabel"
+                                        :position="\Filament\Tables\Enums\SummarizerPosition::Bottom"
                                         :records="$records"
                                     />
                                 </tbody>
@@ -1994,6 +2017,27 @@
                                         </tr>
                                     @endif
 
+                                    @if ($hasTopPositionedSummarizers && (! $isReordering) && count($records))
+                                        @php
+                                            $groupColumn = $group?->getColumn();
+                                        @endphp
+
+                                        <x-filament-tables::summary
+                                            :actions="$hasRecordActionsForAnyRecord"
+                                            :actions-position="$recordActionsPosition"
+                                            :all-table-summary="$hasAllTableSummary"
+                                            :columns="$columns"
+                                            :group-column="$groupColumn"
+                                            :groups-only="$isGroupsOnly"
+                                            :page-summary="$hasPageSummary"
+                                            :plural-model-label="$pluralModelLabel"
+                                            :position="\Filament\Tables\Enums\SummarizerPosition::Top"
+                                            :record-checkbox-position="$recordCheckboxPosition"
+                                            :records="$records"
+                                            :selection-enabled="$isSelectionEnabled"
+                                        />
+                                    @endif
+
                                     @if (count($records))
                                         @php
                                             $isRecordRowStriped = false;
@@ -2460,7 +2504,7 @@
                                             />
                                         @endif
 
-                                        @if ($hasSummary && (! $isReordering))
+                                        @if ($hasBottomPositionedSummarizers && (! $isReordering))
                                             @php
                                                 $groupColumn = $group?->getColumn();
                                             @endphp
@@ -2474,6 +2518,7 @@
                                                 :groups-only="$isGroupsOnly"
                                                 :page-summary="$hasPageSummary"
                                                 :plural-model-label="$pluralModelLabel"
+                                                :position="\Filament\Tables\Enums\SummarizerPosition::Bottom"
                                                 :record-checkbox-position="$recordCheckboxPosition"
                                                 :records="$records"
                                                 :selection-enabled="$isSelectionEnabled"

--- a/packages/tables/src/Columns/Concerns/CanBeSummarized.php
+++ b/packages/tables/src/Columns/Concerns/CanBeSummarized.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Columns\Concerns;
 
 use Closure;
 use Filament\Tables\Columns\Summarizers\Summarizer;
+use Filament\Tables\Enums\SummarizerPosition;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 
@@ -40,20 +41,29 @@ trait CanBeSummarized
     /**
      * @return array<string | int, Summarizer>
      */
-    public function getSummarizers(Builder | Closure | null $query = null): array
+    public function getSummarizers(Builder | Closure | null $query = null, ?SummarizerPosition $position = null): array
     {
+        $summarizers = $this->summarizers;
+
+        if ($position) {
+            $summarizers = array_filter(
+                $summarizers,
+                fn (Summarizer $summarizer): bool => $summarizer->getPosition() === $position,
+            );
+        }
+
         if ($query) {
             return array_filter(
-                $this->summarizers,
+                $summarizers,
                 fn (Summarizer $summarizer): bool => $summarizer->query($query)->isVisible(),
             );
         }
 
-        return $this->summarizers;
+        return $summarizers;
     }
 
-    public function hasSummary(Builder | Closure | null $query = null): bool
+    public function hasSummary(Builder | Closure | null $query = null, ?SummarizerPosition $position = null): bool
     {
-        return (bool) count($this->getSummarizers($query));
+        return (bool) count($this->getSummarizers($query, $position));
     }
 }

--- a/packages/tables/src/Columns/Summarizers/Summarizer.php
+++ b/packages/tables/src/Columns/Summarizers/Summarizer.php
@@ -6,6 +6,7 @@ use Closure;
 use Filament\Support\Components\Contracts\HasEmbeddedView;
 use Filament\Support\Components\ViewComponent;
 use Filament\Support\Concerns\HasExtraAttributes;
+use Filament\Tables\Enums\SummarizerPosition;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Query\Builder;
@@ -24,6 +25,8 @@ class Summarizer extends ViewComponent implements HasEmbeddedView
     protected string $viewIdentifier = 'summarizer';
 
     protected ?string $id = null;
+
+    protected SummarizerPosition | Closure | null $position = null;
 
     /**
      * @var array<string, mixed>
@@ -50,6 +53,18 @@ class Summarizer extends ViewComponent implements HasEmbeddedView
         $this->id = $id;
 
         return $this;
+    }
+
+    public function position(SummarizerPosition | Closure | null $position): static
+    {
+        $this->position = $position;
+
+        return $this;
+    }
+
+    public function getPosition(): SummarizerPosition
+    {
+        return $this->evaluate($this->position) ?? SummarizerPosition::Bottom;
     }
 
     public function using(?Closure $using): static

--- a/packages/tables/src/Enums/SummarizerPosition.php
+++ b/packages/tables/src/Enums/SummarizerPosition.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Filament\Tables\Enums;
+
+enum SummarizerPosition
+{
+    case Top;
+
+    case Bottom;
+}

--- a/packages/tables/src/Table/Concerns/CanSummarizeRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSummarizeRecords.php
@@ -3,6 +3,7 @@
 namespace Filament\Tables\Table\Concerns;
 
 use Closure;
+use Filament\Tables\Enums\SummarizerPosition;
 use Illuminate\Database\Eloquent\Builder;
 
 trait CanSummarizeRecords
@@ -29,10 +30,10 @@ trait CanSummarizeRecords
         return (bool) $this->evaluate($this->hasAllTableSummary);
     }
 
-    public function hasSummary(Builder | Closure | null $query): bool
+    public function hasSummary(Builder | Closure | null $query, ?SummarizerPosition $position = null): bool
     {
         foreach ($this->getColumns() as $column) {
-            if ($column->hasSummary($query)) {
+            if ($column->hasSummary($query, $position)) {
                 return true;
             }
         }

--- a/tests/src/Fixtures/Pages/SummarizerPositionBrowserTest.php
+++ b/tests/src/Fixtures/Pages/SummarizerPositionBrowserTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Pages;
+
+use BackedEnum;
+use Filament\Pages\Page;
+use Filament\Schemas\Components\EmbeddedTable;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Enums\SummarizerPosition;
+use Filament\Tables\Table;
+use Filament\Tests\Fixtures\Models\Post;
+
+class SummarizerPositionBrowserTest extends Page implements HasTable
+{
+    use Tables\Concerns\InteractsWithTable;
+
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedCalculator;
+
+    protected static ?int $navigationSort = 9;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(Post::query())
+            ->columns([
+                Tables\Columns\TextColumn::make('title'),
+                Tables\Columns\TextColumn::make('rating')
+                    ->summarize([
+                        Tables\Columns\Summarizers\Sum::make('topSum')
+                            ->label('Top total')
+                            ->position(SummarizerPosition::Top),
+                        Tables\Columns\Summarizers\Sum::make('bottomSum')
+                            ->label('Bottom total'),
+                    ]),
+            ]);
+    }
+
+    public function content(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                EmbeddedTable::make(),
+            ]);
+    }
+}

--- a/tests/src/Fixtures/Providers/AdminPanelProvider.php
+++ b/tests/src/Fixtures/Providers/AdminPanelProvider.php
@@ -53,6 +53,7 @@ use Filament\Tests\Fixtures\Pages\SectionBrowserTest;
 use Filament\Tests\Fixtures\Pages\SelectTest;
 use Filament\Tests\Fixtures\Pages\Settings;
 use Filament\Tests\Fixtures\Pages\SliderBrowserTest;
+use Filament\Tests\Fixtures\Pages\SummarizerPositionBrowserTest;
 use Filament\Tests\Fixtures\Pages\TabsBrowserTest;
 use Filament\Tests\Fixtures\Pages\TagsInputTest;
 use Filament\Tests\Fixtures\Pages\TextareaTest;
@@ -144,6 +145,7 @@ class AdminPanelProvider extends PanelProvider
                 SelectTest::class,
                 Settings::class,
                 SliderBrowserTest::class,
+                SummarizerPositionBrowserTest::class,
                 TabsBrowserTest::class,
                 TagsInputTest::class,
                 TextareaTest::class,

--- a/tests/src/Tables/Columns/Summarizers/SummarizerTest.php
+++ b/tests/src/Tables/Columns/Summarizers/SummarizerTest.php
@@ -6,6 +6,7 @@ use Filament\Tables\Columns\Summarizers\Range;
 use Filament\Tables\Columns\Summarizers\Sum;
 use Filament\Tables\Columns\Summarizers\Summarizer;
 use Filament\Tables\Columns\Summarizers\Values;
+use Filament\Tables\Enums\SummarizerPosition;
 use Filament\Tests\Fixtures\Models\Post;
 use Filament\Tests\TestCase;
 
@@ -35,6 +36,22 @@ describe('`Summarizer` base class', function (): void {
         $summarizer->id('post-hoc');
 
         expect($summarizer->getId())->toBe('post-hoc');
+    });
+
+    it('defaults `getPosition()` to `SummarizerPosition::Bottom`', function (): void {
+        expect(Summarizer::make()->getPosition())->toBe(SummarizerPosition::Bottom);
+    });
+
+    it('can use `position()` to render the summary at the top of the table', function (): void {
+        expect(Summarizer::make()->position(SummarizerPosition::Top)->getPosition())->toBe(SummarizerPosition::Top);
+    });
+
+    it('can use `position()` with a `Closure`', function (): void {
+        expect(Summarizer::make()->position(static fn (): SummarizerPosition => SummarizerPosition::Top)->getPosition())->toBe(SummarizerPosition::Top);
+    });
+
+    it('can use `position(null)` to reset the position to the default', function (): void {
+        expect(Summarizer::make()->position(SummarizerPosition::Top)->position(null)->getPosition())->toBe(SummarizerPosition::Bottom);
     });
 
     it('can set `using()` callback', function (): void {

--- a/tests/src/Tables/SummaryTest.php
+++ b/tests/src/Tables/SummaryTest.php
@@ -10,8 +10,10 @@ use Filament\Tables\Table;
 use Filament\Tests\Fixtures\Livewire\PostsTable;
 use Filament\Tests\Fixtures\Livewire\PostsTableWithCursorPagination;
 use Filament\Tests\Fixtures\Models\Post;
+use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\Tables\TestCase;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Artisan;
 use Livewire\Component;
 
 use function Filament\Tests\livewire;
@@ -215,6 +217,26 @@ it('can use `position()` to render a summary at the top of the table', function 
 
     livewire(TestTableWithPositionedSummaries::class)
         ->assertSeeInOrder(['Top total', 'Zeta unique title', 'Bottom total']);
+});
+
+it('renders positioned summaries accessibly in the browser', function (): void {
+    retry(10, function (): void {
+        Artisan::call('filament:assets');
+
+        $this->actingAs(User::factory()->create());
+
+        Post::factory()->count(3)->create(['title' => 'Zeta unique title', 'rating' => 2]);
+
+        visit('/summarizer-position-browser-test')
+            ->assertSeeIn('.fi-ta-content-ctn', 'Top total')
+            ->assertSeeIn('.fi-ta-content-ctn', 'Bottom total')
+            ->assertNoSmoke()
+            ->assertNoAccessibilityIssues();
+
+        visit('/summarizer-position-browser-test')
+            ->inDarkMode()
+            ->assertNoAccessibilityIssues();
+    });
 });
 
 class TestTableWithGroupSummariesOnly extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable

--- a/tests/src/Tables/SummaryTest.php
+++ b/tests/src/Tables/SummaryTest.php
@@ -5,6 +5,7 @@ use Filament\Actions\Contracts\HasActions;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Tables;
+use Filament\Tables\Enums\SummarizerPosition;
 use Filament\Tables\Table;
 use Filament\Tests\Fixtures\Livewire\PostsTable;
 use Filament\Tests\Fixtures\Livewire\PostsTableWithCursorPagination;
@@ -209,6 +210,13 @@ it('does not render the trailing group summary with cursor pagination when the n
         ->assertDontSee('A summary');
 });
 
+it('can use `position()` to render a summary at the top of the table', function (): void {
+    Post::factory()->count(3)->create(['title' => 'Zeta unique title', 'rating' => 2]);
+
+    livewire(TestTableWithPositionedSummaries::class)
+        ->assertSeeInOrder(['Top total', 'Zeta unique title', 'Bottom total']);
+});
+
 class TestTableWithGroupSummariesOnly extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
 {
     use InteractsWithActions;
@@ -230,6 +238,35 @@ class TestTableWithGroupSummariesOnly extends Component implements HasActions, H
                 Tables\Grouping\Group::make('is_published'),
             )
             ->summaries(pageCondition: false, allTableCondition: false);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.table');
+    }
+}
+
+class TestTableWithPositionedSummaries extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use Tables\Concerns\InteractsWithTable;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(Post::query())
+            ->columns([
+                Tables\Columns\TextColumn::make('title'),
+                Tables\Columns\TextColumn::make('rating')
+                    ->summarize([
+                        Tables\Columns\Summarizers\Sum::make('topSum')
+                            ->label('Top total')
+                            ->position(SummarizerPosition::Top),
+                        Tables\Columns\Summarizers\Sum::make('bottomSum')
+                            ->label('Bottom total'),
+                    ]),
+            ]);
     }
 
     public function render(): View


### PR DESCRIPTION
## Description

Table summaries are always rendered below the records. On long tables that means scrolling past every row before seeing the totals, while for many reporting tables the totals are exactly what users open the page for.

This adds a `position()` method to summarizers, together with a new `Filament\Tables\Enums\SummarizerPosition` enum (`Top` / `Bottom`), so a summary can be rendered directly below the column headers instead:

```php
use Filament\Tables\Enums\SummarizerPosition;

public function table(Table $table): Table
{
    return $table
        ->columns([
            TextColumn::make('views_count')
                ->summarize(
                    Sum::make()
                        ->position(SummarizerPosition::Top),
                ),
        ]);
}
```

Each summarizer decides individually where it is rendered, so some summaries can be shown above the records and others below on the same table. The summary section is now rendered in up to two places — directly below the column header row and at the bottom as today — and each section only appears when at least one visible summarizer targets that position. Both the page summary and the all-table summary rows respect the position; group summaries are unaffected.

The default is `Bottom`, so existing tables render identical output when the API is unused. The position filter is threaded through `getSummarizers()` / `hasSummary()` as an optional parameter, keeping the existing signatures backwards compatible.

New tests cover the API (default, enum value, `Closure`, resetting with `null`), a render test asserts the top/bottom ordering around the records, and a browser test asserts `assertNoAccessibilityIssues()` in light and dark mode.

## Visual changes

A summary row can now appear directly below the column header row.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
