### PR TITLE
[3.x] fix: use valid Livewire upload references in restriction tests

### DIFF
--- a/tests/src/Forms/Concerns/RestrictsFileUploadsToFormComponentsTest.php
+++ b/tests/src/Forms/Concerns/RestrictsFileUploadsToFormComponentsTest.php
@@ -10,10 +10,21 @@ use Filament\Forms\Form;
 use Filament\Tests\Forms\Fixtures\Livewire;
 use Filament\Tests\TestCase;
 use Illuminate\Contracts\View\View;
+use Livewire\Features\SupportFileUploads\FileUploadConfiguration;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 
 use function Filament\Tests\livewire;
 
 uses(TestCase::class);
+
+function temporaryUploadedFileReference(string $filename): string
+{
+    FileUploadConfiguration::storage();
+
+    return (string) str(
+        TemporaryUploadedFile::createFromLivewire($filename)->serializeForLivewireResponse(),
+    )->after('livewire-file:');
+}
 
 it('blocks `_startUpload` when the form has no file-upload components', function () {
     livewire(RestrictedUploadsTestComponentWithoutFileUpload::class)
@@ -59,13 +70,13 @@ it('blocks `_startUpload` for a layout component state path (`Section`) even tho
 
 it('blocks `_finishUpload` when no form component matches', function () {
     livewire(RestrictedUploadsTestComponentWithFileUpload::class)
-        ->call('_finishUpload', 'data.somethingElse.fileKey', ['livewire-tmp/tampered.jpg'], false)
+        ->call('_finishUpload', 'data.somethingElse.fileKey', [temporaryUploadedFileReference('tampered.jpg')], false)
         ->assertForbidden();
 });
 
 it('allows `_finishUpload` when the property path maps to a `FileUpload` field', function () {
     livewire(RestrictedUploadsTestComponentWithFileUpload::class)
-        ->call('_finishUpload', 'data.photo.fileKey', ['livewire-tmp/legitimate.jpg'], false)
+        ->call('_finishUpload', 'data.photo.fileKey', [temporaryUploadedFileReference('legitimate.jpg')], false)
         ->assertDispatched('upload:finished');
 });
 
@@ -89,13 +100,13 @@ it('blocks `_startUpload` for `componentFileAttachments.{statePath}` when no com
 
 it('allows `_finishUpload` for `componentFileAttachments.{statePath}` uploads targeting a component that supports file attachments', function () {
     livewire(RestrictedUploadsTestComponentWithMarkdownEditor::class)
-        ->call('_finishUpload', 'componentFileAttachments.data.content', ['livewire-tmp/legitimate.jpg'], false)
+        ->call('_finishUpload', 'componentFileAttachments.data.content', [temporaryUploadedFileReference('legitimate.jpg')], false)
         ->assertDispatched('upload:finished');
 });
 
 it('blocks `_finishUpload` for `componentFileAttachments.{statePath}` when the underlying component is unrelated', function () {
     livewire(RestrictedUploadsTestComponentWithFileUpload::class)
-        ->call('_finishUpload', 'componentFileAttachments.data.tampered', ['livewire-tmp/tampered.jpg'], false)
+        ->call('_finishUpload', 'componentFileAttachments.data.tampered', [temporaryUploadedFileReference('tampered.jpg')], false)
         ->assertForbidden();
 });
 


### PR DESCRIPTION
## Description

Fixes the upload restriction tests for the 3.x Forms implementation.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
