### PR TITLE
Fix: Crash when showing all validation messages for per-element rules

### DIFF
--- a/packages/forms/resources/views/components/field-wrapper.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper.blade.php
@@ -54,7 +54,7 @@
 
     if ($hasError && filled($statePath) && blank($errorMessage) && blank($errorMessages)) {
         if ($shouldShowAllValidationMessages) {
-            $errorMessages = $errors->has($statePath) ? $errors->get($statePath) : ($hasNestedRecursiveValidationRules ? $errors->get("{$statePath}.*") : []);
+            $errorMessages = $errors->has($statePath) ? $errors->get($statePath) : ($hasNestedRecursiveValidationRules ? Arr::flatten($errors->get("{$statePath}.*")) : []);
 
             if (count($errorMessages) === 1) {
                 $errorMessage = Arr::first($errorMessages);

--- a/packages/forms/src/Components/Field.php
+++ b/packages/forms/src/Components/Field.php
@@ -312,7 +312,7 @@ class Field extends Component implements Contracts\HasValidationRules
             if ($this->shouldShowAllValidationMessages()) {
                 $errorMessages = $errors->has($statePath)
                     ? $errors->get($statePath)
-                    : ($hasNestedRecursiveValidationRules ? $errors->get("{$statePath}.*") : []);
+                    : ($hasNestedRecursiveValidationRules ? Arr::flatten($errors->get("{$statePath}.*")) : []);
 
                 if (count($errorMessages) === 1) {
                     $errorMessage = Arr::first($errorMessages);

--- a/packages/schemas/src/Components/FusedGroup.php
+++ b/packages/schemas/src/Components/FusedGroup.php
@@ -259,7 +259,7 @@ class FusedGroup extends Component implements CanEntangleWithSingularRelationshi
 
             if ($errors->has("{$statePath}.*")) {
                 if ($childComponent->shouldShowAllValidationMessages()) {
-                    $errorMessages = $errors->get("{$statePath}.*");
+                    $errorMessages = Arr::flatten($errors->get("{$statePath}.*"));
                 } else {
                     $errorMessage = $errors->first("{$statePath}.*");
                 }

--- a/tests/src/Forms/FieldTest.php
+++ b/tests/src/Forms/FieldTest.php
@@ -1,10 +1,12 @@
 <?php
 
+use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\Field;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Schema;
 use Filament\Tests\Fixtures\Livewire\Livewire;
 use Filament\Tests\TestCase;
+use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use Illuminate\Support\ViewErrorBag;
 
@@ -76,6 +78,65 @@ it('can use a Blade component alias via `fieldWrapperView()`', function (): void
         ->toContain('fi-fo-field')
         ->toContain('Name')
         ->toContain('<input');
+});
+
+describe('validation messages for nested recursive rules', function (): void {
+    $shareErrors = function (array $messages): void {
+        view()->share('errors', (new ViewErrorBag)->put('default', new MessageBag($messages)));
+    };
+
+    it('renders a single per-element message', function () use ($shareErrors): void {
+        $shareErrors(['data.choices.0' => ['The first choice is invalid.']]);
+
+        $html = Schema::make(Livewire::make())
+            ->statePath('data')
+            ->components([
+                CheckboxList::make('choices')
+                    ->options(['alpha' => 'Alpha'])
+                    ->showAllValidationMessages(),
+            ])
+            ->toHtml();
+
+        expect($html)
+            ->toContain('The first choice is invalid.');
+    });
+
+    it('renders every per-element message when more than one index fails', function () use ($shareErrors): void {
+        $shareErrors([
+            'data.choices.0' => ['The first choice is invalid.'],
+            'data.choices.1' => ['The second choice is invalid.'],
+        ]);
+
+        $html = Schema::make(Livewire::make())
+            ->statePath('data')
+            ->components([
+                CheckboxList::make('choices')
+                    ->options(['alpha' => 'Alpha'])
+                    ->showAllValidationMessages(),
+            ])
+            ->toHtml();
+
+        expect($html)
+            ->toContain('The first choice is invalid.')
+            ->toContain('The second choice is invalid.');
+    });
+
+    it('renders a per-element message through a Blade field wrapper', function () use ($shareErrors): void {
+        $shareErrors(['data.choices.0' => ['The first choice is invalid.']]);
+
+        $html = Schema::make(Livewire::make())
+            ->statePath('data')
+            ->components([
+                CheckboxList::make('choices')
+                    ->options(['alpha' => 'Alpha'])
+                    ->showAllValidationMessages()
+                    ->fieldWrapperView('test-plugin-wrapper'),
+            ])
+            ->toHtml();
+
+        expect($html)
+            ->toContain('The first choice is invalid.');
+    });
 });
 
 class IdField extends TextInput

--- a/tests/src/Schemas/Components/FusedGroupTest.php
+++ b/tests/src/Schemas/Components/FusedGroupTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\FusedGroup;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
@@ -121,6 +122,38 @@ describe('rendering', function (): void {
 
             expect($html)->toContain('fi-fo-field-wrp-error-message');
             expect($html)->not->toContain('fi-fo-field-wrp-error-list');
+        } finally {
+            view()->share('errors', new ViewErrorBag);
+        }
+    });
+
+    it('renders every per-element error from a child using `showAllValidationMessages()`', function (): void {
+        $errors = new ViewErrorBag;
+        $errors->put('default', new MessageBag([
+            'data.choices.0' => ['The first choice is invalid.'],
+            'data.choices.1' => ['The second choice is invalid.'],
+        ]));
+
+        view()->share('errors', $errors);
+
+        try {
+            $livewire = Livewire::make();
+
+            Schema::make($livewire)
+                ->statePath('data')
+                ->components([
+                    $group = FusedGroup::make()
+                        ->components([
+                            CheckboxList::make('choices')
+                                ->options(['alpha' => 'Alpha'])
+                                ->showAllValidationMessages(),
+                        ]),
+                ])
+                ->fill();
+
+            expect($group->toHtml())
+                ->toContain('The first choice is invalid.')
+                ->toContain('The second choice is invalid.');
         } finally {
             view()->share('errors', new ViewErrorBag);
         }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

A field with a per-element validation rule crashes the entire page instead of rendering a validation message, whenever `showAllValidationMessages()` is enabled on it:



```php
use Filament\Forms\Components\CheckboxList;
use Filament\Forms\Concerns\InteractsWithForms;
use Filament\Forms\Contracts\HasForms;
use Filament\Schemas\Contracts\HasSchemas;
use Filament\Schemas\Schema;
use Livewire\Component;

class SomeForm extends Component implements HasForms, HasSchemas
{
    use InteractsWithForms;

    public array $data = [];

    public function form(Schema $schema): Schema
    {
        return $schema
            ->statePath('data')
            ->components([
                CheckboxList::make('choices')
                    ->showAllValidationMessages()
                    ->options(['alpha' => 'Alpha', 'beta' => 'Beta']),
            ]);
    }

    public function save(): void
    {
        $this->form->getState();
    }
}

// call
livewire(SomeForm::class)
    ->fillForm(['choices' => ['gamma']])
    ->call('save');
```

Expected behavior: 
Validation message: "The selected choices.0 is invalid."

Actual behavior:
```
TypeError: htmlspecialchars(): Argument #1 ($string) must be of type string, array given
```

## Visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
