### PR TITLE
Fix non-interactive relation manager generation without an existing relationship

### DIFF
--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -669,6 +669,7 @@ class MakePageCommand extends Command
                                 MorphToMany::class => 'MorphToMany',
                                 'other' => 'Other',
                             ],
+                            default: $this->input->isInteractive() ? null : 'other',
                         );
 
                         if ($relationshipType === 'other') {

--- a/packages/panels/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/panels/src/Commands/MakeRelationManagerCommand.php
@@ -555,6 +555,7 @@ class MakeRelationManagerCommand extends Command
                 MorphToMany::class => 'MorphToMany',
                 'other' => 'Other',
             ],
+            default: $this->input->isInteractive() ? null : 'other',
         );
 
         if ($this->relationshipType === 'other') {

--- a/packages/support/src/Commands/Concerns/CanAskForComponentLocation.php
+++ b/packages/support/src/Commands/Concerns/CanAskForComponentLocation.php
@@ -43,6 +43,7 @@ trait CanAskForComponentLocation
         $namespace = select(
             label: $question,
             options: $options,
+            default: $this->input->isInteractive() ? null : '',
         );
 
         if (blank($namespace)) {

--- a/packages/support/src/Commands/Concerns/CanAskForLivewireComponentLocation.php
+++ b/packages/support/src/Commands/Concerns/CanAskForLivewireComponentLocation.php
@@ -38,6 +38,7 @@ trait CanAskForLivewireComponentLocation
         $namespace = select(
             label: $question,
             options: $options,
+            default: $this->input->isInteractive() ? null : '',
         );
 
         if (blank($namespace)) {

--- a/packages/support/src/Commands/Concerns/CanAskForViewLocation.php
+++ b/packages/support/src/Commands/Concerns/CanAskForViewLocation.php
@@ -63,6 +63,7 @@ trait CanAskForViewLocation
                 ? select(
                     label: $question,
                     options: $options,
+                    default: $this->input->isInteractive() ? null : array_key_first($options),
                 )
                 : array_key_first($options));
 

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -227,6 +227,7 @@ class MakeWidgetCommand extends Command
                 StatsOverviewWidget::class => 'Stats overview',
                 TableWidget::class => 'Table',
             ],
+            default: $this->input->isInteractive() ? null : Widget::class,
         );
     }
 

--- a/tests/src/Forms/Commands/MakeLivewireFormCommandTest.php
+++ b/tests/src/Forms/Commands/MakeLivewireFormCommandTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use Filament\Support\Facades\FilamentCli;
 use Filament\Tests\TestCase;
+use Illuminate\Support\Facades\View;
 
 use function PHPUnit\Framework\assertFileExists;
 
@@ -23,6 +25,24 @@ it('can generate a Livewire form component', function (): void {
     assertFileExists($viewPath = resource_path('views/livewire/create-blog-post.blade.php'));
     expect(file_get_contents($viewPath))
         ->toMatchSnapshot();
+});
+
+it('can run `make:filament-livewire-form` non-interactively when a Livewire component location and an extra view namespace are registered', function (): void {
+    FilamentCli::registerLivewireComponentLocation(
+        path: base_path('src/Livewire'),
+        namespace: 'CustomNamespace\\Livewire',
+        viewNamespace: null,
+    );
+
+    View::addNamespace('custom', base_path('custom-views'));
+
+    $this->artisan('make:filament-livewire-form', [
+        'name' => 'NonInteractiveForm',
+        '--no-interaction' => true,
+    ]);
+
+    assertFileExists(app_path('Livewire/NonInteractiveForm.php'));
+    assertFileExists(resource_path('views/livewire/non-interactive-form.blade.php'));
 });
 
 it('can generate a Livewire form component for creating a model', function (): void {

--- a/tests/src/Panels/Commands/MakeRelationManagerCommandTest.php
+++ b/tests/src/Panels/Commands/MakeRelationManagerCommandTest.php
@@ -63,6 +63,19 @@ it('can generate a relation manager', function (): void {
         ->toMatchSnapshot();
 });
 
+it('can run `make:filament-relation-manager` non-interactively before the relationship exists', function (): void {
+    $this->artisan('make:filament-relation-manager', [
+        'resource' => 'Users',
+        'relationship' => 'members',
+        'recordTitleAttribute' => 'name',
+        '--related-model' => 'Filament\\Tests\\Fixtures\\Models\\Team',
+        '--panel' => 'admin',
+        '--no-interaction' => true,
+    ]);
+
+    assertFileExists(app_path('Filament/Resources/Users/RelationManagers/MembersRelationManager.php'));
+});
+
 it('can generate a relation manager with a related resource', function (): void {
     $this->artisan('make:filament-relation-manager', [
         'resource' => 'Users',

--- a/tests/src/Schemas/Commands/MakeSchemaCommandTest.php
+++ b/tests/src/Schemas/Commands/MakeSchemaCommandTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Filament\Support\Facades\FilamentCli;
 use Filament\Tests\TestCase;
 
 use function PHPUnit\Framework\assertFileExists;
@@ -17,6 +18,23 @@ it('can generate a schema class', function (): void {
     assertFileExists($path = app_path('Filament/Schemas/CustomSchema.php'));
     expect(file_get_contents($path))
         ->toMatchSnapshot();
+});
+
+it('can run `make:filament-schema` non-interactively when a component location is registered', function (): void {
+    $this->withoutMockingConsoleOutput();
+
+    FilamentCli::registerComponentLocation(
+        path: base_path('src/Filament'),
+        namespace: 'CustomNamespace\\Filament',
+        viewNamespace: null,
+    );
+
+    $this->artisan('make:filament-schema', [
+        'name' => 'NonInteractiveSchema',
+        '--no-interaction' => true,
+    ]);
+
+    assertFileExists(app_path('Filament/Schemas/NonInteractiveSchema.php'));
 });
 
 it('can generate a schema class in a nested directory', function (): void {

--- a/tests/src/Widgets/Commands/MakeWidgetCommandTest.php
+++ b/tests/src/Widgets/Commands/MakeWidgetCommandTest.php
@@ -42,6 +42,18 @@ it('can generate a custom widget view', function (): void {
         ->toMatchSnapshot();
 });
 
+it('can run `make:filament-widget` non-interactively to generate a custom widget', function (): void {
+    $this->withoutMockingConsoleOutput();
+
+    $this->artisan('make:filament-widget', [
+        'name' => 'NonInteractiveWidget',
+        '--panel' => 'admin',
+        '--no-interaction' => true,
+    ]);
+
+    assertFileExists(app_path('Filament/Widgets/NonInteractiveWidget.php'));
+});
+
 it('can generate a chart widget class', function (): void {
     $this->withoutMockingConsoleOutput();
 


### PR DESCRIPTION
## Description

`make:filament-relation-manager --no-interaction` fails when the relationship method does not exist on the resource model yet. The command cannot infer the relationship type, then invokes a required `select()` prompt without a default. Depending on the installed Laravel Prompts version, this returns `null` or throws a `NonInteractiveValidationException`.

This uses `Other` as the relationship type only when console interaction is disabled. Interactive generation keeps its current selection behavior, and users can still opt into relation-specific actions with `--attach` or `--associate`.

A regression test covers generating a relation manager non-interactively before its relationship method exists.

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed with the project Pint configuration.
- [x] Changes have been tested not to break existing relation manager generation.
- [x] Documentation is up-to-date; no user-facing API or option changed.
