### PR TITLE
Add direction argument to table `defaultGroup()`

### DIFF
--- a/packages/tables/docs/07-grouping.md
+++ b/packages/tables/docs/07-grouping.md
@@ -25,6 +25,20 @@ public function table(Table $table): Table
 
 <AutoScreenshot name="tables/grouping" alt="Table with grouping" version="4.x" />
 
+You may also pass a sort direction to the `defaultGroup()` method:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->defaultGroup('status', direction: 'desc');
+}
+```
+
+The second parameter is optional and defaults to `'asc'`.
+
 ## Allowing users to choose between groupings
 
 You may also allow users to pick between different groupings, by passing them in an array to the `groups()` method:

--- a/packages/tables/docs/07-grouping.md
+++ b/packages/tables/docs/07-grouping.md
@@ -25,7 +25,9 @@ public function table(Table $table): Table
 
 <AutoScreenshot name="tables/grouping" alt="Table with grouping" version="4.x" />
 
-You may also pass a sort direction to the `defaultGroup()` method:
+### Setting the default grouping direction
+
+By default, groups are ordered in ascending order. To use descending order by default, pass the `direction` argument to the `defaultGroup()` method:
 
 ```php
 use Filament\Tables\Table;
@@ -36,8 +38,6 @@ public function table(Table $table): Table
         ->defaultGroup('status', direction: 'desc');
 }
 ```
-
-The second parameter is optional and defaults to `'asc'`.
 
 ## Allowing users to choose between groupings
 

--- a/packages/tables/src/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Concerns/CanGroupRecords.php
@@ -76,7 +76,7 @@ trait CanGroupRecords
 
         $group->applyEagerLoading($query);
 
-        $group->orderQuery($query, $this->getTableGroupingDirection() ?? 'asc');
+        $group->orderQuery($query, $this->getTableGroupingDirection() ?? $this->getTable()->getDefaultGroupDirection());
 
         return $query;
     }

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -100,7 +100,7 @@ trait InteractsWithTable
                 $sessionGrouping = session()->get($groupingSessionKey);
                 $this->tableGrouping = is_string($sessionGrouping) ? $sessionGrouping : null;
             } elseif ($this->getTable()->isDefaultGroupSelectable()) {
-                $this->tableGrouping = "{$this->getTable()->getDefaultGroup()->getId()}:asc";
+                $this->tableGrouping = "{$this->getTable()->getDefaultGroup()->getId()}:{$this->getTable()->getDefaultGroupDirection()}";
             }
         }
 

--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -8,10 +8,13 @@ use Filament\Support\Facades\FilamentIcon;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Grouping\Group;
 use Filament\Tables\View\TablesIconAlias;
+use Illuminate\Support\Str;
 
 trait CanGroupRecords
 {
     protected string | Group | Closure | null $defaultGroup = null;
+
+    protected string | Closure | null $defaultGroupDirection = null;
 
     /**
      * @var array<string, Group>
@@ -82,9 +85,10 @@ trait CanGroupRecords
         return $this;
     }
 
-    public function defaultGroup(string | Group | Closure | null $group): static
+    public function defaultGroup(string | Group | Closure | null $group, string | Closure | null $direction = 'asc'): static
     {
         $this->defaultGroup = $group;
+        $this->defaultGroupDirection = $direction;
 
         return $this;
     }
@@ -186,6 +190,11 @@ trait CanGroupRecords
 
         return Group::make($defaultGroup)
             ->table($this);
+    }
+
+    public function getDefaultGroupDirection(): string
+    {
+        return Str::lower($this->evaluate($this->defaultGroupDirection) ?? 'asc');
     }
 
     /**

--- a/tests/src/Fixtures/Livewire/DefaultGroupedPostsTable.php
+++ b/tests/src/Fixtures/Livewire/DefaultGroupedPostsTable.php
@@ -22,9 +22,6 @@ class DefaultGroupedPostsTable extends Component implements HasActions, HasSchem
     {
         return $table
             ->query(Post::query())
-            ->groups([
-                Tables\Grouping\Group::make('title'),
-            ])
             ->defaultGroup('title', 'desc')
             ->columns([
                 Tables\Columns\TextColumn::make('title'),

--- a/tests/src/Fixtures/Livewire/DefaultGroupedPostsTable.php
+++ b/tests/src/Fixtures/Livewire/DefaultGroupedPostsTable.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Livewire;
+
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Tests\Fixtures\Models\Post;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+
+class DefaultGroupedPostsTable extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use Tables\Concerns\InteractsWithTable;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(Post::query())
+            ->groups([
+                Tables\Grouping\Group::make('title'),
+            ])
+            ->defaultGroup('title', 'desc')
+            ->columns([
+                Tables\Columns\TextColumn::make('title'),
+            ]);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.table');
+    }
+}

--- a/tests/src/Fixtures/Livewire/PostsTableWithGroupPersistedInSession.php
+++ b/tests/src/Fixtures/Livewire/PostsTableWithGroupPersistedInSession.php
@@ -30,7 +30,7 @@ class PostsTableWithGroupPersistedInSession extends Component implements HasActi
                 Tables\Grouping\Group::make('title'),
                 Tables\Grouping\Group::make('author.name'),
             ])
-            ->defaultGroup('title')
+            ->defaultGroup('title', 'desc')
             ->persistGroupInSession()
             ->columns([
                 Tables\Columns\TextColumn::make('title')->sortable(),

--- a/tests/src/Tables/GroupingTest.php
+++ b/tests/src/Tables/GroupingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Filament\Tables\Grouping\Group;
+use Filament\Tests\Fixtures\Livewire\DefaultGroupedPostsTable;
 use Filament\Tests\Fixtures\Livewire\GroupedCustomDataTable;
 use Filament\Tests\Fixtures\Livewire\PostsTable;
 use Filament\Tests\Fixtures\Livewire\PostsTableWithGroupPersistedInSession;
@@ -55,6 +56,32 @@ it('can group a table', function (): void {
                 ->and($table->getGrouping())
                 ->getLabel()->toBe('Dynamic label');
         });
+});
+
+it('can group records by a default group in descending order', function (): void {
+    Post::factory()->create(['title' => 'Apple Post']);
+    Post::factory()->create(['title' => 'Cherry Post']);
+    Post::factory()->create(['title' => 'Banana Post']);
+
+    $sortedPosts = Post::query()->orderByDesc('title')->orderBy('id')->get();
+
+    livewire(DefaultGroupedPostsTable::class)
+        ->assertSet('tableGrouping', 'title:desc')
+        ->assertCanSeeTableRecords($sortedPosts, inOrder: true);
+});
+
+it('can set a `defaultGroup()` direction and get with `getDefaultGroupDirection()`', function (): void {
+    $livewire = livewire(PostsTable::class)->instance();
+    $table = $livewire->getTable();
+
+    expect($table->defaultGroup('title', 'DESC')->getDefaultGroupDirection())->toBe('desc');
+});
+
+it('defaults the `defaultGroup()` direction to ascending', function (): void {
+    $livewire = livewire(PostsTable::class)->instance();
+    $table = $livewire->getTable();
+
+    expect($table->defaultGroup('title')->getDefaultGroupDirection())->toBe('asc');
 });
 
 it('can group records by column', function (): void {

--- a/tests/src/Tables/GroupingTest.php
+++ b/tests/src/Tables/GroupingTest.php
@@ -66,15 +66,26 @@ it('can group records by a default group in descending order', function (): void
     $sortedPosts = Post::query()->orderByDesc('title')->orderBy('id')->get();
 
     livewire(DefaultGroupedPostsTable::class)
+        ->assertSet('tableGrouping', null)
+        ->assertCanSeeTableRecords($sortedPosts, inOrder: true);
+
+    livewire(PostsTableWithGroupPersistedInSession::class)
         ->assertSet('tableGrouping', 'title:desc')
         ->assertCanSeeTableRecords($sortedPosts, inOrder: true);
 });
 
-it('can set a `defaultGroup()` direction and get with `getDefaultGroupDirection()`', function (): void {
+it('can set a default group direction with `defaultGroup()`', function (): void {
     $livewire = livewire(PostsTable::class)->instance();
     $table = $livewire->getTable();
 
     expect($table->defaultGroup('title', 'DESC')->getDefaultGroupDirection())->toBe('desc');
+});
+
+it('can set a `defaultGroup()` direction with a `Closure`', function (): void {
+    $livewire = livewire(PostsTable::class)->instance();
+    $table = $livewire->getTable();
+
+    expect($table->defaultGroup('title', static fn (): string => 'DESC')->getDefaultGroupDirection())->toBe('desc');
 });
 
 it('defaults the `defaultGroup()` direction to ascending', function (): void {
@@ -1034,19 +1045,19 @@ describe('session persistence', function (): void {
         Post::factory()->count(10)->create();
 
         livewire(PostsTableWithGroupPersistedInSession::class)
-            ->assertSet('tableGrouping', 'title:asc')
-            ->set('tableGrouping', 'author.name:desc')
-            ->assertSet('tableGrouping', 'author.name:desc');
+            ->assertSet('tableGrouping', 'title:desc')
+            ->set('tableGrouping', 'author.name:asc')
+            ->assertSet('tableGrouping', 'author.name:asc');
 
         livewire(PostsTableWithGroupPersistedInSession::class)
-            ->assertSet('tableGrouping', 'author.name:desc');
+            ->assertSet('tableGrouping', 'author.name:asc');
     });
 
     it('can clear the persisted grouping in the user\'s session', function (): void {
         Post::factory()->count(10)->create();
 
         livewire(PostsTableWithGroupPersistedInSession::class)
-            ->assertSet('tableGrouping', 'title:asc')
+            ->assertSet('tableGrouping', 'title:desc')
             ->set('tableGrouping', null)
             ->assertSet('tableGrouping', null);
 
@@ -1056,11 +1067,11 @@ describe('session persistence', function (): void {
 
     it('does not override explicit `$tableGrouping` with the persisted grouping', function (): void {
         livewire(PostsTableWithGroupPersistedInSession::class)
-            ->assertSet('tableGrouping', 'title:asc');
+            ->assertSet('tableGrouping', 'title:desc');
 
-        Livewire::withQueryParams(['grouping' => 'author.name:desc'])
+        Livewire::withQueryParams(['grouping' => 'author.name:asc'])
             ->test(PostsTableWithGroupPersistedInSession::class)
-            ->assertSet('tableGrouping', 'author.name:desc');
+            ->assertSet('tableGrouping', 'author.name:asc');
     });
 
     it('does not persist the grouping in the user\'s session by default', function (): void {


### PR DESCRIPTION
## Description

When a table has `->defaultGroup('foo')`, the initial grouping direction is hardcoded to `asc`.

```php
// current
$this->tableGrouping = "{$this->getTable()->getDefaultGroup()->getId()}:asc";
```

This PR adds a `$direction` argument to `defaultGroup()`, mirroring the existing `defaultSort()` signature and naming convention.

```php
// suggested change
$table->defaultGroup('created_at', 'desc');
```

## Functional changes

- [x] Did `composer cs`.
- [x] Changes have been tested (3 new tests).
- [x] Docs updated (`packages/tables/docs/07-grouping.md`).
