### PR TITLE
fix(tables): reset stale action records before checking row ActionGroup visibility

### DIFF
--- a/packages/actions/resources/views/components/group.blade.php
+++ b/packages/actions/resources/views/components/group.blade.php
@@ -58,6 +58,28 @@
 
     {{ $group }}
 @elseif (! $group->hasDropdown())
+    @php
+        /**
+         * Reset each child action's own bound record to match the group's current
+         * record before checking visibility. See the longer explanation below (in the
+         * dropdown branch) for why this is necessary.
+         *
+         * $group only has getRecord() when it's a table ActionGroup (via the
+         * InteractsWithRecord trait) - this same view also renders page/form/infolist
+         * action groups, which don't implement HasRecord at all, so this must be
+         * guarded rather than called unconditionally.
+         */
+        if ($group instanceof \Filament\Actions\Contracts\HasRecord) {
+            $currentRecord = $group->getRecord();
+
+            foreach ($group->getActions() as $action) {
+                if ($action instanceof \Filament\Actions\Contracts\HasRecord) {
+                    $action->record($currentRecord);
+                }
+            }
+        }
+    @endphp
+
     @foreach ($group->getActions() as $action)
         @if ($action->isVisible())
             {{ $action }}
@@ -65,6 +87,49 @@
     @endforeach
 @else
     @php
+        /**
+         * When a table row action is clicked, Table::getAction() (see
+         * Filament\Tables\Table\Concerns\HasActions::getAction()) does
+         * `$action->record($mountedRecord)` directly on the SPECIFIC child action
+         * being mounted - not only on the parent ActionGroup. Because that action's
+         * record lookup (InteractsWithRecord::getRecord()) checks its OWN $record
+         * property first and only falls back to the parent group's record if its own
+         * is null, that action keeps using the clicked row's record for the REST of
+         * the request - including when Livewire re-renders the whole table to show
+         * the resulting confirmation modal. So for every other row rendered
+         * afterwards, that one action evaluates its ->visible()/->hidden() closures
+         * against the WRONG (originally-clicked) record, and can wrongly appear - or
+         * wrongly make the whole group non-empty and therefore visible - on rows that
+         * should show no actions at all.
+         *
+         * Fix: before evaluating any child action's visibility for this row, force its
+         * record back to the group's current (correct, per-row) record. This runs on
+         * every render, so it always overwrites whatever Table::getAction() may have
+         * stuck onto an individual action earlier in the same request.
+         *
+         * $group only has getRecord() when it's a table ActionGroup (via the
+         * InteractsWithRecord trait) - this same view also renders page/form/infolist
+         * action groups, which don't implement HasRecord at all, so this must be
+         * guarded rather than called unconditionally.
+         */
+        if ($group instanceof \Filament\Actions\Contracts\HasRecord) {
+            $currentRecord = $group->getRecord();
+
+            foreach ($group->getActions() as $action) {
+                if ($action instanceof \Filament\Actions\Contracts\HasRecord) {
+                    $action->record($currentRecord);
+                }
+
+                if ($action instanceof \Filament\Actions\ActionGroup) {
+                    foreach ($action->getActions() as $nestedAction) {
+                        if ($nestedAction instanceof \Filament\Actions\Contracts\HasRecord) {
+                            $nestedAction->record($currentRecord);
+                        }
+                    }
+                }
+            }
+        }
+
         $actionLists = [];
         $singleActions = [];
 

--- a/packages/tables/resources/views/components/actions.blade.php
+++ b/packages/tables/resources/views/components/actions.blade.php
@@ -10,11 +10,44 @@
 ])
 
 @php
+    /**
+     * Reset every child action inside an ActionGroup's own bound record to the
+     * current row's record, recursively, before the group's visibility is checked
+     * below. Companion fix to resources/views/components/group.blade.php in the
+     * filament/actions package - see that file for the full explanation of the
+     * underlying bug.
+     *
+     * Short version: Table::getAction() sets a record directly on whichever specific
+     * child action was just clicked, and that action keeps using that stale record
+     * for the rest of the request. group.blade.php resets it before deciding what to
+     * put INSIDE the dropdown, but that runs too late to affect whether the trigger
+     * button is shown at all - that decision happens right here, via
+     * $actionGroup->isVisible() (which checks each child's isHiddenInGroup(), which
+     * reads each child's own possibly-stale record). Without this reset, a row can
+     * end up with a visible trigger button whose dropdown is empty: the stale record
+     * made the group look non-empty here, but the corrected record inside
+     * group.blade.php correctly finds nothing to show.
+     */
+    $resetActionGroupChildRecords = function ($action) use (&$resetActionGroupChildRecords, $record): void {
+        if (! ($action instanceof \Filament\Actions\ActionGroup)) {
+            return;
+        }
+
+        foreach ($action->getActions() as $childAction) {
+            if ($childAction instanceof \Filament\Actions\Contracts\HasRecord) {
+                $childAction->record($record);
+            }
+
+            $resetActionGroupChildRecords($childAction);
+        }
+    };
+
     $actions = array_filter(
         $actions,
-        function ($action) use ($record): bool {
+        function ($action) use ($record, $resetActionGroupChildRecords): bool {
             if (! $action instanceof \Filament\Tables\Actions\BulkAction) {
                 $action->record($record);
+                $resetActionGroupChildRecords($action);
             }
 
             return $action->isVisible();

--- a/tests/src/Tables/Actions/ActionGroupTest.php
+++ b/tests/src/Tables/Actions/ActionGroupTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use Filament\Tests\Models\Post;
+use Filament\Tests\Tables\Fixtures\PostsTable;
+use Filament\Tests\Tables\TestCase;
+
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+it('does not leak a mounted action\'s record into other rows\' grouped action visibility', function () {
+    $visiblePost = Post::factory()->create(['is_published' => true]);
+    $hiddenPost = Post::factory()->create(['is_published' => false]);
+
+    // `groupedConditional` requires confirmation, so mounting it for
+    // $visiblePost leaves its record "stuck" on that specific action object
+    // (see Filament\Tables\Table\Concerns\HasActions::getAction()) while the
+    // modal is open and the whole table re-renders.
+    $html = livewire(PostsTable::class)
+        ->mountTableAction('groupedConditional', $visiblePost)
+        ->html();
+
+    // `groupedConditional` is visible only for $visiblePost, so its trigger
+    // (which embeds the acting record's key) must appear exactly once. Before
+    // the fix, the stale $visiblePost record leaked into $hiddenPost's row
+    // too, rendering a second, wrongly-visible copy that pointed at the
+    // wrong record.
+    expect(substr_count($html, "mountTableAction('groupedConditional', '{$visiblePost->getKey()}')"))
+        ->toBe(1);
+});

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -181,6 +181,10 @@ class PostsTable extends Component implements HasForms, Tables\Contracts\HasTabl
                     Tables\Actions\DeleteAction::make('groupedDelete'),
                     Tables\Actions\ForceDeleteAction::make('groupedForceDelete'),
                     Tables\Actions\RestoreAction::make('groupedRestore'),
+                    Tables\Actions\Action::make('groupedConditional')
+                        ->requiresConfirmation()
+                        ->visible(fn (Post $record): bool => $record->is_published)
+                        ->action(fn () => null),
                 ]),
             ])
             ->bulkActions([


### PR DESCRIPTION
## Summary

Fixes #16282 — table row `ActionGroup` visibility (and even its rendered click handler) can leak from whichever row's action was last mounted into every other row rendered in the same response, for v3.

### Root cause

`Filament\Tables\Table\Concerns\HasActions::getAction()` sets the mounted record directly on the specific action that was clicked (`$action->record($mountedRecord)`), not only on the parent `ActionGroup`. Because `InteractsWithRecord::getRecord()` checks an action's own `$record` before falling back to its group, that action keeps using the clicked row's record for the rest of the request — including when Livewire re-renders the whole table to show the resulting confirmation modal.

So for every other row rendered afterwards, that one action evaluates its `->visible()`/`->hidden()` closures (and its click-handler record, via `generateJavaScriptClickHandler()`) against the wrong record. This can make an action wrongly appear on a row it shouldn't (or make the whole group's trigger button appear on a row where every action should be hidden), and the wrongly-shown button ends up pointing at the *other* row's record.

### Fix

Reset each child action's own bound record to the group's current (correct, per-row) record right before checking visibility, in both places that matter:
- `packages/tables/resources/views/components/actions.blade.php` — recursively, before the row's top-level `$action->isVisible()` check (this is what decides whether the trigger button itself renders).
- `packages/actions/resources/views/components/group.blade.php` — before deciding what to render inside the opened dropdown.

Both are guarded to only run for table `ActionGroup`s (`instanceof HasRecord`), since this same view also renders page/form/infolist action groups that don't carry a record at all.

### Test

Added `tests/src/Tables/Actions/ActionGroupTest.php`, plus one new conditionally-visible action (`groupedConditional`) on the shared `PostsTable` fixture. The test mounts a confirmation-requiring grouped action for one record, then asserts the *other* record's row doesn't end up with a spurious extra copy of a different record's action.

I confirmed the new test fails on `3.x` before this fix (asserts `2 === 1`, i.e. the action wrongly renders twice) and passes after it. Ran the full `tests/src/Tables` and `tests/src/Actions` suites afterward — 115 passed, no regressions. Also ran `pint --config pint-strict-imports.json`.

@danharrin — per your comment on #16282 that you'd merge a v3 backport, here it is 🙂
