### PR TITLE
Fix CTRL/CMD+S on Filament v3 create/edit pages

### DIFF
--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -56,13 +56,6 @@
 @endphp
 
 <div
-    @if ($ariaLabelledby)
-        aria-labelledby="{{ $ariaLabelledby }}"
-    @elseif ($heading)
-        aria-labelledby="{{ "{$id}.heading" }}"
-    @endif
-    aria-modal="true"
-    role="dialog"
     x-data="{
         isOpen: false,
 
@@ -120,7 +113,17 @@
         </div>
     @endif
 
-    <div x-cloak x-show="isOpen">
+    <div
+        @if ($ariaLabelledby)
+            aria-labelledby="{{ $ariaLabelledby }}"
+        @elseif ($heading)
+            aria-labelledby="{{ "{$id}.heading" }}"
+        @endif
+        aria-modal="true"
+        role="dialog"
+        x-cloak
+        x-show="isOpen"
+    >
         <div
             aria-hidden="true"
             x-show="isOpen"


### PR DESCRIPTION
## Description

Filament [v3.3.53](https://github.com/filamentphp/filament/blob/34355c9d523fa39aecff6276a871ad73c9b37ff3/package-lock.json#L86-L92) received a frontend rebuild which contained a change in mousetrap.

Full description here: danharrin/alpine-mousetrap#14

TL;DR: All closed modals trip the mousetrap getOpenModal() check, so CTRL/CMD+S is failing since 3.3.53.

## Visual changes

N/A

## Functional changes

CTRL/CMD+S opens the native browser save dialog instead of triggering mousetrap to execute the save operation on create/edit pages.

This fix matches how v4 and v5 modals are built in HTML which matches what mousetrap is currently built to check.

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

***

Remove the aria attributes from the top-level div:

<img width="1009" height="406" alt="image" src="https://github.com/user-attachments/assets/9cf2e645-0885-4cd8-bb54-5907e0c687bd" />

And move them into the child div that controls the visibility of the modal:

<img width="1028" height="370" alt="image" src="https://github.com/user-attachments/assets/c355190e-39d8-432e-972c-e399d7e8086d" />
