### PR TITLE
fix: handle closure conditions in searchable table columns

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanBeSearchable.php
+++ b/packages/tables/src/Columns/Concerns/CanBeSearchable.php
@@ -34,7 +34,7 @@ trait CanBeSearchable
         bool $isIndividual = false,
         bool $isGlobal = true,
     ): static {
-        if (is_bool($condition)) {
+        if (is_bool($condition) || ($condition instanceof Closure)) {
             $this->isSearchable = $condition;
             $this->searchColumns = null;
         } else {

--- a/tests/src/Tables/Columns/ColumnTest.php
+++ b/tests/src/Tables/Columns/ColumnTest.php
@@ -99,6 +99,13 @@ describe('searchable', function (): void {
 
         expect($column->isSearchable())->toBeTrue();
     });
+
+    it('is not searchable when the `searchable()` closure returns false', function (): void {
+        $column = TextColumn::make('title')
+            ->searchable(static fn (): bool => false);
+
+        expect($column->isSearchable())->toBeFalse();
+    });
 });
 
 describe('visibility', function (): void {
@@ -215,6 +222,14 @@ describe('rendering', function (): void {
     it('can render with `searchable()`', function (): void {
         Post::factory()->create();
         livewire(RenderColumnWithSearchable::class)->assertSuccessful();
+    });
+
+    it('can render with `searchable()` using a closure', function (): void {
+        $post = Post::factory()->create();
+
+        livewire(RenderColumnWithSearchableClosure::class)
+            ->searchTable($post->title)
+            ->assertCanSeeTableRecords([$post]);
     });
 
     it('can render with `toggleable()`', function (): void {
@@ -353,6 +368,25 @@ class RenderColumnWithSearchable extends Component implements HasActions, HasSch
     {
         return $table->query(Post::query())->columns([
             TextColumn::make('title')->searchable(),
+        ]);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.table');
+    }
+}
+
+class RenderColumnWithSearchableClosure extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use Tables\Concerns\InteractsWithTable;
+
+    public function table(Table $table): Table
+    {
+        return $table->query(Post::query())->columns([
+            TextColumn::make('title')->searchable(static fn (): bool => true),
         ]);
     }
 


### PR DESCRIPTION
## Description

Fixes closures passed to a table column `searchable()` method being treated as search column names instead of conditions.

This caused global searches to pass a `Closure` to `getJsonSafeColumnName()`, resulting in a `TypeError`. It also meant that a closure returning `false` still marked the column as searchable.

Closures now follow the same condition path as boolean values. Tests cover both a searchable column returning `true` during a global search and a condition returning `false`.

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.