### PR TITLE
Upgrade OpenSpout to v5 and PHP 8.3, as OpenSpout v5 requires PHP 8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <a href="https://github.com/filamentphp/filament/actions"><img alt="Tests passing" src="https://img.shields.io/badge/Tests-passing-green?style=for-the-badge&logo=github"></a>
     <a href="https://laravel.com"><img alt="Laravel v11+" src="https://img.shields.io/badge/Laravel-v11+-FF2D20?style=for-the-badge&logo=laravel"></a>
     <a href="https://livewire.laravel.com"><img alt="Livewire v3" src="https://img.shields.io/badge/Livewire-v3-FB70A9?style=for-the-badge"></a>
-    <a href="https://php.net"><img alt="PHP 8.2+" src="https://img.shields.io/badge/PHP-8.2+-777BB4?style=for-the-badge&logo=php"></a>
+    <a href="https://php.net"><img alt="PHP 8.3+" src="https://img.shields.io/badge/PHP-8.3+-777BB4?style=for-the-badge&logo=php"></a>
 </p>
 
 <p align="center">

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A collection of full-stack components for accelerated Laravel development.",
     "license": "MIT",
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "composer-runtime-api": "^2.1",
         "ext-intl": "*"
     },
@@ -18,7 +18,7 @@
         "league/csv": "^9.27",
         "league/flysystem-aws-s3-v3": "^3.0",
         "nunomaduro/termwind": "^2.0",
-        "openspout/openspout": "^4.23",
+        "openspout/openspout": "^5.0",
         "orchestra/testbench": "^9.0|^10.0|^11.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-browser": "^4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0905dfacfe4d97043d5e781a703e47fb",
+    "content-hash": "4c0813f59c7c6e88ea562a67d98fee84",
     "packages": [],
     "packages-dev": [
         {
@@ -2905,7 +2905,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/support",
-                "reference": "29d6fbba7e13027d1cb215346ef9ab06cd78e69a"
+                "reference": "443a21d46b05bb28f610849aa7d64732f375a54d"
             },
             "require": {
                 "blade-ui-kit/blade-heroicons": "^2.5",
@@ -2916,7 +2916,7 @@
                 "league/uri-components": "^7.0",
                 "livewire/livewire": "^3.5",
                 "nette/php-generator": "^4.0",
-                "php": "^8.2",
+                "php": "^8.3",
                 "ryangjchandler/blade-capture-directive": "^1.0",
                 "spatie/invade": "^2.0",
                 "spatie/laravel-package-tools": "^1.9",
@@ -6332,36 +6332,36 @@
         },
         {
             "name": "openspout/openspout",
-            "version": "v4.32.0",
+            "version": "v5.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/openspout/openspout.git",
-                "reference": "41f045c1f632e1474e15d4c7bc3abcb4a153563d"
+                "reference": "2072cdd00e7b1cd40d9ddcc080f329b12f85775a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/openspout/openspout/zipball/41f045c1f632e1474e15d4c7bc3abcb4a153563d",
-                "reference": "41f045c1f632e1474e15d4c7bc3abcb4a153563d",
+                "url": "https://api.github.com/repos/openspout/openspout/zipball/2072cdd00e7b1cd40d9ddcc080f329b12f85775a",
+                "reference": "2072cdd00e7b1cd40d9ddcc080f329b12f85775a",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "ext-fileinfo": "*",
                 "ext-filter": "*",
                 "ext-libxml": "*",
                 "ext-xmlreader": "*",
                 "ext-zip": "*",
-                "php": "~8.3.0 || ~8.4.0 || ~8.5.0"
+                "php": "~8.4.0 || ~8.5.0"
             },
             "require-dev": {
+                "ext-fileinfo": "*",
                 "ext-zlib": "*",
-                "friendsofphp/php-cs-fixer": "^3.86.0",
-                "infection/infection": "^0.31.2",
-                "phpbench/phpbench": "^1.4.1",
-                "phpstan/phpstan": "^2.1.22",
-                "phpstan/phpstan-phpunit": "^2.0.7",
-                "phpstan/phpstan-strict-rules": "^2.0.6",
-                "phpunit/phpunit": "^12.3.7"
+                "friendsofphp/php-cs-fixer": "^3.95.18",
+                "infection/infection": "^0.34",
+                "phpbench/phpbench": "^1.7.0",
+                "phpstan/phpstan": "^2.2.8",
+                "phpstan/phpstan-phpunit": "^2.0.18",
+                "phpstan/phpstan-strict-rules": "^2.0.12",
+                "phpunit/phpunit": "^13.2.6"
             },
             "suggest": {
                 "ext-iconv": "To handle non UTF-8 CSV files (if \"php-mbstring\" is not already installed or is too limited)",
@@ -6409,7 +6409,7 @@
             ],
             "support": {
                 "issues": "https://github.com/openspout/openspout/issues",
-                "source": "https://github.com/openspout/openspout/tree/v4.32.0"
+                "source": "https://github.com/openspout/openspout/tree/v5.10.2"
             },
             "funding": [
                 {
@@ -6421,7 +6421,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-03T16:03:54+00:00"
+            "time": "2026-08-05T08:27:38+00:00"
         },
         {
             "name": "orchestra/canvas",
@@ -14894,7 +14894,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2",
+        "php": "^8.3",
         "composer-runtime-api": "^2.1",
         "ext-intl": "*"
     },

--- a/docs/01-introduction/02-installation.md
+++ b/docs/01-introduction/02-installation.md
@@ -8,7 +8,7 @@ import RadioGroupOption from "@components/RadioGroupOption.astro"
 
 Filament requires the following to run:
 
-- PHP 8.2+
+- PHP 8.3+
 - Laravel v11.28+
 - Tailwind CSS v4.1+
 

--- a/docs/14-upgrade-guide.md
+++ b/docs/14-upgrade-guide.md
@@ -12,7 +12,7 @@ import Disclosure from "@components/Disclosure.astro"
 
 ## New requirements
 
-- PHP 8.2+
+- PHP 8.3+
 - Laravel v11.28+
 - Tailwind CSS v4.1+, if you’re currently using Tailwind CSS v3.0 with Filament. This doesn’t apply if you’re just using a Filament panel without a custom theme CSS file.
 - Filament no longer requires `doctrine/dbal`, but if your application still does, and you don’t have it installed directly, you should add it to your `composer.json` file.

--- a/packages/actions/composer.json
+++ b/packages/actions/composer.json
@@ -8,14 +8,14 @@
         "source": "https://github.com/filamentphp/filament"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "anourvalar/eloquent-serialize": "^1.3.6",
         "filament/forms": "self.version",
         "filament/infolists": "self.version",
         "filament/notifications": "self.version",
         "filament/support": "self.version",
         "league/csv": "^9.27",
-        "openspout/openspout": "^4.23"
+        "openspout/openspout": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/actions/docs/12-export.md
+++ b/packages/actions/docs/12-export.md
@@ -658,20 +658,21 @@ You can only specify a single character, otherwise an exception will be thrown.
 
 ### Styling XLSX rows
 
-If you want to style the cells of the XLSX file, you may override the `getXlsxCellStyle()` method on the exporter class, returning an [OpenSpout `Style` object](https://github.com/openspout/openspout/blob/4.x/docs/documentation.md#styling):
+If you want to style the cells of the XLSX file, you may override the `getXlsxCellStyle()` method on the exporter class, returning an [OpenSpout `Style` object](https://github.com/openspout/openspout/blob/5.x/docs/documentation.md#styling):
 
 ```php
 use OpenSpout\Common\Entity\Style\Style;
 
 public function getXlsxCellStyle(): ?Style
 {
-    return (new Style())
-        ->setFontSize(12)
-        ->setFontName('Consolas');
+    return new Style(
+        fontSize: 12,
+        fontName: 'Consolas',
+    );
 }
 ```
 
-If you want to use a different style for the header cells of the XLSX file only, you may override the `getXlsxHeaderCellStyle()` method on the exporter class, returning an [OpenSpout `Style` object](https://github.com/openspout/openspout/blob/4.x/docs/documentation.md#styling):
+If you want to use a different style for the header cells of the XLSX file only, you may override the `getXlsxHeaderCellStyle()` method on the exporter class, returning an [OpenSpout `Style` object](https://github.com/openspout/openspout/blob/5.x/docs/documentation.md#styling):
 
 ```php
 use OpenSpout\Common\Entity\Style\CellAlignment;
@@ -681,15 +682,16 @@ use OpenSpout\Common\Entity\Style\Style;
 
 public function getXlsxHeaderCellStyle(): ?Style
 {
-    return (new Style())
-        ->setFontBold()
-        ->setFontItalic()
-        ->setFontSize(14)
-        ->setFontName('Consolas')
-        ->setFontColor(Color::rgb(255, 255, 77))
-        ->setBackgroundColor(Color::rgb(0, 0, 0))
-        ->setCellAlignment(CellAlignment::CENTER)
-        ->setCellVerticalAlignment(CellVerticalAlignment::CENTER);
+    return new Style(
+        fontBold: true,
+        fontItalic: true,
+        fontSize: 14,
+        fontName: 'Consolas',
+        fontColor: Color::rgb(255, 255, 77),
+        cellAlignment: CellAlignment::CENTER,
+        cellVerticalAlignment: CellVerticalAlignment::CENTER,
+        backgroundColor: Color::rgb(0, 0, 0),
+    );
 }
 ```
 
@@ -706,51 +708,49 @@ use OpenSpout\Common\Entity\Style\Style;
  */
 public function makeXlsxRow(array $values, ?Style $style = null): Row
 {
-    return Row::fromValues($values, $style);
+    if ($style === null) {
+        return Row::fromValues($values);
+    }
+
+    return Row::fromValuesWithStyles($values, array_fill(0, count($values), $style));
 }
 ```
 
-When a user exports, they can choose which columns to export. As such, the `$this->columnMap` property may be used to determine which columns are being exported and in which order. You can replace `Row::fromValues()` with an array of `Cell` objects, which allow you to style them individually using [OpenSpout `Style` objects](https://github.com/openspout/openspout/blob/4.x/docs/documentation.md#styling). A `StyleMerger` can be used to merge the default style with the custom style for a cell, allowing you to apply additional styles on top of the default ones:
+When a user exports, they can choose which columns to export. As such, the `$this->columnMap` property may be used to determine which columns are being exported and in which order. You can replace `Row::fromValues()` with an array of `Cell` objects, which allow you to style them individually using [OpenSpout `Style` objects](https://github.com/openspout/openspout/blob/5.x/docs/documentation.md#styling). Since a `Style` object is immutable, use its `with*()` methods to derive a new style from the one passed in, layering additional formatting on top of it:
 
 ```php
 use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Row;
 use OpenSpout\Common\Entity\Style\Style;
-use OpenSpout\Writer\Common\Manager\Style\StyleMerger;
 
 /**
  * @param array<mixed> $values
  */
 public function makeXlsxRow(array $values, ?Style $style = null): Row
 {
-    $styleMerger = new StyleMerger();
-
     $cells = [];
-    
+
     foreach (array_keys($this->columnMap) as $columnIndex => $column) {
         $cells[] = match ($column) {
             'name' => Cell::fromValue(
                 $values[$columnIndex],
-                $styleMerger->merge(
-                    (new Style())->setFontUnderline(),
-                    $style,
-                ),
+                ($style ?? new Style())->withFontUnderline(true),
             ),
             'price' => Cell::fromValue(
                 $values[$columnIndex],
-                (new Style())->setFontSize(12),
+                new Style(fontSize: 12),
             ),
-            default => Cell::fromValue($values[$columnIndex]),
+            default => Cell::fromValue($values[$columnIndex], $style),
         },
     }
-    
-    return new Row($cells, $style);
+
+    return new Row($cells);
 }
 ```
 
 ### Customizing the XLSX writer
 
-If you want to pass "options" to the [OpenSpout XLSX `Writer`](https://github.com/openspout/openspout/blob/4.x/docs/documentation.md#column-widths), you can return an `OpenSpout\Writer\XLSX\Options` instance from the `getXlsxWriterOptions()` method of the exporter class:
+If you want to pass "options" to the [OpenSpout XLSX `Writer`](https://github.com/openspout/openspout/blob/5.x/docs/documentation.md#column-widths), you can return an `OpenSpout\Writer\XLSX\Options` instance from the `getXlsxWriterOptions()` method of the exporter class:
 
 ```php
 use OpenSpout\Writer\XLSX\Options;
@@ -774,9 +774,9 @@ use OpenSpout\Writer\XLSX\Writer;
 
 public function configureXlsxWriterAfterOpen(Writer $writer): Writer
 {
-    $writer->addRow(Row::fromValues(
+    $writer->addRow(Row::fromValuesWithStyles(
         ['This is a custom header added after opening the XLSX writer.'],
-        (new Style())->setShouldWrapText(false),
+        [new Style(shouldWrapText: false)],
     ));
 
     return $writer;
@@ -784,7 +784,7 @@ public function configureXlsxWriterAfterOpen(Writer $writer): Writer
 ```
 
 <Aside variant="warning">
-    Any rows you add here appear above the header row, shifting the exported table down. If you also use `configureXlsxWriterBeforeClose()` to freeze rows, remember to account for the extra rows in `setFreezeRow()`.
+    Any rows you add here appear above the header row, shifting the exported table down. If you also use `configureXlsxWriterBeforeClose()` to freeze rows, remember to account for the extra rows in `withFreezeRow()`.
 </Aside>
 
 If you want to customize the XLSX writer before it is closed, you can override the `configureXlsxWriterBeforeClose()` method on the exporter class. This method receives the `Writer` instance as a parameter, and you can modify it before it is closed:
@@ -795,10 +795,10 @@ use OpenSpout\Writer\XLSX\Writer;
 
 public function configureXlsxWriterBeforeClose(Writer $writer): Writer
 {
-    $sheetView = new SheetView();
-    $sheetView->setFreezeRow(2);
-    $sheetView->setFreezeColumn('B');
-    
+    $sheetView = (new SheetView())
+        ->withFreezeRow(2)
+        ->withFreezeColumn('B');
+
     $sheet = $writer->getCurrentSheet();
     $sheet->setSheetView($sheetView);
     $sheet->setName('export');

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -250,7 +250,11 @@ abstract class Exporter
      */
     public function makeXlsxRow(array $values, ?Style $style = null): Row
     {
-        return Row::fromValues($values, $style);
+        if ($style === null) {
+            return Row::fromValues($values);
+        }
+
+        return Row::fromValuesWithStyles($values, array_fill(0, count($values), $style));
     }
 
     public function configureXlsxWriterAfterOpen(Writer $writer): Writer

--- a/packages/forms/composer.json
+++ b/packages/forms/composer.json
@@ -8,7 +8,7 @@
         "source": "https://github.com/filamentphp/filament"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "danharrin/date-format-converter": "^0.3",
         "filament/actions": "self.version",
         "filament/schemas": "self.version",

--- a/packages/infolists/composer.json
+++ b/packages/infolists/composer.json
@@ -8,7 +8,7 @@
         "source": "https://github.com/filamentphp/filament"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "filament/actions": "self.version",
         "filament/schemas": "self.version",
         "filament/support": "self.version"

--- a/packages/notifications/composer.json
+++ b/packages/notifications/composer.json
@@ -8,7 +8,7 @@
         "source": "https://github.com/filamentphp/filament"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "filament/actions": "self.version",
         "filament/support": "self.version"
     },

--- a/packages/panels/composer.json
+++ b/packages/panels/composer.json
@@ -8,7 +8,7 @@
         "source": "https://github.com/filamentphp/filament"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "chillerlan/php-qrcode": "^5.0",
         "filament/actions": "self.version",
         "filament/forms": "self.version",

--- a/packages/query-builder/composer.json
+++ b/packages/query-builder/composer.json
@@ -8,7 +8,7 @@
         "source": "https://github.com/filamentphp/filament"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "filament/actions": "self.version",
         "filament/forms": "self.version",
         "filament/schemas": "self.version",

--- a/packages/schemas/composer.json
+++ b/packages/schemas/composer.json
@@ -8,7 +8,7 @@
         "source": "https://github.com/filamentphp/filament"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "danharrin/date-format-converter": "^0.3",
         "filament/actions": "self.version",
         "filament/support": "self.version"

--- a/packages/spark-billing-provider/composer.json
+++ b/packages/spark-billing-provider/composer.json
@@ -8,7 +8,7 @@
         "source": "https://github.com/filamentphp/filament"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "filament/filament": "self.version"
     },
     "autoload": {

--- a/packages/spatie-laravel-google-fonts-plugin/composer.json
+++ b/packages/spatie-laravel-google-fonts-plugin/composer.json
@@ -8,7 +8,7 @@
         "source": "https://github.com/filamentphp/filament"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "filament/filament": "self.version",
         "spatie/laravel-google-fonts": "^1.0"
     },

--- a/packages/spatie-laravel-media-library-plugin/composer.json
+++ b/packages/spatie-laravel-media-library-plugin/composer.json
@@ -8,7 +8,7 @@
         "source": "https://github.com/filamentphp/filament"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "filament/support": "self.version",
         "spatie/laravel-medialibrary": "^11.0"
     },

--- a/packages/spatie-laravel-settings-plugin/composer.json
+++ b/packages/spatie-laravel-settings-plugin/composer.json
@@ -8,7 +8,7 @@
         "source": "https://github.com/filamentphp/filament"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "filament/filament": "self.version",
         "spatie/laravel-settings": "^3.0"
     },

--- a/packages/spatie-laravel-tags-plugin/composer.json
+++ b/packages/spatie-laravel-tags-plugin/composer.json
@@ -8,7 +8,7 @@
         "source": "https://github.com/filamentphp/filament"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "filament/support": "self.version",
         "spatie/laravel-tags": "^4.0"
     },

--- a/packages/support/composer.json
+++ b/packages/support/composer.json
@@ -8,7 +8,7 @@
         "source": "https://github.com/filamentphp/filament"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ext-intl": "*",
         "blade-ui-kit/blade-heroicons": "^2.5",
         "danharrin/livewire-rate-limiting": "^2.0",

--- a/packages/tables/composer.json
+++ b/packages/tables/composer.json
@@ -8,7 +8,7 @@
         "source": "https://github.com/filamentphp/filament"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "filament/actions": "self.version",
         "filament/forms": "self.version",
         "filament/query-builder": "self.version",

--- a/packages/upgrade/composer.json
+++ b/packages/upgrade/composer.json
@@ -8,7 +8,7 @@
         "source": "https://github.com/filamentphp/filament"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "nunomaduro/termwind": "^2.0",
         "rector/rector": "^2.0"
     },

--- a/packages/widgets/composer.json
+++ b/packages/widgets/composer.json
@@ -8,7 +8,7 @@
         "source": "https://github.com/filamentphp/filament"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "filament/schemas": "self.version",
         "filament/support": "self.version"
     },


### PR DESCRIPTION
## Description

Upgrade OpenSpout to v5 and PHP 8.3, as OpenSpout v5 requires PHP 8.3.

Be aware of the breaking changes introduced in v5. See the upgrade guide for details:

[OpenSpout v5 Upgrade Guide](https://github.com/openspout/openspout/blob/5.x/UPGRADE.md)

The documentation has been updated accordingly.

Let's review and discuss this PR together.

## Visual changes

None

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [/] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
