### PR TITLE
chore(boost): scoped directive

### DIFF
--- a/packages/panels/resources/boost/guidelines/core.blade.php
+++ b/packages/panels/resources/boost/guidelines/core.blade.php
@@ -1,3 +1,4 @@
+@scoped(['app/Filament/**'])
 ## Filament
 
 - Filament is a Laravel UI framework built on Livewire, Alpine.js, and Tailwind CSS. UIs are defined in PHP via fluent, chainable components. Follow existing conventions in this app.
@@ -249,3 +250,4 @@ livewire(ListUsers::class)
   - `$navigationIcon`: `protected static string | BackedEnum | null` (not `?string`)
   - `$navigationGroup`: `protected static string | UnitEnum | null` (not `?string`)
   - `$view`: `protected string` (not `protected static string`) on `Page` and `Widget` classes
+@endscoped


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

From Laravel Boost 2.5 onwards, path-scoped guidelines are possible.

## Visual changes

Leaner CLAUDE.md file when running `boost:install` with `BOOST_RULES_SCOPED_GUIDELINES=true`

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
