### PR TITLE
Add `$activeWizardStepIndex` utility injection to schema components

### DIFF
--- a/packages/schemas/docs/05-wizards.md
+++ b/packages/schemas/docs/05-wizards.md
@@ -193,6 +193,23 @@ Wizard::make([
 
 <UtilityInjection set="schemaComponents" version="5.x">As well as allowing a static value, the `persistStepInQueryString()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
+## Accessing the current step index inside a step's schema
+
+Any component inside a wizard can inject the `$activeWizardStepIndex` utility into its configuration functions. It resolves to the zero-based index of the wizard's currently active step, or `null` when the component is not contained by a wizard. This is useful to defer expensive work until the step that needs it is actually active:
+
+```php
+use Filament\Forms\Components\Select;
+
+Select::make('authorId')
+    ->options(fn (?int $activeWizardStepIndex): array => ($activeWizardStepIndex === 1)
+        ? Author::query()->pluck('name', 'id')->all()
+        : [])
+```
+
+The index reflects the current step as it is known on the server. It updates as the user navigates between steps, and combines well with [persisting the current step in the query string](#persisting-the-current-step-in-the-urls-query-string) when you need it to survive a full page load.
+
+If you need the wizard instance itself, every component also exposes `getParentWizard()`, which returns the closest ancestor `Wizard`, or `null`.
+
 ## Step lifecycle hooks
 
 You may use the `afterValidation()` and `beforeValidation()` methods to run code before and after validation occurs on the step:

--- a/packages/schemas/src/Components/Component.php
+++ b/packages/schemas/src/Components/Component.php
@@ -5,6 +5,7 @@ namespace Filament\Schemas\Components;
 use Filament\Schemas\Components\Concerns\BelongsToContainer;
 use Filament\Schemas\Components\Concerns\BelongsToModel;
 use Filament\Schemas\Components\Concerns\CanBeConcealed;
+use Filament\Schemas\Components\Concerns\CanBeContainedByWizard;
 use Filament\Schemas\Components\Concerns\CanBeDisabled;
 use Filament\Schemas\Components\Concerns\CanBeGridContainer;
 use Filament\Schemas\Components\Concerns\CanBeHidden;
@@ -48,6 +49,7 @@ class Component extends ViewComponent
     use BelongsToContainer;
     use BelongsToModel;
     use CanBeConcealed;
+    use CanBeContainedByWizard;
     use CanBeDisabled;
     use CanBeGridContainer;
     use CanBeHidden;
@@ -85,6 +87,7 @@ class Component extends ViewComponent
     protected function resolveDefaultClosureDependencyForEvaluationByName(string $parameterName): array
     {
         return match ($parameterName) {
+            'activeWizardStepIndex' => [$this->getActiveWizardStepIndex()],
             'context', 'operation' => [$this->getContainer()->getOperation()],
             'get' => [$this->makeGetUtility()],
             'livewire' => [$this->getLivewire()],

--- a/packages/schemas/src/Components/Concerns/CanBeContainedByWizard.php
+++ b/packages/schemas/src/Components/Concerns/CanBeContainedByWizard.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Filament\Schemas\Components\Concerns;
+
+use Filament\Schemas\Components\Wizard;
+
+trait CanBeContainedByWizard
+{
+    protected Wizard | bool | null $cachedParentWizard = null;
+
+    public function getParentWizard(): ?Wizard
+    {
+        if ($this->cachedParentWizard !== null) {
+            return $this->cachedParentWizard ?: null;
+        }
+
+        $parentComponent = $this->getContainer()->getParentComponent();
+
+        if (! $parentComponent) {
+            $this->cachedParentWizard = false;
+        } elseif ($parentComponent instanceof Wizard) {
+            $this->cachedParentWizard = $parentComponent;
+        } else {
+            $this->cachedParentWizard = $parentComponent->getParentWizard() ?? false;
+        }
+
+        return $this->cachedParentWizard ?: null;
+    }
+
+    public function getActiveWizardStepIndex(): ?int
+    {
+        return $this->getParentWizard()?->getCurrentStepIndex();
+    }
+}

--- a/tests/src/Schemas/Components/WizardTest.php
+++ b/tests/src/Schemas/Components/WizardTest.php
@@ -1,10 +1,12 @@
 <?php
 
+use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Wizard;
 use Filament\Schemas\Components\Wizard\Step;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
+use Filament\Tests\Fixtures\Livewire\Livewire as LivewireFixture;
 use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Facades\Artisan;
@@ -586,5 +588,95 @@ class RenderWizardWithSubmitAction extends Component implements HasSchemas
     public function render(): string
     {
         return '<div>{{ $this->infolist }}</div>';
+    }
+}
+
+it('can inject `$activeWizardStepIndex` into component configuration closures', function (): void {
+    livewire(TestComponentWithActiveWizardStepIndex::class)
+        ->assertFormComponentExists('first', function (TextInput $field): bool {
+            // The wizard starts on step 2 (index `1`), so even a component living in
+            // the first step resolves the wizard's *current* step index, not its own.
+            expect($field->getLabel())->toBe('Active wizard step index: 1');
+
+            return true;
+        })
+        ->assertFormComponentExists('outside', function (TextInput $field): bool {
+            // Outside of any wizard, `$activeWizardStepIndex` resolves to `null`.
+            expect($field->getLabel())->toBe('Active wizard step index: none');
+
+            return true;
+        });
+});
+
+it('resolves `$activeWizardStepIndex` reactively as the wizard advances', function (): void {
+    livewire(TestComponentWithReactiveActiveWizardStepIndex::class)
+        ->assertFormComponentExists('indicator', function (TextInput $field): bool {
+            expect($field->getLabel())->toBe('Active wizard step index: 0');
+
+            return true;
+        })
+        ->goToNextWizardStep()
+        ->assertWizardCurrentStep(2)
+        ->assertFormComponentExists('indicator', function (TextInput $field): bool {
+            expect($field->getLabel())->toBe('Active wizard step index: 1');
+
+            return true;
+        });
+});
+
+class TestComponentWithActiveWizardStepIndex extends LivewireFixture
+{
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->components([
+                Wizard::make([
+                    Step::make('one')
+                        ->schema([
+                            TextInput::make('first')
+                                ->label(fn (?int $activeWizardStepIndex): string => "Active wizard step index: {$activeWizardStepIndex}"),
+                        ]),
+                    Step::make('two')
+                        ->schema([
+                            TextInput::make('second'),
+                        ]),
+                ])
+                    ->startOnStep(2),
+                TextInput::make('outside')
+                    ->label(fn (?int $activeWizardStepIndex): string => 'Active wizard step index: ' . ($activeWizardStepIndex ?? 'none')),
+            ])
+            ->statePath('data');
+    }
+}
+
+class TestComponentWithReactiveActiveWizardStepIndex extends LivewireFixture
+{
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->components([
+                Wizard::make([
+                    Step::make('one')
+                        ->schema([
+                            TextInput::make('indicator')
+                                ->label(fn (?int $activeWizardStepIndex): string => "Active wizard step index: {$activeWizardStepIndex}"),
+                        ]),
+                    Step::make('two')
+                        ->schema([
+                            TextInput::make('second'),
+                        ]),
+                ]),
+            ])
+            ->statePath('data');
     }
 }


### PR DESCRIPTION
## Description

Schema components rendered inside a `Wizard` currently have no first-class way to know which step is active from within their configuration functions. Reaching the wizard means manually walking the component tree (`getContainer()->getParentComponent()` repeatedly), which is brittle and undocumented.

This PR adds a small utility, mirroring the existing `$parentRepeaterItemIndex` injection:

- A new `CanBeContainedByWizard` concern on the base schema `Component` (sibling of `CanBeRepeated`) that resolves the closest ancestor `Wizard`.
- `getParentWizard(): ?Wizard` — the closest ancestor wizard, or `null`.
- A new injectable **`$activeWizardStepIndex`** utility that resolves to the wizard's current zero-based step index (`Wizard::getCurrentStepIndex()`), or `null` when the component is not inside a wizard.

### Why

A common need is to defer expensive work until the step that needs it is actually active — e.g. only building a large option set once the user reaches that step, instead of on every render of the (mounted-but-hidden) later steps:

```php
use Filament\Forms\Components\Select;

Select::make('authorId')
    ->options(fn (?int $activeWizardStepIndex): array => ($activeWizardStepIndex === 1)
        ? Author::query()->pluck('name', 'id')->all()
        : [])
```

The value tracks the current step as known on the server (it updates as the user navigates, and combines with `persistStepInQueryString()` when it needs to survive a full page load).

## Changes

- `packages/schemas/src/Components/Concerns/CanBeContainedByWizard.php` — new concern (`getParentWizard()`, `getActiveWizardStepIndex()`).
- `packages/schemas/src/Components/Component.php` — use the concern; inject `activeWizardStepIndex` in `resolveDefaultClosureDependencyForEvaluationByName()`.
- `tests/src/Schemas/Components/WizardTest.php` — tests for injection (inside a step, `null` outside a wizard) and reactivity across navigation.
- `packages/schemas/docs/05-wizards.md` — documentation.

## Tests

New tests pass (`pest --configuration=phpunit.sqlite.xml tests/src/Schemas/Components/WizardTest.php`). Code passes `pint --config pint-strict-imports.json` and `phpstan` (level 6).

## Notes

Targets `5.x` to match a current release line; happy to retarget or forward-port if maintainers prefer.