### PR TITLE
fix: return early from the multi-factor timebox when no provider is registered

### DIFF
--- a/packages/panels/src/Auth/Pages/Login.php
+++ b/packages/panels/src/Auth/Pages/Login.php
@@ -152,6 +152,10 @@ class Login extends SimplePage
                 return true;
             }
 
+            if (Filament::getMultiFactorAuthenticationProviders() === []) {
+                $timebox->returnEarly();
+            }
+
             return false;
         }, $timeboxDuration);
 

--- a/tests/src/Panels/Auth/LoginTest.php
+++ b/tests/src/Panels/Auth/LoginTest.php
@@ -123,6 +123,52 @@ describe('authentication', function (): void {
         $this->get(route('filament.admin.pages.dashboard'))->assertRedirect(Filament::getLoginUrl());
     });
 
+    it('does not pad a successful authentication when the panel registers no multi-factor authentication providers', function (): void {
+        expect(Filament::getMultiFactorAuthenticationProviders())->toBe([]);
+
+        $userToAuthenticate = User::factory()->create();
+
+        $padding = [];
+
+        Sleep::fake();
+        Sleep::whenFakingSleep(function ($duration) use (&$padding): void {
+            $padding[] = $duration->totalMilliseconds;
+        });
+
+        livewire(Login::class)
+            ->fillForm([
+                'email' => $userToAuthenticate->email,
+                'password' => 'password',
+            ])
+            ->call('authenticate')
+            ->assertRedirect(Filament::getUrl());
+
+        expect($padding)->toBe([]);
+    });
+
+    it('still pads a successful authentication when the panel registers a multi-factor authentication provider (control)', function (): void {
+        Filament::setCurrentPanel('app-authentication');
+
+        $userToAuthenticate = User::factory()->create();
+
+        $padding = [];
+
+        Sleep::fake();
+        Sleep::whenFakingSleep(function ($duration) use (&$padding): void {
+            $padding[] = $duration->totalMilliseconds;
+        });
+
+        livewire(Login::class)
+            ->fillForm([
+                'email' => $userToAuthenticate->email,
+                'password' => 'password',
+            ])
+            ->call('authenticate')
+            ->assertHasNoFormErrors();
+
+        expect($padding)->not->toBe([]);
+    });
+
 });
 
 describe('authentication failures', function (): void {


### PR DESCRIPTION
## Description

`Login::authenticate()` runs its multi-factor lookup inside a `Timebox` so an attacker cannot tell from response time whether an account has a challenge pending:

```php
$needsMultiFactorChallenge = $timebox->call(function (Timebox $timebox) use (...): bool {
    // ...
    return false;
}, $timeboxDuration);
```

Nothing in that closure ever calls `$timebox->returnEarly()`, so `Timebox::call()` sleeps out the remainder of `auth.timebox_duration` on every path, including the one where the panel has no multi-factor authentication providers registered at all. On that panel no challenge can ever be presented, so there is nothing to conceal, and the default 200ms is added to every successful sign-in for nothing.

This returns early only in that case:

```php
if (Filament::getMultiFactorAuthenticationProviders() === []) {
    $timebox->returnEarly();
}
```

The providers come from the panel's own configuration rather than from the user being authenticated, so the branch reveals nothing about the account, and it stops applying the moment a provider is registered. Panels that use multi-factor authentication keep the full padding on every path.

Measured on a production application: 200ms off every sign-in. Reproduction: https://github.com/shaheenfawzy/filament-login-double-hash

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

`tests/src/Panels/Auth/LoginTest.php` gains two tests, both using the `Sleep::fake()` pattern the file already uses: a sign-in on the `admin` panel records no padding, and a sign-in on the `app-authentication` panel still does. The first fails on `5.x` without this change, recording `[199.989]` instead of `[]`; the second passes either way and is there to prove the fix does not disable the timebox where it matters.
