### PR TITLE
docs: explain RichEditor custom view wrappers

### DIFF
--- a/packages/forms/docs/10-rich-editor.md
+++ b/packages/forms/docs/10-rich-editor.md
@@ -17,6 +17,31 @@ RichEditor::make('content')
 
 <AutoScreenshot name="forms/fields/rich-editor/simple" alt="Rich editor" version="5.x" />
 
+## Wrapping the editor in a custom Blade view
+
+The RichEditor uses an embedded default renderer. Do not include the internal `filament-forms::components.rich-editor` view from your own Blade view, as it is not part of the extension API and may change between versions.
+
+If you need to add an outer wrapper, create a custom RichEditor class with your own view:
+
+```php
+use Filament\Forms\Components\RichEditor;
+
+class CustomRichEditor extends RichEditor
+{
+    protected string $view = 'components.custom-rich-editor';
+}
+```
+
+Then, render the component's embedded markup from that view:
+
+```blade
+<div class="my-class">
+    {!! $field->toEmbeddedHtml() !!}
+</div>
+```
+
+The `$field` variable is available automatically in a custom field view. This delegates the editor markup back to Filament, so your wrapper remains independent of the internal implementation. For styling-only changes, prefer the documented CSS hook classes instead.
+
 ## Storing content as JSON
 
 By default, the rich editor stores content as HTML. If you would like to store the content as JSON instead, you can use the `json()` method:

--- a/tests/resources/views/components/custom-rich-editor.blade.php
+++ b/tests/resources/views/components/custom-rich-editor.blade.php
@@ -1,0 +1,3 @@
+<div class="custom-rich-editor">
+    {!! $field->toEmbeddedHtml() !!}
+</div>

--- a/tests/src/Forms/Components/RichEditorTest.php
+++ b/tests/src/Forms/Components/RichEditorTest.php
@@ -29,6 +29,21 @@ beforeEach(function (): void {
     Artisan::call('filament:assets');
 });
 
+test('can render its embedded markup inside a custom view', function (): void {
+    $richEditor = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            CustomViewRichEditor::make('content'),
+        ])
+        ->getComponents()[0];
+
+    $html = $richEditor->toHtml();
+
+    expect($html)
+        ->toContain('custom-rich-editor')
+        ->toContain('fi-fo-rich-editor');
+});
+
 test('fields can be required', function (): void {
     $errors = [];
 
@@ -2200,4 +2215,9 @@ class TestComponentWithRichEditorRecordPreventingTamperingAndCustomMessage exten
     {
         $this->record->update($this->form->getState());
     }
+}
+
+class CustomViewRichEditor extends RichEditor
+{
+    protected string $view = 'components.custom-rich-editor';
 }


### PR DESCRIPTION
Related to #20339.

## Summary

- Document the supported custom wrapper pattern for RichEditor.
- Show how a custom field view delegates to its embedded markup instead of including Filament's internal Blade view.
- Add regression coverage for the documented pattern.

This gives applications upgrading from the previous internal view a stable wrapper path without restoring a duplicate Blade alias.

## Testing

- ./vendor/bin/pest tests/src/Forms/Components/RichEditorTest.php
- ./vendor/bin/pint --test --dirty