### PR TITLE
fix: derive per-key state path when unsetting missing array keys in tests

### DIFF
--- a/packages/schemas/src/Concerns/InteractsWithSchemas.php
+++ b/packages/schemas/src/Concerns/InteractsWithSchemas.php
@@ -474,12 +474,12 @@ trait InteractsWithSchemas
     protected function unsetMissingNumericArrayKeys(array &$target, array $state, string $currentStatePath, ?string $schemaStatePath = null): void
     {
         foreach ($target as $key => $value) {
-            $currentStatePath .= ".{$key}";
+            $keyStatePath = "{$currentStatePath}.{$key}";
 
             if (
                 (is_numeric($key) || array_is_list($state)) &&
                 (! array_key_exists($key, $state)) &&
-                str($currentStatePath)->startsWith($schemaStatePath)
+                str($keyStatePath)->startsWith($schemaStatePath)
             ) {
                 unset($target[$key]);
 
@@ -487,7 +487,7 @@ trait InteractsWithSchemas
             }
 
             if (is_array($value) && is_array($state[$key] ?? null)) {
-                $this->unsetMissingNumericArrayKeys($target[$key], $state[$key], $currentStatePath, $schemaStatePath);
+                $this->unsetMissingNumericArrayKeys($target[$key], $state[$key], $keyStatePath, $schemaStatePath);
             }
         }
     }

--- a/tests/src/Schemas/InteractsWithSchemasTest.php
+++ b/tests/src/Schemas/InteractsWithSchemasTest.php
@@ -89,40 +89,33 @@ it('can validate from the component itself', function (): void {
         ->assertHasFormErrors(['title' => ['required']]);
 });
 
-describe('filling list fields in tests', function (): void {
-    it('can shrink a list field on a mounted action to fewer items', function (): void {
-        // Shrinking is the only direction that needs stale numeric keys unset:
-        // growing and clearing to [] are both handled by data_set() alone. A
-        // mounted action's state path is nested, so a bug in deriving that path
-        // fails silently — the removed item survives and the next assertion
-        // passes against state that was never changed.
-        livewire(TestComponentWithListFields::class)
-            ->mountAction('roles')
-            ->assertSchemaStateSet(['roles' => ['viewer', 'creator']])
-            ->fillForm(['roles' => ['viewer']])
-            ->assertSchemaStateSet(['roles' => ['viewer']]);
-    });
+it('can remove items from a list field in a mounted action form', function (): void {
+    livewire(TestComponentWithListFields::class)
+        ->mountAction('roles')
+        ->assertSchemaStateSet(['roles' => ['viewer', 'creator']])
+        ->fillForm(['roles' => ['viewer']])
+        ->assertSchemaStateSet(['roles' => ['viewer']]);
+});
 
-    it('can shrink a list field on a page-level form to fewer items', function (): void {
-        // A one-segment state path is the case that already worked, so this pins
-        // it against a fix that only corrects the nested path.
-        livewire(TestComponentWithListFields::class)
-            ->assertFormSet(['roles' => ['viewer', 'creator']])
-            ->fillForm(['roles' => ['viewer']])
-            ->assertFormSet(['roles' => ['viewer']]);
-    });
+it('can remove items from a list field in a page form', function (): void {
+    livewire(TestComponentWithListFields::class)
+        ->assertFormSet(['roles' => ['viewer', 'creator']])
+        ->fillForm(['roles' => ['viewer']])
+        ->assertFormSet(['roles' => ['viewer']]);
+});
 
-    it('can grow and clear a list field on a mounted action', function (): void {
-        livewire(TestComponentWithListFields::class)
-            ->mountAction('roles')
-            ->fillForm(['roles' => []])
-            ->assertSchemaStateSet(['roles' => []]);
+it('can clear a list field in a mounted action form', function (): void {
+    livewire(TestComponentWithListFields::class)
+        ->mountAction('roles')
+        ->fillForm(['roles' => []])
+        ->assertSchemaStateSet(['roles' => []]);
+});
 
-        livewire(TestComponentWithListFields::class)
-            ->mountAction('roles')
-            ->fillForm(['roles' => ['viewer', 'creator', 'editor']])
-            ->assertSchemaStateSet(['roles' => ['viewer', 'creator', 'editor']]);
-    });
+it('can add items to a list field in a mounted action form', function (): void {
+    livewire(TestComponentWithListFields::class)
+        ->mountAction('roles')
+        ->fillForm(['roles' => ['viewer', 'creator', 'editor']])
+        ->assertSchemaStateSet(['roles' => ['viewer', 'creator', 'editor']]);
 });
 
 class TestComponentWithListFields extends Livewire
@@ -135,7 +128,14 @@ class TestComponentWithListFields extends Livewire
     public function form(Schema $form): Schema
     {
         return $form
-            ->components([$this->rolesField()])
+            ->components([
+                CheckboxList::make('roles')
+                    ->options([
+                        'viewer' => 'Viewer',
+                        'creator' => 'Creator',
+                        'editor' => 'Editor',
+                    ]),
+            ])
             ->statePath('data');
     }
 
@@ -143,18 +143,15 @@ class TestComponentWithListFields extends Livewire
     {
         return Action::make('roles')
             ->fillForm(['roles' => ['viewer', 'creator']])
-            ->schema([$this->rolesField()])
-            ->action(function (): void {});
-    }
-
-    protected function rolesField(): CheckboxList
-    {
-        return CheckboxList::make('roles')
-            ->options([
-                'viewer' => 'Viewer',
-                'creator' => 'Creator',
-                'editor' => 'Editor',
-            ]);
+            ->schema([
+                CheckboxList::make('roles')
+                    ->options([
+                        'viewer' => 'Viewer',
+                        'creator' => 'Creator',
+                        'editor' => 'Editor',
+                    ]),
+            ])
+            ->action(static function (): void {});
     }
 }
 

--- a/tests/src/Schemas/InteractsWithSchemasTest.php
+++ b/tests/src/Schemas/InteractsWithSchemasTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Filament\Actions\Action;
+use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Schema;
 use Filament\Tests\Fixtures\Livewire\Livewire;
@@ -86,6 +88,75 @@ it('can validate from the component itself', function (): void {
         ->call('submit')
         ->assertHasFormErrors(['title' => ['required']]);
 });
+
+describe('filling list fields in tests', function (): void {
+    it('can shrink a list field on a mounted action to fewer items', function (): void {
+        // Shrinking is the only direction that needs stale numeric keys unset:
+        // growing and clearing to [] are both handled by data_set() alone. A
+        // mounted action's state path is nested, so a bug in deriving that path
+        // fails silently — the removed item survives and the next assertion
+        // passes against state that was never changed.
+        livewire(TestComponentWithListFields::class)
+            ->mountAction('roles')
+            ->assertSchemaStateSet(['roles' => ['viewer', 'creator']])
+            ->fillForm(['roles' => ['viewer']])
+            ->assertSchemaStateSet(['roles' => ['viewer']]);
+    });
+
+    it('can shrink a list field on a page-level form to fewer items', function (): void {
+        // A one-segment state path is the case that already worked, so this pins
+        // it against a fix that only corrects the nested path.
+        livewire(TestComponentWithListFields::class)
+            ->assertFormSet(['roles' => ['viewer', 'creator']])
+            ->fillForm(['roles' => ['viewer']])
+            ->assertFormSet(['roles' => ['viewer']]);
+    });
+
+    it('can grow and clear a list field on a mounted action', function (): void {
+        livewire(TestComponentWithListFields::class)
+            ->mountAction('roles')
+            ->fillForm(['roles' => []])
+            ->assertSchemaStateSet(['roles' => []]);
+
+        livewire(TestComponentWithListFields::class)
+            ->mountAction('roles')
+            ->fillForm(['roles' => ['viewer', 'creator', 'editor']])
+            ->assertSchemaStateSet(['roles' => ['viewer', 'creator', 'editor']]);
+    });
+});
+
+class TestComponentWithListFields extends Livewire
+{
+    public function mount(): void
+    {
+        $this->form->fill(['roles' => ['viewer', 'creator']]);
+    }
+
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->components([$this->rolesField()])
+            ->statePath('data');
+    }
+
+    public function rolesAction(): Action
+    {
+        return Action::make('roles')
+            ->fillForm(['roles' => ['viewer', 'creator']])
+            ->schema([$this->rolesField()])
+            ->action(function (): void {});
+    }
+
+    protected function rolesField(): CheckboxList
+    {
+        return CheckboxList::make('roles')
+            ->options([
+                'viewer' => 'Viewer',
+                'creator' => 'Creator',
+                'editor' => 'Editor',
+            ]);
+    }
+}
 
 class TestComponentWithValidation extends Livewire
 {


### PR DESCRIPTION
## Description

`unsetMissingNumericArrayKeys()` appended `.{$key}` to `$currentStatePath` inside its `foreach`, so each sibling key inherited the preceding keys' segments instead of deriving `parent.key` per key.

Walking `$this->mountedActions`, the entry's keys are ordered `name`, `arguments`, `context`, `data`, so by the time the loop reaches `data` the path has become:

    mountedActions.0.name.arguments.context.data

The `startsWith($schemaStatePath)` guard then never matches `mountedActions.0.data`, which leaves the `unset()` for stale numeric keys unreachable. In a test, filling a mounted action's form with a shorter list silently keeps the removed items:

    // CheckboxList::make('roles'), mounted state ['viewer', 'creator']
    ->fillForm(['roles' => ['viewer']])
    // state is still ['viewer', 'creator']

`callAction(..., data: [...])` and `setActionData()` route through `fillForm()`, so they are affected too. Growing the list works, and clearing it to `[]` works because an empty array stays a leaf for `Arr::dot()` and `data_set()` replaces the whole value. Only a partial shrink breaks, and it breaks silently: the assertion after it passes against state that was never changed.

Page-level forms were unaffected, because their state path is the single segment `data` and every corrupted path still starts with it.

## Visual changes

None

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
