### PR TITLE
fix: prevent Create action unresponsiveness after browser back navigation

### DIFF
--- a/packages/actions/src/Action.php
+++ b/packages/actions/src/Action.php
@@ -370,7 +370,7 @@ class Action extends ViewComponent implements Arrayable
             return null;
         }
 
-        if (filled($this->getUrl()) && (! $this->shouldPostToUrl()) && (! $this->hasAction())) {
+        if (filled($this->getUrl()) && (! $this->shouldPostToUrl())) {
             return null;
         }
 

--- a/packages/actions/src/Action.php
+++ b/packages/actions/src/Action.php
@@ -370,7 +370,7 @@ class Action extends ViewComponent implements Arrayable
             return null;
         }
 
-        if (filled($this->getUrl()) && (! $this->shouldPostToUrl())) {
+        if (filled($this->getUrl()) && (! $this->shouldPostToUrl()) && (! $this->hasAction())) {
             return null;
         }
 

--- a/packages/actions/src/Action.php
+++ b/packages/actions/src/Action.php
@@ -370,6 +370,10 @@ class Action extends ViewComponent implements Arrayable
             return null;
         }
 
+        if (filled($this->getUrl()) && (! $this->shouldPostToUrl())) {
+            return null;
+        }
+
         return $this->getJsClickHandler();
     }
 

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -72,6 +72,8 @@ class CreateRecord extends Page
     public function hydrate(): void
     {
         $this->authorizeAccess();
+
+        $this->isCreating = false;
     }
 
     protected function fillForm(): void
@@ -162,8 +164,6 @@ class CreateRecord extends Page
         }
 
         $redirectUrl = $this->getRedirectUrl();
-
-        $this->isCreating = false;
 
         $this->redirect($redirectUrl, navigate: FilamentView::hasSpaMode($redirectUrl));
     }

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -72,8 +72,6 @@ class CreateRecord extends Page
     public function hydrate(): void
     {
         $this->authorizeAccess();
-
-        $this->isCreating = false;
     }
 
     protected function fillForm(): void
@@ -88,7 +86,13 @@ class CreateRecord extends Page
     public function create(bool $another = false): void
     {
         if ($this->isCreating) {
-            return;
+            $lastCreatedAt = session()->get('last_created_at_' . $this->getId());
+
+            if ($lastCreatedAt && (time() - $lastCreatedAt > 15)) {
+                $this->isCreating = false;
+            } else {
+                return;
+            }
         }
 
         $this->isCreating = true;
@@ -164,6 +168,8 @@ class CreateRecord extends Page
         }
 
         $redirectUrl = $this->getRedirectUrl();
+
+        session()->put('last_created_at_' . $this->getId(), time());
 
         $this->redirect($redirectUrl, navigate: FilamentView::hasSpaMode($redirectUrl));
     }

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -163,6 +163,8 @@ class CreateRecord extends Page
 
         $redirectUrl = $this->getRedirectUrl();
 
+        $this->isCreating = false;
+
         $this->redirect($redirectUrl, navigate: FilamentView::hasSpaMode($redirectUrl));
     }
 

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -541,6 +541,13 @@ describe('properties', function (): void {
             ->assertActionDoesNotHaveUrl('url', 'https://google.com');
     });
 
+    it('returns null for `getLivewireClickHandler()` when action has a URL and does not post to URL', function (): void {
+        $action = Action::make('test')
+            ->url('https://filamentphp.com');
+
+        expect($action->getLivewireClickHandler())->toBeNull();
+    });
+
     it('can open a URL in a new tab', function (): void {
         livewire(Actions::class)
             ->assertActionShouldOpenUrlInNewTab('urlInNewTab')

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -541,19 +541,11 @@ describe('properties', function (): void {
             ->assertActionDoesNotHaveUrl('url', 'https://google.com');
     });
 
-    it('returns null for `getLivewireClickHandler()` when action has a URL, does not post to URL, and has no action closure', function (): void {
+    it('returns null for `getLivewireClickHandler()` when action has a URL and does not post to URL', function (): void {
         $action = Action::make('test')
             ->url('https://filamentphp.com');
 
         expect($action->getLivewireClickHandler())->toBeNull();
-    });
-
-    it('returns click handler for `getLivewireClickHandler()` when action has a URL but also has an action closure', function (): void {
-        $action = Action::make('test')
-            ->url('https://filamentphp.com')
-            ->action(fn () => null);
-
-        expect($action->getLivewireClickHandler())->not()->toBeNull();
     });
 
     it('can open a URL in a new tab', function (): void {

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -541,11 +541,19 @@ describe('properties', function (): void {
             ->assertActionDoesNotHaveUrl('url', 'https://google.com');
     });
 
-    it('returns null for `getLivewireClickHandler()` when action has a URL and does not post to URL', function (): void {
+    it('returns null for `getLivewireClickHandler()` when action has a URL, does not post to URL, and has no action closure', function (): void {
         $action = Action::make('test')
             ->url('https://filamentphp.com');
 
         expect($action->getLivewireClickHandler())->toBeNull();
+    });
+
+    it('returns click handler for `getLivewireClickHandler()` when action has a URL but also has an action closure', function (): void {
+        $action = Action::make('test')
+            ->url('https://filamentphp.com')
+            ->action(fn () => null);
+
+        expect($action->getLivewireClickHandler())->not()->toBeNull();
     });
 
     it('can open a URL in a new tab', function (): void {


### PR DESCRIPTION
Fixes filamentphp/filament#20262

### Description
This PR fixes an issue where clicking the Create action on a resource list page becomes unresponsive after navigating to the Create page and returning via the browser Back button.

### Root Cause
1. **Redundant Livewire Click Handler**: Non-optimized action renderers were attaching `wire:click` handlers to actions even when a navigation `url` was configured. When navigating via `wire:navigate`, the combined click event and SPA navigation caused Livewire event listener state to conflict upon browser back navigation.
2. **Locked `$isCreating` State**: On `CreateRecord.php`, `$isCreating` was set to `true` upon form submission and not reset prior to calling `$this->redirect(...)`. As a result, Livewire saved a component snapshot with `$isCreating = true` in the browser history cache, causing subsequent form submit attempts after browser back navigation to return early.

### Changes Made
- Updated `Action::getLivewireClickHandler()` to return `null` if the action has a URL set and does not post to URL.
- Reset `$this->isCreating = false` right before calling `$this->redirect(...)` in `CreateRecord.php`.
- Added unit test in `ActionTest.php` to verify `getLivewireClickHandler()` behavior when an action has a URL.

### Testing
- Added unit test passes cleanly (`pest tests/src/Actions/ActionTest.php`).
- Verified code formatting with Pint (`vendor/bin/pint`).
