### PR TITLE
Complete pt_BR translations

### DIFF
--- a/packages/actions/resources/lang/pt_BR/export.php
+++ b/packages/actions/resources/lang/pt_BR/export.php
@@ -14,6 +14,18 @@ return [
 
                 'label' => 'Colunas',
 
+                'actions' => [
+
+                    'select_all' => [
+                        'label' => 'Selecionar todas',
+                    ],
+
+                    'deselect_all' => [
+                        'label' => 'Desmarcar todas',
+                    ],
+
+                ],
+
                 'form' => [
 
                     'is_enabled' => [
@@ -63,6 +75,11 @@ return [
         'max_rows' => [
             'title' => 'A exportação é muito grande',
             'body' => 'Não é possível exportar mais de 1 linha de uma vez.|Não é possível exportar mais de :count linhas de uma vez.',
+        ],
+
+        'no_columns' => [
+            'title' => 'Nenhuma coluna selecionada',
+            'body' => 'Selecione pelo menos uma coluna para exportar.',
         ],
 
         'started' => [

--- a/packages/forms/resources/lang/pt_BR/components.php
+++ b/packages/forms/resources/lang/pt_BR/components.php
@@ -122,9 +122,53 @@ return [
 
     ],
 
+    'color_picker' => [
+
+        'panel_label' => 'Seletor de cor',
+
+    ],
+
+    'date_time_picker' => [
+
+        'month_select' => [
+            'label' => 'Mês',
+        ],
+
+        'year_input' => [
+            'label' => 'Ano',
+        ],
+
+        'hour_input' => [
+            'label' => 'Hora',
+        ],
+
+        'minute_input' => [
+            'label' => 'Minuto',
+        ],
+
+        'second_input' => [
+            'label' => 'Segundo',
+        ],
+
+    ],
+
     'file_upload' => [
 
+        'actions' => [
+
+            'download' => [
+                'label' => 'Baixar',
+            ],
+
+            'open' => [
+                'label' => 'Abrir em nova aba',
+            ],
+
+        ],
+
         'editor' => [
+
+            'label' => 'Editor de imagem',
 
             'actions' => [
 
@@ -268,6 +312,18 @@ return [
 
         ],
 
+        'columns' => [
+
+            'actions' => [
+                'label' => 'Ações',
+            ],
+
+            'reorder' => [
+                'label' => 'Reordenar',
+            ],
+
+        ],
+
         'fields' => [
 
             'key' => [
@@ -338,6 +394,18 @@ return [
     ],
 
     'repeater' => [
+
+        'columns' => [
+
+            'actions' => [
+                'label' => 'Ações',
+            ],
+
+            'reorder' => [
+                'label' => 'Reordenar',
+            ],
+
+        ],
 
         'actions' => [
 
@@ -548,6 +616,35 @@ return [
 
                         'color' => [
                             'label' => 'Cor',
+
+                            'options' => [
+                                'slate' => 'Ardósia',
+                                'gray' => 'Cinza',
+                                'zinc' => 'Zinco',
+                                'neutral' => 'Neutro',
+                                'stone' => 'Pedra',
+                                'mauve' => 'Malva',
+                                'olive' => 'Oliva',
+                                'mist' => 'Névoa',
+                                'taupe' => 'Taupe',
+                                'red' => 'Vermelho',
+                                'orange' => 'Laranja',
+                                'amber' => 'Âmbar',
+                                'yellow' => 'Amarelo',
+                                'lime' => 'Verde-limão',
+                                'green' => 'Verde',
+                                'emerald' => 'Esmeralda',
+                                'teal' => 'Verde-azulado',
+                                'cyan' => 'Ciano',
+                                'sky' => 'Azul-celeste',
+                                'blue' => 'Azul',
+                                'indigo' => 'Índigo',
+                                'violet' => 'Violeta',
+                                'purple' => 'Roxo',
+                                'fuchsia' => 'Fúcsia',
+                                'pink' => 'Rosa',
+                                'rose' => 'Rosé',
+                            ],
                         ],
 
                         'custom_color' => [
@@ -568,6 +665,17 @@ return [
 
         'no_merge_tag_search_results_message' => 'Nenhuma tag dinâmica encontrada.',
 
+        'mentions' => [
+            'no_options_message' => 'Nenhuma opção disponível.',
+            'no_search_results_message' => 'Nenhum resultado corresponde à sua pesquisa.',
+            'search_prompt' => 'Comece a digitar para pesquisar...',
+            'searching_message' => 'Pesquisando...',
+        ],
+
+        'toolbar' => [
+            'label' => 'Barra de ferramentas do editor',
+        ],
+
         'tools' => [
             'align_center' => 'Alinhar ao centro',
             'align_end' => 'Alinhar ao fim',
@@ -585,6 +693,9 @@ return [
             'h1' => 'Título',
             'h2' => 'Cabeçalho',
             'h3' => 'Subtítulo',
+            'h4' => 'Cabeçalho 4',
+            'h5' => 'Cabeçalho 5',
+            'h6' => 'Cabeçalho 6',
             'grid' => 'Grade',
             'grid_delete' => 'Deletar grade',
             'highlight' => 'Destacar',
@@ -594,6 +705,7 @@ return [
             'link' => 'Link',
             'merge_tags' => 'Tags dinâmicas',
             'ordered_list' => 'Lista ordenada',
+            'paragraph' => 'Parágrafo',
             'redo' => 'Refazer',
             'small' => 'Texto pequeno',
             'strike' => 'Tachado',
@@ -610,6 +722,7 @@ return [
             'table_merge_cells' => 'Mesclar células',
             'table_split_cell' => 'Dividir célula',
             'table_toggle_header_row' => 'Alternar linha de cabeçalho',
+            'table_toggle_header_cell' => 'Alternar célula de cabeçalho',
             'text_color' => 'Cor do texto',
             'underline' => 'Sublinhado',
             'undo' => 'Desfazer',
@@ -678,6 +791,8 @@ return [
 
         'max_items_message' => 'Apenas :count item pode ser selecionado.|Apenas :count itens podem ser selecionados.',
 
+        'no_options_message' => 'Nenhuma opção disponível.',
+
         'no_search_results_message' => 'Nenhuma opção corresponde à sua pesquisa.',
 
         'placeholder' => 'Selecione uma opção',
@@ -689,7 +804,21 @@ return [
     ],
 
     'tags_input' => [
+
+        'actions' => [
+
+            'delete' => [
+                'label' => 'Excluir',
+            ],
+
+        ],
+
         'placeholder' => 'Nova tag',
+
+        'tag_added' => 'Adicionada: :tag',
+
+        'tag_removed' => 'Removida: :tag',
+
     ],
 
     'text_input' => [

--- a/packages/forms/resources/lang/pt_BR/validation.php
+++ b/packages/forms/resources/lang/pt_BR/validation.php
@@ -7,4 +7,6 @@ return [
         'only_one_must_be_selected' => 'Apenas um campo :attribute deve ser selecionado.',
     ],
 
+    'tampered_file_path' => 'O campo :attribute contém um caminho de arquivo que não é permitido.',
+
 ];

--- a/packages/infolists/resources/lang/pt_BR/components.php
+++ b/packages/infolists/resources/lang/pt_BR/components.php
@@ -15,6 +15,11 @@ return [
 
         ],
 
+        'icon' => [
+            'true' => 'Sim',
+            'false' => 'Não',
+        ],
+
         'key_value' => [
 
             'columns' => [

--- a/packages/notifications/resources/lang/pt_BR/database.php
+++ b/packages/notifications/resources/lang/pt_BR/database.php
@@ -6,6 +6,8 @@ return [
 
         'heading' => 'Notificações',
 
+        'unread_label' => 'Notificação não lida',
+
         'actions' => [
 
             'clear' => [

--- a/packages/notifications/resources/lang/pt_BR/notification.php
+++ b/packages/notifications/resources/lang/pt_BR/notification.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+
+    'actions' => [
+
+        'close' => [
+            'label' => 'Fechar notificação',
+        ],
+
+    ],
+
+];

--- a/packages/panels/resources/lang/pt_BR/layout.php
+++ b/packages/panels/resources/lang/pt_BR/layout.php
@@ -4,6 +4,10 @@ return [
 
     'direction' => 'ltr',
 
+    'skip_to_content' => [
+        'label' => 'Pular para o conteúdo',
+    ],
+
     'actions' => [
 
         'billing' => [
@@ -16,6 +20,7 @@ return [
 
         'open_database_notifications' => [
             'label' => 'Abrir notificações',
+            'label_with_unread_count' => '{1} Notificações, :count notificação não lida|[2,*] Notificações, :count notificações não lidas',
         ],
 
         'open_user_menu' => [
@@ -36,6 +41,8 @@ return [
 
         'theme_switcher' => [
 
+            'label' => 'Tema',
+
             'dark' => [
                 'label' => 'Mudar para tema escuro',
             ],
@@ -50,6 +57,14 @@ return [
 
         ],
 
+    ],
+
+    'navigation' => [
+        'label' => 'Navegação da barra lateral',
+    ],
+
+    'topbar' => [
+        'label' => 'Barra superior',
     ],
 
     'avatar' => [

--- a/packages/query-builder/resources/lang/pt_BR/query-builder.php
+++ b/packages/query-builder/resources/lang/pt_BR/query-builder.php
@@ -14,6 +14,10 @@ return [
 
             'label' => 'Grupos',
 
+            'group' => [
+                'label' => 'Grupo',
+            ],
+
             'block' => [
                 'label' => 'Condição OU',
                 'or' => 'OU',
@@ -34,6 +38,8 @@ return [
     ],
 
     'no_rules' => '(Sem regras)',
+
+    'max_rules_reached_tooltip' => 'Você atingiu o máximo de :count regras.',
 
     'item_separators' => [
         'and' => 'E',

--- a/packages/schemas/resources/lang/pt_BR/components.php
+++ b/packages/schemas/resources/lang/pt_BR/components.php
@@ -2,6 +2,33 @@
 
 return [
 
+    'callout' => [
+
+        'statuses' => [
+            'danger' => 'Erro:',
+            'info' => 'Nota:',
+            'success' => 'Sucesso:',
+            'warning' => 'Aviso:',
+        ],
+
+    ],
+
+    'section' => [
+
+        'actions' => [
+
+            'collapse' => [
+                'label' => 'Recolher seção',
+            ],
+
+            'expand' => [
+                'label' => 'Expandir seção',
+            ],
+
+        ],
+
+    ],
+
     'wizard' => [
 
         'actions' => [
@@ -12,6 +39,19 @@ return [
 
             'next_step' => [
                 'label' => 'Próximo',
+            ],
+
+        ],
+
+        'header' => [
+
+            'step' => [
+
+                'statuses' => [
+                    'completed' => 'Concluído',
+                    'upcoming' => 'Não concluído',
+                ],
+
             ],
 
         ],

--- a/packages/tables/resources/lang/pt_BR/table.php
+++ b/packages/tables/resources/lang/pt_BR/table.php
@@ -12,6 +12,10 @@ return [
                 'label' => 'Aplicar colunas',
             ],
 
+            'reorder' => [
+                'label' => 'Reordenar coluna',
+            ],
+
             'reset' => [
                 'label' => 'Redefinir',
             ],
@@ -26,9 +30,20 @@ return [
             'label' => 'Ação|Ações',
         ],
 
+        'icon' => [
+
+            'boolean' => [
+                'true' => 'Sim',
+                'false' => 'Não',
+            ],
+
+        ],
+
         'select' => [
 
             'loading_message' => 'Carregando...',
+
+            'no_options_message' => 'Nenhuma opção disponível.',
 
             'no_search_results_message' => 'Nenhuma opção corresponde à sua busca.',
 
@@ -113,6 +128,10 @@ return [
             'label' => 'Reordenar registros',
         ],
 
+        'reorder_record' => [
+            'label' => 'Reordenar item :key',
+        ],
+
         'filter' => [
             'label' => 'Filtrar',
         ],
@@ -127,6 +146,10 @@ return [
 
         'column_manager' => [
             'label' => 'Alternar colunas',
+        ],
+
+        'toggle_record_content' => [
+            'label' => 'Expandir/recolher item :key',
         ],
 
     ],
@@ -217,7 +240,11 @@ return [
 
     ],
 
+    'loading' => 'Carregando...',
+
     'reorder_indicator' => 'Arraste e solte os registros na ordem.',
+
+    'result_count' => '{0} Nenhum resultado|{1} :count resultado|[2,*] :count resultados',
 
     'selection_indicator' => [
 

--- a/packages/widgets/resources/lang/pt_BR/chart.php
+++ b/packages/widgets/resources/lang/pt_BR/chart.php
@@ -10,4 +10,28 @@ return [
 
     ],
 
+    'filter' => [
+        'label' => 'Filtrar dados do gráfico',
+    ],
+
+    'filters' => [
+
+        'actions' => [
+
+            'apply' => [
+                'label' => 'Aplicar',
+            ],
+
+            'reset' => [
+                'label' => 'Redefinir',
+            ],
+
+        ],
+
+    ],
+
+    'empty' => [
+        'heading' => 'Sem dados para exibir',
+    ],
+
 ];


### PR DESCRIPTION
## Summary
- Fills every key missing from pt_BR lang files vs en (rich_editor colors/mentions/toolbar, date_time_picker, file_upload actions, key_value/repeater columns, tags_input, select, table reorder/loading/result_count, chart filters, schemas callout/section/wizard, query-builder groups/max-rules, panels layout skip-link/theme-switcher/nav/topbar, infolists boolean icons, forms validation tampered_file_path)
- Adds `packages/notifications/resources/lang/pt_BR/notification.php`, previously missing entirely

## Test plan
- [x] Verified with a script diffing flattened en vs pt_BR keys across all packages — zero missing/extra keys remain
- [x] `php -l` on all 11 changed/added files — no syntax errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)