### PR TITLE
fix: apply the connection table prefix to number constraint aggregate subqueries

### DIFF
--- a/packages/query-builder/src/Constraints/NumberConstraint/Operators/Concerns/CanAggregateRelationships.php
+++ b/packages/query-builder/src/Constraints/NumberConstraint/Operators/Concerns/CanAggregateRelationships.php
@@ -68,7 +68,7 @@ trait CanAggregateRelationships
         $relationship = $query->getModel()->{$relationshipName}();
 
         $relatedModel = $relationship->getModel();
-        $attributeForQuery = $relatedModel->qualifyColumn($attributeForQuery);
+        $attributeForQuery = $relatedModel->getConnection()->getQueryGrammar()->wrap($relatedModel->qualifyColumn($attributeForQuery));
         $castType = $this->getNumericCastType($query);
 
         if ($relationship instanceof BelongsToMany) {

--- a/tests/src/Tables/Filters/QueryBuilderTest.php
+++ b/tests/src/Tables/Filters/QueryBuilderTest.php
@@ -31,6 +31,7 @@ use Filament\Tests\Fixtures\Models\Team;
 use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\Tables\TestCase;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 
 use function Filament\Tests\livewire;
 
@@ -2020,6 +2021,19 @@ describe('relationship method constraints', function (): void {
             ]))
             ->assertCanSeeTableRecords([$inScopeUser])
             ->assertCanNotSeeTableRecords([$outOfScopeUser]);
+    });
+
+    it('qualifies the aggregate column with the connection table prefix', function (): void {
+        DB::connection()->setTablePrefix('fo_');
+
+        $query = User::query();
+
+        IsMinOperator::make('isMin')
+            ->constraint(NumberConstraint::make('posts.rating'))
+            ->settings(['number' => 7, 'aggregate' => 'min'])
+            ->applyToBaseQuery($query);
+
+        expect($query->toSql())->toContain('min("fo_posts"."rating")');
     });
 
 });


### PR DESCRIPTION
## Description

When a `NumberConstraint` on a relationship uses an aggregate, the column inside the aggregate is interpolated straight into `selectRaw()`, so the connection's table prefix is never applied and the query fails with `no such column: items.length` on a prefixed connection. Passing the qualified column through the grammar's `wrap()` gives `min("fo_items"."length")`, matching what `whereColumn()` in the same subquery already produces.

Fixes #20382

## Visual changes

None.

## Functional changes

- Aggregate subqueries built by `NumberConstraint` now resolve against the prefixed table name, so the filter works on connections that set a prefix.
