### PR TITLE
fix: `MorphToSelect` crash when adding an item to a live `Repeater`

### DIFF
--- a/packages/forms/src/Components/MorphToSelect.php
+++ b/packages/forms/src/Components/MorphToSelect.php
@@ -135,7 +135,7 @@ class MorphToSelect extends Component
                 ->preload($component->isPreloaded())
                 ->when(
                     $component->isLive(),
-                    fn (Select $component) => $component->live(onBlur: $this->isLiveOnBlur()),
+                    fn (Select $select) => $select->live(onBlur: $component->isLiveOnBlur()),
                 )
                 ->afterStateUpdated(function () use ($component): void {
                     $component->callAfterStateUpdatedForChildComponent();

--- a/tests/src/Forms/Components/MorphToSelectTest.php
+++ b/tests/src/Forms/Components/MorphToSelectTest.php
@@ -4,7 +4,9 @@ namespace Filament\Tests\Forms\Components;
 
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Actions\Testing\TestAction;
 use Filament\Forms\Components\MorphToSelect;
+use Filament\Forms\Components\Repeater;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
@@ -182,6 +184,16 @@ describe('modifier callback clearing', function (): void {
     });
 });
 
+it('can add an item to a live `Repeater` that contains a `MorphToSelect`', function (): void {
+    livewire(TestComponentWithMorphToSelectInLiveRepeater::class)
+        ->callAction(TestAction::make('add')->schemaComponent('items'))
+        ->assertSchemaStateSet(function (array $state): array {
+            expect($state['items'])->toHaveCount(2);
+
+            return [];
+        });
+});
+
 class TestComponentWithMorphToSelectAndJoinQuery extends Component implements HasActions, HasSchemas
 {
     use InteractsWithActions;
@@ -253,6 +265,42 @@ class TestComponentWithMorphToSelectAndModifyQuery extends Component implements 
     public function save(): void
     {
         $this->form->getState();
+    }
+
+    public function render(): View
+    {
+        return view('livewire.form');
+    }
+}
+
+class TestComponentWithMorphToSelectInLiveRepeater extends Component implements HasActions, HasSchemas
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+
+    public $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->schema([
+                Repeater::make('items')
+                    ->live()
+                    ->schema([
+                        MorphToSelect::make('imageable')
+                            ->model(Image::class)
+                            ->types([
+                                MorphToSelect\Type::make(Post::class)->titleAttribute('title'),
+                                MorphToSelect\Type::make(User::class)->titleAttribute('name'),
+                            ]),
+                    ]),
+            ])
+            ->statePath('data');
     }
 
     public function render(): View


### PR DESCRIPTION
## Description

Adding an item to a `->live()` `Repeater` whose schema contains a `MorphToSelect` throws:

```
Typed property Filament\Schemas\Components\Component::$container must not be accessed before initialization
```

### Reproduction

```php
Repeater::make('items')
    ->live()
    ->schema([
        MorphToSelect::make('imageable')
            ->types([
                MorphToSelect\Type::make(Post::class)->titleAttribute('title'),
            ]),
    ]),
```

Click the repeater's "Add" action → the exception above. Works on v5.6.8; broken since v5.7.0.

### Cause

In `MorphToSelect::setUp()`, the key select is configured with:

```php
->when(
    $component->isLive(),
    fn (Select $component) => $component->live(onBlur: $this->isLiveOnBlur()),
)
```

`$this` inside that closure is bound to the original `MorphToSelect` instance the schema closure was created on. Inside a `Repeater`, item schemas contain *clones* of the schema components. The injected `$component` is the clone, which has a container, but the closure-bound `$this` is the template, which never receives one. Since this `MorphToSelect` is not explicitly live, `isLiveOnBlur()` falls through to `$this->getContainer()->isLiveOnBlur()` and hits the uninitialized `$container`.

The bug is only reachable when the `MorphToSelect` is live *by inheritance* (here: from the live `Repeater`), since an explicit `->live()` makes `isLiveOnBlur()` return early. It surfaced in v5.7.0 because the `Repeater`/schema caching rework changed when template components are attached to a container during the add-item request; the incorrect `$this` binding predates it.

### Fix

Use the injected `$component` (the evaluated instance, which has a container) instead of the closure-bound `$this`, renaming the inner closure parameter so it no longer shadows it.

A regression test is included: without the fix it fails with the exact error above; with the fix it passes.

## Functional changes

- [ ] Documentation added (if a new feature is introduced)
- [x] Tests added (if this is a bug fix or new feature)
