### PR TITLE
Remove the deprecated `setAccessible()` call in `Macroable::mixin()`

### DIFF
--- a/packages/support/src/Concerns/Macroable.php
+++ b/packages/support/src/Concerns/Macroable.php
@@ -27,8 +27,6 @@ trait Macroable
 
         foreach ($methods as $method) {
             if ($replace || (! isset(static::$macros[$method->name][static::class]))) {
-                $method->setAccessible(true);
-
                 static::macro($method->name, $method->invoke($mixin));
             }
         }

--- a/tests/src/Support/MacroableTest.php
+++ b/tests/src/Support/MacroableTest.php
@@ -26,3 +26,35 @@ test('component is macroable', function (): void {
     expect(Section::hasMacro('someMacro'))
         ->toBeFalse();
 });
+
+it('can use `mixin()` to register macros from public and protected methods', function (): void {
+    expect(Field::hasMacro('publicMixinMacro'))
+        ->toBeFalse()
+        ->and(Field::hasMacro('protectedMixinMacro'))
+        ->toBeFalse();
+
+    Field::mixin(new FieldMixin);
+
+    expect(Field::hasMacro('publicMixinMacro'))
+        ->toBeTrue()
+        ->and(Field::hasMacro('protectedMixinMacro'))
+        ->toBeTrue();
+
+    expect(TextInput::make('name')->publicMixinMacro())
+        ->toBe('Hello')
+        ->and(TextInput::make('name')->protectedMixinMacro())
+        ->toBe('Hi');
+});
+
+class FieldMixin
+{
+    public function publicMixinMacro(): Closure
+    {
+        return fn (): string => 'Hello';
+    }
+
+    protected function protectedMixinMacro(): Closure
+    {
+        return fn (): string => 'Hi';
+    }
+}


### PR DESCRIPTION
## Description

`Macroable::mixin()` calls `ReflectionMethod::setAccessible(true)` before invoking each method of the mixin. That method is [deprecated as of PHP 8.5](https://wiki.php.net/rfc/deprecations_php_8_5), and it has had no effect since PHP 8.1, where reflection started ignoring visibility on its own. On PHP 8.5 the call does nothing except raise:

```
Deprecated: Method ReflectionMethod::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1
```

`$method->invoke($mixin)` still reaches the protected methods of a mixin without it, so the call is simply removed. The `ReflectionMethod` import stays, since it is still used for the `IS_PUBLIC | IS_PROTECTED` filter. `filament/support` requires `^8.2`, so no version guard is needed.

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

Notes on the above:

- Pint, Rector and PHPStan (the project's level 6) are clean on the changed files. No JS/CSS changed, so Prettier is unaffected.
- Added a test to `tests/src/Support/MacroableTest.php` covering `mixin()` with both a public and a protected method — the protected case is what the removed line existed for. `tests/src/Support` passes locally: 708 passed (1062 assertions).
- No documentation changes needed; this is not a user-facing behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

