### PR TITLE
Skip leading punctuation when building default avatar initials

### DIFF
--- a/packages/panels/src/AvatarProviders/UiAvatarsProvider.php
+++ b/packages/panels/src/AvatarProviders/UiAvatarsProvider.php
@@ -15,7 +15,13 @@ class UiAvatarsProvider implements Contracts\AvatarProvider
         $name = str(Filament::getNameForDefaultAvatar($record))
             ->trim()
             ->explode(' ')
-            ->map(fn (string $segment): string => filled($segment) ? mb_substr($segment, 0, 1) : '')
+            ->map(function (string $segment): string {
+                // Skip leading punctuation (e.g. a "[SYSTEM] Admin" service-account
+                // naming convention) so it doesn't become part of the initials.
+                $letters = preg_replace('/^[^\p{L}\p{N}]+/u', '', $segment);
+
+                return filled($letters) ? mb_substr($letters, 0, 1) : '';
+            })
             ->join(' ');
 
         $background = Color::convertToHex(FilamentColor::getColor('gray')[950] ?? Color::Gray[950]);

--- a/tests/src/Panels/Configuration/AvatarProviderTest.php
+++ b/tests/src/Panels/Configuration/AvatarProviderTest.php
@@ -43,3 +43,13 @@ it('includes background color in the URL', function (): void {
     expect($url)->toContain('background=');
     expect($url)->toMatch('/background=%23([0-9a-f]{3}){1,2}$/');
 });
+
+it('skips leading punctuation when building initials', function (): void {
+    $provider = new UiAvatarsProvider;
+    $user = User::factory()->create(['name' => '[SYSTEM] Admin']);
+
+    $url = $provider->get($user);
+
+    expect($url)->toContain('name=S+A');
+    expect($url)->not->toContain('name=%5B');
+});


### PR DESCRIPTION
## Summary

Fixes #20384.

`UiAvatarsProvider::get()` builds a user's default avatar initials by taking the first character of each space-separated word in their name, with no filtering for non-letter characters. A name starting with a bracket — a common convention for marking service/system accounts so they stand out in user pickers, e.g. `"[SYSTEM] Admin"` — leaks that bracket into the generated initials: `"[A"` instead of `"SA"`.

This skips leading punctuation per word before taking the initial, so `"[SYSTEM] Admin"` now renders as `"SA"`.

## Reproduction

https://github.com/futzlarson/filament-bracket-avatar-repro

## Testing

Added a Pest test to the existing `AvatarProviderTest.php` covering this case. All 5 tests in the file pass.