### PR TITLE
Fix BackedEnum tab badge icons

### DIFF
--- a/packages/schemas/src/Components/Tabs.php
+++ b/packages/schemas/src/Components/Tabs.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Schemas\Components;
 
+use BackedEnum;
 use Closure;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
@@ -785,7 +786,7 @@ class Tabs extends Component implements HasEmbeddedView
     protected function generateTabBadgeHtml(
         string | int | float $badge,
         string | array | null $color = null,
-        string | Htmlable | null $icon = null,
+        string | BackedEnum | Htmlable | null $icon = null,
         IconPosition | string | null $iconPosition = null,
         string | Htmlable | null $tooltip = null,
     ): string {

--- a/tests/src/Fixtures/Pages/TabsBrowserTest.php
+++ b/tests/src/Fixtures/Pages/TabsBrowserTest.php
@@ -32,6 +32,8 @@ class TabsBrowserTest extends Page
                 Tabs::make('Profile Tabs')
                     ->tabs([
                         Tab::make('Account')
+                            ->badge('Available')
+                            ->badgeIcon(Heroicon::OutlinedCheckCircle)
                             ->schema([
                                 TextInput::make('username')
                                     ->label('Username')

--- a/tests/src/Schemas/Components/TabsTest.php
+++ b/tests/src/Schemas/Components/TabsTest.php
@@ -9,6 +9,7 @@ use Filament\Schemas\Components\Tabs\Tab;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Fixtures\Livewire\Livewire;
 use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\TestCase;
@@ -466,6 +467,12 @@ describe('rendering', function (): void {
         livewire(RenderTabs::class)->assertSuccessful();
     });
 
+    it('can render a tab badge icon with a `BackedEnum`', function (): void {
+        livewire(RenderTabsWithBackedEnumBadgeIcon::class)
+            ->assertSuccessful()
+            ->assertSee('Available');
+    });
+
     it('can render with `scrollable(false)`', function (): void {
         livewire(RenderTabsWithScrollableFalse::class)->assertSuccessful();
     });
@@ -510,6 +517,7 @@ it('can render `Tabs` in the browser', function (): void {
         visit('/tabs-browser-test')
             ->assertSee('Account')
             ->assertSee('Contact')
+            ->assertSee('Available')
             ->assertNoSmoke()
             ->assertNoAccessibilityIssues();
 
@@ -526,6 +534,30 @@ class RenderTabs extends Component implements HasSchemas
     public function infolist(Schema $schema): Schema
     {
         return $schema->state([])->components([Tabs::make('Test')->tabs([Tab::make('Tab 1'), Tab::make('Tab 2')])]);
+    }
+
+    public function render(): string
+    {
+        return '<div>{{ $this->infolist }}</div>';
+    }
+}
+
+class RenderTabsWithBackedEnumBadgeIcon extends Component implements HasSchemas
+{
+    use InteractsWithSchemas;
+
+    public function infolist(Schema $schema): Schema
+    {
+        return $schema
+            ->state([])
+            ->components([
+                Tabs::make('Status')
+                    ->tabs([
+                        Tab::make('Products')
+                            ->badge('Available')
+                            ->badgeIcon(Heroicon::OutlinedCheckCircle),
+                    ]),
+            ]);
     }
 
     public function render(): string


### PR DESCRIPTION
## Description

  Fixes #20233.

  Tab badge icons configured using the documented `Heroicon` enum cause a
  `TypeError` when rendered.

  `Tab::badgeIcon()` accepts a `BackedEnum`, and the icon rendering helper also
  supports `BackedEnum`, but `Tabs::generateTabBadgeHtml()` did not include it in
  the `$icon` parameter type.

  This change aligns the renderer parameter type with the public component API
  and adds regression coverage.

  ## Visual changes

  No visual changes. Tab badge icons now render as expected when provided as a
  `Heroicon` enum.

  ## Functional changes

  - [x] Code style has been fixed by running the `composer cs` command.
  - [x] Changes have been tested to not break existing functionality.
  - [x] Documentation is up-to-date.

  ## Testing

  - Added a regression test for rendering a tab badge icon using
    `Heroicon::OutlinedCheckCircle`.
  - Updated the tabs browser fixture to render the same enum badge icon.
