### PR TITLE
fix: preserve configuration context when mounting navigation

### DIFF
--- a/packages/panels/src/Navigation/NavigationManager.php
+++ b/packages/panels/src/Navigation/NavigationManager.php
@@ -186,9 +186,10 @@ class NavigationManager
         $previousPageConfigurationKey = Filament::getCurrentPageConfigurationKey();
         $previousResourceConfigurationKey = Filament::getCurrentResourceConfigurationKey();
 
-        Filament::setCurrentPageConfigurationKey(null);
-
         try {
+            Filament::setCurrentPageConfigurationKey(null);
+            Filament::setCurrentResourceConfigurationKey(null);
+
             foreach ($this->panel->getPages() as $page) {
                 $page::registerNavigationItems();
             }
@@ -200,8 +201,6 @@ class NavigationManager
 
                 Filament::setCurrentPageConfigurationKey(null);
             }
-
-            Filament::setCurrentResourceConfigurationKey(null);
 
             foreach ($this->panel->getResources() as $resource) {
                 $resource::registerNavigationItems();

--- a/packages/panels/src/Navigation/NavigationManager.php
+++ b/packages/panels/src/Navigation/NavigationManager.php
@@ -183,31 +183,43 @@ class NavigationManager
 
     public function mountNavigation(): void
     {
-        foreach ($this->panel->getPages() as $page) {
-            $page::registerNavigationItems();
-        }
+        $previousPageConfigurationKey = Filament::getCurrentPageConfigurationKey();
+        $previousResourceConfigurationKey = Filament::getCurrentResourceConfigurationKey();
 
-        foreach ($this->panel->getPageConfigurations() as $configuration) {
-            Filament::setCurrentPageConfigurationKey($configuration->getKey());
+        Filament::setCurrentPageConfigurationKey(null);
 
-            $configuration->page::registerNavigationItems();
+        try {
+            foreach ($this->panel->getPages() as $page) {
+                $page::registerNavigationItems();
+            }
 
-            Filament::setCurrentPageConfigurationKey(null);
-        }
+            foreach ($this->panel->getPageConfigurations() as $configuration) {
+                Filament::setCurrentPageConfigurationKey($configuration->getKey());
 
-        foreach ($this->panel->getResources() as $resource) {
-            $resource::registerNavigationItems();
-        }
+                $configuration->page::registerNavigationItems();
 
-        foreach ($this->panel->getResourceConfigurations() as $configuration) {
-            Filament::setCurrentResourceConfigurationKey($configuration->getKey());
-
-            $configuration->resource::registerNavigationItems();
+                Filament::setCurrentPageConfigurationKey(null);
+            }
 
             Filament::setCurrentResourceConfigurationKey(null);
-        }
 
-        $this->isNavigationMounted = true;
+            foreach ($this->panel->getResources() as $resource) {
+                $resource::registerNavigationItems();
+            }
+
+            foreach ($this->panel->getResourceConfigurations() as $configuration) {
+                Filament::setCurrentResourceConfigurationKey($configuration->getKey());
+
+                $configuration->resource::registerNavigationItems();
+
+                Filament::setCurrentResourceConfigurationKey(null);
+            }
+
+            $this->isNavigationMounted = true;
+        } finally {
+            Filament::setCurrentPageConfigurationKey($previousPageConfigurationKey);
+            Filament::setCurrentResourceConfigurationKey($previousResourceConfigurationKey);
+        }
     }
 
     /**

--- a/tests/src/Panels/Configuration/NavigationTest.php
+++ b/tests/src/Panels/Configuration/NavigationTest.php
@@ -47,6 +47,14 @@ describe('resource configuration navigation', function (): void {
         expect($urls)->toContain(ConfigurablePostResource::getUrl(configuration: 'archived'));
     });
 
+    it('preserves the active resource configuration key when mounting navigation', function (): void {
+        Filament::forResourceConfiguration(ConfigurablePostResource::class, 'featured');
+
+        Filament::getNavigation();
+
+        expect(Filament::getCurrentResourceConfigurationKey())->toBe('featured');
+    });
+
     it('shows correct navigation labels for resource configurations', function (): void {
         $navigation = Filament::getNavigation();
 
@@ -101,6 +109,33 @@ describe('page configuration navigation', function (): void {
         expect($urls)->toContain(ConfigurableSettings::getUrl());
         expect($urls)->toContain(ConfigurableSettings::withConfiguration('general', fn () => ConfigurableSettings::getUrl()));
         expect($urls)->toContain(ConfigurableSettings::withConfiguration('advanced', fn () => ConfigurableSettings::getUrl()));
+    });
+
+    it('registers separate navigation items for each page configuration when one is active', function (): void {
+        $defaultUrl = ConfigurableSettings::getUrl();
+
+        Filament::forPageConfiguration(ConfigurableSettings::class, 'general');
+
+        $items = collect(Filament::getNavigation())
+            ->flatMap(fn ($group) => $group->getItems())
+            ->filter(fn (NavigationItem $item) => str_contains($item->getUrl(), 'settings'))
+            ->values();
+
+        expect($items)->toHaveCount(3);
+
+        $urls = $items->map(fn (NavigationItem $item) => $item->getUrl())->all();
+
+        expect($urls)->toContain($defaultUrl);
+        expect($urls)->toContain(ConfigurableSettings::withConfiguration('general', fn () => ConfigurableSettings::getUrl()));
+        expect($urls)->toContain(ConfigurableSettings::withConfiguration('advanced', fn () => ConfigurableSettings::getUrl()));
+    });
+
+    it('preserves the active page configuration key when mounting navigation', function (): void {
+        Filament::forPageConfiguration(ConfigurableSettings::class, 'general');
+
+        Filament::getNavigation();
+
+        expect(Filament::getCurrentPageConfigurationKey())->toBe('general');
     });
 
     it('shows correct navigation labels for page configurations', function (): void {

--- a/tests/src/Panels/Configuration/NavigationTest.php
+++ b/tests/src/Panels/Configuration/NavigationTest.php
@@ -28,6 +28,25 @@ describe('resource configuration navigation', function (): void {
         expect($urls)->toContain(ConfigurablePostResource::getUrl(configuration: 'archived'));
     });
 
+    it('registers separate navigation items for each resource configuration when one is active', function (): void {
+        $defaultUrl = ConfigurablePostResource::getUrl();
+
+        Filament::forResourceConfiguration(ConfigurablePostResource::class, 'featured');
+
+        $items = collect(Filament::getNavigation())
+            ->flatMap(fn ($group) => $group->getItems())
+            ->filter(fn (NavigationItem $item) => str_contains($item->getUrl(), 'posts'))
+            ->values();
+
+        expect($items)->toHaveCount(3);
+
+        $urls = $items->map(fn (NavigationItem $item) => $item->getUrl())->all();
+
+        expect($urls)->toContain($defaultUrl);
+        expect($urls)->toContain(ConfigurablePostResource::getUrl(configuration: 'featured'));
+        expect($urls)->toContain(ConfigurablePostResource::getUrl(configuration: 'archived'));
+    });
+
     it('shows correct navigation labels for resource configurations', function (): void {
         $navigation = Filament::getNavigation();
 

--- a/tests/src/Panels/Configuration/NavigationTest.php
+++ b/tests/src/Panels/Configuration/NavigationTest.php
@@ -31,20 +31,22 @@ describe('resource configuration navigation', function (): void {
     it('registers separate navigation items for each resource configuration when one is active', function (): void {
         $defaultUrl = ConfigurablePostResource::getUrl();
 
-        Filament::forResourceConfiguration(ConfigurablePostResource::class, 'featured');
+        ConfigurablePostResource::withConfiguration('featured', static function () use ($defaultUrl): void {
+            $items = collect(Filament::getNavigation())
+                ->flatMap(static fn ($group) => $group->getItems())
+                ->filter(static fn (NavigationItem $item) => str_contains($item->getUrl(), 'posts'))
+                ->values();
 
-        $items = collect(Filament::getNavigation())
-            ->flatMap(fn ($group) => $group->getItems())
-            ->filter(fn (NavigationItem $item) => str_contains($item->getUrl(), 'posts'))
-            ->values();
+            expect($items)->toHaveCount(3);
 
-        expect($items)->toHaveCount(3);
+            $urls = $items->map(static fn (NavigationItem $item) => $item->getUrl())->all();
 
-        $urls = $items->map(fn (NavigationItem $item) => $item->getUrl())->all();
+            expect($urls)->toContain($defaultUrl);
+            expect($urls)->toContain(ConfigurablePostResource::getUrl(configuration: 'featured'));
+            expect($urls)->toContain(ConfigurablePostResource::getUrl(configuration: 'archived'));
 
-        expect($urls)->toContain($defaultUrl);
-        expect($urls)->toContain(ConfigurablePostResource::getUrl(configuration: 'featured'));
-        expect($urls)->toContain(ConfigurablePostResource::getUrl(configuration: 'archived'));
+            expect(ConfigurablePostResource::getConfiguration()?->getKey())->toBe('featured');
+        });
     });
 
     it('shows correct navigation labels for resource configurations', function (): void {
@@ -101,6 +103,27 @@ describe('page configuration navigation', function (): void {
         expect($urls)->toContain(ConfigurableSettings::getUrl());
         expect($urls)->toContain(ConfigurableSettings::withConfiguration('general', fn () => ConfigurableSettings::getUrl()));
         expect($urls)->toContain(ConfigurableSettings::withConfiguration('advanced', fn () => ConfigurableSettings::getUrl()));
+    });
+
+    it('registers separate navigation items for each page configuration when one is active', function (): void {
+        $defaultUrl = ConfigurableSettings::getUrl();
+
+        ConfigurableSettings::withConfiguration('general', static function () use ($defaultUrl): void {
+            $items = collect(Filament::getNavigation())
+                ->flatMap(static fn ($group) => $group->getItems())
+                ->filter(static fn (NavigationItem $item) => str_contains($item->getUrl(), 'settings'))
+                ->values();
+
+            expect($items)->toHaveCount(3);
+
+            $urls = $items->map(static fn (NavigationItem $item) => $item->getUrl())->all();
+
+            expect($urls)->toContain($defaultUrl);
+            expect($urls)->toContain(ConfigurableSettings::getUrl(configuration: 'general'));
+            expect($urls)->toContain(ConfigurableSettings::getUrl(configuration: 'advanced'));
+
+            expect(ConfigurableSettings::getConfiguration()?->getKey())->toBe('general');
+        });
     });
 
     it('shows correct navigation labels for page configurations', function (): void {


### PR DESCRIPTION

## Description
### Fixed : #20244 

Navigation was mounted while the current page or resource configuration was active, causing default navigation items to use the active configuration.

Clear the configuration context while mounting navigation and restore the active configuration afterwards.

## Visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
