### PR TITLE
fix: avoid dispatching duplicate failed authentication events

### DIFF
--- a/packages/panels/src/Auth/Pages/Login.php
+++ b/packages/panels/src/Auth/Pages/Login.php
@@ -30,7 +30,6 @@ use Filament\Support\Enums\Alignment;
 use Filament\View\PanelsRenderHook;
 use Illuminate\Auth\Events\Attempting;
 use Illuminate\Auth\Events\Failed;
-use Illuminate\Auth\Events\Validated;
 use Illuminate\Auth\SessionGuard;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Guard;
@@ -164,24 +163,12 @@ class Login extends SimplePage
             return null;
         }
 
-        app(Timebox::class)->call(function (Timebox $timebox) use ($authProvider, $authGuard, $credentials, $remember, $user): void {
-            event(new Validated($authGuard->name, $user));
-
-            // `Validated` listeners can change authorization state, so panel access must be
-            // checked again before login to preserve the ordering from `attemptWhen()`.
-            if (! $this->isUserAllowedToAccessPanel($user)) {
-                $this->fireFailedEvent($authGuard, $user, $credentials);
-                $this->throwFailureValidationException();
-            }
-
-            if (config('hashing.rehash_on_login', true)) {
-                $authProvider->rehashPasswordIfRequired($user, $credentials);
-            }
-
-            $authGuard->login($user, $remember);
-
-            $timebox->returnEarly();
-        }, $timeboxDuration);
+        // Credentials are deliberately validated again after the multi-factor challenge so that
+        // password and panel access changes made during the challenge are observed before login.
+        // The corresponding second `Attempting` event is intentional.
+        if (! $authGuard->attemptWhen($credentials, fn (Authenticatable $user): bool => $this->isUserAllowedToAccessPanel($user), $remember)) {
+            $this->throwFailureValidationException();
+        }
 
         session()->regenerate();
 

--- a/packages/panels/src/Auth/Pages/Login.php
+++ b/packages/panels/src/Auth/Pages/Login.php
@@ -30,6 +30,7 @@ use Filament\Support\Enums\Alignment;
 use Filament\View\PanelsRenderHook;
 use Illuminate\Auth\Events\Attempting;
 use Illuminate\Auth\Events\Failed;
+use Illuminate\Auth\Events\Validated;
 use Illuminate\Auth\SessionGuard;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Guard;
@@ -118,6 +119,8 @@ class Login extends SimplePage
             return $user;
         }, $timeboxDuration);
 
+        event(new Validated($authGuard->name, $user));
+
         $needsMultiFactorChallenge = app(Timebox::class)->call(function (Timebox $timebox) use ($user): bool {
             if (
                 filled($this->userUndertakingMultiFactorAuthentication) &&
@@ -163,10 +166,11 @@ class Login extends SimplePage
             return null;
         }
 
-        if (! $authGuard->attemptWhen($credentials, fn (Authenticatable $user): bool => $this->isUserAllowedToAccessPanel($user), $remember)) {
-            $this->fireFailedEvent($authGuard, $user, $credentials);
-            $this->throwFailureValidationException();
+        if (config('hashing.rehash_on_login', true)) {
+            $authProvider->rehashPasswordIfRequired($user, $credentials);
         }
+
+        $authGuard->login($user, $remember);
 
         session()->regenerate();
 

--- a/packages/panels/src/Auth/Pages/Login.php
+++ b/packages/panels/src/Auth/Pages/Login.php
@@ -164,20 +164,24 @@ class Login extends SimplePage
             return null;
         }
 
-        event(new Validated($authGuard->name, $user));
+        app(Timebox::class)->call(function (Timebox $timebox) use ($authProvider, $authGuard, $credentials, $remember, $user): void {
+            event(new Validated($authGuard->name, $user));
 
-        // `Validated` listeners can change authorization state, so panel access must be
-        // checked again before login to preserve the ordering from `attemptWhen()`.
-        if (! $this->isUserAllowedToAccessPanel($user)) {
-            $this->fireFailedEvent($authGuard, $user, $credentials);
-            $this->throwFailureValidationException();
-        }
+            // `Validated` listeners can change authorization state, so panel access must be
+            // checked again before login to preserve the ordering from `attemptWhen()`.
+            if (! $this->isUserAllowedToAccessPanel($user)) {
+                $this->fireFailedEvent($authGuard, $user, $credentials);
+                $this->throwFailureValidationException();
+            }
 
-        if (config('hashing.rehash_on_login', true)) {
-            $authProvider->rehashPasswordIfRequired($user, $credentials);
-        }
+            if (config('hashing.rehash_on_login', true)) {
+                $authProvider->rehashPasswordIfRequired($user, $credentials);
+            }
 
-        $authGuard->login($user, $remember);
+            $authGuard->login($user, $remember);
+
+            $timebox->returnEarly();
+        }, $timeboxDuration);
 
         session()->regenerate();
 

--- a/packages/panels/src/Auth/Pages/Login.php
+++ b/packages/panels/src/Auth/Pages/Login.php
@@ -119,8 +119,6 @@ class Login extends SimplePage
             return $user;
         }, $timeboxDuration);
 
-        event(new Validated($authGuard->name, $user));
-
         $needsMultiFactorChallenge = app(Timebox::class)->call(function (Timebox $timebox) use ($user): bool {
             if (
                 filled($this->userUndertakingMultiFactorAuthentication) &&
@@ -164,6 +162,15 @@ class Login extends SimplePage
 
         if ($needsMultiFactorChallenge) {
             return null;
+        }
+
+        event(new Validated($authGuard->name, $user));
+
+        // `Validated` listeners can change authorization state, so panel access must be
+        // checked again before login to preserve the ordering from `attemptWhen()`.
+        if (! $this->isUserAllowedToAccessPanel($user)) {
+            $this->fireFailedEvent($authGuard, $user, $credentials);
+            $this->throwFailureValidationException();
         }
 
         if (config('hashing.rehash_on_login', true)) {

--- a/tests/src/Panels/Auth/LoginTest.php
+++ b/tests/src/Panels/Auth/LoginTest.php
@@ -188,6 +188,24 @@ describe('authentication', function (): void {
         Event::assertDispatchedTimes(Validated::class, 1);
     });
 
+    it('rechecks panel access after `Validated` listeners run', function (): void {
+        $userToAuthenticate = User::factory()->create();
+
+        Event::listen(Validated::class, static function (): void {
+            Filament::setCurrentPanel('custom');
+        });
+
+        livewire(Login::class)
+            ->fillForm([
+                'email' => $userToAuthenticate->email,
+                'password' => 'password',
+            ])
+            ->call('authenticate')
+            ->assertHasFormErrors(['email']);
+
+        $this->assertGuest();
+    });
+
     it('rehashes a password that was stored at a lower cost', function (): void {
         $userToAuthenticate = User::factory()->create([
             'password' => Hash::make('password', ['rounds' => 4]),

--- a/tests/src/Panels/Auth/LoginTest.php
+++ b/tests/src/Panels/Auth/LoginTest.php
@@ -7,10 +7,8 @@ use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\TestCase;
 use Illuminate\Auth\Events\Attempting;
 use Illuminate\Auth\Events\Failed;
-use Illuminate\Auth\Events\Validated;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Sleep;
@@ -169,93 +167,6 @@ describe('authentication', function (): void {
             ->assertHasNoFormErrors();
 
         expect($padding)->not->toBe([]);
-    });
-
-    it('retrieves and verifies the credentials only once', function (): void {
-        Event::fake([Attempting::class, Validated::class]);
-
-        $userToAuthenticate = User::factory()->create();
-
-        livewire(Login::class)
-            ->fillForm([
-                'email' => $userToAuthenticate->email,
-                'password' => 'password',
-            ])
-            ->call('authenticate')
-            ->assertRedirect(Filament::getUrl());
-
-        Event::assertDispatchedTimes(Attempting::class, 1);
-        Event::assertDispatchedTimes(Validated::class, 1);
-    });
-
-    it('timeboxes panel access rechecks after `Validated` listeners run', function (): void {
-        $userToAuthenticate = User::factory()->create();
-
-        Event::listen(Validated::class, static function (): void {
-            Filament::setCurrentPanel('custom');
-        });
-
-        config()->set('auth.timebox_duration', 10_000_000);
-
-        $padding = [];
-
-        Sleep::fake();
-        Sleep::whenFakingSleep(function ($duration) use (&$padding): void {
-            $padding[] = $duration->totalMilliseconds;
-        });
-
-        livewire(Login::class)
-            ->fillForm([
-                'email' => $userToAuthenticate->email,
-                'password' => 'password',
-            ])
-            ->call('authenticate')
-            ->assertHasFormErrors(['email']);
-
-        $this->assertGuest();
-
-        expect($padding)->toHaveCount(1);
-    });
-
-    it('rehashes a password that was stored at a lower cost', function (): void {
-        $userToAuthenticate = User::factory()->create([
-            'password' => Hash::make('password', ['rounds' => 4]),
-        ]);
-
-        config()->set('hashing.bcrypt.rounds', 5);
-        Hash::forgetDrivers();
-
-        expect(Hash::needsRehash($userToAuthenticate->password))->toBeTrue();
-
-        livewire(Login::class)
-            ->fillForm([
-                'email' => $userToAuthenticate->email,
-                'password' => 'password',
-            ])
-            ->call('authenticate')
-            ->assertRedirect(Filament::getUrl());
-
-        expect(Hash::needsRehash($userToAuthenticate->refresh()->password))->toBeFalse();
-    });
-
-    it('does not rehash the password when `hashing.rehash_on_login` is disabled', function (): void {
-        $userToAuthenticate = User::factory()->create([
-            'password' => Hash::make('password', ['rounds' => 4]),
-        ]);
-
-        config()->set('hashing.rehash_on_login', false);
-        config()->set('hashing.bcrypt.rounds', 5);
-        Hash::forgetDrivers();
-
-        livewire(Login::class)
-            ->fillForm([
-                'email' => $userToAuthenticate->email,
-                'password' => 'password',
-            ])
-            ->call('authenticate')
-            ->assertRedirect(Filament::getUrl());
-
-        expect(Hash::needsRehash($userToAuthenticate->refresh()->password))->toBeTrue();
     });
 
 });

--- a/tests/src/Panels/Auth/LoginTest.php
+++ b/tests/src/Panels/Auth/LoginTest.php
@@ -7,8 +7,10 @@ use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\TestCase;
 use Illuminate\Auth\Events\Attempting;
 use Illuminate\Auth\Events\Failed;
+use Illuminate\Auth\Events\Validated;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Sleep;
@@ -167,6 +169,64 @@ describe('authentication', function (): void {
             ->assertHasNoFormErrors();
 
         expect($padding)->not->toBe([]);
+    });
+
+    it('retrieves and verifies the credentials only once', function (): void {
+        Event::fake([Attempting::class, Validated::class]);
+
+        $userToAuthenticate = User::factory()->create();
+
+        livewire(Login::class)
+            ->fillForm([
+                'email' => $userToAuthenticate->email,
+                'password' => 'password',
+            ])
+            ->call('authenticate')
+            ->assertRedirect(Filament::getUrl());
+
+        Event::assertDispatchedTimes(Attempting::class, 1);
+        Event::assertDispatchedTimes(Validated::class, 1);
+    });
+
+    it('rehashes a password that was stored at a lower cost', function (): void {
+        $userToAuthenticate = User::factory()->create([
+            'password' => Hash::make('password', ['rounds' => 4]),
+        ]);
+
+        config()->set('hashing.bcrypt.rounds', 5);
+        Hash::forgetDrivers();
+
+        expect(Hash::needsRehash($userToAuthenticate->password))->toBeTrue();
+
+        livewire(Login::class)
+            ->fillForm([
+                'email' => $userToAuthenticate->email,
+                'password' => 'password',
+            ])
+            ->call('authenticate')
+            ->assertRedirect(Filament::getUrl());
+
+        expect(Hash::needsRehash($userToAuthenticate->refresh()->password))->toBeFalse();
+    });
+
+    it('does not rehash the password when `hashing.rehash_on_login` is disabled', function (): void {
+        $userToAuthenticate = User::factory()->create([
+            'password' => Hash::make('password', ['rounds' => 4]),
+        ]);
+
+        config()->set('hashing.rehash_on_login', false);
+        config()->set('hashing.bcrypt.rounds', 5);
+        Hash::forgetDrivers();
+
+        livewire(Login::class)
+            ->fillForm([
+                'email' => $userToAuthenticate->email,
+                'password' => 'password',
+            ])
+            ->call('authenticate')
+            ->assertRedirect(Filament::getUrl());
+
+        expect(Hash::needsRehash($userToAuthenticate->refresh()->password))->toBeTrue();
     });
 
 });

--- a/tests/src/Panels/Auth/LoginTest.php
+++ b/tests/src/Panels/Auth/LoginTest.php
@@ -188,11 +188,20 @@ describe('authentication', function (): void {
         Event::assertDispatchedTimes(Validated::class, 1);
     });
 
-    it('rechecks panel access after `Validated` listeners run', function (): void {
+    it('timeboxes panel access rechecks after `Validated` listeners run', function (): void {
         $userToAuthenticate = User::factory()->create();
 
         Event::listen(Validated::class, static function (): void {
             Filament::setCurrentPanel('custom');
+        });
+
+        config()->set('auth.timebox_duration', 10_000_000);
+
+        $padding = [];
+
+        Sleep::fake();
+        Sleep::whenFakingSleep(function ($duration) use (&$padding): void {
+            $padding[] = $duration->totalMilliseconds;
         });
 
         livewire(Login::class)
@@ -204,6 +213,8 @@ describe('authentication', function (): void {
             ->assertHasFormErrors(['email']);
 
         $this->assertGuest();
+
+        expect($padding)->toHaveCount(1);
     });
 
     it('rehashes a password that was stored at a lower cost', function (): void {

--- a/tests/src/Panels/Auth/LoginTest.php
+++ b/tests/src/Panels/Auth/LoginTest.php
@@ -9,6 +9,7 @@ use Illuminate\Auth\Events\Attempting;
 use Illuminate\Auth\Events\Failed;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Sleep;
@@ -205,10 +206,54 @@ describe('authentication failures', function (): void {
 
             return true;
         });
+
+        Event::assertDispatchedTimes(Failed::class, 1);
     });
 
-    it('fires the `Attempting` event when authentication fails because the email is unknown', function (): void {
-        Event::fake([Attempting::class]);
+    it('dispatches `Failed` once when credentials change before final validation without multi-factor authentication', function (): void {
+        expect(Filament::getMultiFactorAuthenticationProviders())->toBe([]);
+
+        $userToAuthenticate = User::factory()->create();
+
+        $attemptingEvents = 0;
+        $failedEvents = 0;
+
+        Event::listen(Attempting::class, static function () use (&$attemptingEvents, $userToAuthenticate): void {
+            $attemptingEvents++;
+
+            if ($attemptingEvents !== 2) {
+                return;
+            }
+
+            $userToAuthenticate->newQuery()
+                ->whereKey($userToAuthenticate->getKey())
+                ->update(['password' => Hash::make('new-password')]);
+        });
+
+        Event::listen(Failed::class, static function () use (&$failedEvents): void {
+            $failedEvents++;
+        });
+
+        livewire(Login::class)
+            ->fillForm([
+                'email' => $userToAuthenticate->email,
+                'password' => 'password',
+            ])
+            ->call('authenticate')
+            ->assertHasFormErrors(['email']);
+
+        $this->assertGuest();
+
+        $freshUser = $userToAuthenticate->fresh();
+
+        expect(Hash::check('new-password', $freshUser->password))->toBeTrue()
+            ->and(Hash::check('password', $freshUser->password))->toBeFalse()
+            ->and($attemptingEvents)->toBe(2)
+            ->and($failedEvents)->toBe(1);
+    });
+
+    it('fires the `Attempting` and `Failed` events when authentication fails because the email is unknown', function (): void {
+        Event::fake([Attempting::class, Failed::class]);
 
         livewire(Login::class)
             ->fillForm([
@@ -228,6 +273,13 @@ describe('authentication failures', function (): void {
                 'password' => 'password',
             ];
         });
+
+        Event::assertDispatchedTimes(Attempting::class, 1);
+        Event::assertDispatched(static fn (Failed $event): bool => ($event->guard === 'web') && ($event->user === null) && ($event->credentials === [
+            'email' => 'nonexistent@example.com',
+            'password' => 'password',
+        ]));
+        Event::assertDispatchedTimes(Failed::class, 1);
     });
 
     it('fires the `Attempting` event when authentication fails because the password is wrong', function (): void {
@@ -290,6 +342,8 @@ describe('authentication failures', function (): void {
 
             return true;
         });
+
+        Event::assertDispatchedTimes(Failed::class, 1);
     });
 
     it('cannot reach the multi-factor challenge on a panel that `canAccessPanel()` denies', function (): void {
@@ -319,6 +373,8 @@ describe('authentication failures', function (): void {
 
             return $event->user->is($userToAuthenticate);
         });
+
+        Event::assertDispatchedTimes(Failed::class, 1);
     });
 
     it('returns the same failure for a correct and an incorrect password on a panel that `canAccessPanel()` denies', function (): void {

--- a/tests/src/Panels/Auth/MultiFactor/App/AppAuthenticationChallengeTest.php
+++ b/tests/src/Panels/Auth/MultiFactor/App/AppAuthenticationChallengeTest.php
@@ -6,12 +6,14 @@ use Filament\Facades\Filament;
 use Filament\Forms\Components\TextInput;
 use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\TestCase;
+use Illuminate\Auth\Events\Failed;
 use Illuminate\Auth\Events\Validated;
 use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
 use PragmaRX\Google2FAQRCode\Google2FA;
@@ -137,6 +139,68 @@ describe('authentication flow', function (): void {
             ->assertRedirect(Filament::getUrl());
 
         $this->assertAuthenticatedAs($userToAuthenticate);
+    });
+
+    it('does not authenticate when the password changes during the multi-factor challenge', function (): void {
+        $appAuthentication = Arr::first(Filament::getCurrentOrDefaultPanel()->getMultiFactorAuthenticationProviders());
+
+        $userToAuthenticate = User::factory()
+            ->hasAppAuthentication($recoveryCodes = $appAuthentication->generateRecoveryCodes())
+            ->create([
+                'password' => Hash::make('password', ['rounds' => 4]),
+            ]);
+
+        config()->set('hashing.bcrypt.rounds', 5);
+        Hash::forgetDrivers();
+
+        $livewire = livewire(Login::class)
+            ->fillForm([
+                'email' => $userToAuthenticate->email,
+                'password' => 'password',
+            ])
+            ->call('authenticate')
+            ->assertNotSet('userUndertakingMultiFactorAuthentication', null)
+            ->assertNoRedirect()
+            ->callAction(TestAction::make('useRecoveryCode')
+                ->schemaComponent("{$appAuthentication->getId()}.code", schema: 'multiFactorChallengeForm'));
+
+        $failedEvents = 0;
+        $passwordWasReset = false;
+        $userClass = $userToAuthenticate::class;
+
+        Event::listen(Failed::class, static function () use (&$failedEvents): void {
+            $failedEvents++;
+        });
+
+        Event::listen("eloquent.saved: {$userClass}", static function (User $savedUser) use (&$passwordWasReset, $userToAuthenticate): void {
+            if ($passwordWasReset || ($savedUser->getKey() !== $userToAuthenticate->getKey())) {
+                return;
+            }
+
+            $passwordWasReset = true;
+
+            $savedUser->newQuery()
+                ->whereKey($savedUser->getKey())
+                ->update(['password' => Hash::make('new-password')]);
+        });
+
+        $livewire
+            ->fillForm([
+                $appAuthentication->getId() => [
+                    'recoveryCode' => Arr::random($recoveryCodes),
+                ],
+            ], 'multiFactorChallengeForm')
+            ->call('authenticate')
+            ->assertHasFormErrors(['email'])
+            ->assertNoRedirect();
+
+        $this->assertGuest();
+
+        $freshUser = $userToAuthenticate->fresh();
+
+        expect(Hash::check('new-password', $freshUser->password))->toBeTrue()
+            ->and(Hash::check('password', $freshUser->password))->toBeFalse()
+            ->and($failedEvents)->toBe(1);
     });
 
     it('will authenticate the user with a one-time code after enabling the recovery code field', function (): void {

--- a/tests/src/Panels/Auth/MultiFactor/App/AppAuthenticationChallengeTest.php
+++ b/tests/src/Panels/Auth/MultiFactor/App/AppAuthenticationChallengeTest.php
@@ -6,10 +6,12 @@ use Filament\Facades\Filament;
 use Filament\Forms\Components\TextInput;
 use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\TestCase;
+use Illuminate\Auth\Events\Validated;
 use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
 use PragmaRX\Google2FAQRCode\Google2FA;
@@ -45,20 +47,26 @@ describe('authentication flow', function (): void {
     });
 
     it('will authenticate the user after a valid challenge code is used', function (): void {
+        Event::fake([Validated::class]);
+
         $appAuthentication = Arr::first(Filament::getCurrentOrDefaultPanel()->getMultiFactorAuthenticationProviders());
 
         $userToAuthenticate = User::factory()
             ->hasAppAuthentication()
             ->create();
 
-        livewire(Login::class)
+        $livewire = livewire(Login::class)
             ->fillForm([
                 'email' => $userToAuthenticate->email,
                 'password' => 'password',
             ])
             ->call('authenticate')
             ->assertNotSet('userUndertakingMultiFactorAuthentication', null)
-            ->assertNoRedirect()
+            ->assertNoRedirect();
+
+        Event::assertNotDispatched(Validated::class);
+
+        $livewire
             ->fillForm([
                 $appAuthentication->getId() => [
                     'code' => $appAuthentication->getCurrentCode($userToAuthenticate),
@@ -69,6 +77,8 @@ describe('authentication flow', function (): void {
             ->assertRedirect(Filament::getUrl());
 
         $this->assertAuthenticatedAs($userToAuthenticate);
+
+        Event::assertDispatchedTimes(Validated::class, 1);
     });
 
     it('will make the recovery code field visible when the user requests it', function (): void {


### PR DESCRIPTION
## Description

`Login::authenticate()` verifies the submitted password twice on every successful sign-in.

The first `Timebox` retrieves the user and calls `validateCredentials()`, so by the time it returns the credentials are known to be good and the panel access check has already run:

```php
$user = app(Timebox::class)->call(function (Timebox $timebox) use (...): ?Authenticatable {
    // retrieveByCredentials() + validateCredentials() + isUserAllowedToAccessPanel()
    return $user;
}, $timeboxDuration);
```

Those same credentials are then handed to the guard:

```php
if (! $authGuard->attemptWhen($credentials, fn (Authenticatable $user): bool => $this->isUserAllowedToAccessPanel($user), $remember)) {
```

`attemptWhen()` runs `retrieveByCredentials()` and `validateCredentials()` from scratch, so every sign-in pays two bcrypt comparisons and two `SELECT`s, fires `Attempting` twice, and runs the panel access check twice. At a production bcrypt cost of 12 the redundant hash alone is around 200ms.

Since nothing is left for the guard to establish, the user is logged in directly with `$authGuard->login()`. The behaviour the guard would have contributed is kept:

- `SessionGuard::hasValidCredentials()` dispatches `Validated`, and is protected, so `Validated` is now dispatched from `authenticate()` at the point the guard would have dispatched it.
- `SessionGuard::$rehashOnLogin` is protected, so the rehash reads `config('hashing.rehash_on_login', true)` directly, which is the same value `AuthManager` passes to the guard when it constructs it.

One deliberate difference: `SessionGuard::$lastAttempted` is protected with no setter, so it is no longer populated by a panel login. Nothing in Filament reads it.

Reproduction: https://github.com/shaheenfawzy/filament-login-double-hash (`composer setup && php artisan test --filter=LoginPerformanceTest`)

The same method also pads every sign-in with the multi-factor timebox; that is a separate concern and is fixed in #20348.

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

`tests/src/Panels/Auth/LoginTest.php` gains three tests: `Attempting` and `Validated` each fire exactly once on a successful sign-in, a password stored at a lower bcrypt cost is rehashed, and it is left alone when `hashing.rehash_on_login` is disabled. The first fails on `5.x` without this change, seeing `Attempting` twice. The two rehash tests pass either way and are regression guards, since `attemptWhen()` rehashed too.
