### PR TITLE
Fix badge color condition in getNavigationBadgeColor

### DIFF
--- a/docs/06-navigation/01-overview.md
+++ b/docs/06-navigation/01-overview.md
@@ -85,7 +85,7 @@ If a badge value is returned by `getNavigationBadge()`, it will display using th
 ```php
 public static function getNavigationBadgeColor(): ?string
 {
-    return static::getModel()::count() > 10 ? 'warning' : 'primary';
+    return static::getModel()::count() < 10 ? 'warning' : 'primary';
 }
 ```
 


### PR DESCRIPTION
## Description

The getNavigationBadgeColor() example in the documentation returns 'warning' when the record count is greater than 10, and 'primary' otherwise. This seems backwards for a typical use case a "warning" badge color is usually meant to draw attention when a value drops below an expected threshold (e.g. low stock, too few records), not when it exceeds one. The current example effectively flags "warning" for having more records, which is counter to how most implementations of this pattern are used in practice.

## Visual changes

### Before
```php
public static function getNavigationBadgeColor(): ?string
{
    return static::getModel()::count() > 10 ? 'warning' : 'primary';
}
```
<img width="330" height="218" alt="image" src="https://github.com/user-attachments/assets/d635908a-3640-4a84-ab4a-69f04eb6e12b" />

### After
```php
public static function getNavigationBadgeColor(): ?string
{
    return static::getModel()::count() < 10 ? 'warning' : 'primary';
}
```
<img width="330" height="218" alt="image" src="https://github.com/user-attachments/assets/35c47bf1-7206-42b1-996d-9c29b631ee68" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.