### PR TITLE
fix: cast `TextInput` state to an integer when using `integer()`

### DIFF
--- a/packages/forms/src/Components/TextInput.php
+++ b/packages/forms/src/Components/TextInput.php
@@ -37,6 +37,8 @@ class TextInput extends Field implements CanHaveNumericState, Contracts\CanBeLen
 
     protected bool | Closure $isEmail = false;
 
+    protected bool | Closure $isInteger = false;
+
     protected bool | Closure $isNumeric = false;
 
     protected bool | Closure $isPassword = false;
@@ -85,6 +87,8 @@ class TextInput extends Field implements CanHaveNumericState, Contracts\CanBeLen
 
     public function integer(bool | Closure $condition = true): static
     {
+        $this->isInteger = $condition;
+
         $this->numeric($condition);
         $this->inputMode(static fn (): ?string => $condition ? 'numeric' : null);
         $this->step(static fn (): ?int => $condition ? 1 : null);
@@ -274,6 +278,11 @@ class TextInput extends Field implements CanHaveNumericState, Contracts\CanBeLen
         return (bool) $this->evaluate($this->isEmail);
     }
 
+    public function isInteger(): bool
+    {
+        return (bool) $this->evaluate($this->isInteger);
+    }
+
     public function isNumeric(): bool
     {
         return (bool) $this->evaluate($this->isNumeric);
@@ -302,7 +311,7 @@ class TextInput extends Field implements CanHaveNumericState, Contracts\CanBeLen
         return [
             ...parent::getDefaultStateCasts(),
             ...($this->hasStripCharacters() ? [app(StripCharactersStateCast::class, ['characters' => $this->getStripCharacters()])] : []),
-            ...($this->isNumeric() ? [app(NumberStateCast::class, ['isNullable' => true])] : []),
+            ...($this->isNumeric() ? [app(NumberStateCast::class, ['isNullable' => true, 'isInteger' => $this->isInteger()])] : []),
         ];
     }
 

--- a/packages/schemas/src/Components/StateCasts/NumberStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/NumberStateCast.php
@@ -8,23 +8,24 @@ class NumberStateCast implements StateCast
 {
     public function __construct(
         protected bool $isNullable = true,
+        protected bool $isInteger = false,
     ) {}
 
-    public function get(mixed $state): ?float
+    public function get(mixed $state): int | float | null
     {
         if ($this->isNullable && blank($state)) {
             return null;
         }
 
-        return floatval($state);
+        return $this->isInteger ? intval($state) : floatval($state);
     }
 
-    public function set(mixed $state): ?float
+    public function set(mixed $state): int | float | null
     {
         if ($this->isNullable && blank($state)) {
             return null;
         }
 
-        return floatval($state);
+        return $this->isInteger ? intval($state) : floatval($state);
     }
 }

--- a/tests/src/Forms/Components/TextInputTest.php
+++ b/tests/src/Forms/Components/TextInputTest.php
@@ -47,6 +47,14 @@ it('can strip characters before applying `numeric()` state cast', function (mixe
     [null, null],
 ]);
 
+it('casts state to an integer when using `integer()`', function (): void {
+    $component = livewire(TestComponentWithIntegerTextInput::class)
+        ->fillForm(['quantity' => '1234'])
+        ->call('save');
+
+    expect($component->get('data.quantity'))->toBe(1234);
+});
+
 it('can set `email()`', function (): void {
     $input = TextInput::make('email');
 
@@ -280,6 +288,26 @@ class TestComponentWithNumericAndStripCharacters extends Livewire
                 TextInput::make('price')
                     ->numeric()
                     ->stripCharacters(','),
+            ])
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->data = $this->form->getState();
+    }
+}
+
+class TestComponentWithIntegerTextInput extends Livewire
+{
+    public $data = [];
+
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->schema([
+                TextInput::make('quantity')
+                    ->integer(),
             ])
             ->statePath('data');
     }


### PR DESCRIPTION
## Description

Fixes #20364

`TextInput::make('quantity')->integer()` used the same state cast as `numeric()`, which runs `floatval()`. So `getState()` gave back `1234.0` instead of `1234`. Saving to a model hid this, since the model cast corrected the type, but data read straight out of a schema (an action's `$data`, for example) kept the float.

`integer()` now tells `NumberStateCast` to use `intval()` instead.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.