### PR TITLE
translation: update and complete Swahili (sw) translations

### DIFF
--- a/packages/actions/resources/lang/sw/delete.php
+++ b/packages/actions/resources/lang/sw/delete.php
@@ -3,59 +3,55 @@
 return [
 
     'single' => [
-
         'label' => 'Futa',
 
         'modal' => [
-
             'heading' => 'Futa :label',
 
             'actions' => [
-
                 'delete' => [
                     'label' => 'Futa',
                 ],
-
             ],
-
         ],
 
         'notifications' => [
-
             'deleted' => [
                 'title' => 'Imefutwa',
             ],
-
         ],
-
     ],
 
     'multiple' => [
-
         'label' => 'Futa chaguo',
 
         'modal' => [
-
             'heading' => 'Futa chaguo :label',
 
             'actions' => [
-
                 'delete' => [
                     'label' => 'Futa',
                 ],
-
             ],
-
         ],
 
         'notifications' => [
-
             'deleted' => [
                 'title' => 'Imefutwa',
             ],
 
-        ],
+            'deleted_partial' => [
+                'title' => 'Imefuta :count kati ya :total',
+                'missing_authorization_failure_message' => 'Hauna ruhusa ya kufuta :count.',
+                'missing_processing_failure_message' => ':count haikuweza kufutwa.',
+            ],
 
+            'deleted_none' => [
+                'title' => 'Imeshindwa kufuta',
+                'missing_authorization_failure_message' => 'Hauna ruhusa ya kufuta :count.',
+                'missing_processing_failure_message' => ':count haikuweza kufutwa.',
+            ],
+        ],
     ],
 
 ];

--- a/packages/actions/resources/lang/sw/export.php
+++ b/packages/actions/resources/lang/sw/export.php
@@ -1,0 +1,76 @@
+<?php
+
+return [
+
+    'label' => 'Hamisha :label',
+
+    'modal' => [
+        'heading' => 'Hamisha :label',
+
+        'form' => [
+            'columns' => [
+                'label' => 'Safu wima',
+
+                'actions' => [
+                    'select_all' => [
+                        'label' => 'Chagua vyote',
+                    ],
+
+                    'deselect_all' => [
+                        'label' => 'Ondoa uchaguzi wote',
+                    ],
+                ],
+
+                'form' => [
+                    'is_enabled' => [
+                        'label' => ':column imewashwa',
+                    ],
+
+                    'label' => [
+                        'label' => 'Lebo ya :column',
+                    ],
+                ],
+            ],
+        ],
+
+        'actions' => [
+            'export' => [
+                'label' => 'Hamisha',
+            ],
+        ],
+    ],
+
+    'notifications' => [
+        'completed' => [
+            'title' => 'Kuhamisha Kumekamilika',
+
+            'actions' => [
+                'download_csv' => [
+                    'label' => 'Pakua .csv',
+                ],
+
+                'download_xlsx' => [
+                    'label' => 'Pakua .xlsx',
+                ],
+            ],
+        ],
+
+        'max_rows' => [
+            'title' => 'Kuhamisha ni kubwa mno',
+            'body' => 'Huwezi kuhamisha zaidi ya safu 1 kwa wakati mmoja.|Huwezi kuhamisha zaidi ya safu :count kwa wakati mmoja.',
+        ],
+
+        'no_columns' => [
+            'title' => 'Hakuna safu wima zilizochaguliwa',
+            'body' => 'Tafadhali chagua angalau safu wima moja ya kuhamisha.',
+        ],
+
+        'started' => [
+            'title' => 'Kuhamisha Kumeanza',
+            'body' => 'Kuhamisha kwako kumeanza na safu 1 itashughulikiwa nyuma ya pazia. Utapokea taarifa yenye kiungo cha kupakia inapokamilika.|Kuhamisha kwako kumeanza na safu :count zitashughulikiwa nyuma ya pazia. Utapokea taarifa yenye kiungo cha kupakia inapokamilika.',
+        ],
+    ],
+
+    'file_name' => 'export-:export_id-:model',
+
+];

--- a/packages/actions/resources/lang/sw/force-delete.php
+++ b/packages/actions/resources/lang/sw/force-delete.php
@@ -3,59 +3,55 @@
 return [
 
     'single' => [
-
         'label' => 'Futa kwa lazima',
 
         'modal' => [
-
             'heading' => 'Futa kwa lazima :label',
 
             'actions' => [
-
                 'delete' => [
                     'label' => 'Futa',
                 ],
-
             ],
-
         ],
 
         'notifications' => [
-
             'deleted' => [
                 'title' => 'Imefutwa',
             ],
-
         ],
-
     ],
 
     'multiple' => [
-
         'label' => 'Futa kwa lazima chaguo',
 
         'modal' => [
-
             'heading' => 'Futa kwa lazima chaguo :label',
 
             'actions' => [
-
                 'delete' => [
                     'label' => 'Futa',
                 ],
-
             ],
-
         ],
 
         'notifications' => [
-
             'deleted' => [
                 'title' => 'Imefutwa',
             ],
 
-        ],
+            'deleted_partial' => [
+                'title' => 'Imefuta kabisa :count kati ya :total',
+                'missing_authorization_failure_message' => 'Hauna ruhusa ya kufuta kabisa :count.',
+                'missing_processing_failure_message' => ':count haikuweza kufutwa kabisa.',
+            ],
 
+            'deleted_none' => [
+                'title' => 'Imeshindwa kufuta kabisa',
+                'missing_authorization_failure_message' => 'Hauna ruhusa ya kufuta kabisa :count.',
+                'missing_processing_failure_message' => ':count haikuweza kufutwa kabisa.',
+            ],
+        ],
     ],
 
 ];

--- a/packages/actions/resources/lang/sw/import.php
+++ b/packages/actions/resources/lang/sw/import.php
@@ -1,0 +1,71 @@
+<?php
+
+return [
+
+    'label' => 'Ingiza :label',
+
+    'modal' => [
+        'heading' => 'Ingiza :label',
+
+        'form' => [
+            'file' => [
+                'label' => 'Faili',
+
+                'placeholder' => 'Pakia faili la CSV',
+
+                'rules' => [
+                    'duplicate_columns' => '{0} Faili hairuhusiwi kuwa na zaidi ya kichwa kimoja tupu cha safu wima.|{1,*} Faili hairuhusiwi kuwa na vichwa vinavyojirudia vya safu wima: :columns.',
+                ],
+            ],
+
+            'columns' => [
+                'label' => 'Safu wima',
+                'placeholder' => 'Chagua safu wima',
+            ],
+        ],
+
+        'actions' => [
+            'download_example' => [
+                'label' => 'Pakua faili mfano la CSV',
+            ],
+
+            'import' => [
+                'label' => 'Ingiza',
+            ],
+        ],
+    ],
+
+    'notifications' => [
+        'completed' => [
+            'title' => 'Kuingiza Kumekamilika',
+
+            'actions' => [
+                'download_failed_rows_csv' => [
+                    'label' => 'Pakua maelezo ya mstari ulioshindikana|Pakua maelezo ya mistari iliyoshindikana',
+                ],
+            ],
+        ],
+
+        'max_rows' => [
+            'title' => 'Faili la CSV lililopakiwa ni kubwa mno',
+            'body' => 'Huwezi kuingiza zaidi ya mstari 1 kwa wakati mmoja.|Huwezi kuingiza zaidi ya mistari :count kwa wakati mmoja.',
+        ],
+
+        'started' => [
+            'title' => 'Kuingiza Kumeanza',
+            'body' => 'Kuingiza kwako kumeanza na mstari 1 utashughulikiwa nyuma ya pazia.|Kuingiza kwako kumeanza na mistari :count itashughulikiwa nyuma ya pazia.',
+        ],
+    ],
+
+    'example_csv' => [
+        'file_name' => ':importer-example',
+    ],
+
+    'failure_csv' => [
+        'file_name' => 'import-:import_id-:csv_name-failed-rows',
+        'error_header' => 'hitilafu',
+        'system_error' => 'Hitilafu ya mfumo, tafadhali wasiliana na usaidizi.',
+        'column_mapping_required_for_new_record' => 'Safu wima ya :attribute haijahusishwa na safu wima yoyote katika faili, lakini inahitajika kuunda rekodi mpya.',
+    ],
+
+];

--- a/packages/actions/resources/lang/sw/notifications.php
+++ b/packages/actions/resources/lang/sw/notifications.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+
+    'throttled' => [
+        'title' => 'Majaribio mengi mno',
+        'body' => 'Tafadhali jaribu tena baada ya sekunde :seconds.',
+    ],
+
+];

--- a/packages/actions/resources/lang/sw/restore.php
+++ b/packages/actions/resources/lang/sw/restore.php
@@ -3,59 +3,55 @@
 return [
 
     'single' => [
-
         'label' => 'Rudisha',
 
         'modal' => [
-
             'heading' => 'Rudisha :label',
 
             'actions' => [
-
                 'restore' => [
                     'label' => 'Rudisha',
                 ],
-
             ],
-
         ],
 
         'notifications' => [
-
             'restored' => [
                 'title' => 'Imerudishwa',
             ],
-
         ],
-
     ],
 
     'multiple' => [
-
         'label' => 'Rudisha chaguo',
 
         'modal' => [
-
             'heading' => 'Rudisha chaguo :label',
 
             'actions' => [
-
                 'restore' => [
                     'label' => 'Rudisha',
                 ],
-
             ],
-
         ],
 
         'notifications' => [
-
             'restored' => [
                 'title' => 'Imerudishwa',
             ],
 
-        ],
+            'restored_partial' => [
+                'title' => 'Imerejesha :count kati ya :total',
+                'missing_authorization_failure_message' => 'Hauna ruhusa ya kurejesha :count.',
+                'missing_processing_failure_message' => ':count haikuweza kurejeshwa.',
+            ],
 
+            'restored_none' => [
+                'title' => 'Imeshindwa kurejesha',
+                'missing_authorization_failure_message' => 'Hauna ruhusa ya kurejesha :count.',
+                'missing_processing_failure_message' => ':count haikuweza kurejeshwa.',
+            ],
+        ],
     ],
 
 ];

--- a/packages/forms/resources/lang/sw/components.php
+++ b/packages/forms/resources/lang/sw/components.php
@@ -3,13 +3,344 @@
 return [
 
     'builder' => [
-
         'actions' => [
-
             'clone' => [
                 'label' => 'Iga',
             ],
 
+            'add' => [
+                'label' => 'Ongeza kwenye :label',
+
+                'modal' => [
+                    'heading' => 'Ongeza kwa :label',
+
+                    'actions' => [
+                        'add' => [
+                            'label' => 'Ongeza',
+                        ],
+                    ],
+                ],
+            ],
+
+            'add_between' => [
+                'label' => 'Ingiza',
+
+                'modal' => [
+                    'heading' => 'Ongeza kwa :label',
+
+                    'actions' => [
+                        'add' => [
+                            'label' => 'Ongeza',
+                        ],
+                    ],
+                ],
+            ],
+
+            'delete' => [
+                'label' => 'Futa',
+            ],
+
+            'edit' => [
+                'label' => 'Hariri',
+
+                'modal' => [
+                    'heading' => 'Hariri kipande',
+
+                    'actions' => [
+                        'save' => [
+                            'label' => 'Hifadhi mabadiliko',
+                        ],
+                    ],
+                ],
+            ],
+
+            'reorder' => [
+                'label' => 'Hamisha',
+            ],
+
+            'move_down' => [
+                'label' => 'Sogeza chini',
+            ],
+
+            'move_up' => [
+                'label' => 'Sogeza juu',
+            ],
+
+            'collapse' => [
+                'label' => 'Kunja',
+            ],
+
+            'expand' => [
+                'label' => 'Kunjua',
+            ],
+
+            'collapse_all' => [
+                'label' => 'Kunja zote',
+            ],
+
+            'expand_all' => [
+                'label' => 'Kunjua zote',
+            ],
+        ],
+    ],
+
+    'checkbox_list' => [
+        'actions' => [
+            'deselect_all' => [
+                'label' => 'Ondoa uchaguzi wote',
+            ],
+
+            'select_all' => [
+                'label' => 'Chagua vyote',
+            ],
+        ],
+    ],
+
+    'color_picker' => [
+        'panel_label' => 'Kichagua rangi',
+    ],
+
+    'date_time_picker' => [
+        'month_select' => [
+            'label' => 'Mwezi',
+        ],
+
+        'year_input' => [
+            'label' => 'Mwaka',
+        ],
+
+        'hour_input' => [
+            'label' => 'Saa',
+        ],
+
+        'minute_input' => [
+            'label' => 'Dakika',
+        ],
+
+        'second_input' => [
+            'label' => 'Sekunde',
+        ],
+    ],
+
+    'file_upload' => [
+        'actions' => [
+            'download' => [
+                'label' => 'Pakua',
+            ],
+
+            'open' => [
+                'label' => 'Fungua kwenye kichupo kipya',
+            ],
+        ],
+
+        'editor' => [
+            'label' => 'Kihariri picha',
+
+            'actions' => [
+                'cancel' => [
+                    'label' => 'Ghairi',
+                ],
+
+                'drag_crop' => [
+                    'label' => 'Hali ya kuvuta "kata"',
+                ],
+
+                'drag_move' => [
+                    'label' => 'Hali ya kuvuta "hamisha"',
+                ],
+
+                'flip_horizontal' => [
+                    'label' => 'Geuza picha kwa usawa',
+                ],
+
+                'flip_vertical' => [
+                    'label' => 'Geuza picha kwa wima',
+                ],
+
+                'move_down' => [
+                    'label' => 'Hamisha picha chini',
+                ],
+
+                'move_left' => [
+                    'label' => 'Hamisha picha kushoto',
+                ],
+
+                'move_right' => [
+                    'label' => 'Hamisha picha kulia',
+                ],
+
+                'move_up' => [
+                    'label' => 'Hamisha picha juu',
+                ],
+
+                'reset' => [
+                    'label' => 'Weka upya',
+                ],
+
+                'rotate_left' => [
+                    'label' => 'Zungusha picha kwenda kushoto',
+                ],
+
+                'rotate_right' => [
+                    'label' => 'Zungusha picha kwenda kulia',
+                ],
+
+                'set_aspect_ratio' => [
+                    'label' => 'Weka uwiano wa pande kuwa :ratio',
+                ],
+
+                'save' => [
+                    'label' => 'Hifadhi',
+                ],
+
+                'zoom_100' => [
+                    'label' => 'Weka ukubwa wa picha hadi 100%',
+                ],
+
+                'zoom_in' => [
+                    'label' => 'Kuza ndani',
+                ],
+
+                'zoom_out' => [
+                    'label' => 'Kuza nje',
+                ],
+            ],
+
+            'fields' => [
+                'height' => [
+                    'label' => 'Urefu',
+                    'unit' => 'px',
+                ],
+
+                'rotation' => [
+                    'label' => 'Mzunguko',
+                    'unit' => 'deg',
+                ],
+
+                'width' => [
+                    'label' => 'Upana',
+                    'unit' => 'px',
+                ],
+
+                'x_position' => [
+                    'label' => 'X',
+                    'unit' => 'px',
+                ],
+
+                'y_position' => [
+                    'label' => 'Y',
+                    'unit' => 'px',
+                ],
+            ],
+
+            'aspect_ratios' => [
+                'label' => 'Uwiano wa pande',
+
+                'no_fixed' => [
+                    'label' => 'Huria',
+                ],
+            ],
+
+            'svg' => [
+                'messages' => [
+                    'confirmation' => 'Kuhariri faili za SVG haipendekezwi kwa sababu kunaweza kusababisha upotezaji wa ubora unapozidisha ukubwa.\\n Una uhakika unataka kuendelea?',
+                    'disabled' => 'Kuhariri faili za SVG kumezimwa kwa sababu kunaweza kusababisha upotezaji wa ubora unapozidisha ukubwa.',
+                ],
+            ],
+        ],
+    ],
+
+    'key_value' => [
+        'actions' => [
+            'add' => [
+                'label' => 'Ongeza mstari',
+            ],
+
+            'delete' => [
+                'label' => 'Futa mstari',
+            ],
+
+            'reorder' => [
+                'label' => 'Pangilia mstari',
+            ],
+        ],
+
+        'columns' => [
+            'actions' => [
+                'label' => 'Vitendo',
+            ],
+
+            'reorder' => [
+                'label' => 'Panga upya',
+            ],
+        ],
+
+        'fields' => [
+            'key' => [
+                'label' => 'Ufunguo',
+            ],
+
+            'value' => [
+                'label' => 'Thamani',
+            ],
+        ],
+    ],
+
+    'markdown_editor' => [
+        'file_attachments_accepted_file_types_message' => 'Faili zilizopakiwa lazima ziwe na aina: :values.',
+
+        'file_attachments_max_size_message' => 'Faili zilizopakiwa hazipaswi kuzidi kilobaiti :max.',
+
+        'tools' => [
+            'attach_files' => 'Ambatisha faili',
+            'blockquote' => 'Nukuu',
+            'bold' => 'Nzito',
+            'bullet_list' => 'Orodha ya vitone',
+            'code_block' => 'Kizuizi cha msimbo',
+            'heading' => 'Kichwa',
+            'italic' => 'Italiki',
+            'link' => 'Kiungo',
+            'ordered_list' => 'Orodha yenye nambari',
+            'redo' => 'Rudia',
+            'strike' => 'Piga kupitia',
+            'table' => 'Jedwali',
+            'undo' => 'Tengua',
+        ],
+    ],
+
+    'modal_table_select' => [
+        'actions' => [
+            'select' => [
+                'label' => 'Chagua',
+
+                'actions' => [
+                    'select' => [
+                        'label' => 'Chagua',
+                    ],
+                ],
+            ],
+        ],
+    ],
+
+    'radio' => [
+        'boolean' => [
+            'true' => 'Ndiyo',
+            'false' => 'Hapana',
+        ],
+    ],
+
+    'repeater' => [
+        'columns' => [
+            'actions' => [
+                'label' => 'Vitendo',
+            ],
+
+            'reorder' => [
+                'label' => 'Panga upya',
+            ],
+        ],
+
+        'actions' => [
             'add' => [
                 'label' => 'Ongeza kwenye :label',
             ],
@@ -22,99 +353,6 @@ return [
                 'label' => 'Futa',
             ],
 
-            'reorder' => [
-                'label' => 'Hamisha',
-            ],
-
-            'move_down' => [
-                'label' => 'Sogeza chini',
-            ],
-
-            'move_up' => [
-                'label' => 'Sogeza juu',
-            ],
-
-            'collapse' => [
-                'label' => 'Kunja',
-            ],
-
-            'expand' => [
-                'label' => 'Kunjua',
-            ],
-
-            'collapse_all' => [
-                'label' => 'Kunja zote',
-            ],
-
-            'expand_all' => [
-                'label' => 'Kunjua zote',
-            ],
-
-        ],
-
-    ],
-
-    'key_value' => [
-
-        'actions' => [
-
-            'add' => [
-                'label' => 'Ongeza safu',
-            ],
-
-            'delete' => [
-                'label' => 'Futa safu',
-            ],
-
-            'reorder' => [
-                'label' => 'Pangilia safu',
-            ],
-
-        ],
-
-        'fields' => [
-
-            'key' => [
-                'label' => 'Ufunguo',
-            ],
-
-            'value' => [
-                'label' => 'Thamani',
-            ],
-
-        ],
-
-    ],
-
-    'markdown_editor' => [
-
-        'tools' => [
-            'attach_files' => 'Ambatisha faili',
-            'bold' => 'Nzito',
-            'bullet_list' => 'Orodha ya vitone',
-            'code_block' => 'Kizuizi cha msimbo',
-            'edit' => 'Hariri',
-            'italic' => 'Italiki',
-            'link' => 'Kiungo',
-            'ordered_list' => 'Orodha yenye nambari',
-            'preview' => 'Onyesha awali',
-            'strike' => 'Piga kupitia',
-        ],
-
-    ],
-
-    'repeater' => [
-
-        'actions' => [
-
-            'add' => [
-                'label' => 'Ongeza kwenye :label',
-            ],
-
-            'delete' => [
-                'label' => 'Futa',
-            ],
-
             'clone' => [
                 'label' => 'Iga',
             ],
@@ -146,75 +384,280 @@ return [
             'expand_all' => [
                 'label' => 'Kunjua zote',
             ],
-
         ],
-
     ],
 
     'rich_editor' => [
+        'actions' => [
+            'attach_files' => [
+                'label' => 'Pakia faili',
 
-        'dialogs' => [
+                'modal' => [
+                    'heading' => 'Pakia faili',
 
-            'link' => [
+                    'form' => [
+                        'file' => [
+                            'label' => [
+                                'new' => 'Faili',
+                                'existing' => 'Badilisha faili',
+                            ],
+                        ],
 
-                'actions' => [
-                    'link' => 'Unganisha',
-                    'unlink' => 'Tenganisha',
+                        'alt' => [
+                            'label' => [
+                                'new' => 'Maandishi mbadala',
+                                'existing' => 'Badilisha maandishi mbadala',
+                            ],
+                        ],
+                    ],
                 ],
-
-                'label' => 'URL',
-
-                'placeholder' => 'Ingiza URL',
-
             ],
 
+            'custom_block' => [
+                'modal' => [
+                    'actions' => [
+                        'insert' => [
+                            'label' => 'Weka',
+                        ],
+
+                        'save' => [
+                            'label' => 'Hifadhi',
+                        ],
+                    ],
+                ],
+            ],
+
+            'grid' => [
+                'label' => 'Gridi',
+
+                'modal' => [
+                    'heading' => 'Gridi',
+
+                    'form' => [
+                        'preset' => [
+                            'label' => 'Mpangilio',
+
+                            'placeholder' => 'Hakuna',
+
+                            'options' => [
+                                'two' => 'Mbili',
+                                'three' => 'Tatu',
+                                'four' => 'Nne',
+                                'five' => 'Tano',
+                                'two_start_third' => 'Two (Start Third)',
+                                'two_end_third' => 'Two (End Third)',
+                                'two_start_fourth' => 'Two (Start Fourth)',
+                                'two_end_fourth' => 'Two (End Fourth)',
+                            ],
+                        ],
+
+                        'columns' => [
+                            'label' => 'Safu wima',
+                        ],
+
+                        'from_breakpoint' => [
+                            'label' => 'Kutoka kwenye breakpoint',
+
+                            'options' => [
+                                'default' => 'Zote',
+                                'sm' => 'Ndogo',
+                                'md' => 'Wastani',
+                                'lg' => 'Kubwa',
+                                'xl' => 'Kubwa zaidi',
+                                '2xl' => 'Kubwa mno',
+                            ],
+                        ],
+
+                        'is_asymmetric' => [
+                            'label' => 'Safu wima mbili zisizo sawa',
+                        ],
+
+                        'start_span' => [
+                            'label' => 'Upana wa mwanzo',
+                        ],
+
+                        'end_span' => [
+                            'label' => 'Upana wa mwisho',
+                        ],
+                    ],
+                ],
+            ],
+
+            'link' => [
+                'label' => 'Kiungo',
+
+                'modal' => [
+                    'heading' => 'Kiungo',
+
+                    'form' => [
+                        'url' => [
+                            'label' => 'URL',
+                        ],
+
+                        'should_open_in_new_tab' => [
+                            'label' => 'Fungua kwenye kichupo kipya',
+                        ],
+                    ],
+                ],
+            ],
+
+            'text_color' => [
+                'label' => 'Rangi ya maandishi',
+
+                'modal' => [
+                    'heading' => 'Rangi ya maandishi',
+
+                    'form' => [
+                        'color' => [
+                            'label' => 'Rangi',
+
+                            'options' => [
+                                'slate' => 'Slate',
+                                'gray' => 'Kijivu',
+                                'zinc' => 'Zinc',
+                                'neutral' => 'Neutral',
+                                'stone' => 'Stone',
+                                'mauve' => 'Mauve',
+                                'olive' => 'Olive',
+                                'mist' => 'Mist',
+                                'taupe' => 'Taupe',
+                                'red' => 'Nyekundu',
+                                'orange' => 'Machungwa',
+                                'amber' => 'Amber',
+                                'yellow' => 'Njano',
+                                'lime' => 'Lime',
+                                'green' => 'Kijani',
+                                'emerald' => 'Emerald',
+                                'teal' => 'Teal',
+                                'cyan' => 'Cyan',
+                                'sky' => 'Sky',
+                                'blue' => 'Bluu',
+                                'indigo' => 'Indigo',
+                                'violet' => 'Violet',
+                                'purple' => 'Zambarau',
+                                'fuchsia' => 'Fuchsia',
+                                'pink' => 'Pinki',
+                                'rose' => 'Rose',
+                            ],
+                        ],
+
+                        'custom_color' => [
+                            'label' => 'Rangi maalum',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+
+        'file_attachments_accepted_file_types_message' => 'Faili zilizopakiwa lazima ziwe na aina: :values.',
+
+        'file_attachments_max_size_message' => 'Faili zilizopakiwa hazipaswi kuzidi kilobaiti :max.',
+
+        'no_merge_tag_search_results_message' => 'Hakuna matokeo ya lebo za kuunganisha.',
+
+        'mentions' => [
+            'no_options_message' => 'Hakuna chaguo zilizopo.',
+            'no_search_results_message' => 'Hakuna matokeo yanayolingana na utafutaji wako.',
+            'search_prompt' => 'Anza kuandika ili kutafuta...',
+            'searching_message' => 'Inatafuta...',
+        ],
+
+        'toolbar' => [
+            'label' => 'Upau wa vifaa vya kihariri',
         ],
 
         'tools' => [
+            'align_center' => 'Panga katikati',
+            'align_end' => 'Panga mwisho',
+            'align_justify' => 'Panga sawazisha',
+            'align_start' => 'Panga mwanzo',
             'attach_files' => 'Ambatisha faili',
             'blockquote' => 'Nukuu ya kuzuia',
             'bold' => 'Nzito',
             'bullet_list' => 'Orodha ya vitone',
+            'clear_formatting' => 'Ondoa uumbizaji',
+            'code' => 'Msimbo',
             'code_block' => 'Kizuizi cha msimbo',
-            'h1' => 'Kichwa',
-            'h2' => 'Kichwa',
-            'h3' => 'Kichwa kidogo',
+            'custom_blocks' => 'Vipande',
+            'details' => 'Maelezo',
+            'h1' => 'Kichwa kikuu',
+            'h2' => 'Kichwa 2',
+            'h3' => 'Kichwa 3',
+            'h4' => 'Kichwa 4',
+            'h5' => 'Kichwa 5',
+            'h6' => 'Kichwa 6',
+            'grid' => 'Gridi',
+            'grid_delete' => 'Futa gridi',
+            'highlight' => 'Angaza',
+            'horizontal_rule' => 'Mstari wa mlalo',
             'italic' => 'Italiki',
-            'link' => 'Link',
+            'lead' => 'Maandishi ya utangulizi',
+            'link' => 'Kiungo',
+            'merge_tags' => 'Lebo za kuunganisha',
             'ordered_list' => 'Orodha yenye nambari',
+            'paragraph' => 'Aya',
             'redo' => 'Rudia',
+            'small' => 'Maandishi madogo',
             'strike' => 'Piga kupitia',
-            'undo' => 'Tendua',
+            'subscript' => 'Maandishi ya chini',
+            'superscript' => 'Maandishi ya juu',
+            'table' => 'Jedwali',
+            'table_delete' => 'Futa jedwali',
+            'table_add_column_before' => 'Ongeza safu wima kabla',
+            'table_add_column_after' => 'Ongeza safu wima baada',
+            'table_delete_column' => 'Futa safu wima',
+            'table_add_row_before' => 'Ongeza mstari juu',
+            'table_add_row_after' => 'Ongeza mstari chini',
+            'table_delete_row' => 'Futa mstari',
+            'table_merge_cells' => 'Unganisha seli',
+            'table_split_cell' => 'Gawanya seli',
+            'table_toggle_header_row' => 'Badili mstari wa vichwa',
+            'table_toggle_header_cell' => 'Badili seli ya kichwa',
+            'text_color' => 'Rangi ya maandishi',
+            'underline' => 'Piga mstari',
+            'undo' => 'Tengua',
         ],
 
+        'uploading_file_message' => 'Inapakia faili...',
     ],
 
     'select' => [
-
         'actions' => [
-
             'create_option' => [
+                'label' => 'Unda',
 
                 'modal' => [
-
                     'heading' => 'Tengeneza',
 
                     'actions' => [
-
                         'create' => [
                             'label' => 'Tengeneza',
                         ],
 
+                        'create_another' => [
+                            'label' => 'Unda & unda nyingine',
+                        ],
                     ],
-
                 ],
-
             ],
 
+            'edit_option' => [
+                'label' => 'Hariri',
+
+                'modal' => [
+                    'heading' => 'Hariri',
+
+                    'actions' => [
+                        'save' => [
+                            'label' => 'Hifadhi',
+                        ],
+                    ],
+                ],
+            ],
         ],
 
         'boolean' => [
-            'true' => 'Ndio',
+            'true' => 'Ndiyo',
             'false' => 'Hapana',
         ],
 
@@ -222,18 +665,53 @@ return [
 
         'max_items_message' => 'Ni :count pekee ndiyo inaweza kuchaguliwa.',
 
+        'no_options_message' => 'Hakuna chaguo zilizopo.',
+
         'no_search_results_message' => 'Hakuna chaguzi zinazolingana na utafutaji wako.',
 
         'placeholder' => 'Chagua chaguo',
 
         'searching_message' => 'Inatafuta...',
 
-        'search_prompt' => 'Anza kuandika ili kufafuta...',
-
+        'search_prompt' => 'Anza kuandika ili kutafuta...',
     ],
 
     'tags_input' => [
+        'actions' => [
+            'delete' => [
+                'label' => 'Futa',
+            ],
+        ],
+
         'placeholder' => 'Lebo mpya',
+
+        'tag_added' => 'Imeongezwa: :tag',
+
+        'tag_removed' => 'Imeondolewa: :tag',
+    ],
+
+    'text_input' => [
+        'actions' => [
+            'copy' => [
+                'label' => 'Nakili',
+                'message' => 'Imenakiliwa',
+            ],
+
+            'hide_password' => [
+                'label' => 'Ficha nenosiri',
+            ],
+
+            'show_password' => [
+                'label' => 'Onyesha nenosiri',
+            ],
+        ],
+    ],
+
+    'toggle_buttons' => [
+        'boolean' => [
+            'true' => 'Ndiyo',
+            'false' => 'Hapana',
+        ],
     ],
 
 ];

--- a/packages/forms/resources/lang/sw/validation.php
+++ b/packages/forms/resources/lang/sw/validation.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+
+    'distinct' => [
+        'must_be_selected' => 'Angalau sehemu moja ya :attribute lazima ichaguliwe.',
+        'only_one_must_be_selected' => 'Sehemu moja tu ya :attribute lazima ichaguliwe.',
+    ],
+
+    'tampered_file_path' => 'Sehemu ya :attribute ina njia ya faili isiyo ruhusiwa.',
+
+];

--- a/packages/infolists/resources/lang/sw/components.php
+++ b/packages/infolists/resources/lang/sw/components.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+
+    'entries' => [
+        'text' => [
+            'actions' => [
+                'collapse_list' => 'Ficha :count',
+                'expand_list' => 'Onyesha :count zaidi',
+            ],
+
+            'more_list_items' => 'na :count zaidi',
+        ],
+
+        'icon' => [
+            'true' => 'Ndiyo',
+            'false' => 'Hapana',
+        ],
+
+        'key_value' => [
+            'columns' => [
+                'key' => [
+                    'label' => 'Ufunguo',
+                ],
+
+                'value' => [
+                    'label' => 'Thamani',
+                ],
+            ],
+
+            'placeholder' => 'Hakuna vipengele',
+        ],
+    ],
+
+];

--- a/packages/notifications/resources/lang/sw/database.php
+++ b/packages/notifications/resources/lang/sw/database.php
@@ -3,11 +3,11 @@
 return [
 
     'modal' => [
-
         'heading' => 'Arifa',
 
-        'actions' => [
+        'unread_label' => 'Taarifa ambayo haijasomwa',
 
+        'actions' => [
             'clear' => [
                 'label' => 'Safisha',
             ],
@@ -15,14 +15,12 @@ return [
             'mark_all_as_read' => [
                 'label' => 'Weka alama zote kama zimesomwa',
             ],
-
         ],
 
         'empty' => [
             'heading' => 'Hakuna arifa hapa',
-            'description' => 'Tafadhali angalia tena baadae',
+            'description' => 'Tafadhali angalia tena baadaye',
         ],
-
     ],
 
 ];

--- a/packages/notifications/resources/lang/sw/notification.php
+++ b/packages/notifications/resources/lang/sw/notification.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+
+    'actions' => [
+        'close' => [
+            'label' => 'Funga taarifa',
+        ],
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/auth/http/controllers/block-email-change-verification-controller.php
+++ b/packages/panels/resources/lang/sw/auth/http/controllers/block-email-change-verification-controller.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+
+    'notifications' => [
+        'blocked' => [
+            'title' => 'Ubadilishaji wa barua pepe umefungiwa',
+            'body' => 'Umefanikiwa kuzuia jaribio la kubadilisha barua pepe kuwa :email. Ikiwa wewe si uliyeomba mabadiliko haya, tafadhali wasiliana nasi mara moja.',
+        ],
+
+        'failed' => [
+            'title' => 'Imeshindwa kuzuia ubadilishaji wa barua pepe',
+            'body' => 'Kwa bahati mbaya, huwezi kuzuia barua pepe kubadilishwa kuwa :email kwa sababu ilikuwa imeshathibitishwa kabla ya kuyazuia. Ikiwa wewe si uliyeomba mabadiliko haya, tafadhali wasiliana nasi mara moja.',
+        ],
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/auth/http/controllers/email-change-verification-controller.php
+++ b/packages/panels/resources/lang/sw/auth/http/controllers/email-change-verification-controller.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+
+    'notifications' => [
+        'unavailable' => [
+            'title' => 'Barua pepe hiyo haipo tena.',
+            'body' => 'Ilitumika na akaunti nyingine wakati kiungo chako cha uthibitishaji bado hakijatumika.',
+        ],
+
+        'verified' => [
+            'title' => 'Barua pepe imebadilishwa',
+            'body' => 'Barua pepe yako imebadilishwa kwa mafanikio kuwa :email.',
+        ],
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/auth/multi-factor/app/actions/disable.php
+++ b/packages/panels/resources/lang/sw/auth/multi-factor/app/actions/disable.php
@@ -1,0 +1,55 @@
+<?php
+
+return [
+
+    'label' => 'Zima',
+
+    'modal' => [
+        'heading' => 'Zima programu ya uthibitishaji',
+
+        'description' => 'Una uhakika unataka kuacha kutumia programu ya uthibitishaji? Kuzima hii kutatondoa tabaka zaidi la usalama kwenye akaunti yako.',
+
+        'form' => [
+            'code' => [
+                'label' => 'Weka msimbo wa tarakimu 6 kutoka programu ya uthibitishaji',
+
+                'validation_attribute' => 'msimbo',
+
+                'actions' => [
+                    'use_recovery_code' => [
+                        'label' => 'Tumia kificho cha urejesho badala yake',
+                    ],
+                ],
+
+                'messages' => [
+                    'invalid' => 'Msimbo uliouweka ni batili.',
+                    'rate_limited' => 'Majaribio mengi mno. Tafadhali jaribu tena baadaye.',
+                ],
+            ],
+
+            'recovery_code' => [
+                'label' => 'Au, weka kificho cha urejesho',
+
+                'validation_attribute' => 'kificho cha urejesho',
+
+                'messages' => [
+                    'invalid' => 'Kificho cha urejesho ulichouweka ni batili.',
+                    'rate_limited' => 'Majaribio mengi mno. Tafadhali jaribu tena baadaye.',
+                ],
+            ],
+        ],
+
+        'actions' => [
+            'submit' => [
+                'label' => 'Zima programu ya uthibitishaji',
+            ],
+        ],
+    ],
+
+    'notifications' => [
+        'disabled' => [
+            'title' => 'Programu ya uthibitishaji imezimwa',
+        ],
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/auth/multi-factor/app/actions/regenerate-recovery-codes.php
+++ b/packages/panels/resources/lang/sw/auth/multi-factor/app/actions/regenerate-recovery-codes.php
@@ -1,0 +1,57 @@
+<?php
+
+return [
+
+    'label' => 'Tengeneza upya vificho vya urejesho',
+
+    'modal' => [
+        'heading' => 'Tengeneza upya vificho vya urejesho vya programu ya uthibitishaji',
+
+        'description' => 'Ukipoteza vificho vyako vya urejesho, unaweza kuvitengeneza upya hapa. Vificho vyako vya zamani vita batilishwa mara moja.',
+
+        'form' => [
+            'code' => [
+                'label' => 'Weka msimbo wa tarakimu 6 kutoka programu ya uthibitishaji',
+
+                'validation_attribute' => 'msimbo',
+
+                'messages' => [
+                    'invalid' => 'Msimbo uliouweka ni batili.',
+                    'rate_limited' => 'Majaribio mengi mno. Tafadhali jaribu tena baadaye.',
+                ],
+            ],
+
+            'password' => [
+                'label' => 'Au, weka nenosiri lako la sasa',
+                'validation_attribute' => 'nenosiri',
+            ],
+        ],
+
+        'actions' => [
+            'submit' => [
+                'label' => 'Tengeneza upya vificho vya urejesho',
+            ],
+        ],
+    ],
+
+    'notifications' => [
+        'regenerated' => [
+            'title' => 'Vificho vipya vya urejesho vya programu ya uthibitishaji vimetengenezwa',
+        ],
+    ],
+
+    'show_new_recovery_codes' => [
+        'modal' => [
+            'heading' => 'Vificho vipya vya urejesho',
+
+            'description' => 'Tafadhali hifadhi vificho vifavyo vya urejesho mahali salama. Vitaonyeshwa mara moja tu, lakini utahitaji ukipoteza ufikiaji wa programu yako ya uthibitishaji:',
+
+            'actions' => [
+                'submit' => [
+                    'label' => 'Funga',
+                ],
+            ],
+        ],
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/auth/multi-factor/app/actions/set-up.php
+++ b/packages/panels/resources/lang/sw/auth/multi-factor/app/actions/set-up.php
@@ -1,0 +1,59 @@
+<?php
+
+return [
+
+    'label' => 'Weka',
+
+    'modal' => [
+        'heading' => 'Weka programu ya uthibitishaji',
+
+        'description' => 'Utahitaji programu kama Google Authenticator (<x-filament::link href="https://itunes.apple.com/us/app/google-authenticator/id388497605" target="_blank">iOS</x-filament::link>, <x-filament::link href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2" target="_blank">Android</x-filament::link>) kukamilisha utaratibu huu.',
+
+        'content' => [
+            'qr_code' => [
+                'instruction' => 'Changanua msimbo huu wa QR kwa kutumia programu yako ya uthibitishaji:',
+                'alt' => 'Msimbo wa QR wa kuchanganuliwa kwa programu ya uthibitishaji',
+            ],
+
+            'text_code' => [
+                'instruction' => 'Au weka msimbo huu kwa mkono:',
+
+                'messages' => [
+                    'copied' => 'Imenakiliwa',
+                ],
+            ],
+
+            'recovery_codes' => [
+                'instruction' => 'Tafadhali hifadhi vificho vifavyo vya urejesho mahali salama. Vitaonyeshwa mara moja tu, lakini utahitaji ukipoteza ufikiaji wa programu yako ya uthibitishaji:',
+            ],
+        ],
+
+        'form' => [
+            'code' => [
+                'label' => 'Weka msimbo wa tarakimu 6 kutoka programu ya uthibitishaji',
+
+                'validation_attribute' => 'msimbo',
+
+                'below_content' => 'Utahitaji kuweka msimbo wa tarakimu 6 kutoka programu yako ya uthibitishaji kila unapoingia au kufanya vitendo nyeti.',
+
+                'messages' => [
+                    'invalid' => 'Msimbo uliouweka ni batili.',
+                    'rate_limited' => 'Majaribio mengi mno. Tafadhali jaribu tena baadaye.',
+                ],
+            ],
+        ],
+
+        'actions' => [
+            'submit' => [
+                'label' => 'Washa programu ya uthibitishaji',
+            ],
+        ],
+    ],
+
+    'notifications' => [
+        'enabled' => [
+            'title' => 'Programu ya uthibitishaji imewashwa',
+        ],
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/auth/multi-factor/app/provider.php
+++ b/packages/panels/resources/lang/sw/auth/multi-factor/app/provider.php
@@ -1,0 +1,48 @@
+<?php
+
+return [
+
+    'management_schema' => [
+        'actions' => [
+            'label' => 'Programu ya uthibitishaji',
+
+            'below_content' => 'Tumia programu salama kutengeneza msimbo wa muda wa kuthibitisha kuingia.',
+
+            'messages' => [
+                'enabled' => 'Imewashwa',
+                'disabled' => 'Imezimwa',
+            ],
+        ],
+    ],
+
+    'login_form' => [
+        'label' => 'Tumia msimbo kutoka programu yako ya uthibitishaji',
+
+        'code' => [
+            'label' => 'Weka msimbo wa tarakimu 6 kutoka programu ya uthibitishaji',
+
+            'validation_attribute' => 'msimbo',
+
+            'actions' => [
+                'use_recovery_code' => [
+                    'label' => 'Tumia kificho cha urejesho badala yake',
+                ],
+            ],
+
+            'messages' => [
+                'invalid' => 'Msimbo uliouweka ni batili.',
+            ],
+        ],
+
+        'recovery_code' => [
+            'label' => 'Au, weka kificho cha urejesho',
+
+            'validation_attribute' => 'kificho cha urejesho',
+
+            'messages' => [
+                'invalid' => 'Kificho cha urejesho ulichouweka ni batili.',
+            ],
+        ],
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/auth/multi-factor/email/actions/disable.php
+++ b/packages/panels/resources/lang/sw/auth/multi-factor/email/actions/disable.php
@@ -1,0 +1,54 @@
+<?php
+
+return [
+
+    'label' => 'Zima',
+
+    'modal' => [
+        'heading' => 'Zima misimbo ya uthibitishaji wa barua pepe',
+
+        'description' => 'Una uhakika unataka kuacha kupokea misimbo ya uthibitishaji wa barua pepe? Kuzima hii kutatondoa tabaka zaidi la usalama kwenye akaunti yako.',
+
+        'form' => [
+            'code' => [
+                'label' => 'Weka msimbo wa tarakimu 6 tulioikutumia kwa barua pepe',
+
+                'validation_attribute' => 'msimbo',
+
+                'actions' => [
+                    'resend' => [
+                        'label' => 'Tuma msimbo mpya kwa barua pepe',
+
+                        'notifications' => [
+                            'resent' => [
+                                'title' => 'Tumekutumia msimbo mpya kwa barua pepe',
+                            ],
+
+                            'throttled' => [
+                                'title' => 'Majaribio mengi mno ya kutuma tena. Tafadhali subiri kabla ya kuomba msimbo mwingine.',
+                            ],
+                        ],
+                    ],
+                ],
+
+                'messages' => [
+                    'invalid' => 'Msimbo uliouweka ni batili.',
+                    'rate_limited' => 'Majaribio mengi mno. Tafadhali jaribu tena baadaye.',
+                ],
+            ],
+        ],
+
+        'actions' => [
+            'submit' => [
+                'label' => 'Zima misimbo ya uthibitishaji wa barua pepe',
+            ],
+        ],
+    ],
+
+    'notifications' => [
+        'disabled' => [
+            'title' => 'Misimbo ya uthibitishaji wa barua pepe imezimwa',
+        ],
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/auth/multi-factor/email/actions/set-up.php
+++ b/packages/panels/resources/lang/sw/auth/multi-factor/email/actions/set-up.php
@@ -1,0 +1,54 @@
+<?php
+
+return [
+
+    'label' => 'Weka',
+
+    'modal' => [
+        'heading' => 'Weka misimbo ya uthibitishaji wa barua pepe',
+
+        'description' => 'Utahitaji kuweka msimbo wenye tarakimu 6 tunaoikutumia kwa barua pepe kila unapoingia au kufanya vitendo nyeti. Angalia barua pepe yako kupata msimbo wa tarakimu 6 ili kukamilisha usanidi.',
+
+        'form' => [
+            'code' => [
+                'label' => 'Weka msimbo wa tarakimu 6 tulioikutumia kwa barua pepe',
+
+                'validation_attribute' => 'msimbo',
+
+                'actions' => [
+                    'resend' => [
+                        'label' => 'Tuma msimbo mpya kwa barua pepe',
+
+                        'notifications' => [
+                            'resent' => [
+                                'title' => 'Tumekutumia msimbo mpya kwa barua pepe',
+                            ],
+
+                            'throttled' => [
+                                'title' => 'Majaribio mengi mno ya kutuma tena. Tafadhali subiri kabla ya kuomba msimbo mwingine.',
+                            ],
+                        ],
+                    ],
+                ],
+
+                'messages' => [
+                    'invalid' => 'Msimbo uliouweka ni batili.',
+                    'rate_limited' => 'Majaribio mengi mno. Tafadhali jaribu tena baadaye.',
+                ],
+            ],
+        ],
+
+        'actions' => [
+            'submit' => [
+                'label' => 'Washa misimbo ya uthibitishaji wa barua pepe',
+            ],
+        ],
+    ],
+
+    'notifications' => [
+        'enabled' => [
+            'title' => 'Misimbo ya uthibitishaji wa barua pepe imewashwa',
+        ],
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/auth/multi-factor/email/notifications/verify-email-authentication.php
+++ b/packages/panels/resources/lang/sw/auth/multi-factor/email/notifications/verify-email-authentication.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+
+    'subject' => 'Hiki ni msimbo wako wa kuingia',
+
+    'lines' => [
+        0 => 'Msimbo wako wa kuingia ni: :code',
+        1 => 'Msimbo huu utamalizika baada ya dakika moja.|Msimbo huu utamalizika baada ya dakika :minutes.',
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/auth/multi-factor/email/provider.php
+++ b/packages/panels/resources/lang/sw/auth/multi-factor/email/provider.php
@@ -1,0 +1,48 @@
+<?php
+
+return [
+
+    'management_schema' => [
+        'actions' => [
+            'label' => 'Misimbo ya uthibitishaji wa barua pepe',
+
+            'below_content' => 'Pokea msimbo wa muda kwenye barua pepe yako ili kuthibitisha utambulisho wako wakati wa kuingia.',
+
+            'messages' => [
+                'enabled' => 'Imewashwa',
+                'disabled' => 'Imezimwa',
+            ],
+        ],
+    ],
+
+    'login_form' => [
+        'label' => 'Tuma msimbo kwenye barua pepe yako',
+
+        'code' => [
+            'label' => 'Weka msimbo wa tarakimu 6 tulioikutumia kwa barua pepe',
+
+            'validation_attribute' => 'msimbo',
+
+            'actions' => [
+                'resend' => [
+                    'label' => 'Tuma msimbo mpya kwa barua pepe',
+
+                    'notifications' => [
+                        'resent' => [
+                            'title' => 'Tumekutumia msimbo mpya kwa barua pepe',
+                        ],
+
+                        'throttled' => [
+                            'title' => 'Majaribio mengi mno ya kutuma tena. Tafadhali subiri kabla ya kuomba msimbo mwingine.',
+                        ],
+                    ],
+                ],
+            ],
+
+            'messages' => [
+                'invalid' => 'Msimbo uliouweka ni batili.',
+            ],
+        ],
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/auth/multi-factor/pages/set-up-required-multi-factor-authentication.php
+++ b/packages/panels/resources/lang/sw/auth/multi-factor/pages/set-up-required-multi-factor-authentication.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+
+    'title' => 'Weka uthibitishaji wa hatua mbili (2FA)',
+
+    'heading' => 'Weka uthibitishaji wa hatua mbili',
+
+    'subheading' => '2FA huongeza tabaka zaidi la usalama kwenye akaunti yako kwa kuhitaji uthibitishaji wa pili unapoingia.',
+
+    'actions' => [
+        'continue' => [
+            'label' => 'Endelea',
+        ],
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/auth/multi-factor/recovery-codes-modal-content.php
+++ b/packages/panels/resources/lang/sw/auth/multi-factor/recovery-codes-modal-content.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+
+    'actions' => [
+        0 => 'Bofya ili',
+
+        'copy' => [
+            'label' => 'kunakili',
+        ],
+
+        1 => 'au',
+
+        'download' => [
+            'label' => 'kupakua',
+        ],
+
+        2 => 'vificho vyote kwa pamoja.',
+    ],
+
+    'messages' => [
+        'copied' => 'Imenakiliwa',
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/auth/notifications/notice-of-email-change-request.php
+++ b/packages/panels/resources/lang/sw/auth/notifications/notice-of-email-change-request.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+
+    'subject' => 'Barua pepe yako inabadilishwa',
+
+    'lines' => [
+        0 => 'Tumepokea ombi la kubadilisha barua pepe inayohusiana na akaunti yako. Nenosiri lako lilitumika kuthibitisha mabadiliko haya.',
+        1 => 'Ikithibitishwa, barua pepe mpya kwenye akaunti yako itakuwa: :email.',
+        2 => 'Unaweza kuzuia mabadiliko kabla ya kuthibitishwa kwa kubofya kitufe hapo chini.',
+        3 => 'Ikiwa wewe si uliomba ombi hili, tafadhali wasiliana nasi mara moja.',
+    ],
+
+    'action' => 'Zuia Ubadilishaji wa Barua pepe',
+
+];

--- a/packages/panels/resources/lang/sw/auth/pages/edit-profile.php
+++ b/packages/panels/resources/lang/sw/auth/pages/edit-profile.php
@@ -1,0 +1,65 @@
+<?php
+
+return [
+
+    'label' => 'Wasifu',
+
+    'form' => [
+        'email' => [
+            'label' => 'Barua pepe',
+        ],
+
+        'name' => [
+            'label' => 'Jina',
+        ],
+
+        'password' => [
+            'label' => 'Nenosiri jipya',
+            'validation_attribute' => 'nenosiri',
+        ],
+
+        'password_confirmation' => [
+            'label' => 'Thibitisha nenosiri jipya',
+            'validation_attribute' => 'uthibitisho wa nenosiri',
+        ],
+
+        'current_password' => [
+            'label' => 'Nenosiri la sasa',
+            'below_content' => 'Kwa usalama, tafadhali thibitisha nenosiri lako ili kuendelea.',
+            'validation_attribute' => 'nenosiri la sasa',
+        ],
+
+        'actions' => [
+            'save' => [
+                'label' => 'Hifadhi mabadiliko',
+            ],
+        ],
+    ],
+
+    'multi_factor_authentication' => [
+        'label' => 'Uthibitishaji wa hatua mbili (2FA)',
+    ],
+
+    'notifications' => [
+        'email_change_verification_sent' => [
+            'title' => 'Ombi la kubadilisha barua pepe limetumwa',
+            'body' => 'Ombi la kubadilisha barua pepe yako limetumwa kwenda :email. Tafadhali angalia barua pepe yako ili kuthibitisha mabadiliko.',
+        ],
+
+        'saved' => [
+            'title' => 'Imehifadhiwa',
+        ],
+
+        'throttled' => [
+            'title' => 'Maombi mengi mno. Tafadhali jaribu tena baada ya sekunde :seconds.',
+            'body' => 'Tafadhali jaribu tena baada ya sekunde :seconds.',
+        ],
+    ],
+
+    'actions' => [
+        'cancel' => [
+            'label' => 'Ghairi',
+        ],
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/auth/pages/email-verification/email-verification-prompt.php
+++ b/packages/panels/resources/lang/sw/auth/pages/email-verification/email-verification-prompt.php
@@ -1,0 +1,31 @@
+<?php
+
+return [
+
+    'title' => 'Thibitisha barua pepe yako',
+
+    'heading' => 'Thibitisha barua pepe yako',
+
+    'actions' => [
+        'resend_notification' => [
+            'label' => 'Tuma tena',
+        ],
+    ],
+
+    'messages' => [
+        'notification_not_received' => 'Hujapokea barua pepe tuliyotuma?',
+        'notification_sent' => 'Tumetuma barua pepe kwenda :email yenye maelekezo ya jinsi ya kuthibitisha barua pepe yako.',
+    ],
+
+    'notifications' => [
+        'notification_resent' => [
+            'title' => 'Tumetuma barua pepe tena.',
+        ],
+
+        'notification_resend_throttled' => [
+            'title' => 'Majaribio mengi mno ya kutuma tena',
+            'body' => 'Tafadhali jaribu tena baada ya sekunde :seconds.',
+        ],
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/auth/pages/login.php
+++ b/packages/panels/resources/lang/sw/auth/pages/login.php
@@ -6,8 +6,18 @@ return [
 
     'heading' => 'Ingia kwenye akaunti yako',
 
-    'form' => [
+    'actions' => [
+        'register' => [
+            'before' => 'au',
+            'label' => 'jisajili akaunti',
+        ],
 
+        'request_password_reset' => [
+            'label' => 'Umesahau nenosiri?',
+        ],
+    ],
+
+    'form' => [
         'email' => [
             'label' => 'Barua pepe',
         ],
@@ -21,27 +31,39 @@ return [
         ],
 
         'actions' => [
-
             'authenticate' => [
                 'label' => 'Ingia',
             ],
-
         ],
+    ],
 
+    'multi_factor' => [
+        'heading' => 'Thibitisha utambulisho wako',
+
+        'subheading' => 'Ili kuendelea kuingia, unahitaji kuthibitisha utambulisho wako.',
+
+        'form' => [
+            'provider' => [
+                'label' => 'Ungependa kuthibitisha kwa njia gani?',
+            ],
+
+            'actions' => [
+                'authenticate' => [
+                    'label' => 'Thibitisha kuingia',
+                ],
+            ],
+        ],
     ],
 
     'messages' => [
-
         'failed' => 'Hati hizi hazilingani na rekodi zetu.',
-
     ],
 
     'notifications' => [
-
         'throttled' => [
             'title' => 'Majaribio mengi sana ya kuingia. Tafadhali jaribu tena ndani ya sekunde :seconds.',
+            'body' => 'Tafadhali jaribu tena baada ya sekunde :seconds.',
         ],
-
     ],
 
 ];

--- a/packages/panels/resources/lang/sw/auth/pages/password-reset/request-password-reset.php
+++ b/packages/panels/resources/lang/sw/auth/pages/password-reset/request-password-reset.php
@@ -1,0 +1,38 @@
+<?php
+
+return [
+
+    'title' => 'Weka upya nenosiri lako',
+
+    'heading' => 'Umesahau nenosiri?',
+
+    'actions' => [
+        'login' => [
+            'label' => 'rudi kuingia',
+        ],
+    ],
+
+    'form' => [
+        'email' => [
+            'label' => 'Barua pepe',
+        ],
+
+        'actions' => [
+            'request' => [
+                'label' => 'Tuma barua pepe',
+            ],
+        ],
+    ],
+
+    'notifications' => [
+        'sent' => [
+            'body' => 'Ikiwa akaunti yako haipo, hutapokea barua pepe.',
+        ],
+
+        'throttled' => [
+            'title' => 'Maombi mengi mno',
+            'body' => 'Tafadhali jaribu tena baada ya sekunde :seconds.',
+        ],
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/auth/pages/password-reset/reset-password.php
+++ b/packages/panels/resources/lang/sw/auth/pages/password-reset/reset-password.php
@@ -1,0 +1,37 @@
+<?php
+
+return [
+
+    'title' => 'Weka upya nenosiri lako',
+
+    'heading' => 'Weka upya nenosiri lako',
+
+    'form' => [
+        'email' => [
+            'label' => 'Barua pepe',
+        ],
+
+        'password' => [
+            'label' => 'Nenosiri',
+            'validation_attribute' => 'nenosiri',
+        ],
+
+        'password_confirmation' => [
+            'label' => 'Thibitisha nenosiri',
+        ],
+
+        'actions' => [
+            'reset' => [
+                'label' => 'Weka upya nenosiri',
+            ],
+        ],
+    ],
+
+    'notifications' => [
+        'throttled' => [
+            'title' => 'Majaribio mengi mno ya kuweka upya',
+            'body' => 'Tafadhali jaribu tena baada ya sekunde :seconds.',
+        ],
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/auth/pages/register.php
+++ b/packages/panels/resources/lang/sw/auth/pages/register.php
@@ -1,0 +1,48 @@
+<?php
+
+return [
+
+    'title' => 'Jisajili',
+
+    'heading' => 'Jisajili',
+
+    'actions' => [
+        'login' => [
+            'before' => 'au',
+            'label' => 'ingia kwenye akaunti yako',
+        ],
+    ],
+
+    'form' => [
+        'email' => [
+            'label' => 'Barua pepe',
+        ],
+
+        'name' => [
+            'label' => 'Jina',
+        ],
+
+        'password' => [
+            'label' => 'Nenosiri',
+            'validation_attribute' => 'nenosiri',
+        ],
+
+        'password_confirmation' => [
+            'label' => 'Thibitisha nenosiri',
+        ],
+
+        'actions' => [
+            'register' => [
+                'label' => 'Jisajili',
+            ],
+        ],
+    ],
+
+    'notifications' => [
+        'throttled' => [
+            'title' => 'Majaribio mengi mno ya kujisajili',
+            'body' => 'Tafadhali jaribu tena baada ya sekunde :seconds.',
+        ],
+    ],
+
+];

--- a/packages/panels/resources/lang/sw/error-notifications.php
+++ b/packages/panels/resources/lang/sw/error-notifications.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    'title' => 'Hitilafu wakati wa kupakia ukurasa',
+
+    'body' => 'Kulikuwa na hitilafu wakati wa kujaribu kupakia ukurasa huu. Tafadhali jaribu tena baadaye.',
+
+];

--- a/packages/panels/resources/lang/sw/layout.php
+++ b/packages/panels/resources/lang/sw/layout.php
@@ -4,7 +4,14 @@ return [
 
     'direction' => 'ltr',
 
+    'skip_to_content' => [
+        'label' => 'Ruka hadi maudhui',
+    ],
+
     'actions' => [
+        'billing' => [
+            'label' => 'Simamia usajili',
+        ],
 
         'logout' => [
             'label' => 'Toka',
@@ -12,13 +19,25 @@ return [
 
         'open_database_notifications' => [
             'label' => 'Fungua arifa',
+            'label_with_unread_count' => '{1} Taarifa, :count haijasomwa|[2,*] Taarifa, :count hazijasomwa',
         ],
 
         'open_user_menu' => [
             'label' => 'Menyu ya Mtumiaji',
         ],
 
+        'sidebar' => [
+            'collapse' => [
+                'label' => 'Kunja upau wa kando',
+            ],
+
+            'expand' => [
+                'label' => 'Panua upau wa kando',
+            ],
+        ],
+
         'theme_switcher' => [
+            'label' => 'Mandhari',
 
             'dark' => [
                 'label' => 'Geuza hali ya giza',
@@ -28,8 +47,33 @@ return [
                 'label' => 'Geuza hali ya mwanga',
             ],
 
+            'system' => [
+                'label' => 'Washa mandhari ya mfumo',
+            ],
         ],
+    ],
 
+    'navigation' => [
+        'label' => 'Urambazaji wa upau wa kando',
+    ],
+
+    'topbar' => [
+        'label' => 'Upau wa juu',
+    ],
+
+    'avatar' => [
+        'alt' => 'Taswira ya :name',
+    ],
+
+    'logo' => [
+        'alt' => 'Nembo ya :name',
+    ],
+
+    'tenant_menu' => [
+        'search_field' => [
+            'label' => 'Utafutaji wa mpangaji',
+            'placeholder' => 'Tafuta',
+        ],
     ],
 
 ];

--- a/packages/panels/resources/lang/sw/pages/dashboard.php
+++ b/packages/panels/resources/lang/sw/pages/dashboard.php
@@ -4,4 +4,20 @@ return [
 
     'title' => 'Dashibodi',
 
+    'actions' => [
+        'filter' => [
+            'label' => 'Chuja',
+
+            'modal' => [
+                'heading' => 'Chuja',
+
+                'actions' => [
+                    'apply' => [
+                        'label' => 'Tekeleza',
+                    ],
+                ],
+            ],
+        ],
+    ],
+
 ];

--- a/packages/panels/resources/lang/sw/pages/tenancy/edit-tenant-profile.php
+++ b/packages/panels/resources/lang/sw/pages/tenancy/edit-tenant-profile.php
@@ -2,27 +2,11 @@
 
 return [
 
-    'title' => 'Hariri :label',
-
-    'breadcrumb' => 'Hariri',
-
-    'navigation_label' => 'Hariri',
-
     'form' => [
         'actions' => [
-            'cancel' => [
-                'label' => 'Ghairi',
-            ],
-
             'save' => [
                 'label' => 'Hifadhi mabadiliko',
             ],
-        ],
-    ],
-
-    'content' => [
-        'tab' => [
-            'label' => 'Hariri',
         ],
     ],
 

--- a/packages/panels/resources/lang/sw/resources/pages/manage-related-records.php
+++ b/packages/panels/resources/lang/sw/resources/pages/manage-related-records.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'title' => 'Simamia :relationship za :label',
+
+];

--- a/packages/panels/resources/lang/sw/resources/pages/view-record.php
+++ b/packages/panels/resources/lang/sw/resources/pages/view-record.php
@@ -6,12 +6,12 @@ return [
 
     'breadcrumb' => 'Angalia',
 
-    'content' => [
+    'navigation_label' => 'Angalia',
 
+    'content' => [
         'tab' => [
             'label' => 'Angalia',
         ],
-
     ],
 
 ];

--- a/packages/panels/resources/lang/sw/unsaved-changes-alert.php
+++ b/packages/panels/resources/lang/sw/unsaved-changes-alert.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'body' => 'Una mabadiliko ambayo hayajahifadhiwa. Una uhakika unataka kuondoka kwenye ukurasa huu?',
+
+];

--- a/packages/query-builder/resources/lang/sw/query-builder.php
+++ b/packages/query-builder/resources/lang/sw/query-builder.php
@@ -1,0 +1,484 @@
+<?php
+
+return [
+
+    'label' => 'Kijenzi cha maswali',
+
+    'form' => [
+        'operator' => [
+            'label' => 'Opereta',
+        ],
+
+        'or_groups' => [
+            'label' => 'Makundi',
+
+            'group' => [
+                'label' => 'Kundi',
+            ],
+
+            'block' => [
+                'label' => 'Sharti la OR',
+                'or' => 'OR',
+            ],
+        ],
+
+        'rules' => [
+            'label' => 'Sheria',
+
+            'item' => [
+                'and' => 'AND',
+            ],
+        ],
+    ],
+
+    'no_rules' => '(Hakuna sheria)',
+
+    'max_rules_reached_tooltip' => 'Umefikia kikomo cha sheria :count.',
+
+    'item_separators' => [
+        'and' => 'AND',
+        'or' => 'OR',
+    ],
+
+    'operators' => [
+        'is_filled' => [
+            'label' => [
+                'direct' => 'Imejazwa',
+                'inverse' => 'Ni tupu',
+            ],
+
+            'summary' => [
+                'direct' => ':attribute imejazwa',
+                'inverse' => ':attribute ni tupu',
+            ],
+        ],
+
+        'boolean' => [
+            'is_true' => [
+                'label' => [
+                    'direct' => 'Ni kweli',
+                    'inverse' => 'Si kweli',
+                ],
+
+                'summary' => [
+                    'direct' => ':attribute ni kweli',
+                    'inverse' => ':attribute si kweli',
+                ],
+            ],
+        ],
+
+        'date' => [
+            'is_after' => [
+                'label' => [
+                    'direct' => 'Ni baada ya',
+                    'inverse' => 'Si baada ya',
+                ],
+
+                'summary' => [
+                    'direct' => ':attribute ni baada ya :date',
+                    'inverse' => ':attribute si baada ya :date',
+                ],
+            ],
+
+            'is_before' => [
+                'label' => [
+                    'direct' => 'Ni kabla ya',
+                    'inverse' => 'Si kabla ya',
+                ],
+
+                'summary' => [
+                    'direct' => ':attribute ni kabla ya :date',
+                    'inverse' => ':attribute si kabla ya :date',
+                ],
+            ],
+
+            'is_date' => [
+                'label' => [
+                    'direct' => 'Ni tarehe',
+                    'inverse' => 'Si tarehe',
+                ],
+
+                'summary' => [
+                    'direct' => ':attribute ni :date',
+                    'inverse' => ':attribute si :date',
+                ],
+            ],
+
+            'is_month' => [
+                'label' => [
+                    'direct' => 'Ni mwezi',
+                    'inverse' => 'Si mwezi',
+                ],
+
+                'summary' => [
+                    'direct' => ':attribute ni :month',
+                    'inverse' => ':attribute si :month',
+                ],
+            ],
+
+            'is_year' => [
+                'label' => [
+                    'direct' => 'Ni mwaka',
+                    'inverse' => 'Si mwaka',
+                ],
+
+                'summary' => [
+                    'direct' => ':attribute ni :year',
+                    'inverse' => ':attribute si :year',
+                ],
+            ],
+
+            'unit_labels' => [
+                'second' => 'Sekunde',
+                'minute' => 'Dakika',
+                'hour' => 'Saa',
+                'day' => 'Siku',
+                'week' => 'Wiki',
+                'month' => 'Miezi',
+                'quarter' => 'Robo',
+                'year' => 'Miaka',
+            ],
+
+            'presets' => [
+                'past_decade' => 'Muongo uliopita',
+                'past_5_years' => 'Miaka 5 iliyopita',
+                'past_2_years' => 'Miaka 2 iliyopita',
+                'past_year' => 'Mwaka uliopita',
+                'past_6_months' => 'Miezi 6 iliyopita',
+                'past_quarter' => 'Robo iliyopita',
+                'past_month' => 'Mwezi uliopita',
+                'past_2_weeks' => 'Wiki 2 zilizopita',
+                'past_week' => 'Wiki iliyopita',
+                'past_hour' => 'Saa iliyopita',
+                'past_minute' => 'Dakika iliyopita',
+                'this_decade' => 'Muongo huu',
+                'this_year' => 'Mwaka huu',
+                'this_quarter' => 'Robo hii',
+                'this_month' => 'Mwezi huu',
+                'today' => 'Leo',
+                'this_hour' => 'Saa hii',
+                'this_minute' => 'Dakika hii',
+                'next_minute' => 'Dakika ijayo',
+                'next_hour' => 'Saa ijayo',
+                'next_week' => 'Wiki ijayo',
+                'next_2_weeks' => 'Wiki 2 zijazo',
+                'next_month' => 'Mwezi ujao',
+                'next_quarter' => 'Robo ijayo',
+                'next_6_months' => 'Miezi 6 ijayo',
+                'next_year' => 'Mwaka ujao',
+                'next_2_years' => 'Miaka 2 ijayo',
+                'next_5_years' => 'Miaka 5 ijayo',
+                'next_decade' => 'Muongo ujao',
+                'custom' => 'Maalum',
+            ],
+
+            'form' => [
+                'date' => [
+                    'label' => 'Tarehe',
+                ],
+
+                'month' => [
+                    'label' => 'Mwezi',
+                ],
+
+                'year' => [
+                    'label' => 'Mwaka',
+                ],
+
+                'mode' => [
+                    'label' => 'Aina ya tarehe',
+
+                    'options' => [
+                        'absolute' => 'Tarehe maalum',
+                        'relative' => 'Kipindi kinachohama',
+                    ],
+                ],
+
+                'preset' => [
+                    'label' => 'Kipindi',
+                ],
+
+                'relative_value' => [
+                    'label' => 'Ngapi',
+                ],
+
+                'relative_unit' => [
+                    'label' => 'Kitengo cha muda',
+                ],
+
+                'tense' => [
+                    'label' => 'Muda',
+
+                    'options' => [
+                        'past' => 'Iliyopita',
+                        'future' => 'Ijayo',
+                    ],
+                ],
+            ],
+        ],
+
+        'number' => [
+            'equals' => [
+                'label' => [
+                    'direct' => 'Sawa na',
+                    'inverse' => 'Si sawa na',
+                ],
+
+                'summary' => [
+                    'direct' => ':attribute ni sawa na :number',
+                    'inverse' => ':attribute si sawa na :number',
+                ],
+            ],
+
+            'is_max' => [
+                'label' => [
+                    'direct' => 'Ni kikomo cha juu',
+                    'inverse' => 'Ni kubwa kuliko',
+                ],
+
+                'summary' => [
+                    'direct' => ':attribute ni kikomo cha juu cha :number',
+                    'inverse' => ':attribute ni kubwa kuliko :number',
+                ],
+            ],
+
+            'is_min' => [
+                'label' => [
+                    'direct' => 'Ni kikomo cha chini',
+                    'inverse' => 'Ni ndogo kuliko',
+                ],
+
+                'summary' => [
+                    'direct' => ':attribute ni kikomo cha chini cha :number',
+                    'inverse' => ':attribute ni ndogo kuliko :number',
+                ],
+            ],
+
+            'aggregates' => [
+                'average' => [
+                    'label' => 'Wastani',
+                    'summary' => 'Wastani wa :attribute',
+                ],
+
+                'max' => [
+                    'label' => 'Max',
+                    'summary' => 'Max ya :attribute',
+                ],
+
+                'min' => [
+                    'label' => 'Min',
+                    'summary' => 'Min ya :attribute',
+                ],
+
+                'sum' => [
+                    'label' => 'Jumla',
+                    'summary' => 'Jumla ya :attribute',
+                ],
+            ],
+
+            'form' => [
+                'aggregate' => [
+                    'label' => 'Jumuisho',
+                ],
+
+                'number' => [
+                    'label' => 'Namba',
+                ],
+            ],
+        ],
+
+        'relationship' => [
+            'equals' => [
+                'label' => [
+                    'direct' => 'Ina',
+                    'inverse' => 'Haina',
+                ],
+
+                'summary' => [
+                    'direct' => 'Ina :count :relationship',
+                    'inverse' => 'Haina :count :relationship',
+                ],
+            ],
+
+            'has_max' => [
+                'label' => [
+                    'direct' => 'Ina kikomo cha juu',
+                    'inverse' => 'Ina zaidi ya',
+                ],
+
+                'summary' => [
+                    'direct' => 'Ina kikomo cha juu cha :count :relationship',
+                    'inverse' => 'Ina zaidi ya :count :relationship',
+                ],
+            ],
+
+            'has_min' => [
+                'label' => [
+                    'direct' => 'Ina kikomo cha chini',
+                    'inverse' => 'Ina chini ya',
+                ],
+
+                'summary' => [
+                    'direct' => 'Ina kikomo cha chini cha :count :relationship',
+                    'inverse' => 'Ina chini ya :count :relationship',
+                ],
+            ],
+
+            'is_empty' => [
+                'label' => [
+                    'direct' => 'Ni tupu',
+                    'inverse' => 'Si tupu',
+                ],
+
+                'summary' => [
+                    'direct' => ':relationship ni tupu',
+                    'inverse' => ':relationship si tupu',
+                ],
+            ],
+
+            'is_related_to' => [
+                'label' => [
+                    'single' => [
+                        'direct' => 'Ni',
+                        'inverse' => 'Si',
+                    ],
+
+                    'multiple' => [
+                        'direct' => 'Ina',
+                        'inverse' => 'Haina',
+                    ],
+                ],
+
+                'summary' => [
+                    'single' => [
+                        'direct' => ':relationship ni :values',
+                        'inverse' => ':relationship si :values',
+                    ],
+
+                    'multiple' => [
+                        'direct' => ':relationship ina :values',
+                        'inverse' => ':relationship haina :values',
+                    ],
+
+                    'values_glue' => [
+                        0 => ', ',
+                        'final' => ' au ',
+                    ],
+                ],
+
+                'form' => [
+                    'value' => [
+                        'label' => 'Thamani',
+                    ],
+
+                    'values' => [
+                        'label' => 'Thamani',
+                    ],
+                ],
+            ],
+
+            'form' => [
+                'count' => [
+                    'label' => 'Idadi',
+                ],
+            ],
+        ],
+
+        'select' => [
+            'is' => [
+                'label' => [
+                    'direct' => 'Ni',
+                    'inverse' => 'Si',
+                ],
+
+                'summary' => [
+                    'direct' => ':attribute ni :values',
+
+                    'inverse' => ':attribute si :values',
+
+                    'values_glue' => [
+                        0 => ', ',
+                        'final' => ' au ',
+                    ],
+                ],
+
+                'form' => [
+                    'value' => [
+                        'label' => 'Thamani',
+                    ],
+
+                    'values' => [
+                        'label' => 'Thamani',
+                    ],
+                ],
+            ],
+        ],
+
+        'text' => [
+            'contains' => [
+                'label' => [
+                    'direct' => 'Ina',
+                    'inverse' => 'Haina',
+                ],
+
+                'summary' => [
+                    'direct' => ':attribute ina :text',
+                    'inverse' => ':attribute haina :text',
+                ],
+            ],
+
+            'ends_with' => [
+                'label' => [
+                    'direct' => 'Huishia na',
+                    'inverse' => 'Hauishi na',
+                ],
+
+                'summary' => [
+                    'direct' => ':attribute huishia na :text',
+                    'inverse' => ':attribute hauishi na :text',
+                ],
+            ],
+
+            'equals' => [
+                'label' => [
+                    'direct' => 'Sawa na',
+                    'inverse' => 'Si sawa na',
+                ],
+
+                'summary' => [
+                    'direct' => ':attribute ni sawa na :text',
+                    'inverse' => ':attribute si sawa na :text',
+                ],
+            ],
+
+            'starts_with' => [
+                'label' => [
+                    'direct' => 'Huanza na',
+                    'inverse' => 'Hakianzi na',
+                ],
+
+                'summary' => [
+                    'direct' => ':attribute huanza na :text',
+                    'inverse' => ':attribute hakianzi na :text',
+                ],
+            ],
+
+            'form' => [
+                'text' => [
+                    'label' => 'Maandishi',
+                ],
+            ],
+        ],
+    ],
+
+    'actions' => [
+        'add_rule' => [
+            'label' => 'Ongeza sheria',
+        ],
+
+        'add_rule_group' => [
+            'label' => 'Ongeza OR',
+        ],
+    ],
+
+];

--- a/packages/schemas/resources/lang/sw/components.php
+++ b/packages/schemas/resources/lang/sw/components.php
@@ -2,10 +2,29 @@
 
 return [
 
-    'wizard' => [
+    'callout' => [
+        'statuses' => [
+            'danger' => 'Hitilafu:',
+            'info' => 'Kumbuka:',
+            'success' => 'Mafanikio:',
+            'warning' => 'Onyo:',
+        ],
+    ],
 
+    'section' => [
         'actions' => [
+            'collapse' => [
+                'label' => 'Kunja sehemu',
+            ],
 
+            'expand' => [
+                'label' => 'Panua sehemu',
+            ],
+        ],
+    ],
+
+    'wizard' => [
+        'actions' => [
             'previous_step' => [
                 'label' => 'Nyuma',
             ],
@@ -13,9 +32,16 @@ return [
             'next_step' => [
                 'label' => 'Mbele',
             ],
-
         ],
 
+        'header' => [
+            'step' => [
+                'statuses' => [
+                    'completed' => 'Imekamilika',
+                    'upcoming' => 'Haijakamilika',
+                ],
+            ],
+        ],
     ],
 
 ];

--- a/packages/spatie-laravel-settings-plugin/resources/lang/sw/pages/settings-page.php
+++ b/packages/spatie-laravel-settings-plugin/resources/lang/sw/pages/settings-page.php
@@ -2,27 +2,11 @@
 
 return [
 
-    'title' => 'Hariri :label',
-
-    'breadcrumb' => 'Hariri',
-
-    'navigation_label' => 'Hariri',
-
     'form' => [
         'actions' => [
-            'cancel' => [
-                'label' => 'Ghairi',
-            ],
-
             'save' => [
                 'label' => 'Hifadhi mabadiliko',
             ],
-        ],
-    ],
-
-    'content' => [
-        'tab' => [
-            'label' => 'Hariri',
         ],
     ],
 

--- a/packages/support/resources/lang/sw/components/badge.php
+++ b/packages/support/resources/lang/sw/components/badge.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+
+    'actions' => [
+        'delete' => [
+            'label' => 'Ondoa',
+        ],
+    ],
+
+];

--- a/packages/support/resources/lang/sw/components/breadcrumbs.php
+++ b/packages/support/resources/lang/sw/components/breadcrumbs.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'label' => 'Njia ya kurasa',
+
+];

--- a/packages/support/resources/lang/sw/components/input/one-time-code.php
+++ b/packages/support/resources/lang/sw/components/input/one-time-code.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'aria_label' => 'Herufi ya :position kati ya :count',
+
+];

--- a/packages/support/resources/lang/sw/components/loading-section.php
+++ b/packages/support/resources/lang/sw/components/loading-section.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'label' => 'Inapakia...',
+
+];

--- a/packages/support/resources/lang/sw/components/pagination.php
+++ b/packages/support/resources/lang/sw/components/pagination.php
@@ -4,26 +4,29 @@ return [
 
     'label' => 'Urambazaji wa kurasa',
 
-    'overview' => 'Onesha :first mpaka :last ya :total ya matokeo',
+    'overview' => '{1} Inaonyesha kipengee 1|[2,*] Inaonyesha :first hadi :last kati ya vipengee :total',
 
     'fields' => [
-
         'records_per_page' => [
-
             'label' => 'kwa kurasa',
 
             'options' => [
                 'all' => 'Zote',
             ],
-
         ],
-
     ],
 
     'actions' => [
+        'first' => [
+            'label' => 'Mwanzo',
+        ],
 
         'go_to_page' => [
             'label' => 'Nenda kwenye kurasa :page',
+        ],
+
+        'last' => [
+            'label' => 'Mwisho',
         ],
 
         'next' => [
@@ -33,7 +36,6 @@ return [
         'previous' => [
             'label' => 'Nyuma',
         ],
-
     ],
 
 ];

--- a/packages/support/resources/lang/sw/components/section.php
+++ b/packages/support/resources/lang/sw/components/section.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+
+    'actions' => [
+        'collapse' => [
+            'label' => 'Kunja sehemu',
+        ],
+
+        'expand' => [
+            'label' => 'Panua sehemu',
+        ],
+    ],
+
+];

--- a/packages/support/resources/lang/sw/components/tabs.php
+++ b/packages/support/resources/lang/sw/components/tabs.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'label' => 'Vichupo',
+
+];

--- a/packages/tables/resources/lang/sw/table.php
+++ b/packages/tables/resources/lang/sw/table.php
@@ -2,16 +2,56 @@
 
 return [
 
-    'columns' => [
+    'column_manager' => [
+        'heading' => 'Safu wima',
 
-        'text' => [
-            'more_list_items' => 'na :count zaidi',
+        'actions' => [
+            'apply' => [
+                'label' => 'Tekeleza safu wima',
+            ],
+
+            'reorder' => [
+                'label' => 'Panga upya safu wima',
+            ],
+
+            'reset' => [
+                'label' => 'Weka upya',
+            ],
+        ],
+    ],
+
+    'columns' => [
+        'actions' => [
+            'label' => 'Kitendo|Vitendo',
         ],
 
+        'icon' => [
+            'boolean' => [
+                'true' => 'Ndiyo',
+                'false' => 'Hapana',
+            ],
+        ],
+
+        'select' => [
+            'loading_message' => 'Inapakia...',
+            'no_options_message' => 'Hakuna chaguo zilizopo.',
+            'no_search_results_message' => 'Hakuna chaguo linalolingana na utafutaji wako.',
+            'placeholder' => 'Chagua chaguo',
+            'searching_message' => 'Inatafuta...',
+            'search_prompt' => 'Anza kuandika ili kutafuta...',
+        ],
+
+        'text' => [
+            'actions' => [
+                'collapse_list' => 'Ficha :count',
+                'expand_list' => 'Onyesha :count zaidi',
+            ],
+
+            'more_list_items' => 'na :count zaidi',
+        ],
     ],
 
     'fields' => [
-
         'bulk_select_page' => [
             'label' => 'Chagua/acha kuchagua vipengee vyote kwa vitendo vingi.',
         ],
@@ -20,15 +60,42 @@ return [
             'label' => 'Chagua/acha kuchagua kipengele :key kwa vitendo vingi.',
         ],
 
+        'bulk_select_group' => [
+            'label' => 'Chagua/ondoa uchaguzi wa kundi :title kwa vitendo vya wingi.',
+        ],
+
         'search' => [
             'label' => 'Tafuta',
             'placeholder' => 'Tafuta',
+            'indicator' => 'Tafuta',
+        ],
+    ],
+
+    'summary' => [
+        'heading' => 'Muhtasari',
+
+        'subheadings' => [
+            'all' => ':label zote',
+            'group' => 'Muhtasari wa :group',
+            'page' => 'Ukurasa huu',
         ],
 
+        'summarizers' => [
+            'average' => [
+                'label' => 'Wastani',
+            ],
+
+            'count' => [
+                'label' => 'Idadi',
+            ],
+
+            'sum' => [
+                'label' => 'Jumla',
+            ],
+        ],
     ],
 
     'actions' => [
-
         'disable_reordering' => [
             'label' => 'Maliza kupangilia rekodi upya',
         ],
@@ -37,27 +104,41 @@ return [
             'label' => 'Pangilia rekodi',
         ],
 
+        'reorder_record' => [
+            'label' => 'Panga upya kipengee :key',
+        ],
+
         'filter' => [
             'label' => 'Chuja',
         ],
 
+        'group' => [
+            'label' => 'Kundi',
+        ],
+
         'open_bulk_actions' => [
-            'label' => 'Fungua matendo',
+            'label' => 'Fungua vitendo vya wingi',
         ],
 
         'column_manager' => [
             'label' => 'Geuza safu',
         ],
 
+        'toggle_record_content' => [
+            'label' => 'Panua/kunja kipengee :key',
+        ],
     ],
 
     'empty' => [
         'heading' => 'Hakuna rekodi zilizopatikana',
+        'description' => 'Unda :model ili kuanza.',
     ],
 
     'filters' => [
-
         'actions' => [
+            'apply' => [
+                'label' => 'Tekeleza vichujio',
+            ],
 
             'remove' => [
                 'label' => 'Toa mchujo',
@@ -71,8 +152,9 @@ return [
             'reset' => [
                 'label' => 'Weka upya michujo',
             ],
-
         ],
+
+        'heading' => 'Vichujio',
 
         'indicator' => 'Michujo inayotumika',
 
@@ -82,30 +164,47 @@ return [
 
         'select' => [
             'placeholder' => 'Zote',
+
+            'relationship' => [
+                'empty_option_label' => 'Hakuna',
+            ],
         ],
 
         'trashed' => [
-
             'label' => 'Rekodi zilizofutwa',
-
             'only_trashed' => 'Rekodi zilizofutwa pekee',
-
             'with_trashed' => 'Pamoja na rekodi zilizofutwa',
-
             'without_trashed' => 'Bila rekodi zilizofutwa',
-
         ],
-
     ],
+
+    'grouping' => [
+        'fields' => [
+            'group' => [
+                'label' => 'Panga kwa',
+            ],
+
+            'direction' => [
+                'label' => 'Mwelekeo wa makundi',
+
+                'options' => [
+                    'asc' => 'Kupanda',
+                    'desc' => 'Kushuka',
+                ],
+            ],
+        ],
+    ],
+
+    'loading' => 'Inapakia...',
 
     'reorder_indicator' => 'Buruta na uangushe rekodi kwa mpangilio.',
 
-    'selection_indicator' => [
+    'result_count' => '{0} Hakuna matokeo|{1} kipengee :count|[2,*] vipengee :count',
 
+    'selection_indicator' => [
         'selected_count' => 'Rekodi 1 imeshaguliwa|Rekodi :count zimeshaguliwa',
 
         'actions' => [
-
             'select_all' => [
                 'label' => 'Chagua :count',
             ],
@@ -113,32 +212,26 @@ return [
             'deselect_all' => [
                 'label' => 'Acha kuchagua zote',
             ],
-
         ],
-
     ],
 
     'sorting' => [
-
         'fields' => [
-
             'column' => [
                 'label' => 'Panga kwa',
             ],
 
             'direction' => [
-
                 'label' => 'Panga mwelekeo',
 
                 'options' => [
                     'asc' => 'Kupanda',
                     'desc' => 'Kushuka',
                 ],
-
             ],
-
         ],
-
     ],
+
+    'default_model_label' => 'rekodi',
 
 ];

--- a/packages/widgets/resources/lang/sw/chart.php
+++ b/packages/widgets/resources/lang/sw/chart.php
@@ -1,0 +1,31 @@
+<?php
+
+return [
+
+    'actions' => [
+        'filter' => [
+            'label' => 'Chuja',
+        ],
+    ],
+
+    'filter' => [
+        'label' => 'Chuja data ya chati',
+    ],
+
+    'filters' => [
+        'actions' => [
+            'apply' => [
+                'label' => 'Tekeleza',
+            ],
+
+            'reset' => [
+                'label' => 'Weka upya',
+            ],
+        ],
+    ],
+
+    'empty' => [
+        'heading' => 'Hakuna data ya kuonyesha',
+    ],
+
+];


### PR DESCRIPTION
## Description

Completes the Swahili (`sw`) locale so it is fully up to date with the `4.x` English source.

**Changes**
- Adds **694 missing translation keys across 50 files** in 13 packages: actions, forms, infolists, notifications, panels (including the full multi-factor authentication suite, password reset, email verification, registration, tenancy pages), query-builder, spatie-laravel-settings-plugin, support, tables, widgets
- Removes 6 stale keys no longer present in the English source
- Fixes existing strings found during review:
  - untranslated rich editor `link` tool (`Link` → `Kiungo`)
  - duplicated rich editor `h1`/`h2` headings (both were `Kichwa`); now `Title` = `Kichwa kikuu`, `Heading 2` = `Kichwa 2`, consistent with `h3`\u2013`h6`
  - `key_value` row actions used `safu` (column) instead of `mstari` (row)
  - pagination `overview` lost its CLDR plural prefixes; restored with proper `{1}` / `[2,*]` forms
  - minor spelling/terminology: `baadae` → `baadaye`, `Ndio` → `Ndiyo`, edit actions aligned on `Hariri`

**Terminology notes**
- 2FA = *Uthibitishaji wa hatua mbili*
- Natural color names translated (Red → *Nyekundu*, Gray → *Kijivu*, …); non-obvious palette names kept as-is (Slate, Zinc, Amber, …)
- Technical strings kept verbatim: filename templates (`export-:export_id-:model`), units (`px`, `deg`), placeholders, plural pipes

## Testing

- Verified with the official tool: `(new FindOutdatedTranslations(locales: collect([new Locale('sw')])))->getResults()` → **0 missing / 0 removed**
- `php -l` passes on all 50 touched files
- Formatting matches existing locale files (blank-line conventions, compact leaf arrays, unquoted integer keys)