### PR TITLE
refactor(support): resolve vendor path via Composer Factory and NullIO

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -351,7 +351,7 @@ if (! function_exists('Filament\Support\discover_app_classes')) {
     {
         $vendorDir = class_exists(\Composer\InstalledVersions::class)
             ? dirname((new \ReflectionClass(\Composer\InstalledVersions::class))->getFileName(), 2)
-            : base_path('vendor');
+            : 'vendor';
 
         $autoloadPath = $vendorDir . '/autoload.php';
 

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -3,8 +3,8 @@
 namespace Filament\Support;
 
 use BackedEnum;
-use Composer\Factory;
-use Composer\IO\NullIO;
+use Composer\InstalledVersions;
+use ReflectionClass;
 use Filament\Support\Contracts\LoadingIndicator;
 use Filament\Support\Contracts\ScalableIcon;
 use Filament\Support\Enums\IconSize;

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -3,8 +3,6 @@
 namespace Filament\Support;
 
 use BackedEnum;
-use Composer\InstalledVersions;
-use ReflectionClass;
 use Filament\Support\Contracts\LoadingIndicator;
 use Filament\Support\Contracts\ScalableIcon;
 use Filament\Support\Enums\IconSize;
@@ -351,18 +349,27 @@ if (! function_exists('Filament\Support\discover_app_classes')) {
      */
     function discover_app_classes(?string $parentClass = null): array
     {
-        $composer = Factory::create(new NullIO());
-        $vendorDir = $composer->getConfig()->get('vendor-dir');
+        $vendorDir = class_exists(\Composer\InstalledVersions::class)
+            ? dirname((new \ReflectionClass(\Composer\InstalledVersions::class))->getFileName(), 2)
+            : base_path('vendor');
 
-        $classLoader = require $vendorDir . '/autoload.php';
+        $autoloadPath = $vendorDir . '/autoload.php';
 
-        $vendorPath = realpath($vendorDir) ?: $vendorDir;
+        if (! is_file($autoloadPath)) {
+            return [];
+        }
+
+        /** @var \Composer\Autoload\ClassLoader $classLoader */
+        $classLoader = require $autoloadPath;
+
+        $realVendorDir = realpath($vendorDir) ?: $vendorDir;
+        $vendorPathPrefix = rtrim($realVendorDir, '/\\') . DIRECTORY_SEPARATOR;
 
         return collect($classLoader->getClassMap())
-            ->filter(function (string $file, string $class) use ($parentClass, $vendorPath): bool {
+            ->filter(function (string $file, string $class) use ($parentClass, $vendorPathPrefix): bool {
                 $filePath = realpath($file) ?: $file;
 
-                if (str_starts_with($filePath, $vendorPath)) {
+                if (str_starts_with($filePath, $vendorPathPrefix)) {
                     return false;
                 }
 

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -367,6 +367,10 @@ if (! function_exists('Filament\Support\discover_app_classes')) {
 
         return collect($classLoader->getClassMap())
             ->filter(function (string $file, string $class) use ($parentClass, $vendorPathPrefix): bool {
+                if (str_starts_with($file, $vendorPathPrefix)) {
+                    return false;
+                }
+
                 $filePath = realpath($file) ?: $file;
 
                 if (str_starts_with($filePath, $vendorPathPrefix)) {

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -3,6 +3,8 @@
 namespace Filament\Support;
 
 use BackedEnum;
+use Composer\Factory;
+use Composer\IO\NullIO;
 use Filament\Support\Contracts\LoadingIndicator;
 use Filament\Support\Contracts\ScalableIcon;
 use Filament\Support\Enums\IconSize;
@@ -349,11 +351,18 @@ if (! function_exists('Filament\Support\discover_app_classes')) {
      */
     function discover_app_classes(?string $parentClass = null): array
     {
-        $classLoader = require 'vendor/autoload.php';
+        $composer = Factory::create(new NullIO());
+        $vendorDir = $composer->getConfig()->get('vendor-dir');
+
+        $classLoader = require $vendorDir . '/autoload.php';
+
+        $vendorPath = realpath($vendorDir) ?: $vendorDir;
 
         return collect($classLoader->getClassMap())
-            ->filter(function (string $file, string $class) use ($parentClass): bool {
-                if (! str($file)->startsWith(base_path('vendor' . DIRECTORY_SEPARATOR . 'composer/../../'))) {
+            ->filter(function (string $file, string $class) use ($parentClass, $vendorPath): bool {
+                $filePath = realpath($file) ?: $file;
+
+                if (str_starts_with($filePath, $vendorPath)) {
                     return false;
                 }
 


### PR DESCRIPTION
Dynamically resolve the project vendor directory using `Composer\InstalledVersions` and enforce strict path prefix matching with a trailing directory separator.

## Description

This PR refactors `discover_app_classes()` to dynamically determine the location of the Composer `vendor` directory at runtime using reflection on `Composer\InstalledVersions`, with a fallback to `base_path('vendor')`. It also fixes potential false positives in vendor path comparisons.

### Changes
* **Runtime Vendor Resolution:** Replaced hardcoded relative vendor path lookups with reflection on `Composer\InstalledVersions::class`. This avoids introducing dev dependencies like `Composer\Factory` while guaranteeing full production compatibility.
* **Custom Vendor Support:** Seamlessly supports non-standard Composer configurations where `vendor-dir` has been relocated (e.g., `third_party/`).
* **Strict Path Exclusion:** Appends a trailing `DIRECTORY_SEPARATOR` to `$vendorPathPrefix` and performs checks against both raw and `realpath()` resolved paths to prevent unintended matching of sibling directories (e.g., `/var/www/vendor2`).

> **Note:** This change specifically fixes class discovery in `discover_app_classes()`. However, other areas in the codebase may still contain legacy hardcoded `vendor/` references or assumptions about directory structures that could benefit from similar refactoring for complete custom `vendor-dir` support.

## Visual changes

None. Purely backend/architectural refactor.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date (checked, but as far as I know it has never been mentioned in the docs).