### PR TITLE
Fix: don't reserve three columns for a stats widget that has fewer stats

### DIFF
--- a/packages/widgets/src/StatsOverviewWidget.php
+++ b/packages/widgets/src/StatsOverviewWidget.php
@@ -68,7 +68,9 @@ class StatsOverviewWidget extends Widget implements HasSchemas
         $count = count($this->getCachedStats());
 
         if ($count < 3) {
-            return ['@xl' => 3, '!@lg' => 3];
+            $columns = max($count, 1);
+
+            return ['@xl' => $columns, '!@lg' => $columns];
         }
 
         if (($count % 3) !== 1) {

--- a/tests/src/Widgets/StatsOverviewWidgetTest.php
+++ b/tests/src/Widgets/StatsOverviewWidgetTest.php
@@ -38,11 +38,25 @@ it('returns description from `getSectionContentComponent()` when `$description` 
     expect($widget->instance()->getSectionContentComponent()->getDescription())->toBe('Key metrics');
 });
 
-it('returns a 3-column layout for fewer than 3 stats via `getColumns()`', function (): void {
+it('returns a 1-column layout for 1 stat via `getColumns()`', function (): void {
+    $widget = Livewire::test(TestStatsOverviewWidgetOneStat::class);
+
+    expect($widget->instance()->getSectionContentComponent()->getColumns())
+        ->toBe(['@xl' => 1, '!@lg' => 1]);
+});
+
+it('returns a 2-column layout for 2 stats via `getColumns()`', function (): void {
     $widget = Livewire::test(TestStatsOverviewWidgetTwoStats::class);
 
     expect($widget->instance()->getSectionContentComponent()->getColumns())
-        ->toBe(['@xl' => 3, '!@lg' => 3]);
+        ->toBe(['@xl' => 2, '!@lg' => 2]);
+});
+
+it('returns a 1-column layout for no stats via `getColumns()`', function (): void {
+    $widget = Livewire::test(TestStatsOverviewWidgetDefault::class);
+
+    expect($widget->instance()->getSectionContentComponent()->getColumns())
+        ->toBe(['@xl' => 1, '!@lg' => 1]);
 });
 
 it('returns a 4-column layout when stat count mod 3 is 1 via `getColumns()`', function (): void {
@@ -134,6 +148,16 @@ class TestStatsOverviewWidgetWithChart extends StatsOverviewWidget
         return [
             Stat::make('Users', 100)
                 ->chart(static::$chartData),
+        ];
+    }
+}
+
+class TestStatsOverviewWidgetOneStat extends StatsOverviewWidget
+{
+    protected function getStats(): array
+    {
+        return [
+            Stat::make('Users', 100),
         ];
     }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

A stats widget holding a single stat renders that stat in the first of three columns as soon as the widget itself is wide enough, leaving two thirds of it blank and squeezing the value until it overflows the card.


## Visual changes

Before (width > 1878px):
<img width="1648" height="239" alt="CleanShot 2026-08-05 at 08 48 15" src="https://github.com/user-attachments/assets/0783dc65-fd0b-4af5-b31f-6f4c7db37550" />

After (width > 1878px):
<img width="1649" height="196" alt="CleanShot 2026-08-05 at 08 49 21" src="https://github.com/user-attachments/assets/903ba1c7-474d-4bc8-9f01-4f02040e9c87" />



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
