### PR TITLE
fix: register tenancy for configurable resources

### DIFF
--- a/packages/panels/src/Panel.php
+++ b/packages/panels/src/Panel.php
@@ -84,7 +84,12 @@ class Panel extends Component
     public function boot(): void
     {
         if ($this->hasTenancy()) {
-            foreach ($this->getResources() as $resource) {
+            $resourceClasses = array_unique([
+                ...$this->resources,
+                ...array_keys($this->resourceConfigurations),
+            ]);
+
+            foreach ($resourceClasses as $resource) {
                 $resource::observeTenancyModelCreation($this);
                 $resource::registerTenancyModelGlobalScope($this);
             }

--- a/tests/src/Fixtures/Models/ConfiguredTenantScopedUser.php
+++ b/tests/src/Fixtures/Models/ConfiguredTenantScopedUser.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class ConfiguredTenantScopedUser extends User
+{
+    protected $table = 'users';
+
+    public function teams(): BelongsToMany
+    {
+        return $this->belongsToMany(Team::class, 'team_user', 'user_id', 'team_id');
+    }
+}

--- a/tests/src/Fixtures/Resources/Tenancy/ConfiguredTenantScopedUsers/ConfiguredTenantScopedUserResource.php
+++ b/tests/src/Fixtures/Resources/Tenancy/ConfiguredTenantScopedUsers/ConfiguredTenantScopedUserResource.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Resources\Tenancy\ConfiguredTenantScopedUsers;
+
+use Filament\Resources\Resource;
+use Filament\Resources\ResourceConfiguration;
+use Filament\Tests\Fixtures\Models\ConfiguredTenantScopedUser;
+
+class ConfiguredTenantScopedUserResource extends Resource
+{
+    protected static ?string $model = ConfiguredTenantScopedUser::class;
+
+    protected static ?string $configurationClass = ResourceConfiguration::class;
+
+    protected static ?string $tenantOwnershipRelationshipName = 'teams';
+}

--- a/tests/src/Panels/Tenancy/MultiResourceTenancyTest.php
+++ b/tests/src/Panels/Tenancy/MultiResourceTenancyTest.php
@@ -1,8 +1,11 @@
 <?php
 
 use Filament\Facades\Filament;
+use Filament\Panel;
+use Filament\Tests\Fixtures\Models\ConfiguredTenantScopedUser;
 use Filament\Tests\Fixtures\Models\Team;
 use Filament\Tests\Fixtures\Models\User;
+use Filament\Tests\Fixtures\Resources\Tenancy\ConfiguredTenantScopedUsers\ConfiguredTenantScopedUserResource;
 use Filament\Tests\Fixtures\Resources\Tenancy\NonTenantScopedUsers\NonTenantScopedUserResource;
 use Filament\Tests\Fixtures\Resources\Tenancy\TenantScopedUsers\TenantScopedUserResource;
 use Filament\Tests\Panels\Pages\TestCase;
@@ -54,6 +57,49 @@ it('can scope a resource to the current tenant', function (): void {
     expect($results->pluck('id')->toArray())
         ->toContain($userInTenant->id)
         ->not->toContain($userNotInTenant->id);
+});
+
+it('can register tenancy for a configured resource', function (): void {
+    $panel = Panel::make()
+        ->id('configured-resource-tenancy')
+        ->tenant(Team::class)
+        ->resources([
+            ConfiguredTenantScopedUserResource::make(),
+        ]);
+
+    Filament::setCurrentPanel($panel);
+
+    $team = Team::factory()->create();
+
+    $userInTenant = ConfiguredTenantScopedUser::create([
+        'name' => 'User in tenant',
+        'email' => 'user-in-tenant@example.com',
+        'password' => bcrypt('password'),
+    ]);
+    $userInTenant->teams()->attach($team);
+
+    $userNotInTenant = ConfiguredTenantScopedUser::create([
+        'name' => 'User not in tenant',
+        'email' => 'user-not-in-tenant@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    Filament::setTenant($team);
+    $panel->boot();
+
+    $results = ConfiguredTenantScopedUserResource::getEloquentQuery()->get();
+
+    expect($results->pluck('id')->toArray())
+        ->toContain($userInTenant->id)
+        ->not->toContain($userNotInTenant->id);
+
+    $newUser = ConfiguredTenantScopedUser::create([
+        'name' => 'New user',
+        'email' => 'new-user@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    expect($team->users()->where('user_id', $newUser->id)->exists())->toBeTrue();
 });
 
 it('can create a model when multiple resources observe tenancy model creation on the same model', function (): void {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fixes tenancy registration when registering **configurable resources** (`ResourceConfiguration`) instead of standard class strings on a panel.

Previously, tenancy initialization only processed explicitly registered resource classes via `$this->getResources()`. When a plugin or application registered a resource via a configuration object, the resource was omitted from tenancy boot, preventing its model from observing tenancy creation and applying tenant global scopes.
## Visual changes

None.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
