### PR TITLE
Feature: Pausing and resuming actions

### DIFF
--- a/packages/actions/docs/01-overview.md
+++ b/packages/actions/docs/01-overview.md
@@ -508,6 +508,140 @@ Action::make('delete')
     })
 ```
 
+## Pausing an action
+
+An action can be paused, which stops it before it runs, but keeps it mounted along with any data that the user has already entered. The next time it is called, it resumes instead of starting again: the stages that already completed, such as rate limiting and the hooks around form validation, are not repeated.
+
+This is useful when an action needs something more from the user before it may run - confirming their identity, for example - and you want to ask for it once their form has been validated, without the action running in the meantime.
+
+Register a condition with `pauseWhen()`. It is evaluated after the action's schema is validated, and before the `before()` hook:
+
+```php
+use Filament\Actions\Action;
+
+Action::make('transferFunds')
+    ->schema([
+        // ...
+    ])
+    ->pauseWhen(fn (): bool => ! session()->has('identity_confirmed_at'))
+    ->action(function (array $data): void {
+        // ...
+    })
+```
+
+Conditions accumulate rather than replace each other, so a plugin may pause an action without overwriting a condition that you registered, and the other way around.
+
+Alternatively, `$action->pause()` may be called from inside the `before()` hook or the action itself:
+
+```php
+use Filament\Actions\Action;
+
+Action::make('transferFunds')
+    ->before(function (Action $action): void {
+        if (session()->has('identity_confirmed_at')) {
+            return;
+        }
+
+        $action->pause();
+    })
+    ->action(function (): void {
+        // ...
+    })
+```
+
+<Aside variant="info">
+    A hook that pauses is not called again when the action resumes, since it already ran up to the point that it paused. Pause conditions are the exception: they are evaluated every time, including on resumption. They are what keeps a paused action paused, so an action whose conditions are still met simply pauses again.
+</Aside>
+
+### Asking the user for something before an action resumes
+
+Since a paused action stays mounted, another action can be mounted on top of it, and its modal is stacked above the paused action's modal. Once the user has done what the pause was waiting for, unmount the child action and call the parent action again, which resumes it:
+
+```php
+use Filament\Actions\Action;
+
+Action::make('transferFunds')
+    ->schema([
+        // ...
+    ])
+    ->pauseWhen(function (Action $action): bool {
+        if (session()->has('identity_confirmed_at')) {
+            return false;
+        }
+
+        $action->getLivewire()->mountAction('confirmIdentity');
+
+        return true;
+    })
+    ->registerModalActions([
+        Action::make('confirmIdentity')
+            ->schema([
+                // ...
+            ])
+            ->action(function (Action $action): void {
+                session()->put('identity_confirmed_at', now());
+
+                $livewire = $action->getLivewire();
+
+                array_pop($livewire->mountedActions);
+
+                $livewire->callMountedAction();
+            }),
+    ])
+    ->action(function (array $data): void {
+        // ...
+    })
+```
+
+The parent action's data survives the round trip, so it receives everything that the user entered before it paused.
+
+The nested action can also write to it. The paused action's schema state lives on the Livewire component at `mountedActions.{nestingIndex}.data`, so a nested action can fill in a field that the user left empty, and the paused action receives it once it resumes:
+
+```php
+use Filament\Actions\Action;
+
+Action::make('createInvoice')
+    ->schema([
+        TextInput::make('title')
+            ->required(),
+        TextInput::make('reference'),
+    ])
+    ->pauseWhen(function (Action $action): bool {
+        if (filled($action->getData()['reference'] ?? null)) {
+            return false;
+        }
+
+        $action->getLivewire()->mountAction('generateReference');
+
+        return true;
+    })
+    ->registerModalActions([
+        Action::make('generateReference')
+            ->schema([
+                TextInput::make('prefix')
+                    ->required(),
+            ])
+            ->action(function (Action $action, array $data): void {
+                $livewire = $action->getLivewire();
+
+                data_set($livewire->mountedActions, '0.data.reference', "{$data['prefix']}-123");
+
+                array_pop($livewire->mountedActions);
+
+                $livewire->callMountedAction();
+            }),
+    ])
+    ->action(function (array $data): void {
+        // `$data['reference']` is now filled in.
+    })
+```
+
+Since a resumed action validates its schema again, anything that a nested action writes into it is validated by the rules of the paused action, just as if the user had entered it themselves.
+
+<Aside variant="warning">
+    Whatever a pause condition checks must be decided on the server. The action can be called again from the browser at any time - after its child action is cancelled, for example - and resuming re-evaluates the conditions, so the action only runs once they genuinely no longer hold.
+</Aside>
+
 ## Using actions in schemas
 
 Action objects can be inserted anywhere in a [schema](../schemas/overview), such as in [form field slots](../forms/overview#adding-extra-content-to-a-field), [section headers and footers](../schemas/sections), or alongside [prime components](../schemas/primes). When an action is used in a schema, it has access to the schema's state via [utility injection](#injecting-utilities-from-a-schema) - you can use `$schemaGet` and `$schemaSet` in closures to read and modify form field values.

--- a/packages/actions/src/Action.php
+++ b/packages/actions/src/Action.php
@@ -66,6 +66,7 @@ class Action extends ViewComponent implements Arrayable
     use Concerns\CanBeLabeledFrom;
     use Concerns\CanBeMounted;
     use Concerns\CanBeOutlined;
+    use Concerns\CanBePaused;
     use Concerns\CanBeRateLimited;
     use Concerns\CanBeSorted;
     use Concerns\CanCallParentAction;

--- a/packages/actions/src/Concerns/CanBePaused.php
+++ b/packages/actions/src/Concerns/CanBePaused.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Filament\Actions\Concerns;
+
+use Closure;
+use Filament\Support\Exceptions\Pause;
+
+trait CanBePaused
+{
+    /**
+     * @var array<bool | Closure>
+     */
+    protected array $pauseConditions = [];
+
+    /**
+     * Conditions accumulate instead of replacing each other, so that a plugin can
+     * pause an action without overwriting a condition that the app registered, and
+     * vice versa.
+     */
+    public function pauseWhen(bool | Closure $condition = true): static
+    {
+        $this->pauseConditions[] = $condition;
+
+        return $this;
+    }
+
+    public function shouldPause(): bool
+    {
+        foreach ($this->pauseConditions as $condition) {
+            if ($this->evaluate($condition)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function pause(bool $shouldRollBackDatabaseTransaction = false): void
+    {
+        throw (new Pause)->rollBackDatabaseTransaction($shouldRollBackDatabaseTransaction);
+    }
+}

--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -6,6 +6,7 @@ use Closure;
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
 use DanHarrin\LivewireRateLimiting\WithRateLimiting;
 use Filament\Actions\Action;
+use Filament\Actions\Enums\ActionCallStage;
 use Filament\Actions\Enums\ActionStatus;
 use Filament\Actions\Exceptions\ActionNotResolvableException;
 use Filament\Schemas\Components\Contracts\ExposesStateToActionData;
@@ -14,6 +15,7 @@ use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Filament\Support\Exceptions\Cancel;
 use Filament\Support\Exceptions\Halt;
+use Filament\Support\Exceptions\Pause;
 use Filament\Support\Livewire\Partials\PartialsComponentHook;
 use Filament\Tables\Contracts\HasTable;
 use Illuminate\Auth\Access\Response;
@@ -21,6 +23,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\Url;
 use ReflectionMethod;
 use ReflectionNamedType;
@@ -37,6 +40,16 @@ trait InteractsWithActions /** @phpstan-ignore trait.unused */
      * @var array<array<string, mixed>> | null
      */
     public ?array $mountedActions = [];
+
+    /**
+     * The stage that each paused mounted action paused in, keyed by its nesting index.
+     * Locked, since resuming an action skips the stages that already completed, which
+     * is not a decision that the browser may make.
+     *
+     * @var array<int, int>
+     */
+    #[Locked]
+    public array $pausedMountedActions = [];
 
     protected ?int $originallyMountedActionIndex = null;
 
@@ -252,7 +265,20 @@ trait InteractsWithActions /** @phpstan-ignore trait.unused */
             return null;
         }
 
-        if ($rateLimit = $action->getRateLimit()) {
+        // Resolved before a pause condition has the chance to mount another action on
+        // top of this one, which would make the last mounted action the wrong one.
+        $nestingIndex = $action->getNestingIndex() ?? array_key_last($this->mountedActions);
+
+        // The action is no longer paused from this point on. If it pauses again, the
+        // stage that it pauses in is recorded afresh.
+        $pausedAtStage = $this->pullMountedActionPausedAtStage($nestingIndex);
+
+        $stage = ActionCallStage::RateLimit;
+
+        if (
+            ($rateLimit = $action->getRateLimit()) &&
+            $stage->isAfter($pausedAtStage)
+        ) {
             try {
                 $this->rateLimit($rateLimit, method: json_encode(array_map(fn (array $action): array => Arr::except($action, ['data']), $this->mountedActions)));
             } catch (TooManyRequestsException $exception) {
@@ -284,24 +310,51 @@ trait InteractsWithActions /** @phpstan-ignore trait.unused */
                 }
             }
 
-            if ($this->mountedActionHasSchema(mountedAction: $action)) {
-                $action->callBeforeFormValidated();
+            // Pause conditions are re-evaluated every time, including when the action
+            // is resumed. They are what keeps a paused action paused, so skipping them
+            // on resumption would let the action be resumed without them being met.
+            $callPauseConditionsAndBefore = function () use ($action, $pausedAtStage, &$stage): void {
+                $stage = ActionCallStage::PauseConditions;
 
-                $schema->getState(afterValidate: function (array $state) use ($action, $schemaState): void {
-                    $action->callAfterFormValidated();
+                if ($action->shouldPause()) {
+                    $action->pause();
+                }
+
+                $stage = ActionCallStage::Before;
+
+                if (! $stage->isAfter($pausedAtStage)) {
+                    return;
+                }
+
+                $action->callBefore();
+            };
+
+            // A resumed action is always validated again, since its data can have
+            // changed since it paused. Only the hooks around validation are skipped,
+            // as they already ran.
+            $stage = ActionCallStage::Validation;
+            $hasBeenValidated = ! $stage->isAfter($pausedAtStage);
+
+            if ($this->mountedActionHasSchema(mountedAction: $action)) {
+                $hasBeenValidated || $action->callBeforeFormValidated();
+
+                $schema->getState(afterValidate: function (array $state) use ($action, $callPauseConditionsAndBefore, $hasBeenValidated, $schemaState): void {
+                    $hasBeenValidated || $action->callAfterFormValidated();
 
                     $action->data([
                         ...$schemaState,
                         ...$state,
                     ]);
 
-                    $action->callBefore();
+                    $callPauseConditionsAndBefore();
                 });
             } else {
                 $action->data($schemaState);
 
-                $action->callBefore();
+                $callPauseConditionsAndBefore();
             }
+
+            $stage = ActionCallStage::Call;
 
             $result = $action->call([
                 'form' => $schema,
@@ -322,6 +375,16 @@ trait InteractsWithActions /** @phpstan-ignore trait.unused */
                     $action->dispatchFailureRedirect();
                 },
             })();
+        } catch (Pause $exception) {
+            $exception->shouldRollbackDatabaseTransaction() ?
+                $action->rollBackDatabaseTransaction() :
+                $action->commitDatabaseTransaction();
+
+            $this->pausedMountedActions[$nestingIndex] = $stage->value;
+
+            $action->arguments($originalActionArguments);
+
+            return null;
         } catch (Halt $exception) {
             $exception->shouldRollbackDatabaseTransaction() ?
                 $action->rollBackDatabaseTransaction() :
@@ -383,6 +446,47 @@ trait InteractsWithActions /** @phpstan-ignore trait.unused */
         return $result;
     }
 
+    public function isMountedActionPaused(?Action $mountedAction = null): bool
+    {
+        $mountedAction ??= $this->getMountedAction();
+
+        if (! $mountedAction) {
+            return false;
+        }
+
+        return array_key_exists($mountedAction->getNestingIndex(), $this->pausedMountedActions);
+    }
+
+    /**
+     * Returns the stage that the action paused in, and forgets it, so that the action
+     * is only ever resumed from it once.
+     */
+    protected function pullMountedActionPausedAtStage(int $nestingIndex): ?ActionCallStage
+    {
+        if (! array_key_exists($nestingIndex, $this->pausedMountedActions)) {
+            return null;
+        }
+
+        $stage = ActionCallStage::tryFrom($this->pausedMountedActions[$nestingIndex]);
+
+        unset($this->pausedMountedActions[$nestingIndex]);
+
+        return $stage;
+    }
+
+    protected function forgetUnmountedPausedActions(): void
+    {
+        $mountedActionsCount = count($this->mountedActions ?? []);
+
+        foreach (array_keys($this->pausedMountedActions) as $nestingIndex) {
+            if ($nestingIndex < $mountedActionsCount) {
+                continue;
+            }
+
+            unset($this->pausedMountedActions[$nestingIndex]);
+        }
+    }
+
     public function forceRender(): void
     {
         app(PartialsComponentHook::class)->forceRender($this);
@@ -419,6 +523,7 @@ trait InteractsWithActions /** @phpstan-ignore trait.unused */
     public function replaceMountedAction(string $name, array $arguments = [], array $context = []): void
     {
         $this->mountedActions = [];
+        $this->pausedMountedActions = [];
         $this->cachedMountedActions = null;
 
         foreach ($this->cachedSchemas as $schemaName => $schema) {
@@ -798,6 +903,8 @@ trait InteractsWithActions /** @phpstan-ignore trait.unused */
         }
 
         $this->syncActionModals();
+
+        $this->forgetUnmountedPausedActions();
 
         while (count($this->cachedMountedActions ?? []) > count($this->mountedActions)) {
             array_pop($this->cachedMountedActions);

--- a/packages/actions/src/Enums/ActionCallStage.php
+++ b/packages/actions/src/Enums/ActionCallStage.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Filament\Actions\Enums;
+
+/**
+ * The stages that an action passes through when it is called, in order. When an
+ * action is paused, the stage that it paused in is recorded, so that resuming it
+ * does not repeat the stages that already completed.
+ */
+enum ActionCallStage: int
+{
+    case RateLimit = 1;
+
+    case Validation = 2;
+
+    case PauseConditions = 3;
+
+    case Before = 4;
+
+    case Call = 5;
+
+    public function isAfter(?self $stage): bool
+    {
+        if (! $stage) {
+            return true;
+        }
+
+        return $this->value > $stage->value;
+    }
+}

--- a/packages/support/src/Exceptions/Pause.php
+++ b/packages/support/src/Exceptions/Pause.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Filament\Support\Exceptions;
+
+use Exception;
+
+class Pause extends Exception
+{
+    protected bool $shouldRollbackDatabaseTransaction = false;
+
+    public function rollBackDatabaseTransaction(bool $condition = true): static
+    {
+        $this->shouldRollbackDatabaseTransaction = $condition;
+
+        return $this;
+    }
+
+    public function shouldRollbackDatabaseTransaction(): bool
+    {
+        return $this->shouldRollbackDatabaseTransaction;
+    }
+}

--- a/tests/src/Actions/PauseTest.php
+++ b/tests/src/Actions/PauseTest.php
@@ -1,0 +1,216 @@
+<?php
+
+use Filament\Actions\Enums\ActionCallStage;
+use Filament\Actions\Testing\TestAction;
+use Filament\Tests\Actions\TestCase;
+use Filament\Tests\Fixtures\Livewire\PostsTable;
+use Filament\Tests\Fixtures\Models\Post;
+use Filament\Tests\Fixtures\Pages\Actions;
+
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+describe('pausing an action', function (): void {
+    it('does not call an action that pauses, and keeps it mounted', function (): void {
+        $livewire = livewire(Actions::class)
+            ->callAction('pause')
+            ->assertNotDispatched('pause-called')
+            ->assertActionMounted('pause');
+
+        expect($livewire->instance()->pausedMountedActions)
+            ->toBe([0 => ActionCallStage::PauseConditions->value]);
+    });
+
+    it('does not call the `before()` hook of an action that pauses before it', function (): void {
+        livewire(Actions::class)
+            ->callAction('pause')
+            ->assertNotDispatched('pause-before-called')
+            ->assertNotDispatched('pause-after-called')
+            ->assertSet('pauseHookCallCounts', []);
+    });
+
+    it('calls an action once it no longer pauses', function (): void {
+        livewire(Actions::class)
+            ->callAction('pause')
+            ->assertNotDispatched('pause-called')
+            ->set('shouldPauseActions', false)
+            ->callMountedAction()
+            ->assertDispatched('pause-before-called')
+            ->assertDispatched('pause-called')
+            ->assertDispatched('pause-after-called')
+            ->assertActionNotMounted();
+    });
+
+    it('only calls the `before()` hook once across pausing and resuming', function (): void {
+        livewire(Actions::class)
+            ->callAction('pause')
+            ->set('shouldPauseActions', false)
+            ->callMountedAction()
+            ->assertSet('pauseHookCallCounts', ['pause-before' => 1]);
+    });
+
+    it('forgets that an action was paused once it is unmounted', function (): void {
+        $livewire = livewire(Actions::class)
+            ->callAction('pause')
+            ->unmountAction();
+
+        expect($livewire->instance()->pausedMountedActions)->toBe([]);
+    });
+});
+
+describe('pausing from a lifecycle hook', function (): void {
+    it('can pause from the `before()` hook', function (): void {
+        $livewire = livewire(Actions::class)
+            ->callAction('pause-from-before')
+            ->assertSet('pauseHookCallCounts', ['pause-from-before-before' => 1])
+            ->assertNotDispatched('pause-from-before-called')
+            ->assertActionMounted('pause-from-before');
+
+        expect($livewire->instance()->pausedMountedActions)
+            ->toBe([0 => ActionCallStage::Before->value]);
+    });
+
+    it('does not call the `before()` hook again after it paused', function (): void {
+        livewire(Actions::class)
+            ->callAction('pause-from-before')
+            ->set('shouldPauseActions', false)
+            ->callMountedAction()
+            ->assertDispatched('pause-from-before-called')
+            ->assertSet('pauseHookCallCounts', ['pause-from-before-before' => 1]);
+    });
+});
+
+describe('pausing an action with a schema', function (): void {
+    it('validates the schema before evaluating whether to pause', function (): void {
+        $livewire = livewire(Actions::class)
+            ->mountAction('pause-with-schema')
+            ->setActionData(['payload' => null])
+            ->callMountedAction()
+            ->assertHasErrors()
+            ->assertActionMounted('pause-with-schema');
+
+        // Validation failed, so the action never reached its pause conditions.
+        expect($livewire->instance()->pausedMountedActions)->toBe([]);
+    });
+
+    it('keeps the schema data across pausing and resuming', function (): void {
+        livewire(Actions::class)
+            ->mountAction('pause-with-schema')
+            ->setActionData(['payload' => 'foo'])
+            ->callMountedAction()
+            ->assertNotDispatched('pause-with-schema-called')
+            ->set('shouldPauseActions', false)
+            ->callMountedAction()
+            ->assertDispatched('pause-with-schema-called', data: ['payload' => 'foo']);
+    });
+
+    it('only calls the validation hooks once across pausing and resuming', function (): void {
+        livewire(Actions::class)
+            ->mountAction('pause-with-schema')
+            ->setActionData(['payload' => 'foo'])
+            ->callMountedAction()
+            ->set('shouldPauseActions', false)
+            ->callMountedAction()
+            ->assertDispatched('pause-with-schema-called')
+            ->assertSet('pauseHookCallCounts', [
+                'pause-with-schema-before-form-validated' => 1,
+                'pause-with-schema-after-form-validated' => 1,
+                'pause-with-schema-before' => 1,
+            ]);
+    });
+});
+
+describe('pausing a bulk action', function (): void {
+    it('keeps the selected records across pausing and resuming', function (): void {
+        $posts = Post::factory()->count(3)->create();
+
+        $livewire = livewire(PostsTable::class)
+            ->selectTableRecords($posts)
+            ->callAction(TestAction::make('pause')->table()->bulk())
+            ->assertNotDispatched('pause-called');
+
+        expect($livewire->instance()->isMountedActionPaused())->toBeTrue();
+
+        $livewire
+            ->set('shouldPauseActions', false)
+            ->callMountedAction()
+            ->assertDispatched('pause-called', count: 3);
+    });
+});
+
+describe('rate limiting a paused action', function (): void {
+    it('does not consume another attempt when an action is resumed', function (): void {
+        // The limit is 2 attempts. Without pausing being accounted for, the pause and
+        // the resumption would consume both of them, and the action would never run.
+        livewire(Actions::class)
+            ->callAction('rate-limited-pause')
+            ->assertNotDispatched('rate-limited-pause-called')
+            ->set('shouldPauseActions', false)
+            ->callMountedAction()
+            ->assertNotNotified('Too many attempts')
+            ->assertDispatched('rate-limited-pause-called')
+            ->callAction('rate-limited-pause')
+            ->assertNotNotified('Too many attempts');
+    });
+});
+
+describe('resuming from a nested action', function (): void {
+    it('mounts the nested action that the pause condition mounts', function (): void {
+        $livewire = livewire(Actions::class)
+            ->callAction('pause-until-confirmed')
+            ->assertNotDispatched('pause-until-confirmed-called')
+            ->assertActionMounted(TestAction::make('confirm-pause')->schemaComponent(null));
+
+        expect(array_column($livewire->instance()->mountedActions, 'name'))
+            ->toBe(['pause-until-confirmed', 'confirm-pause']);
+    });
+
+    it('does not resume the parent action when the nested action fails validation', function (): void {
+        livewire(Actions::class)
+            ->callAction('pause-until-confirmed')
+            ->setActionData(['code' => '000000'])
+            ->callMountedAction()
+            ->assertHasErrors()
+            ->assertNotDispatched('pause-until-confirmed-called');
+    });
+
+    it('resumes the parent action when the nested action succeeds', function (): void {
+        livewire(Actions::class)
+            ->callAction('pause-until-confirmed')
+            ->setActionData(['code' => '123456'])
+            ->callMountedAction()
+            ->assertDispatched('pause-until-confirmed-called')
+            ->assertActionNotMounted();
+    });
+
+    it('can fill the schema of the paused action from the nested action', function (): void {
+        livewire(Actions::class)
+            ->mountAction('pause-until-filled')
+            ->setActionData([
+                'title' => 'Foo',
+                'reference' => null,
+            ])
+            ->callMountedAction()
+            ->assertNotDispatched('pause-until-filled-called')
+            ->assertActionMounted(TestAction::make('generate-reference')->schemaComponent(null))
+            ->setActionData(['prefix' => 'INV'])
+            ->callMountedAction()
+            ->assertDispatched('pause-until-filled-called', data: [
+                'title' => 'Foo',
+                'reference' => 'INV-123',
+            ])
+            ->assertActionNotMounted();
+    });
+
+    it('pauses again when the parent action is called without the nested action being confirmed', function (): void {
+        // Cancelling the nested action must not leave the parent resumable, otherwise
+        // the browser could call the parent action without ever satisfying the pause.
+        livewire(Actions::class)
+            ->callAction('pause-until-confirmed')
+            ->unmountAction()
+            ->callMountedAction()
+            ->assertNotDispatched('pause-until-confirmed-called')
+            ->assertActionMounted(TestAction::make('confirm-pause')->schemaComponent(null));
+    });
+});

--- a/tests/src/Fixtures/Livewire/PostsTable.php
+++ b/tests/src/Fixtures/Livewire/PostsTable.php
@@ -40,6 +40,8 @@ class PostsTable extends Component implements HasActions, HasSchemas, Tables\Con
      */
     public static array $authorizedRecordKeys = [];
 
+    public bool $shouldPauseActions = true;
+
     public function table(Table $table): Table
     {
         return $table
@@ -391,6 +393,12 @@ class PostsTable extends Component implements HasActions, HasSchemas, Tables\Con
                         $this->dispatch('halt-called');
 
                         $action->halt();
+                    }),
+                BulkAction::make('pause')
+                    ->requiresConfirmation()
+                    ->pauseWhen(fn (): bool => $this->shouldPauseActions)
+                    ->action(function (Collection $records): void {
+                        $this->dispatch('pause-called', count: $records->count());
                     }),
                 BulkAction::make('visible'),
                 BulkAction::make('hidden')

--- a/tests/src/Fixtures/Pages/Actions.php
+++ b/tests/src/Fixtures/Pages/Actions.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Tests\Fixtures\Pages;
 
+use Closure;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Forms\Components\TextInput;
@@ -14,6 +15,41 @@ use Filament\Tests\Fixtures\Models\Post;
 class Actions extends Page
 {
     protected string $view = 'pages.actions';
+
+    public bool $shouldPauseActions = true;
+
+    /**
+     * Counts hook calls across requests, which dispatched events cannot do, since only
+     * the events of the latest request are asserted against.
+     *
+     * @var array<string, int>
+     */
+    public array $pauseHookCallCounts = [];
+
+    /**
+     * Not a Livewire property, so that it only lives for the request that sets it, the
+     * way that a confirmation of the user's identity should.
+     */
+    protected bool $isPauseConfirmed = false;
+
+    /**
+     * Confirms the paused parent action, unmounts this nested action, and resumes the
+     * parent, which is how a plugin would resume an action once the user has satisfied
+     * whatever the pause was waiting for.
+     */
+    public function countPauseHookCall(string $hook): void
+    {
+        $this->pauseHookCallCounts[$hook] = ($this->pauseHookCallCounts[$hook] ?? 0) + 1;
+    }
+
+    public function confirmPause(): void
+    {
+        $this->isPauseConfirmed = true;
+
+        array_pop($this->mountedActions);
+
+        $this->callMountedAction();
+    }
 
     protected function getHeaderActions(): array
     {
@@ -229,6 +265,102 @@ class Actions extends Page
                 ->action(fn () => $this->dispatch(
                     'rate-limited-called',
                 )),
+            Action::make('pause')
+                ->requiresConfirmation()
+                ->pauseWhen(fn (): bool => $this->shouldPauseActions)
+                ->before(function (): void {
+                    $this->countPauseHookCall('pause-before');
+                    $this->dispatch('pause-before-called');
+                })
+                ->action(fn () => $this->dispatch('pause-called'))
+                ->after(fn () => $this->dispatch('pause-after-called')),
+            Action::make('pause-with-schema')
+                ->schema([
+                    TextInput::make('payload')
+                        ->required(),
+                ])
+                ->beforeFormValidated(fn () => $this->countPauseHookCall('pause-with-schema-before-form-validated'))
+                ->afterFormValidated(fn () => $this->countPauseHookCall('pause-with-schema-after-form-validated'))
+                ->pauseWhen(fn (): bool => $this->shouldPauseActions)
+                ->before(fn () => $this->countPauseHookCall('pause-with-schema-before'))
+                ->action(fn (array $data) => $this->dispatch('pause-with-schema-called', data: $data)),
+            Action::make('pause-from-before')
+                ->requiresConfirmation()
+                ->before(function (Action $action): void {
+                    $this->countPauseHookCall('pause-from-before-before');
+
+                    if (! $this->shouldPauseActions) {
+                        return;
+                    }
+
+                    $action->pause();
+                })
+                ->action(fn () => $this->dispatch('pause-from-before-called')),
+            Action::make('rate-limited-pause')
+                ->rateLimit(2)
+                ->pauseWhen(fn (): bool => $this->shouldPauseActions)
+                ->action(fn () => $this->dispatch('rate-limited-pause-called')),
+            Action::make('pause-until-filled')
+                ->schema([
+                    TextInput::make('title')
+                        ->required(),
+                    TextInput::make('reference'),
+                ])
+                ->pauseWhen(function (Action $action): bool {
+                    if (filled($action->getData()['reference'] ?? null)) {
+                        return false;
+                    }
+
+                    $action->getLivewire()->mountAction('generate-reference');
+
+                    return true;
+                })
+                ->registerModalActions([
+                    Action::make('generate-reference')
+                        ->schema([
+                            TextInput::make('prefix')
+                                ->required(),
+                        ])
+                        ->action(function (Action $action, array $data): void {
+                            $livewire = $action->getLivewire();
+
+                            data_set($livewire->mountedActions, '0.data.reference', "{$data['prefix']}-123");
+
+                            array_pop($livewire->mountedActions);
+
+                            $livewire->callMountedAction();
+                        }),
+                ])
+                ->action(fn (array $data) => $this->dispatch('pause-until-filled-called', data: $data)),
+            Action::make('pause-until-confirmed')
+                ->requiresConfirmation()
+                ->pauseWhen(function (): bool {
+                    if ($this->isPauseConfirmed) {
+                        return false;
+                    }
+
+                    $this->mountAction('confirm-pause');
+
+                    return true;
+                })
+                ->registerModalActions([
+                    Action::make('confirm-pause')
+                        ->schema([
+                            TextInput::make('code')
+                                ->required()
+                                ->rule(static fn (): Closure => static function (string $attribute, mixed $value, Closure $fail): void {
+                                    if ($value === '123456') {
+                                        return;
+                                    }
+
+                                    $fail('The code is invalid.');
+                                }),
+                        ])
+                        ->action(function (Actions $livewire): void {
+                            $livewire->confirmPause();
+                        }),
+                ])
+                ->action(fn () => $this->dispatch('pause-until-confirmed-called')),
             Action::make('predefined-arguments')
                 ->arguments(['foo' => 'bar', 'baz' => 'qux'])
                 ->label(fn (array $arguments): string => "Action for {$arguments['foo']}")


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This pattern already exists: people build it today on top of `halt()`. An action checks in `before()` whether something is satisfied; if not, it mounts an additional action and interrupts itself with `halt()`. The child modal collects whatever was missing, then removes itself from the stack and calls `callMountedAction()` back on the parent.

This works, but every retry is a new attempt, not a continuation, from Filament’s perspective, so the whole process runs again. There are three effects that cannot be fixed from the outside:

- Limiter: `->rateLimit(3)` effectively gives you one successful flow, because interrupting and resuming each consume one hit. The limiter runs before any hook the author controls.
- `beforeFormValidated()` and `afterFormValidated()` run twice. There is no way to prevent them from being called; at best, you can make your own code idempotent, which the documentation does not mention.
- `ActionCalling` event fires twice, which breaks audit flows based on that event.

There is also an extensibility problem: `before()` is a single closure, so a plugin cannot hook into it without overwriting the application’s hook. The only non-overridable extension point today is the undocumented `ActionCalling` event.

### What changes
An action can now be paused. A paused action remains mounted together with the data the user has already entered, and the next call is a resume of that action: stages that have already run are not repeated.
Conditions are registered through `pauseWhen()`. They are evaluated after schema validation and before the `before()` hook:

```php
Action::make('transferFunds')
    ->schema([
        // ...
    ])
    ->pauseWhen(fn (): bool => ! session()->has('identity_confirmed_at'))
    ->action(function (array $data): void {
        // ...
    })
```

Conditions accumulate instead of overwriting each other, so a plugin can pause an action without stepping on a condition registered by the application, and vice versa. Alternatively, `$action->pause()` can be called imperatively from `before()` or from the action body.

### Use cases

- Data freshness. Someone opened an edit form, and the record changed underneath them in the meantime. You pause, show the diff, and let the user decide. Today this cannot be done cleanly: `requiresConfirmation()` runs before the form, while this is only known after validation.

- Conflict detection: another user has already managed to perform the operation.

- Impact preview: "This operation will affect 1,240 records and delete 3 related invoices. Continue?", calculated on the server after validation.

- Re-authentication before a sensitive operation: password, OTP code.

- Missing data: the action needs a delivery address that the customer does not have. A modal adds it and fills the parent form, and the user does not lose anything they have already entered.

- Limits or billing: "You’re out of credits", top-up modal, resume.

### Security

The stage at which the action stopped is stored in `#[Locked] public array $pausedMountedActions`, so the browser cannot forge it to bypass the limiter or validation hooks.

Pause conditions are recalculated on every call, including on resume. This is intentional: the browser can call `callMountedAction()` on a paused action at any moment, even after cancelling the child modal, so execution is decided by the conditions, not by saved state.

### Backward compatibility

Nothing changes for actions that do not use pausing. One public Livewire property has been added: an empty array until something is paused.

### Demo

Working demo: [https://github.com/webard/filament-pauseable-otp-demo](https://github.com/webard/filament-pauseable-otp-demo)

```bash
git clone -b filament-pauseable-extracted-otp https://github.com/webard/filament.git filament
git clone https://github.com/webard/filament-pauseable-otp-demo.git demo
cd demo && composer setup && php artisan serve
```

Both clones need to sit next to each other, because the demo points to Filament through relative paths: `../filament/packages/*`.

> Note: the demo branch merges this PR with [#20353](https://github.com/filamentphp/filament/pull/20353), which extracts the multi-factor challenge outside the login page.

### Proof of concept

https://github.com/webard/filament-otp-actions

The package adds a `requiresOtpConfirmation()` macro to actions, which confirms an action using a one-time code from the multi-factor method configured by the user. It is built entirely on the public API introduced by this PR: it registers a condition through `pauseWhen()`, mounts its own challenge modal, and resumes the action after a valid code.

> Note: this package uses functionality from [#20353](https://github.com/filamentphp/filament/pull/20353), which extracts the multi-factor challenge outside the login page.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
