### PR TITLE
fix: use `preloadOptions()` instead of `preload()` in select column docs

### DIFF
--- a/packages/tables/docs/02-columns/06-select.md
+++ b/packages/tables/docs/02-columns/06-select.md
@@ -218,10 +218,10 @@ use Filament\Tables\Columns\SelectColumn;
 SelectColumn::make('author_id')
     ->optionsRelationship(name: 'author', titleAttribute: 'name')
     ->searchableOptions()
-    ->preload(FeatureFlag::active())
+    ->preloadOptions(FeatureFlag::active())
 ```
 
-<UtilityInjection set="tableColumns" version="4.x">As well as allowing a static value, the `preload()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="tableColumns" version="4.x">As well as allowing a static value, the `preloadOptions()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 ### Excluding the current record
 


### PR DESCRIPTION
## Description

The select column docs used `preload()`, but the actual method on `SelectColumn` is `preloadOptions()`.
## Visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
