### PR TITLE
fix: disable the clone action when max items on repeater is reached

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeCloned.php
+++ b/packages/forms/src/Components/Concerns/CanBeCloned.php
@@ -21,6 +21,10 @@ trait CanBeCloned
             return false;
         }
 
+        if (filled($this->getMaxItems()) && ($this->getMaxItems() <= $this->getItemsCount())) {
+            return false;
+        }
+
         return (bool) $this->evaluate($this->isCloneable);
     }
 }


### PR DESCRIPTION
## Description

When the max items is reached on a reached on a `cloneable` field (Repeater/Builder), I would expect the hidden to disappear. This already happens to the `add item` action, now the `clonable` action does the same.

## Visual changes

**Before (cloneable action visible):**
<img width="921" height="129" alt="image" src="https://github.com/user-attachments/assets/94b35667-c5ea-4bdd-acc8-aa7438f9daec" />

**After (clonable action is hidden):**
<img width="915" height="130" alt="image" src="https://github.com/user-attachments/assets/7ad4e33a-7237-4e44-b2fd-3fe680cb218d" />

## Functional changes

- When the max items is reached, it is no longer possible to clone an item. The validation already made sure that you cannot save it, but now it isn't possible to clone it at all.
