### PR TITLE
Fix: forget a closed action's cached schema when it is unmounted

### DIFF
--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -421,12 +421,12 @@ trait InteractsWithActions /** @phpstan-ignore trait.unused */
         $this->mountedActions = [];
         $this->cachedMountedActions = null;
 
-        $this->unCacheMountedActionSchemas();
+        $this->forgetCachedMountedActionSchemas();
 
         $this->mountAction($name, $arguments, $context);
     }
 
-    protected function unCacheMountedActionSchemas(int $fromNestingIndex = 0): void
+    protected function forgetCachedMountedActionSchemas(int $fromNestingIndex = 0): void
     {
         foreach (array_keys($this->cachedSchemas) as $schemaName) {
             if (! str_starts_with($schemaName, 'mountedActionSchema')) {
@@ -816,7 +816,7 @@ trait InteractsWithActions /** @phpstan-ignore trait.unused */
         // action mounted at one of those indexes later in this request would otherwise be handed
         // the schema of the action that used to be there, since `getMountedActionSchema()` reads
         // the cache before it builds anything.
-        $this->unCacheMountedActionSchemas(fromNestingIndex: count($this->mountedActions));
+        $this->forgetCachedMountedActionSchemas(fromNestingIndex: count($this->mountedActions));
 
         if (! count($this->mountedActions)) {
             $action?->clearRecordAfter();

--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -421,13 +421,22 @@ trait InteractsWithActions /** @phpstan-ignore trait.unused */
         $this->mountedActions = [];
         $this->cachedMountedActions = null;
 
-        foreach ($this->cachedSchemas as $schemaName => $schema) {
-            if (str($schemaName)->startsWith('mountedActionSchema')) {
+        $this->unCacheMountedActionSchemas();
+
+        $this->mountAction($name, $arguments, $context);
+    }
+
+    protected function unCacheMountedActionSchemas(int $fromNestingIndex = 0): void
+    {
+        foreach (array_keys($this->cachedSchemas) as $schemaName) {
+            if (! str_starts_with($schemaName, 'mountedActionSchema')) {
+                continue;
+            }
+
+            if (((int) substr($schemaName, strlen('mountedActionSchema'))) >= $fromNestingIndex) {
                 unset($this->cachedSchemas[$schemaName]);
             }
         }
-
-        $this->mountAction($name, $arguments, $context);
     }
 
     public function cacheAction(Action $action): Action
@@ -802,6 +811,12 @@ trait InteractsWithActions /** @phpstan-ignore trait.unused */
         while (count($this->cachedMountedActions ?? []) > count($this->mountedActions)) {
             array_pop($this->cachedMountedActions);
         }
+
+        // The schemas of the actions that have just closed, which are cached by nesting index: an
+        // action mounted at one of those indexes later in this request would otherwise be handed
+        // the schema of the action that used to be there, since `getMountedActionSchema()` reads
+        // the cache before it builds anything.
+        $this->unCacheMountedActionSchemas(fromNestingIndex: count($this->mountedActions));
 
         if (! count($this->mountedActions)) {
             $action?->clearRecordAfter();

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -6,7 +6,6 @@ use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
 use Filament\Actions\Enums\ActionStatus;
 use Filament\Actions\Testing\TestAction;
-use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
@@ -479,6 +478,48 @@ describe('nested actions', function (): void {
                 ]),
             ])
             ->assertDispatched('arguments-test-called', foo: $foo, bar: $bar, baz: $baz);
+    });
+});
+
+describe('unmounting actions', function (): void {
+    it('forgets a nested action schema before another action is mounted at the same index', function (): void {
+        $livewire = livewire(Actions::class)
+            ->mountAction('staleSchemaParent')
+            ->mountAction('first');
+
+        expect(array_keys($livewire->instance()->getSchema('mountedActionSchema1')->getFlatFields()))
+            ->toBe(['alpha']);
+
+        $livewire->call('unmountThenMountAction', 'second');
+
+        expect(array_keys($livewire->instance()->getSchema('mountedActionSchema1')->getFlatFields()))
+            ->toBe(['beta']);
+    });
+
+    it('forgets a root action schema before another action is mounted at the same index', function (): void {
+        $livewire = livewire(Actions::class)
+            ->mountAction('staleSchemaParent');
+
+        expect(array_keys($livewire->instance()->getSchema('mountedActionSchema0')->getFlatFields()))
+            ->toBe(['parentField']);
+
+        $livewire->call('unmountThenMountAction', 'staleSchemaOther');
+
+        expect(array_keys($livewire->instance()->getSchema('mountedActionSchema0')->getFlatFields()))
+            ->toBe(['otherField']);
+    });
+
+    it('preserves the schema of an action that remains mounted', function (): void {
+        $livewire = livewire(Actions::class)
+            ->mountAction('staleSchemaParent')
+            ->mountAction('first');
+
+        $livewire->call('unmountAction');
+
+        expect(array_keys($livewire->instance()->getSchema('mountedActionSchema0')->getFlatFields()))
+            ->toBe(['parentField'])
+            ->and($livewire->instance()->getSchema('mountedActionSchema1'))
+            ->toBeNull();
     });
 });
 
@@ -2381,92 +2422,3 @@ describe('authorization', function (): void {
         });
     });
 });
-
-describe('unmounting actions', function (): void {
-    it('does not hand a closed action\'s schema to the next action mounted in its place', function (): void {
-        $component = livewire(StaleMountedActionSchemaHarness::class)
-            ->mountAction('parent')
-            ->mountAction('first');
-
-        expect(array_keys($component->instance()->getSchema('mountedActionSchema1')->getFlatFields()))
-            ->toBe(['alpha']);
-
-        $component->call('unmountThenMountAction', 'second');
-
-        expect(array_keys($component->instance()->getSchema('mountedActionSchema1')->getFlatFields()))
-            ->toBe(['beta']);
-    });
-
-    it('does not hand it over at the root of the stack either', function (): void {
-        $component = livewire(StaleMountedActionSchemaHarness::class)
-            ->mountAction('parent');
-
-        expect(array_keys($component->instance()->getSchema('mountedActionSchema0')->getFlatFields()))
-            ->toBe(['parentField']);
-
-        $component->call('unmountThenMountAction', 'other');
-
-        expect(array_keys($component->instance()->getSchema('mountedActionSchema0')->getFlatFields()))
-            ->toBe(['otherField']);
-    });
-
-    it('keeps the schema of an action that is still mounted', function (): void {
-        $component = livewire(StaleMountedActionSchemaHarness::class)
-            ->mountAction('parent')
-            ->mountAction('first');
-
-        $component->call('unmountAction');
-
-        expect(array_keys($component->instance()->getSchema('mountedActionSchema0')->getFlatFields()))
-            ->toBe(['parentField'])
-            ->and($component->instance()->getSchema('mountedActionSchema1'))
-            ->toBeNull();
-    });
-});
-
-class StaleMountedActionSchemaHarness extends Component implements HasActions, HasSchemas
-{
-    use InteractsWithActions;
-    use InteractsWithSchemas;
-
-    public function parentAction(): Action
-    {
-        return Action::make('parent')
-            ->schema([
-                TextInput::make('parentField'),
-            ])
-            ->registerModalActions([
-                Action::make('first')
-                    ->schema([
-                        TextInput::make('alpha'),
-                    ])
-                    ->action(fn () => null),
-                Action::make('second')
-                    ->schema([
-                        TextInput::make('beta'),
-                    ])
-                    ->action(fn () => null),
-            ])
-            ->action(fn () => null);
-    }
-
-    public function unmountThenMountAction(string $name): void
-    {
-        $this->unmountAction();
-        $this->mountAction($name);
-    }
-
-    public function otherAction(): Action
-    {
-        return Action::make('other')
-            ->schema([
-                TextInput::make('otherField'),
-            ])
-            ->action(fn () => null);
-    }
-
-    public function render(): View
-    {
-        return view('livewire.form');
-    }
-}

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -6,6 +6,7 @@ use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
 use Filament\Actions\Enums\ActionStatus;
 use Filament\Actions\Testing\TestAction;
+use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
@@ -2380,3 +2381,92 @@ describe('authorization', function (): void {
         });
     });
 });
+
+describe('unmounting actions', function (): void {
+    it('does not hand a closed action\'s schema to the next action mounted in its place', function (): void {
+        $component = livewire(StaleMountedActionSchemaHarness::class)
+            ->mountAction('parent')
+            ->mountAction('first');
+
+        expect(array_keys($component->instance()->getSchema('mountedActionSchema1')->getFlatFields()))
+            ->toBe(['alpha']);
+
+        $component->call('unmountThenMountAction', 'second');
+
+        expect(array_keys($component->instance()->getSchema('mountedActionSchema1')->getFlatFields()))
+            ->toBe(['beta']);
+    });
+
+    it('does not hand it over at the root of the stack either', function (): void {
+        $component = livewire(StaleMountedActionSchemaHarness::class)
+            ->mountAction('parent');
+
+        expect(array_keys($component->instance()->getSchema('mountedActionSchema0')->getFlatFields()))
+            ->toBe(['parentField']);
+
+        $component->call('unmountThenMountAction', 'other');
+
+        expect(array_keys($component->instance()->getSchema('mountedActionSchema0')->getFlatFields()))
+            ->toBe(['otherField']);
+    });
+
+    it('keeps the schema of an action that is still mounted', function (): void {
+        $component = livewire(StaleMountedActionSchemaHarness::class)
+            ->mountAction('parent')
+            ->mountAction('first');
+
+        $component->call('unmountAction');
+
+        expect(array_keys($component->instance()->getSchema('mountedActionSchema0')->getFlatFields()))
+            ->toBe(['parentField'])
+            ->and($component->instance()->getSchema('mountedActionSchema1'))
+            ->toBeNull();
+    });
+});
+
+class StaleMountedActionSchemaHarness extends Component implements HasActions, HasSchemas
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+
+    public function parentAction(): Action
+    {
+        return Action::make('parent')
+            ->schema([
+                TextInput::make('parentField'),
+            ])
+            ->registerModalActions([
+                Action::make('first')
+                    ->schema([
+                        TextInput::make('alpha'),
+                    ])
+                    ->action(fn () => null),
+                Action::make('second')
+                    ->schema([
+                        TextInput::make('beta'),
+                    ])
+                    ->action(fn () => null),
+            ])
+            ->action(fn () => null);
+    }
+
+    public function unmountThenMountAction(string $name): void
+    {
+        $this->unmountAction();
+        $this->mountAction($name);
+    }
+
+    public function otherAction(): Action
+    {
+        return Action::make('other')
+            ->schema([
+                TextInput::make('otherField'),
+            ])
+            ->action(fn () => null);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.form');
+    }
+}

--- a/tests/src/Fixtures/Pages/Actions.php
+++ b/tests/src/Fixtures/Pages/Actions.php
@@ -121,6 +121,28 @@ class Actions extends Page
                         ])
                         ->action(fn () => null),
                 ]),
+            Action::make('staleSchemaParent')
+                ->schema([
+                    TextInput::make('parentField'),
+                ])
+                ->registerModalActions([
+                    Action::make('first')
+                        ->schema([
+                            TextInput::make('alpha'),
+                        ])
+                        ->action(fn () => null),
+                    Action::make('second')
+                        ->schema([
+                            TextInput::make('beta'),
+                        ])
+                        ->action(fn () => null),
+                ])
+                ->action(fn () => null),
+            Action::make('staleSchemaOther')
+                ->schema([
+                    TextInput::make('otherField'),
+                ])
+                ->action(fn () => null),
             Action::make('grandparentWithModalCloseCancellation')
                 ->schema([
                     TextInput::make('grandparentValue')
@@ -280,5 +302,11 @@ class Actions extends Page
                     $this->dispatch('enforcement-authorized-called');
                 }),
         ];
+    }
+
+    public function unmountThenMountAction(string $name): void
+    {
+        $this->unmountAction();
+        $this->mountAction($name);
     }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

`unmountAction()` pops the action off `mountedActions`, but leaves its schema in `cachedSchemas`
under `mountedActionSchema{nestingIndex}`. `getMountedActionSchema()` reads that cache before it
builds anything, so an action mounted at the same nesting index later in the same request is handed the schema of
the action that has just closed.

This causes actions to have their own header and footer, but someone else’s form. The bug appeared while testing the `modalClickThrough()` method. It occurred when I opened one action and then, without closing the current one, opened another.


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
