### PR TITLE
Update Spanish translations, Datepicker labels

### DIFF
--- a/packages/forms/resources/lang/es/components.php
+++ b/packages/forms/resources/lang/es/components.php
@@ -128,6 +128,30 @@ return [
 
     ],
 
+    'date_time_picker' => [
+
+        'month_select' => [
+            'label' => 'Mes',
+        ],
+
+        'year_input' => [
+            'label' => 'Año',
+        ],
+
+        'hour_input' => [
+            'label' => 'Hora',
+        ],
+
+        'minute_input' => [
+            'label' => 'Minuto',
+        ],
+
+        'second_input' => [
+            'label' => 'Segundo',
+        ],
+
+    ],
+
     'file_upload' => [
 
         'actions' => [


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

### Update Spanish translations, `DateTimePicker` labels

[**forms**] `components.php`

| Key                                 | Line | Status  |
|:------------------------------------|------|:--------|
| date_time_picker.month_select.label | 134  | Missing |
| date_time_picker.year_input.label   | 138  | Missing |
| date_time_picker.hour_input.label   | 142  | Missing |
| date_time_picker.minute_input.label | 146  | Missing |
| date_time_picker.second_input.label | 150  | Missing |

**Total outdated translations**: 1

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
