### PR TITLE
fix: table search throws \`Array to string conversion\` for bracket-l…

### DIFF
--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -206,7 +206,13 @@ trait CanSearchRecords
 
     public function getTableSearch(): ?string
     {
-        return filled($this->tableSearch) ? Str::trim(strval($this->tableSearch)) : null;
+        $search = $this->tableSearch;
+
+        if (is_array($search)) {
+            $search = json_encode($search);
+        }
+
+        return filled($search) ? Str::trim(strval($search)) : null;
     }
 
     public function hasTableSearch(): bool

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -106,7 +106,9 @@ trait InteractsWithTable
             $this->tableSearch = session()->get($searchSessionKey);
         }
 
-        $this->tableSearch = strval($this->tableSearch);
+        $this->tableSearch = is_array($this->tableSearch)
+            ? json_encode($this->tableSearch)
+            : strval($this->tableSearch);
 
         if ($shouldPersistSearchInSession) {
             session()->put(

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -236,6 +236,14 @@ describe('searching', function (): void {
             ->assertCanNotSeeTableRecords($posts->where('title', '!=', $title));
     });
 
+    it('does not error when `tableSearch` is tampered into an array', function (): void {
+        Post::factory()->count(10)->create();
+
+        livewire(PostsTable::class)
+            ->set('tableSearch', [123])
+            ->assertOk();
+    });
+
     it('can search individual column records', function (): void {
         $posts = Post::factory()->count(10)->create();
 

--- a/tests/src/Tables/Concerns/CanSearchRecordsTest.php
+++ b/tests/src/Tables/Concerns/CanSearchRecordsTest.php
@@ -72,4 +72,7 @@ it('can trim the search query', function (): void {
 
     $trait->tableSearch = "\u{1160}\u{1160}test\u{1160}\u{1160}";
     $this->assertSame('test', $trait->getTableSearch());
+
+    $trait->tableSearch = [123];
+    $this->assertSame('[123]', $trait->getTableSearch());
 });


### PR DESCRIPTION
Searching a table for a value that looks like JSON — e.g. `[123]` — crashed with `ErrorException: Array to string conversion` at `packages/tables/src/Concerns/InteractsWithTable.php:109`.

`$tableSearch` is synced to the URL via Livewire's `#[Url(as: 'search')]` attribute. Livewire's own URL-sync code unconditionally runs `json_decode()` on incoming query string values to detect structured data. `"[123]"` happens to be valid JSON (a one-element array), so Livewire silently decodes it into the PHP array `[123]` and assigns it directly to `$tableSearch`, which has no strict type. `bootedInteractsWithTable()` then unconditionally called `strval()` on it, and `strval()` on an array throws "Array to string conversion".

This is the same class of bug the codebase already guards against for per-column searches (`CanSearchRecords::castTableColumnSearches()` already checks `is_array()` before `strval()`) — the single global search property never got the same treatment.

The fix guards both call sites and, when the value is an array, re-encodes it back to JSON before treating it as a string. This exactly reverses Livewire's `json_decode()`, so `[123]` round-trips back to the literal string `[123]` the user searched for, instead of silently discarding their search or crashing.

Fixes #20372

## Visual changes

N/A — no visual/markup changes, only defensive handling of an edge-case input value.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.