### PR TITLE
Convert Laravel Boost guidelines into an Agent Skill

### DIFF
--- a/docs/01-introduction/03-ai.md
+++ b/docs/01-introduction/03-ai.md
@@ -9,7 +9,7 @@ import Aside from "@components/Aside.astro"
     This page is inspired by Laravel's [AI Assisted Development documentation](https://laravel.com/docs/ai). Laravel Boost is developed by the Laravel team, and you can find out more about it in their official docs, alongside other information about building Laravel projects with AI assistance.
 </Aside>
 
-AI coding agents like [Claude Code](https://www.claude.com/product/claude-code), [Cursor](https://cursor.com), and [GitHub Copilot](https://github.com/features/copilot) can significantly accelerate your Filament development. Filament includes guidelines for [Laravel Boost](https://laravel.com/ai/boost) that teach AI agents how to write idiomatic Filament code and follow framework conventions. Laravel Boost even allows your agent to search the Filament documentation for answers when it encounters unfamiliar requirements.
+AI coding agents like [Claude Code](https://www.claude.com/product/claude-code), [Cursor](https://cursor.com), and [GitHub Copilot](https://github.com/features/copilot) can significantly accelerate your Filament development. Filament includes an Agent Skill for [Laravel Boost](https://laravel.com/ai/boost) that teaches AI agents how to write idiomatic Filament code and follow framework conventions. Laravel Boost even allows your agent to search the Filament documentation for answers when it encounters unfamiliar requirements.
 
 ## Installing Laravel Boost
 
@@ -19,25 +19,29 @@ Install Boost as a development dependency:
 composer require laravel/boost --dev
 ```
 
-Then run the interactive installer and select **Filament** when prompted:
+Then run the interactive installer. Select **Agent Skills**, followed by **filament/filament (skills)** when prompted:
 
 ```bash
 php artisan boost:install
 ```
 
-The installer will detect your IDE and AI agents, generating the necessary configuration files. To verify installation, check your `AGENTS.md`, `CLAUDE.md`, or similar file for a new **Filament** section.
+The installer will detect your IDE and AI agents, generating the necessary configuration files. To verify installation, check your agent's skills directory for `filament-development/SKILL.md`.
+
+<Aside variant="info">
+    If you installed Boost before Filament provided an Agent Skill, rerun `php artisan boost:install` and select **Agent Skills**. Running `php artisan boost:update` alone does not enable new features.
+</Aside>
 
 For more information about Laravel Boost, including available tools, documentation search, and IDE integration, see the [Laravel AI documentation](https://laravel.com/docs/ai).
 
 ## Filament Blueprint
 
-The guidelines included with Boost are designed primarily for **implementing agents**: they help agents write correct Filament code once they know what to build. However, the quality of AI-generated code depends heavily on the quality of the plan. When an implementing agent has a clear, detailed specification, it can focus entirely on writing correct code rather than guessing at requirements or making assumptions about your intent.
+The Filament skill is designed primarily for **implementing agents**: it helps agents write correct Filament code once they know what to build. However, the quality of AI-generated code depends heavily on the quality of the plan. When an implementing agent has a clear, detailed specification, it can focus entirely on writing correct code rather than guessing at requirements or making assumptions about your intent.
 
 For complex features, you may find that agents struggle with the planning phase: choosing the right components, structuring relationships, and anticipating edge cases. A vague plan leads to vague code, and you end up spending more time correcting the agent than you saved by using it.
 
 **Filament Blueprint is a premium extension that helps AI agents produce accurate, detailed implementation plans for Filament.** It's compatible with Filament v4 and above.
 
-Blueprint bridges the gap between what you want and what AI agents build. Instead of hoping an agent understands Filament's conventions, Blueprint provides structured planning guidelines that produce unambiguous specification documents.
+Blueprint bridges the gap between what you want and what AI agents build. Instead of hoping an agent understands Filament's conventions, Blueprint provides a structured planning skill that produces unambiguous specification documents.
 
 A blueprint specifies everything an implementing agent needs:
 
@@ -49,9 +53,9 @@ A blueprint specifies everything an implementing agent needs:
 - **Testing**: What to test and how to verify it works
 - **More**: Reactive fields, wizards, imports/exports, bulk actions, widgets, multi-tenancy, and more
 
-The guidelines cover details that agents commonly get wrong, like namespaces, method names, component selection, and nested layout calculations, so the implementing agent can write correct code on the first try.
+The planning skill covers details that agents commonly get wrong, like namespaces, method names, component selection, and nested layout calculations, so the implementing agent can write correct code on the first try.
 
-The planning guidelines are designed for planning agents only, they shouldn't consume the implementing agent's context window. The planning agent copies all necessary details (namespaces, documentation URLs to fetch, exact method syntax) into the blueprint itself, so the implementing agent has everything it needs without loading the guidelines.
+The planning skill is designed for planning agents only, so it shouldn't consume the implementing agent's context window. The planning agent copies all necessary details (namespaces, documentation URLs to fetch, exact method syntax) into the blueprint itself, so the implementing agent has everything it needs without loading the planning skill.
 
 If you're interested in an example of a plan that Claude Opus 4.5 can write with and without Blueprint, visit the [Blueprint Plan Example](#blueprint-plan-example) section.
 
@@ -67,7 +71,7 @@ composer config --auth http-basic.packages.filamentphp.com "YOUR_EMAIL_ADDRESS" 
 composer require filament/blueprint --dev
 ```
 
-Then run the Boost installer, enable **Agent Skills**, and select **filament/blueprint** when prompted:
+Then run the Boost installer. Select **Agent Skills**, followed by **filament/blueprint (skills)** when prompted:
 
 ```bash
 php artisan boost:install

--- a/packages/panels/resources/boost/skills/filament-development/SKILL.md
+++ b/packages/panels/resources/boost/skills/filament-development/SKILL.md
@@ -1,25 +1,29 @@
 ---
-name: filament
-description: Use this skill when you need to edit an app or admin panel UI built using Filament Resources, RelationManagers, Pages, Forms, or Widgets.
+name: filament-development
+description:
+  Builds Filament application and admin panel interfaces. Use when creating,
+  modifying, testing, or debugging Filament panels, resources, relation managers,
+  pages, schemas, forms, tables, actions, infolists, widgets, imports, or exports.
 ---
 
-## Filament
+# Filament Development
 
 - Filament is a Laravel UI framework built on Livewire, Alpine.js, and Tailwind CSS. UIs are defined in PHP via fluent, chainable components. Follow existing conventions in this app.
 - Use the `search-docs` tool for official documentation on Artisan commands, code examples, testing, relationships, and idiomatic practices. If `search-docs` is unavailable, refer to https://filamentphp.com/docs.
 
-### Artisan
+## Artisan
 
-- Always use Filament-specific Artisan commands to create files. Find available commands with the `list-artisan-commands` tool, or run `php artisan --help`.
+- Always use Filament-specific Artisan commands to create files. Find available commands with the `list-artisan-commands` tool, or run `php artisan list`.
 - Inspect required options before running, and always pass `--no-interaction`.
 
-### Patterns
+## Patterns
 
 Always use static `make()` methods to initialize components. Most configuration methods accept a `Closure` for dynamic values.
 
 Use `Get $get` to read other form field values for conditional logic:
 
-#### Conditional form field visibility
+### Conditional form field visibility
+
 ```php
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -37,7 +41,8 @@ TextInput::make('company_name')
 
 Use `Set $set` inside `->afterStateUpdated()` on a `->live()` field to mutate another field reactively. Prefer `->live(onBlur: true)` on text inputs to avoid per-keystroke updates:
 
-#### Reactive field update
+### Reactive field update
+
 ```php
 use Filament\Schemas\Components\Utilities\Set;
 use Illuminate\Support\Str;
@@ -54,9 +59,10 @@ TextInput::make('slug')
     ->required(),
 ```
 
-Compose layout by nesting `Section` and `Grid`. Children need explicit `->columnSpan()` or `->columnSpanFull()`:
+Compose layout by nesting `Section` and `Grid`. Children span one column by default. Use `->columnSpan()` to span multiple columns or `->columnSpanFull()` to span the full width:
 
-#### Section and Grid layout
+### `Section` and `Grid` layout
+
 ```php
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
@@ -64,10 +70,8 @@ use Filament\Schemas\Components\Section;
 Section::make('Details')
     ->schema([
         Grid::make(2)->schema([
-            TextInput::make('first_name')
-                ->columnSpan(1),
-            TextInput::make('last_name')
-                ->columnSpan(1),
+            TextInput::make('first_name'),
+            TextInput::make('last_name'),
             TextInput::make('bio')
                 ->columnSpanFull(),
         ]),
@@ -76,7 +80,8 @@ Section::make('Details')
 
 Use `Repeater` for inline `HasMany` management. `->relationship()` with no args binds to the relationship matching the field name:
 
-#### Repeater for HasMany
+### `Repeater` for `HasMany`
+
 ```php
 use Filament\Forms\Components\Repeater;
 
@@ -93,7 +98,8 @@ Repeater::make('qualifications')
 
 Use `state()` with a `Closure` to compute derived column values:
 
-#### Computed table column value
+### Computed table column value
+
 ```php
 use Filament\Tables\Columns\TextColumn;
 
@@ -103,7 +109,8 @@ TextColumn::make('full_name')
 
 Use `SelectFilter` for enum or relationship filters, and `Filter` with a `->query()` closure for custom logic:
 
-#### Table filters
+### Table filters
+
 ```php
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\SelectFilter;
@@ -121,7 +128,8 @@ Filter::make('verified')
 
 Actions are buttons that encapsulate optional modal forms and behavior:
 
-#### Action with modal form
+### Action with modal form
+
 ```php
 use Filament\Actions\Action;
 
@@ -134,14 +142,15 @@ Action::make('updateEmail')
     ->action(fn (array $data, User $record) => $record->update($data)),
 ```
 
-### Testing
+## Testing
 
 Testing setup (requires `pestphp/pest-plugin-livewire` in `composer.json`):
 
 - Always call `$this->actingAs(User::factory()->create())` before testing panel functionality.
-- For edit pages, pass `['record' => $user->id]`, use `->call('save')` (not `->call('create')`), and do not assert `->assertRedirect()` (edit pages do not redirect after save).
+- For edit pages, pass `['record' => $user->id]` and use `->call('save')` (not `->call('create')`). Edit pages do not redirect after saving by default, so only assert a redirect when one is configured or `getRedirectUrl()` is overridden.
 
-#### Table test
+### Table test
+
 ```php
 use function Pest\Livewire\livewire;
 
@@ -152,7 +161,8 @@ livewire(ListUsers::class)
     ->assertCanNotSeeTableRecords($users->skip(1));
 ```
 
-#### Create resource test
+### Create resource test
+
 ```php
 use function Pest\Laravel\assertDatabaseHas;
 
@@ -172,7 +182,8 @@ assertDatabaseHas(User::class, [
 ]);
 ```
 
-#### Edit resource test
+### Edit resource test
+
 ```php
 livewire(EditUser::class, ['record' => $user->id])
     ->fillForm(['name' => 'Updated'])
@@ -186,7 +197,8 @@ assertDatabaseHas(User::class, [
 ]);
 ```
 
-#### Testing validation
+### Testing validation
+
 ```php
 livewire(CreateUser::class)
     ->fillForm([
@@ -203,7 +215,8 @@ livewire(CreateUser::class)
 
 Use `->callAction(DeleteAction::class)` for page actions, or `->callAction(TestAction::make('name')->table($record))` for table actions:
 
-#### Calling actions
+### Calling actions
+
 ```php
 use Filament\Actions\Testing\TestAction;
 
@@ -214,7 +227,7 @@ livewire(ListUsers::class)
     ->assertNotified();
 ```
 
-### Correct Namespaces
+## Correct namespaces
 
 - Form fields (`TextInput`, `Select`, `Repeater`, etc.): `Filament\Forms\Components\`
 - Infolist entries (`TextEntry`, `IconEntry`, etc.): `Filament\Infolists\Components\`
@@ -225,11 +238,11 @@ livewire(ListUsers::class)
 - Actions (`DeleteAction`, `CreateAction`, etc.): `Filament\Actions\`. Never use `Filament\Tables\Actions\`, `Filament\Forms\Actions\`, or any other sub-namespace for actions.
 - Icons: `Filament\Support\Icons\Heroicon` enum (e.g., `Heroicon::PencilSquare`)
 
-### Common Mistakes
+## Common mistakes
 
 - **Never assume public file visibility.** File visibility is `private` by default. Always use `->visibility('public')` when public access is needed.
 - **Never assume full-width layout.** `Grid`, `Section`, `Fieldset`, and `Repeater` do not span all columns by default.
-- **Use `Select::make('author_id')->relationship('author', 'name')` for BelongsTo fields.** `BelongsToSelect` does not exist in v2.
+- **Use `Select::make('author_id')->relationship('author', 'name')` for `BelongsTo` fields.** `BelongsToSelect` does not exist; use `Select::relationship()`.
 - **`Repeater` uses `->schema()`, not `->fields()`.**
 - **Never add `->dehydrated(false)` to fields that need to be saved.** It strips the value from form state before `->action()` or the save handler runs. Only use it for helper/UI-only fields.
 - **Use correct property types when overriding `Page`, `Resource`, and `Widget` properties.** These properties have union types or modifiers that must be preserved:

--- a/packages/panels/resources/boost/skills/filament/SKILL.md
+++ b/packages/panels/resources/boost/skills/filament/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: filament
+description: Use this skill when you need to edit an app or admin panel UI built using Filament Resources, RelationManagers, Pages, Forms, or Widgets.
+---
+
 ## Filament
 
 - Filament is a Laravel UI framework built on Livewire, Alpine.js, and Tailwind CSS. UIs are defined in PHP via fluent, chainable components. Follow existing conventions in this app.
@@ -14,8 +19,8 @@ Always use static `make()` methods to initialize components. Most configuration 
 
 Use `Get $get` to read other form field values for conditional logic:
 
-@verbatim
-<code-snippet name="Conditional form field visibility" lang="php">
+#### Conditional form field visibility
+```php
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Utilities\Get;
@@ -28,14 +33,12 @@ Select::make('type')
 TextInput::make('company_name')
     ->required()
     ->visible(fn (Get $get): bool => $get('type') === 'business'),
-
-</code-snippet>
-@endverbatim
+```
 
 Use `Set $set` inside `->afterStateUpdated()` on a `->live()` field to mutate another field reactively. Prefer `->live(onBlur: true)` on text inputs to avoid per-keystroke updates:
 
-@verbatim
-<code-snippet name="Reactive field update" lang="php">
+#### Reactive field update
+```php
 use Filament\Schemas\Components\Utilities\Set;
 use Illuminate\Support\Str;
 
@@ -49,14 +52,12 @@ TextInput::make('title')
 
 TextInput::make('slug')
     ->required(),
-
-</code-snippet>
-@endverbatim
+```
 
 Compose layout by nesting `Section` and `Grid`. Children need explicit `->columnSpan()` or `->columnSpanFull()`:
 
-@verbatim
-<code-snippet name="Section and Grid layout" lang="php">
+#### Section and Grid layout
+```php
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 
@@ -71,14 +72,12 @@ Section::make('Details')
                 ->columnSpanFull(),
         ]),
     ]),
-
-</code-snippet>
-@endverbatim
+```
 
 Use `Repeater` for inline `HasMany` management. `->relationship()` with no args binds to the relationship matching the field name:
 
-@verbatim
-<code-snippet name="Repeater for HasMany" lang="php">
+#### Repeater for HasMany
+```php
 use Filament\Forms\Components\Repeater;
 
 Repeater::make('qualifications')
@@ -90,26 +89,22 @@ Repeater::make('qualifications')
             ->required(),
     ])
     ->columns(2),
-
-</code-snippet>
-@endverbatim
+```
 
 Use `state()` with a `Closure` to compute derived column values:
 
-@verbatim
-<code-snippet name="Computed table column value" lang="php">
+#### Computed table column value
+```php
 use Filament\Tables\Columns\TextColumn;
 
 TextColumn::make('full_name')
     ->state(fn (User $record): string => "{$record->first_name} {$record->last_name}"),
-
-</code-snippet>
-@endverbatim
+```
 
 Use `SelectFilter` for enum or relationship filters, and `Filter` with a `->query()` closure for custom logic:
 
-@verbatim
-<code-snippet name="Table filters" lang="php">
+#### Table filters
+```php
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\SelectFilter;
 use Illuminate\Database\Eloquent\Builder;
@@ -122,14 +117,12 @@ SelectFilter::make('author')
 
 Filter::make('verified')
     ->query(fn (Builder $query) => $query->whereNotNull('email_verified_at')),
-
-</code-snippet>
-@endverbatim
+```
 
 Actions are buttons that encapsulate optional modal forms and behavior:
 
-@verbatim
-<code-snippet name="Action with modal form" lang="php">
+#### Action with modal form
+```php
 use Filament\Actions\Action;
 
 Action::make('updateEmail')
@@ -139,9 +132,7 @@ Action::make('updateEmail')
             ->required(),
     ])
     ->action(fn (array $data, User $record) => $record->update($data)),
-
-</code-snippet>
-@endverbatim
+```
 
 ### Testing
 
@@ -150,8 +141,8 @@ Testing setup (requires `pestphp/pest-plugin-livewire` in `composer.json`):
 - Always call `$this->actingAs(User::factory()->create())` before testing panel functionality.
 - For edit pages, pass `['record' => $user->id]`, use `->call('save')` (not `->call('create')`), and do not assert `->assertRedirect()` (edit pages do not redirect after save).
 
-@verbatim
-<code-snippet name="Table test" lang="php">
+#### Table test
+```php
 use function Pest\Livewire\livewire;
 
 livewire(ListUsers::class)
@@ -159,10 +150,10 @@ livewire(ListUsers::class)
     ->searchTable($users->first()->name)
     ->assertCanSeeTableRecords($users->take(1))
     ->assertCanNotSeeTableRecords($users->skip(1));
+```
 
-</code-snippet>
-
-<code-snippet name="Create resource test" lang="php">
+#### Create resource test
+```php
 use function Pest\Laravel\assertDatabaseHas;
 
 livewire(CreateUser::class)
@@ -179,10 +170,10 @@ assertDatabaseHas(User::class, [
     'name' => 'Test',
     'email' => 'test@example.com',
 ]);
+```
 
-</code-snippet>
-
-<code-snippet name="Edit resource test" lang="php">
+#### Edit resource test
+```php
 livewire(EditUser::class, ['record' => $user->id])
     ->fillForm(['name' => 'Updated'])
     ->call('save')
@@ -193,10 +184,10 @@ assertDatabaseHas(User::class, [
     'id' => $user->id,
     'name' => 'Updated',
 ]);
+```
 
-</code-snippet>
-
-<code-snippet name="Testing validation" lang="php">
+#### Testing validation
+```php
 livewire(CreateUser::class)
     ->fillForm([
         'name' => null,
@@ -208,14 +199,12 @@ livewire(CreateUser::class)
         'email' => 'email',
     ])
     ->assertNotNotified();
-
-</code-snippet>
-@endverbatim
+```
 
 Use `->callAction(DeleteAction::class)` for page actions, or `->callAction(TestAction::make('name')->table($record))` for table actions:
 
-@verbatim
-<code-snippet name="Calling actions" lang="php">
+#### Calling actions
+```php
 use Filament\Actions\Testing\TestAction;
 
 livewire(ListUsers::class)
@@ -223,9 +212,7 @@ livewire(ListUsers::class)
         'role' => 'admin',
     ])
     ->assertNotified();
-
-</code-snippet>
-@endverbatim
+```
 
 ### Correct Namespaces
 
@@ -242,10 +229,10 @@ livewire(ListUsers::class)
 
 - **Never assume public file visibility.** File visibility is `private` by default. Always use `->visibility('public')` when public access is needed.
 - **Never assume full-width layout.** `Grid`, `Section`, `Fieldset`, and `Repeater` do not span all columns by default.
-- **Use `Select::make('author_id')->relationship('author', 'name')` for BelongsTo fields.** `BelongsToSelect` does not exist in v4.
+- **Use `Select::make('author_id')->relationship('author', 'name')` for BelongsTo fields.** `BelongsToSelect` does not exist in v2.
 - **`Repeater` uses `->schema()`, not `->fields()`.**
 - **Never add `->dehydrated(false)` to fields that need to be saved.** It strips the value from form state before `->action()` or the save handler runs. Only use it for helper/UI-only fields.
-- **Use correct property types when overriding `Page`, `Resource`, and `Widget` properties.** These properties have union types or changed modifiers that must be preserved:
+- **Use correct property types when overriding `Page`, `Resource`, and `Widget` properties.** These properties have union types or modifiers that must be preserved:
   - `$navigationIcon`: `protected static string | BackedEnum | null` (not `?string`)
   - `$navigationGroup`: `protected static string | UnitEnum | null` (not `?string`)
   - `$view`: `protected string` (not `protected static string`) on `Page` and `Widget` classes


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The Filament guidelines for Laravel Boost are quite long and they can eat up a lot of tokens unnecessarily.  I find myself having to manually deselect Filament each time I run a `boost:update`.  I converted them into an [Agent Skill](https://agentskills.io/) (SKILL.md) so that they will only be loaded when required.  I didn't change the actual content, but I did convert the non-standard `<code-snippet>` tags into regular headings and triple-backticks in order to be more consistent and compact.

The skill description could probably use some finessing, but it has been working for me.

It wasn't clear which branch you wanted new submissions to, so I went with the default branch, but it should apply cleanly to all 3.1

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
