### PR TITLE
fix: avoid null array offsets in Actions view and MorphToSelect on PHP 8.5

### DIFF
--- a/packages/forms/src/Components/MorphToSelect.php
+++ b/packages/forms/src/Components/MorphToSelect.php
@@ -113,15 +113,15 @@ class MorphToSelect extends Component
                     });
 
             $keySelect = Select::make($keyColumn)
-                ->label(fn (Get $get): ?string => ($types[$get($typeColumn)] ?? null)?->getLabel())
+                ->label(fn (Get $get): ?string => ($types[$get($typeColumn) ?? ''] ?? null)?->getLabel())
                 ->hiddenLabel()
-                ->options(fn (Select $component, Get $get): ?array => $component->evaluate(($types[$get($typeColumn)] ?? null)?->getOptionsUsing))
+                ->options(fn (Select $component, Get $get): ?array => $component->evaluate(($types[$get($typeColumn) ?? ''] ?? null)?->getOptionsUsing))
                 ->dynamicOptions(fn (Select $component): ?bool => $component->isPreloaded() ? null : false)
-                ->getSearchResultsUsing(fn (Select $component, Get $get, $search): ?array => $component->evaluate(($types[$get($typeColumn)] ?? null)?->getSearchResultsUsing, ['search' => $search]))
-                ->getOptionLabelUsing(fn (Select $component, Get $get, $value): ?string => $component->evaluate(($types[$get($typeColumn)] ?? null)?->getOptionLabelUsing, ['value' => $value]))
+                ->getSearchResultsUsing(fn (Select $component, Get $get, $search): ?array => $component->evaluate(($types[$get($typeColumn) ?? ''] ?? null)?->getSearchResultsUsing, ['search' => $search]))
+                ->getOptionLabelUsing(fn (Select $component, Get $get, $value): ?string => $component->evaluate(($types[$get($typeColumn) ?? ''] ?? null)?->getOptionLabelUsing, ['value' => $value]))
                 ->native($component->isNative())
-                ->required(fn (Get $get): bool => filled(($types[$get($typeColumn)] ?? null)))
-                ->hidden(fn (Get $get): bool => blank(($types[$get($typeColumn)] ?? null)))
+                ->required(fn (Get $get): bool => filled(($types[$get($typeColumn) ?? ''] ?? null)))
+                ->hidden(fn (Get $get): bool => blank(($types[$get($typeColumn) ?? ''] ?? null)))
                 ->dehydratedWhenHidden()
                 ->searchable($component->isSearchable())
                 ->searchDebounce($component->getSearchDebounce())
@@ -140,7 +140,7 @@ class MorphToSelect extends Component
                 ->afterStateUpdated(function () use ($component): void {
                     $component->callAfterStateUpdatedForChildComponent();
                 })
-                ->actionSchemaModel(fn (Get $get): ?string => ($types[$get($typeColumn)] ?? null)?->getModel());
+                ->actionSchemaModel(fn (Get $get): ?string => ($types[$get($typeColumn) ?? ''] ?? null)?->getModel());
 
             if ($callback = $component->getModifyTypeSelectUsingCallback()) {
                 $typeSelect = $component->evaluate($callback, [

--- a/packages/schemas/src/Components/Actions.php
+++ b/packages/schemas/src/Components/Actions.php
@@ -249,7 +249,7 @@ class Actions extends Component implements HasEmbeddedView
                         ->class([
                             'fi-ac',
                             'fi-width-full' => $isFullWidth,
-                            (($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : null)) => ! $isFullWidth,
+                            (($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : '')) => ! $isFullWidth,
                         ])->toHtml() ?>
                 >
                     <?php foreach ($visibleActions as $action) { ?>


### PR DESCRIPTION
PHP 8.5 deprecates using null as an array offset. Two remaining sites fire it: the `Actions` component view uses a null class-array key when no alignment is set, and `MorphToSelect` looks up `$types[$get($typeColumn)]` while the type is unset. Same pattern as #20210, #19491, #19081; behavior is unchanged (the null key was already coerced to an empty string).