### PR TITLE
Add Filipino (fil) translations

### DIFF
--- a/packages/actions/resources/lang/fil/associate.php
+++ b/packages/actions/resources/lang/fil/associate.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+    'single' => [
+        'label' => 'Iugnay',
+        'modal' => [
+            'heading' => 'Iugnay ang :label',
+            'fields' => [
+                'record_id' => [
+                    'label' => 'Rekord',
+                ],
+            ],
+            'actions' => [
+                'associate' => [
+                    'label' => 'Iugnay',
+                ],
+                'associate_another' => [
+                    'label' => 'Iugnay at mag-ugnay pa',
+                ],
+            ],
+        ],
+        'notifications' => [
+            'associated' => [
+                'title' => 'Naiugnay na',
+            ],
+        ],
+    ],
+];

--- a/packages/actions/resources/lang/fil/attach.php
+++ b/packages/actions/resources/lang/fil/attach.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+    'single' => [
+        'label' => 'Ilakip',
+        'modal' => [
+            'heading' => 'Ilakip ang :label',
+            'fields' => [
+                'record_id' => [
+                    'label' => 'Rekord',
+                ],
+            ],
+            'actions' => [
+                'attach' => [
+                    'label' => 'Ilakip',
+                ],
+                'attach_another' => [
+                    'label' => 'Ilakip at maglakip pa',
+                ],
+            ],
+        ],
+        'notifications' => [
+            'attached' => [
+                'title' => 'Nailakip na',
+            ],
+        ],
+    ],
+];

--- a/packages/actions/resources/lang/fil/create.php
+++ b/packages/actions/resources/lang/fil/create.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    'single' => [
+        'label' => 'Bagong :label',
+        'modal' => [
+            'heading' => 'Gumawa ng :label',
+            'actions' => [
+                'create' => [
+                    'label' => 'Gumawa',
+                ],
+                'create_another' => [
+                    'label' => 'Gumawa at gumawa pa',
+                ],
+            ],
+        ],
+        'notifications' => [
+            'created' => [
+                'title' => 'Nagawa na',
+            ],
+        ],
+    ],
+];

--- a/packages/actions/resources/lang/fil/delete.php
+++ b/packages/actions/resources/lang/fil/delete.php
@@ -1,0 +1,46 @@
+<?php
+
+return [
+    'single' => [
+        'label' => 'I-delete',
+        'modal' => [
+            'heading' => 'I-delete ang :label',
+            'actions' => [
+                'delete' => [
+                    'label' => 'I-delete',
+                ],
+            ],
+        ],
+        'notifications' => [
+            'deleted' => [
+                'title' => 'Na-delete na',
+            ],
+        ],
+    ],
+    'multiple' => [
+        'label' => 'I-delete ang mga napili',
+        'modal' => [
+            'heading' => 'I-delete ang mga napiling :label',
+            'actions' => [
+                'delete' => [
+                    'label' => 'I-delete',
+                ],
+            ],
+        ],
+        'notifications' => [
+            'deleted' => [
+                'title' => 'Na-delete na',
+            ],
+            'deleted_partial' => [
+                'title' => 'Na-delete ang :count sa :total',
+                'missing_authorization_failure_message' => 'Wala kang pahintulot na i-delete ang :count.',
+                'missing_processing_failure_message' => 'Hindi ma-delete ang :count.',
+            ],
+            'deleted_none' => [
+                'title' => 'Hindi na-delete',
+                'missing_authorization_failure_message' => 'Wala kang pahintulot na i-delete ang :count.',
+                'missing_processing_failure_message' => 'Hindi ma-delete ang :count.',
+            ],
+        ],
+    ],
+];

--- a/packages/actions/resources/lang/fil/detach.php
+++ b/packages/actions/resources/lang/fil/detach.php
@@ -1,0 +1,36 @@
+<?php
+
+return [
+    'single' => [
+        'label' => 'Tanggalin ang pagkakalakip',
+        'modal' => [
+            'heading' => 'Tanggalin ang pagkakalakip ng :label',
+            'actions' => [
+                'detach' => [
+                    'label' => 'Tanggalin ang pagkakalakip',
+                ],
+            ],
+        ],
+        'notifications' => [
+            'detached' => [
+                'title' => 'Natanggal na ang pagkakalakip',
+            ],
+        ],
+    ],
+    'multiple' => [
+        'label' => 'Tanggalin ang pagkakalakip ng mga napili',
+        'modal' => [
+            'heading' => 'Tanggalin ang pagkakalakip ng mga napiling :label',
+            'actions' => [
+                'detach' => [
+                    'label' => 'Tanggalin ang pagkakalakip',
+                ],
+            ],
+        ],
+        'notifications' => [
+            'detached' => [
+                'title' => 'Natanggal na ang pagkakalakip',
+            ],
+        ],
+    ],
+];

--- a/packages/actions/resources/lang/fil/dissociate.php
+++ b/packages/actions/resources/lang/fil/dissociate.php
@@ -1,0 +1,36 @@
+<?php
+
+return [
+    'single' => [
+        'label' => 'Alisin ang pagkakaugnay',
+        'modal' => [
+            'heading' => 'Alisin ang pagkakaugnay ng :label',
+            'actions' => [
+                'dissociate' => [
+                    'label' => 'Alisin ang pagkakaugnay',
+                ],
+            ],
+        ],
+        'notifications' => [
+            'dissociated' => [
+                'title' => 'Naalis na ang pagkakaugnay',
+            ],
+        ],
+    ],
+    'multiple' => [
+        'label' => 'Alisin ang pagkakaugnay ng mga napili',
+        'modal' => [
+            'heading' => 'Alisin ang pagkakaugnay ng mga napiling :label',
+            'actions' => [
+                'dissociate' => [
+                    'label' => 'Alisin ang pagkakaugnay',
+                ],
+            ],
+        ],
+        'notifications' => [
+            'dissociated' => [
+                'title' => 'Naalis na ang pagkakaugnay',
+            ],
+        ],
+    ],
+];

--- a/packages/actions/resources/lang/fil/edit.php
+++ b/packages/actions/resources/lang/fil/edit.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+    'single' => [
+        'label' => 'I-edit',
+        'modal' => [
+            'heading' => 'I-edit ang :label',
+            'actions' => [
+                'save' => [
+                    'label' => 'I-save ang mga pagbabago',
+                ],
+            ],
+        ],
+        'notifications' => [
+            'saved' => [
+                'title' => 'Na-save na',
+            ],
+        ],
+    ],
+];

--- a/packages/actions/resources/lang/fil/export.php
+++ b/packages/actions/resources/lang/fil/export.php
@@ -1,0 +1,60 @@
+<?php
+
+return [
+    'label' => 'I-export ang :label',
+    'modal' => [
+        'heading' => 'I-export ang :label',
+        'form' => [
+            'columns' => [
+                'label' => 'Mga column',
+                'actions' => [
+                    'select_all' => [
+                        'label' => 'Piliin lahat',
+                    ],
+                    'deselect_all' => [
+                        'label' => 'Alisin ang lahat ng napili',
+                    ],
+                ],
+                'form' => [
+                    'is_enabled' => [
+                        'label' => 'Naka-enable ang :column',
+                    ],
+                    'label' => [
+                        'label' => 'Label ng :column',
+                    ],
+                ],
+            ],
+        ],
+        'actions' => [
+            'export' => [
+                'label' => 'I-export',
+            ],
+        ],
+    ],
+    'notifications' => [
+        'completed' => [
+            'title' => 'Tapos na ang pag-export',
+            'actions' => [
+                'download_csv' => [
+                    'label' => 'I-download ang .csv',
+                ],
+                'download_xlsx' => [
+                    'label' => 'I-download ang .xlsx',
+                ],
+            ],
+        ],
+        'max_rows' => [
+            'title' => 'Masyadong malaki ang ie-export',
+            'body' => 'Hindi ka maaaring mag-export ng higit sa 1 row nang sabay.|Hindi ka maaaring mag-export ng higit sa :count row nang sabay.',
+        ],
+        'no_columns' => [
+            'title' => 'Walang napiling column',
+            'body' => 'Pumili ng kahit isang column na ie-export.',
+        ],
+        'started' => [
+            'title' => 'Nagsimula na ang pag-export',
+            'body' => 'Nagsimula na ang pag-export mo at ipoproseso sa background ang 1 row. Makakatanggap ka ng notification na may download link kapag tapos na.|Nagsimula na ang pag-export mo at ipoproseso sa background ang :count row. Makakatanggap ka ng notification na may download link kapag tapos na.',
+        ],
+    ],
+    'file_name' => 'export-:export_id-:model',
+];

--- a/packages/actions/resources/lang/fil/force-delete.php
+++ b/packages/actions/resources/lang/fil/force-delete.php
@@ -1,0 +1,46 @@
+<?php
+
+return [
+    'single' => [
+        'label' => 'Permanenteng i-delete',
+        'modal' => [
+            'heading' => 'Permanenteng i-delete ang :label',
+            'actions' => [
+                'delete' => [
+                    'label' => 'I-delete',
+                ],
+            ],
+        ],
+        'notifications' => [
+            'deleted' => [
+                'title' => 'Na-delete na',
+            ],
+        ],
+    ],
+    'multiple' => [
+        'label' => 'Permanenteng i-delete ang mga napili',
+        'modal' => [
+            'heading' => 'Permanenteng i-delete ang mga napiling :label',
+            'actions' => [
+                'delete' => [
+                    'label' => 'I-delete',
+                ],
+            ],
+        ],
+        'notifications' => [
+            'deleted' => [
+                'title' => 'Na-delete na',
+            ],
+            'deleted_partial' => [
+                'title' => 'Na-delete ang :count sa :total',
+                'missing_authorization_failure_message' => 'Wala kang pahintulot na i-delete ang :count.',
+                'missing_processing_failure_message' => 'Hindi ma-delete ang :count.',
+            ],
+            'deleted_none' => [
+                'title' => 'Hindi na-delete',
+                'missing_authorization_failure_message' => 'Wala kang pahintulot na i-delete ang :count.',
+                'missing_processing_failure_message' => 'Hindi ma-delete ang :count.',
+            ],
+        ],
+    ],
+];

--- a/packages/actions/resources/lang/fil/group.php
+++ b/packages/actions/resources/lang/fil/group.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'trigger' => [
+        'label' => 'Mga action',
+    ],
+];

--- a/packages/actions/resources/lang/fil/import.php
+++ b/packages/actions/resources/lang/fil/import.php
@@ -1,0 +1,56 @@
+<?php
+
+return [
+    'label' => 'I-import ang :label',
+    'modal' => [
+        'heading' => 'I-import ang :label',
+        'form' => [
+            'file' => [
+                'label' => 'File',
+                'placeholder' => 'Mag-upload ng CSV file',
+                'rules' => [
+                    'duplicate_columns' => '{0} Hindi dapat magkaroon ng higit sa isang blankong column header ang file.|{1,*} Hindi dapat magkaroon ng mga duplicate na column header ang file: :columns.',
+                ],
+            ],
+            'columns' => [
+                'label' => 'Mga column',
+                'placeholder' => 'Pumili ng column',
+            ],
+        ],
+        'actions' => [
+            'download_example' => [
+                'label' => 'I-download ang halimbawang CSV file',
+            ],
+            'import' => [
+                'label' => 'I-import',
+            ],
+        ],
+    ],
+    'notifications' => [
+        'completed' => [
+            'title' => 'Tapos na ang pag-import',
+            'actions' => [
+                'download_failed_rows_csv' => [
+                    'label' => 'I-download ang impormasyon tungkol sa hindi na-import na row|I-download ang impormasyon tungkol sa mga hindi na-import na row',
+                ],
+            ],
+        ],
+        'max_rows' => [
+            'title' => 'Masyadong malaki ang na-upload na CSV file',
+            'body' => 'Hindi ka maaaring mag-import ng higit sa 1 row nang sabay.|Hindi ka maaaring mag-import ng higit sa :count row nang sabay.',
+        ],
+        'started' => [
+            'title' => 'Nagsimula na ang pag-import',
+            'body' => 'Nagsimula na ang pag-import mo at ipoproseso sa background ang 1 row.|Nagsimula na ang pag-import mo at ipoproseso sa background ang :count row.',
+        ],
+    ],
+    'example_csv' => [
+        'file_name' => ':importer-halimbawa',
+    ],
+    'failure_csv' => [
+        'file_name' => 'import-:import_id-:csv_name-mga-hindi-na-import-na-row',
+        'error_header' => 'error',
+        'system_error' => 'May error sa system. Makipag-ugnayan sa support.',
+        'column_mapping_required_for_new_record' => 'Hindi itinugma ang :attribute column sa anumang column sa file, pero kailangan ito para gumawa ng mga bagong rekord.',
+    ],
+];

--- a/packages/actions/resources/lang/fil/modal.php
+++ b/packages/actions/resources/lang/fil/modal.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'confirmation' => 'Sigurado ka bang gusto mong gawin ito?',
+    'actions' => [
+        'cancel' => [
+            'label' => 'Kanselahin',
+        ],
+        'confirm' => [
+            'label' => 'Kumpirmahin',
+        ],
+        'submit' => [
+            'label' => 'Isumite',
+        ],
+    ],
+];

--- a/packages/actions/resources/lang/fil/notifications.php
+++ b/packages/actions/resources/lang/fil/notifications.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'throttled' => [
+        'title' => 'Masyadong maraming pagsubok',
+        'body' => 'Subukan ulit pagkalipas ng :seconds segundo.',
+    ],
+];

--- a/packages/actions/resources/lang/fil/replicate.php
+++ b/packages/actions/resources/lang/fil/replicate.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+    'single' => [
+        'label' => 'Gumawa ng kopya',
+        'modal' => [
+            'heading' => 'Gumawa ng kopya ng :label',
+            'actions' => [
+                'replicate' => [
+                    'label' => 'Gumawa ng kopya',
+                ],
+            ],
+        ],
+        'notifications' => [
+            'replicated' => [
+                'title' => 'Nakopya na',
+            ],
+        ],
+    ],
+];

--- a/packages/actions/resources/lang/fil/restore.php
+++ b/packages/actions/resources/lang/fil/restore.php
@@ -1,0 +1,46 @@
+<?php
+
+return [
+    'single' => [
+        'label' => 'I-restore',
+        'modal' => [
+            'heading' => 'I-restore ang :label',
+            'actions' => [
+                'restore' => [
+                    'label' => 'I-restore',
+                ],
+            ],
+        ],
+        'notifications' => [
+            'restored' => [
+                'title' => 'Na-restore na',
+            ],
+        ],
+    ],
+    'multiple' => [
+        'label' => 'I-restore ang mga napili',
+        'modal' => [
+            'heading' => 'I-restore ang mga napiling :label',
+            'actions' => [
+                'restore' => [
+                    'label' => 'I-restore',
+                ],
+            ],
+        ],
+        'notifications' => [
+            'restored' => [
+                'title' => 'Na-restore na',
+            ],
+            'restored_partial' => [
+                'title' => 'Na-restore ang :count sa :total',
+                'missing_authorization_failure_message' => 'Wala kang pahintulot na i-restore ang :count.',
+                'missing_processing_failure_message' => 'Hindi ma-restore ang :count.',
+            ],
+            'restored_none' => [
+                'title' => 'Hindi na-restore',
+                'missing_authorization_failure_message' => 'Wala kang pahintulot na i-restore ang :count.',
+                'missing_processing_failure_message' => 'Hindi ma-restore ang :count.',
+            ],
+        ],
+    ],
+];

--- a/packages/actions/resources/lang/fil/view.php
+++ b/packages/actions/resources/lang/fil/view.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'single' => [
+        'label' => 'Tingnan',
+        'modal' => [
+            'heading' => 'Tingnan ang :label',
+            'actions' => [
+                'close' => [
+                    'label' => 'Isara',
+                ],
+            ],
+        ],
+    ],
+];

--- a/packages/forms/resources/lang/fil/components.php
+++ b/packages/forms/resources/lang/fil/components.php
@@ -1,0 +1,587 @@
+<?php
+
+return [
+    'builder' => [
+        'actions' => [
+            'clone' => [
+                'label' => 'I-clone',
+            ],
+            'add' => [
+                'label' => 'Idagdag sa :label',
+                'modal' => [
+                    'heading' => 'Idagdag sa :label',
+                    'actions' => [
+                        'add' => [
+                            'label' => 'Idagdag',
+                        ],
+                    ],
+                ],
+            ],
+            'add_between' => [
+                'label' => 'Ipasok sa pagitan ng mga block',
+                'modal' => [
+                    'heading' => 'Idagdag sa :label',
+                    'actions' => [
+                        'add' => [
+                            'label' => 'Idagdag',
+                        ],
+                    ],
+                ],
+            ],
+            'delete' => [
+                'label' => 'I-delete',
+            ],
+            'edit' => [
+                'label' => 'I-edit',
+                'modal' => [
+                    'heading' => 'I-edit ang block',
+                    'actions' => [
+                        'save' => [
+                            'label' => 'I-save ang mga pagbabago',
+                        ],
+                    ],
+                ],
+            ],
+            'reorder' => [
+                'label' => 'Ilipat',
+            ],
+            'move_down' => [
+                'label' => 'Ilipat pababa',
+            ],
+            'move_up' => [
+                'label' => 'Ilipat pataas',
+            ],
+            'collapse' => [
+                'label' => 'I-collapse',
+            ],
+            'expand' => [
+                'label' => 'I-expand',
+            ],
+            'collapse_all' => [
+                'label' => 'I-collapse lahat',
+            ],
+            'expand_all' => [
+                'label' => 'I-expand lahat',
+            ],
+        ],
+    ],
+    'checkbox_list' => [
+        'actions' => [
+            'deselect_all' => [
+                'label' => 'Alisin lahat ng napili',
+            ],
+            'select_all' => [
+                'label' => 'Piliin lahat',
+            ],
+        ],
+    ],
+    'color_picker' => [
+        'panel_label' => 'Pampili ng kulay',
+    ],
+    'date_time_picker' => [
+        'month_select' => [
+            'label' => 'Buwan',
+        ],
+        'year_input' => [
+            'label' => 'Taon',
+        ],
+        'hour_input' => [
+            'label' => 'Oras',
+        ],
+        'minute_input' => [
+            'label' => 'Minuto',
+        ],
+        'second_input' => [
+            'label' => 'Segundo',
+        ],
+    ],
+    'file_upload' => [
+        'actions' => [
+            'download' => [
+                'label' => 'I-download',
+            ],
+            'open' => [
+                'label' => 'Buksan sa bagong tab',
+            ],
+        ],
+        'editor' => [
+            'label' => 'Image editor',
+            'actions' => [
+                'cancel' => [
+                    'label' => 'Kanselahin',
+                ],
+                'drag_crop' => [
+                    'label' => 'Drag mode na "crop"',
+                ],
+                'drag_move' => [
+                    'label' => 'Drag mode na "move"',
+                ],
+                'flip_horizontal' => [
+                    'label' => 'I-flip nang pahalang ang larawan',
+                ],
+                'flip_vertical' => [
+                    'label' => 'I-flip nang patayo ang larawan',
+                ],
+                'move_down' => [
+                    'label' => 'Ilipat pababa ang larawan',
+                ],
+                'move_left' => [
+                    'label' => 'Ilipat pakaliwa ang larawan',
+                ],
+                'move_right' => [
+                    'label' => 'Ilipat pakanan ang larawan',
+                ],
+                'move_up' => [
+                    'label' => 'Ilipat pataas ang larawan',
+                ],
+                'reset' => [
+                    'label' => 'I-reset',
+                ],
+                'rotate_left' => [
+                    'label' => 'I-rotate pakaliwa ang larawan',
+                ],
+                'rotate_right' => [
+                    'label' => 'I-rotate pakanan ang larawan',
+                ],
+                'set_aspect_ratio' => [
+                    'label' => 'Itakda ang aspect ratio sa :ratio',
+                ],
+                'save' => [
+                    'label' => 'I-save',
+                ],
+                'zoom_100' => [
+                    'label' => 'I-zoom ang larawan sa 100%',
+                ],
+                'zoom_in' => [
+                    'label' => 'I-zoom in',
+                ],
+                'zoom_out' => [
+                    'label' => 'I-zoom out',
+                ],
+            ],
+            'fields' => [
+                'height' => [
+                    'label' => 'Taas',
+                    'unit' => 'px',
+                ],
+                'rotation' => [
+                    'label' => 'Pag-ikot',
+                    'unit' => 'deg',
+                ],
+                'width' => [
+                    'label' => 'Lapad',
+                    'unit' => 'px',
+                ],
+                'x_position' => [
+                    'label' => 'X',
+                    'unit' => 'px',
+                ],
+                'y_position' => [
+                    'label' => 'Y',
+                    'unit' => 'px',
+                ],
+            ],
+            'aspect_ratios' => [
+                'label' => 'Mga aspect ratio',
+                'no_fixed' => [
+                    'label' => 'Malaya',
+                ],
+            ],
+            'svg' => [
+                'messages' => [
+                    'confirmation' => 'Hindi inirerekomenda ang pag-edit ng mga SVG file dahil puwedeng bumaba ang kalidad kapag binabago ang laki.\\n Sigurado ka bang gusto mong magpatuloy?',
+                    'disabled' => 'Naka-disable ang pag-edit ng mga SVG file dahil puwedeng bumaba ang kalidad kapag binabago ang laki.',
+                ],
+            ],
+        ],
+    ],
+    'key_value' => [
+        'actions' => [
+            'add' => [
+                'label' => 'Magdagdag ng row',
+            ],
+            'delete' => [
+                'label' => 'I-delete ang row',
+            ],
+            'reorder' => [
+                'label' => 'Ayusin ang row',
+            ],
+        ],
+        'columns' => [
+            'actions' => [
+                'label' => 'Mga action',
+            ],
+            'reorder' => [
+                'label' => 'Ayusin',
+            ],
+        ],
+        'fields' => [
+            'key' => [
+                'label' => 'Key',
+            ],
+            'value' => [
+                'label' => 'Value',
+            ],
+        ],
+    ],
+    'markdown_editor' => [
+        'file_attachments_accepted_file_types_message' => 'Dapat ganito ang uri ng mga in-upload na file: :values.',
+        'file_attachments_max_size_message' => 'Hindi dapat lumampas sa :max kilobytes ang mga in-upload na file.',
+        'tools' => [
+            'attach_files' => 'Mag-attach ng mga file',
+            'blockquote' => 'Blockquote',
+            'bold' => 'Bold',
+            'bullet_list' => 'Bullet list',
+            'code_block' => 'Code block',
+            'heading' => 'Heading',
+            'italic' => 'Italic',
+            'link' => 'Link',
+            'ordered_list' => 'Numbered list',
+            'redo' => 'Ulitin',
+            'strike' => 'Strikethrough',
+            'table' => 'Table',
+            'undo' => 'I-undo',
+        ],
+    ],
+    'modal_table_select' => [
+        'actions' => [
+            'select' => [
+                'label' => 'Piliin',
+                'actions' => [
+                    'select' => [
+                        'label' => 'Piliin',
+                    ],
+                ],
+            ],
+        ],
+    ],
+    'radio' => [
+        'boolean' => [
+            'true' => 'Oo',
+            'false' => 'Hindi',
+        ],
+    ],
+    'repeater' => [
+        'columns' => [
+            'actions' => [
+                'label' => 'Mga action',
+            ],
+            'reorder' => [
+                'label' => 'Ayusin',
+            ],
+        ],
+        'actions' => [
+            'add' => [
+                'label' => 'Idagdag sa :label',
+            ],
+            'add_between' => [
+                'label' => 'Ipasok sa pagitan',
+            ],
+            'delete' => [
+                'label' => 'I-delete',
+            ],
+            'clone' => [
+                'label' => 'I-clone',
+            ],
+            'reorder' => [
+                'label' => 'Ilipat',
+            ],
+            'move_down' => [
+                'label' => 'Ilipat pababa',
+            ],
+            'move_up' => [
+                'label' => 'Ilipat pataas',
+            ],
+            'collapse' => [
+                'label' => 'I-collapse',
+            ],
+            'expand' => [
+                'label' => 'I-expand',
+            ],
+            'collapse_all' => [
+                'label' => 'I-collapse lahat',
+            ],
+            'expand_all' => [
+                'label' => 'I-expand lahat',
+            ],
+        ],
+    ],
+    'rich_editor' => [
+        'actions' => [
+            'attach_files' => [
+                'label' => 'Mag-upload ng file',
+                'modal' => [
+                    'heading' => 'Mag-upload ng file',
+                    'form' => [
+                        'file' => [
+                            'label' => [
+                                'new' => 'File',
+                                'existing' => 'Palitan ang file',
+                            ],
+                        ],
+                        'alt' => [
+                            'label' => [
+                                'new' => 'Alt text',
+                                'existing' => 'Baguhin ang alt text',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'custom_block' => [
+                'modal' => [
+                    'actions' => [
+                        'insert' => [
+                            'label' => 'Ipasok',
+                        ],
+                        'save' => [
+                            'label' => 'I-save',
+                        ],
+                    ],
+                ],
+            ],
+            'grid' => [
+                'label' => 'Grid',
+                'modal' => [
+                    'heading' => 'Grid',
+                    'form' => [
+                        'preset' => [
+                            'label' => 'Preset',
+                            'placeholder' => 'Wala',
+                            'options' => [
+                                'two' => 'Dalawa',
+                                'three' => 'Tatlo',
+                                'four' => 'Apat',
+                                'five' => 'Lima',
+                                'two_start_third' => 'Dalawa (Ikatlo sa simula)',
+                                'two_end_third' => 'Dalawa (Ikatlo sa dulo)',
+                                'two_start_fourth' => 'Dalawa (Ikaapat sa simula)',
+                                'two_end_fourth' => 'Dalawa (Ikaapat sa dulo)',
+                            ],
+                        ],
+                        'columns' => [
+                            'label' => 'Mga column',
+                        ],
+                        'from_breakpoint' => [
+                            'label' => 'Mula sa breakpoint',
+                            'options' => [
+                                'default' => 'Lahat',
+                                'sm' => 'Maliit',
+                                'md' => 'Katamtaman',
+                                'lg' => 'Malaki',
+                                'xl' => 'Napakalaki',
+                                '2xl' => 'Dalawang beses na napakalaki',
+                            ],
+                        ],
+                        'is_asymmetric' => [
+                            'label' => 'Dalawang hindi pantay na column',
+                        ],
+                        'start_span' => [
+                            'label' => 'Panimulang span',
+                        ],
+                        'end_span' => [
+                            'label' => 'Panghuling span',
+                        ],
+                    ],
+                ],
+            ],
+            'link' => [
+                'label' => 'Link',
+                'modal' => [
+                    'heading' => 'Link',
+                    'form' => [
+                        'url' => [
+                            'label' => 'URL',
+                        ],
+                        'should_open_in_new_tab' => [
+                            'label' => 'Buksan sa bagong tab',
+                        ],
+                    ],
+                ],
+            ],
+            'text_color' => [
+                'label' => 'Kulay ng text',
+                'modal' => [
+                    'heading' => 'Kulay ng text',
+                    'form' => [
+                        'color' => [
+                            'label' => 'Kulay',
+                            'options' => [
+                                'slate' => 'Slate',
+                                'gray' => 'Gray',
+                                'zinc' => 'Zinc',
+                                'neutral' => 'Neutral',
+                                'stone' => 'Stone',
+                                'mauve' => 'Mauve',
+                                'olive' => 'Olive',
+                                'mist' => 'Mist',
+                                'taupe' => 'Taupe',
+                                'red' => 'Pula',
+                                'orange' => 'Orange',
+                                'amber' => 'Amber',
+                                'yellow' => 'Dilaw',
+                                'lime' => 'Lime',
+                                'green' => 'Berde',
+                                'emerald' => 'Emerald',
+                                'teal' => 'Teal',
+                                'cyan' => 'Cyan',
+                                'sky' => 'Sky',
+                                'blue' => 'Asul',
+                                'indigo' => 'Indigo',
+                                'violet' => 'Violet',
+                                'purple' => 'Lila',
+                                'fuchsia' => 'Fuchsia',
+                                'pink' => 'Pink',
+                                'rose' => 'Rose',
+                            ],
+                        ],
+                        'custom_color' => [
+                            'label' => 'Custom na kulay',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+        'file_attachments_accepted_file_types_message' => 'Dapat ganito ang uri ng mga in-upload na file: :values.',
+        'file_attachments_max_size_message' => 'Hindi dapat lumampas sa :max kilobytes ang mga in-upload na file.',
+        'no_merge_tag_search_results_message' => 'Walang nahanap na merge tag.',
+        'mentions' => [
+            'no_options_message' => 'Walang available na option.',
+            'no_search_results_message' => 'Walang resultang tugma sa search mo.',
+            'search_prompt' => 'Mag-type para mag-search...',
+            'searching_message' => 'Naghahanap...',
+        ],
+        'toolbar' => [
+            'label' => 'Editor toolbar',
+        ],
+        'tools' => [
+            'align_center' => 'I-align sa gitna',
+            'align_end' => 'I-align sa dulo',
+            'align_justify' => 'I-justify',
+            'align_start' => 'I-align sa simula',
+            'attach_files' => 'Mag-attach ng mga file',
+            'blockquote' => 'Blockquote',
+            'bold' => 'Bold',
+            'bullet_list' => 'Bullet list',
+            'clear_formatting' => 'Alisin ang formatting',
+            'code' => 'Code',
+            'code_block' => 'Code block',
+            'custom_blocks' => 'Mga block',
+            'details' => 'Mga detalye',
+            'h1' => 'Pamagat',
+            'h2' => 'Heading 2',
+            'h3' => 'Heading 3',
+            'h4' => 'Heading 4',
+            'h5' => 'Heading 5',
+            'h6' => 'Heading 6',
+            'grid' => 'Grid',
+            'grid_delete' => 'I-delete ang grid',
+            'highlight' => 'I-highlight',
+            'horizontal_rule' => 'Pahalang na linya',
+            'italic' => 'Italic',
+            'lead' => 'Lead text',
+            'link' => 'Link',
+            'merge_tags' => 'Mga merge tag',
+            'ordered_list' => 'Numbered list',
+            'paragraph' => 'Talata',
+            'redo' => 'Ulitin',
+            'small' => 'Maliit na text',
+            'strike' => 'Strikethrough',
+            'subscript' => 'Subscript',
+            'superscript' => 'Superscript',
+            'table' => 'Table',
+            'table_delete' => 'I-delete ang table',
+            'table_add_column_before' => 'Magdagdag ng column bago nito',
+            'table_add_column_after' => 'Magdagdag ng column pagkatapos nito',
+            'table_delete_column' => 'I-delete ang column',
+            'table_add_row_before' => 'Magdagdag ng row sa itaas',
+            'table_add_row_after' => 'Magdagdag ng row sa ibaba',
+            'table_delete_row' => 'I-delete ang row',
+            'table_merge_cells' => 'Pagsamahin ang mga cell',
+            'table_split_cell' => 'Hatiin ang cell',
+            'table_toggle_header_row' => 'I-toggle ang header row',
+            'table_toggle_header_cell' => 'I-toggle ang header cell',
+            'text_color' => 'Kulay ng text',
+            'underline' => 'Salungguhitan',
+            'undo' => 'I-undo',
+        ],
+        'uploading_file_message' => 'Ina-upload ang file...',
+    ],
+    'select' => [
+        'actions' => [
+            'clear' => [
+                'label' => 'I-clear',
+            ],
+            'create_option' => [
+                'label' => 'Gumawa',
+                'modal' => [
+                    'heading' => 'Gumawa',
+                    'actions' => [
+                        'create' => [
+                            'label' => 'Gumawa',
+                        ],
+                        'create_another' => [
+                            'label' => 'Gumawa at gumawa pa ng isa',
+                        ],
+                    ],
+                ],
+            ],
+            'edit_option' => [
+                'label' => 'I-edit',
+                'modal' => [
+                    'heading' => 'I-edit',
+                    'actions' => [
+                        'save' => [
+                            'label' => 'I-save',
+                        ],
+                    ],
+                ],
+            ],
+            'remove_option' => [
+                'label' => 'Alisin ang :label',
+            ],
+        ],
+        'boolean' => [
+            'true' => 'Oo',
+            'false' => 'Hindi',
+        ],
+        'loading_message' => 'Naglo-load...',
+        'max_items_message' => ':count lang ang puwedeng piliin.',
+        'no_options_message' => 'Walang available na option.',
+        'no_search_results_message' => 'Walang option na tugma sa search mo.',
+        'placeholder' => 'Pumili ng option',
+        'searching_message' => 'Naghahanap...',
+        'search_label' => 'Maghanap',
+        'search_prompt' => 'Mag-type para mag-search...',
+    ],
+    'tags_input' => [
+        'actions' => [
+            'delete' => [
+                'label' => 'I-delete',
+            ],
+        ],
+        'placeholder' => 'Bagong tag',
+        'tag_added' => 'Idinagdag: :tag',
+        'tag_removed' => 'Inalis: :tag',
+    ],
+    'text_input' => [
+        'actions' => [
+            'copy' => [
+                'label' => 'Kopyahin',
+                'message' => 'Nakopya',
+            ],
+            'hide_password' => [
+                'label' => 'Itago ang password',
+            ],
+            'show_password' => [
+                'label' => 'Ipakita ang password',
+            ],
+        ],
+    ],
+    'toggle_buttons' => [
+        'boolean' => [
+            'true' => 'Oo',
+            'false' => 'Hindi',
+        ],
+    ],
+];

--- a/packages/forms/resources/lang/fil/validation.php
+++ b/packages/forms/resources/lang/fil/validation.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'distinct' => [
+        'must_be_selected' => 'Dapat pumili ng kahit isang :attribute field.',
+        'only_one_must_be_selected' => 'Isang :attribute field lang ang dapat piliin.',
+    ],
+    'tampered_file_path' => 'May file path ang :attribute field na hindi pinapayagan.',
+];

--- a/packages/infolists/resources/lang/fil/components.php
+++ b/packages/infolists/resources/lang/fil/components.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+    'entries' => [
+        'text' => [
+            'actions' => [
+                'collapse_list' => 'Magpakita ng mas kaunting :count',
+                'expand_list' => 'Magpakita ng :count pa',
+            ],
+            'more_list_items' => 'at :count pa',
+        ],
+        'icon' => [
+            'true' => 'Oo',
+            'false' => 'Hindi',
+        ],
+        'key_value' => [
+            'columns' => [
+                'key' => [
+                    'label' => 'Susi',
+                ],
+                'value' => [
+                    'label' => 'Halaga',
+                ],
+            ],
+            'placeholder' => 'Walang entry',
+        ],
+    ],
+];

--- a/packages/notifications/resources/lang/fil/database.php
+++ b/packages/notifications/resources/lang/fil/database.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+    'modal' => [
+        'heading' => 'Mga Notification',
+        'unread_label' => 'Hindi pa nababasang notification',
+        'actions' => [
+            'clear' => [
+                'label' => 'I-clear',
+            ],
+            'mark_all_as_read' => [
+                'label' => 'Markahan lahat bilang nabasa',
+            ],
+        ],
+        'empty' => [
+            'heading' => 'Walang notification',
+            'description' => 'Pakitingnan ulit mamaya.',
+        ],
+    ],
+];

--- a/packages/notifications/resources/lang/fil/notification.php
+++ b/packages/notifications/resources/lang/fil/notification.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'actions' => [
+        'close' => [
+            'label' => 'Isara ang notification',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/http/controllers/block-email-change-verification-controller.php
+++ b/packages/panels/resources/lang/fil/auth/http/controllers/block-email-change-verification-controller.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'notifications' => [
+        'blocked' => [
+            'title' => 'Na-block ang pagpapalit ng email address',
+            'body' => 'Matagumpay mong na-block ang pagtatangkang palitan ang email address ng :email. Kung hindi ikaw ang gumawa ng orihinal na request, makipag-ugnayan agad sa amin.',
+        ],
+        'failed' => [
+            'title' => 'Hindi na-block ang pagpapalit ng email address',
+            'body' => 'Hindi na napigilan ang pagpapalit ng email address sa :email dahil na-verify na ito bago mo na-block. Kung hindi ikaw ang gumawa ng orihinal na request, makipag-ugnayan agad sa amin.',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/http/controllers/email-change-verification-controller.php
+++ b/packages/panels/resources/lang/fil/auth/http/controllers/email-change-verification-controller.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'notifications' => [
+        'unavailable' => [
+            'title' => 'Hindi na available ang email address na iyon.',
+            'body' => 'Ginamit ito ng ibang account habang hindi pa nagagamit ang verification link mo.',
+        ],
+        'verified' => [
+            'title' => 'Napalitan ang email address',
+            'body' => 'Matagumpay na napalitan ang email address mo ng :email.',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/multi-factor/app/actions/disable.php
+++ b/packages/panels/resources/lang/fil/auth/multi-factor/app/actions/disable.php
@@ -1,0 +1,42 @@
+<?php
+
+return [
+    'label' => 'I-off',
+    'modal' => [
+        'heading' => 'I-disable ang authenticator app',
+        'description' => 'Sigurado ka bang gusto mong ihinto ang paggamit ng authenticator app? Kapag na-disable ito, mawawala ang dagdag na proteksiyon sa account mo.',
+        'form' => [
+            'code' => [
+                'label' => 'Ilagay ang 6-digit code mula sa authenticator app',
+                'validation_attribute' => 'verification code',
+                'actions' => [
+                    'use_recovery_code' => [
+                        'label' => 'Gumamit na lang ng recovery code',
+                    ],
+                ],
+                'messages' => [
+                    'invalid' => 'Hindi valid ang inilagay mong code.',
+                    'rate_limited' => 'Masyadong maraming attempt. Subukan ulit mamaya.',
+                ],
+            ],
+            'recovery_code' => [
+                'label' => 'O, maglagay ng recovery code',
+                'validation_attribute' => 'code para sa recovery',
+                'messages' => [
+                    'invalid' => 'Hindi valid ang inilagay mong recovery code.',
+                    'rate_limited' => 'Masyadong maraming attempt. Subukan ulit mamaya.',
+                ],
+            ],
+        ],
+        'actions' => [
+            'submit' => [
+                'label' => 'I-disable ang authenticator app',
+            ],
+        ],
+    ],
+    'notifications' => [
+        'disabled' => [
+            'title' => 'Na-disable na ang authenticator app',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/multi-factor/app/actions/regenerate-recovery-codes.php
+++ b/packages/panels/resources/lang/fil/auth/multi-factor/app/actions/regenerate-recovery-codes.php
@@ -1,0 +1,44 @@
+<?php
+
+return [
+    'label' => 'Gumawa ulit ng mga recovery code',
+    'modal' => [
+        'heading' => 'Gumawa ulit ng mga recovery code ng authenticator app',
+        'description' => 'Kung nawala ang mga recovery code mo, puwede kang gumawa ulit dito. Agad na mawawalan ng bisa ang mga luma mong recovery code.',
+        'form' => [
+            'code' => [
+                'label' => 'Ilagay ang 6-digit code mula sa authenticator app',
+                'validation_attribute' => 'verification code',
+                'messages' => [
+                    'invalid' => 'Hindi valid ang inilagay mong code.',
+                    'rate_limited' => 'Masyadong maraming attempt. Subukan ulit mamaya.',
+                ],
+            ],
+            'password' => [
+                'label' => 'O, ilagay ang kasalukuyan mong password',
+                'validation_attribute' => 'kasalukuyang password',
+            ],
+        ],
+        'actions' => [
+            'submit' => [
+                'label' => 'Gumawa ulit ng mga recovery code',
+            ],
+        ],
+    ],
+    'notifications' => [
+        'regenerated' => [
+            'title' => 'Nagawa na ang mga bagong recovery code ng authenticator app',
+        ],
+    ],
+    'show_new_recovery_codes' => [
+        'modal' => [
+            'heading' => 'Mga bagong recovery code',
+            'description' => 'I-save ang mga sumusunod na recovery code sa ligtas na lugar. Isang beses lang ipapakita ang mga ito, pero kakailanganin mo ang mga ito kung mawalan ka ng access sa authenticator app mo:',
+            'actions' => [
+                'submit' => [
+                    'label' => 'Isara',
+                ],
+            ],
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/multi-factor/app/actions/set-up.php
+++ b/packages/panels/resources/lang/fil/auth/multi-factor/app/actions/set-up.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'label' => 'I-set up',
+    'modal' => [
+        'heading' => 'I-set up ang authenticator app',
+        'description' => 'Kakailanganin mo ng app tulad ng Google Authenticator (<x-filament::link href="https://itunes.apple.com/us/app/google-authenticator/id388497605" target="_blank">iOS</x-filament::link>, <x-filament::link href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2" target="_blank">Android</x-filament::link>) para makumpleto ito.',
+        'content' => [
+            'qr_code' => [
+                'instruction' => 'I-scan ang QR code na ito gamit ang authenticator app mo:',
+                'alt' => 'QR code na i-scan gamit ang authenticator app',
+            ],
+            'text_code' => [
+                'instruction' => 'O ilagay nang manual ang code na ito:',
+                'messages' => [
+                    'copied' => 'Nakopya',
+                ],
+            ],
+            'recovery_codes' => [
+                'instruction' => 'I-save ang mga sumusunod na recovery code sa ligtas na lugar. Isang beses lang ipapakita ang mga ito, pero kakailanganin mo ang mga ito kung mawalan ka ng access sa authenticator app mo:',
+            ],
+        ],
+        'form' => [
+            'code' => [
+                'label' => 'Ilagay ang 6-digit code mula sa authenticator app',
+                'validation_attribute' => 'verification code',
+                'below_content' => 'Kakailanganin mong ilagay ang 6-digit code mula sa authenticator app tuwing magsa-sign in ka o gagawa ng sensitibong action.',
+                'messages' => [
+                    'invalid' => 'Hindi valid ang inilagay mong code.',
+                    'rate_limited' => 'Masyadong maraming attempt. Subukan ulit mamaya.',
+                ],
+            ],
+        ],
+        'actions' => [
+            'submit' => [
+                'label' => 'I-enable ang authenticator app',
+            ],
+        ],
+    ],
+    'notifications' => [
+        'enabled' => [
+            'title' => 'Na-enable na ang authenticator app',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/multi-factor/app/provider.php
+++ b/packages/panels/resources/lang/fil/auth/multi-factor/app/provider.php
@@ -1,0 +1,36 @@
+<?php
+
+return [
+    'management_schema' => [
+        'actions' => [
+            'label' => 'App na authenticator',
+            'below_content' => 'Gumamit ng secure na app para gumawa ng pansamantalang code para sa login verification.',
+            'messages' => [
+                'enabled' => 'Naka-enable',
+                'disabled' => 'Naka-disable',
+            ],
+        ],
+    ],
+    'login_form' => [
+        'label' => 'Gumamit ng code mula sa authenticator app mo',
+        'code' => [
+            'label' => 'Ilagay ang 6-digit code mula sa authenticator app',
+            'validation_attribute' => 'verification code',
+            'actions' => [
+                'use_recovery_code' => [
+                    'label' => 'Gumamit na lang ng recovery code',
+                ],
+            ],
+            'messages' => [
+                'invalid' => 'Hindi valid ang inilagay mong code.',
+            ],
+        ],
+        'recovery_code' => [
+            'label' => 'O, maglagay ng recovery code',
+            'validation_attribute' => 'code para sa recovery',
+            'messages' => [
+                'invalid' => 'Hindi valid ang inilagay mong recovery code.',
+            ],
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/multi-factor/email/actions/disable.php
+++ b/packages/panels/resources/lang/fil/auth/multi-factor/email/actions/disable.php
@@ -1,0 +1,42 @@
+<?php
+
+return [
+    'label' => 'I-off',
+    'modal' => [
+        'heading' => 'I-disable ang mga email verification code',
+        'description' => 'Sigurado ka bang gusto mong ihinto ang pagtanggap ng mga email verification code? Kapag na-disable ito, mawawala ang dagdag na proteksiyon sa account mo.',
+        'form' => [
+            'code' => [
+                'label' => 'Ilagay ang 6-digit code na ipinadala namin sa email mo',
+                'validation_attribute' => 'verification code',
+                'actions' => [
+                    'resend' => [
+                        'label' => 'Magpadala ng bagong code sa email',
+                        'notifications' => [
+                            'resent' => [
+                                'title' => 'Nagpadala kami ng bagong code sa email mo',
+                            ],
+                            'throttled' => [
+                                'title' => 'Masyadong maraming resend attempt. Maghintay bago humiling ng panibagong code.',
+                            ],
+                        ],
+                    ],
+                ],
+                'messages' => [
+                    'invalid' => 'Hindi valid ang inilagay mong code.',
+                    'rate_limited' => 'Masyadong maraming attempt. Subukan ulit mamaya.',
+                ],
+            ],
+        ],
+        'actions' => [
+            'submit' => [
+                'label' => 'I-disable ang mga email verification code',
+            ],
+        ],
+    ],
+    'notifications' => [
+        'disabled' => [
+            'title' => 'Na-disable na ang mga email verification code',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/multi-factor/email/actions/set-up.php
+++ b/packages/panels/resources/lang/fil/auth/multi-factor/email/actions/set-up.php
@@ -1,0 +1,42 @@
+<?php
+
+return [
+    'label' => 'I-set up',
+    'modal' => [
+        'heading' => 'I-set up ang mga email verification code',
+        'description' => 'Kakailanganin mong ilagay ang 6-digit code na ipapadala namin sa email mo tuwing magsa-sign in ka o gagawa ng sensitibong action. Tingnan ang email mo para sa 6-digit code upang makumpleto ang setup.',
+        'form' => [
+            'code' => [
+                'label' => 'Ilagay ang 6-digit code na ipinadala namin sa email mo',
+                'validation_attribute' => 'verification code',
+                'actions' => [
+                    'resend' => [
+                        'label' => 'Magpadala ng bagong code sa email',
+                        'notifications' => [
+                            'resent' => [
+                                'title' => 'Nagpadala kami ng bagong code sa email mo',
+                            ],
+                            'throttled' => [
+                                'title' => 'Masyadong maraming resend attempt. Maghintay bago humiling ng panibagong code.',
+                            ],
+                        ],
+                    ],
+                ],
+                'messages' => [
+                    'invalid' => 'Hindi valid ang inilagay mong code.',
+                    'rate_limited' => 'Masyadong maraming attempt. Subukan ulit mamaya.',
+                ],
+            ],
+        ],
+        'actions' => [
+            'submit' => [
+                'label' => 'I-enable ang mga email verification code',
+            ],
+        ],
+    ],
+    'notifications' => [
+        'enabled' => [
+            'title' => 'Na-enable na ang mga email verification code',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/multi-factor/email/notifications/verify-email-authentication.php
+++ b/packages/panels/resources/lang/fil/auth/multi-factor/email/notifications/verify-email-authentication.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'subject' => 'Narito ang sign-in code mo',
+    'lines' => [
+        0 => 'Ang sign-in code mo ay: :code',
+        1 => 'Mag-e-expire ang code na ito pagkalipas ng isang minuto.|Mag-e-expire ang code na ito pagkalipas ng :minutes minuto.',
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/multi-factor/email/provider.php
+++ b/packages/panels/resources/lang/fil/auth/multi-factor/email/provider.php
@@ -1,0 +1,37 @@
+<?php
+
+return [
+    'management_schema' => [
+        'actions' => [
+            'label' => 'Mga email verification code',
+            'below_content' => 'Tumanggap ng pansamantalang code sa email address mo para i-verify ang pagkakakilanlan mo habang nagla-login.',
+            'messages' => [
+                'enabled' => 'Naka-enable',
+                'disabled' => 'Naka-disable',
+            ],
+        ],
+    ],
+    'login_form' => [
+        'label' => 'Magpadala ng code sa email mo',
+        'code' => [
+            'label' => 'Ilagay ang 6-digit code na ipinadala namin sa email mo',
+            'validation_attribute' => 'verification code',
+            'actions' => [
+                'resend' => [
+                    'label' => 'Magpadala ng bagong code sa email',
+                    'notifications' => [
+                        'resent' => [
+                            'title' => 'Nagpadala kami ng bagong code sa email mo',
+                        ],
+                        'throttled' => [
+                            'title' => 'Masyadong maraming resend attempt. Maghintay bago humiling ng panibagong code.',
+                        ],
+                    ],
+                ],
+            ],
+            'messages' => [
+                'invalid' => 'Hindi valid ang inilagay mong code.',
+            ],
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/multi-factor/pages/set-up-required-multi-factor-authentication.php
+++ b/packages/panels/resources/lang/fil/auth/multi-factor/pages/set-up-required-multi-factor-authentication.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'title' => 'I-set up ang two-factor authentication (2FA)',
+    'heading' => 'I-set up ang two-factor authentication',
+    'subheading' => 'Nagdaragdag ang 2FA ng proteksiyon sa account mo sa pamamagitan ng paghingi ng pangalawang verification kapag nagsa-sign in.',
+    'actions' => [
+        'continue' => [
+            'label' => 'Magpatuloy',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/multi-factor/recovery-codes-modal-content.php
+++ b/packages/panels/resources/lang/fil/auth/multi-factor/recovery-codes-modal-content.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'actions' => [
+        0 => 'I-click para',
+        'copy' => [
+            'label' => 'kopyahin',
+        ],
+        1 => 'o',
+        'download' => [
+            'label' => 'i-download',
+        ],
+        2 => 'ang lahat ng code nang sabay-sabay.',
+    ],
+    'messages' => [
+        'copied' => 'Nakopya',
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/notifications/notice-of-email-change-request.php
+++ b/packages/panels/resources/lang/fil/auth/notifications/notice-of-email-change-request.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'subject' => 'Pinapalitan ang email address mo',
+    'lines' => [
+        0 => 'Nakatanggap kami ng request na palitan ang email address na konektado sa account mo. Ginamit ang password mo para kumpirmahin ang pagbabagong ito.',
+        1 => 'Kapag na-verify na, ang bagong email address sa account mo ay: :email.',
+        2 => 'Puwede mong i-block ang pagbabago bago ito ma-verify sa pamamagitan ng pag-click sa button sa ibaba.',
+        3 => 'Kung hindi ikaw ang gumawa ng request na ito, makipag-ugnayan agad sa amin.',
+    ],
+    'action' => 'I-block ang Pagpapalit ng Email',
+];

--- a/packages/panels/resources/lang/fil/auth/pages/edit-profile.php
+++ b/packages/panels/resources/lang/fil/auth/pages/edit-profile.php
@@ -1,0 +1,52 @@
+<?php
+
+return [
+    'label' => 'Aking profile',
+    'form' => [
+        'email' => [
+            'label' => 'Address ng email',
+        ],
+        'name' => [
+            'label' => 'Pangalan',
+        ],
+        'password' => [
+            'label' => 'Bagong password',
+            'validation_attribute' => 'bagong password',
+        ],
+        'password_confirmation' => [
+            'label' => 'Kumpirmahin ang bagong password',
+            'validation_attribute' => 'pagkumpirma ng password',
+        ],
+        'current_password' => [
+            'label' => 'Kasalukuyang password',
+            'below_content' => 'Para sa seguridad, kumpirmahin ang password mo para magpatuloy.',
+            'validation_attribute' => 'kasalukuyang password',
+        ],
+        'actions' => [
+            'save' => [
+                'label' => 'I-save ang mga pagbabago',
+            ],
+        ],
+    ],
+    'multi_factor_authentication' => [
+        'label' => 'Dalawang hakbang na authentication (2FA)',
+    ],
+    'notifications' => [
+        'email_change_verification_sent' => [
+            'title' => 'Naipadala ang request na palitan ang email address',
+            'body' => 'Naipadala sa :email ang request na palitan ang email address mo. Tingnan ang email mo para i-verify ang pagbabago.',
+        ],
+        'saved' => [
+            'title' => 'Na-save',
+        ],
+        'throttled' => [
+            'title' => 'Masyadong maraming request. Subukan ulit pagkalipas ng :seconds segundo.',
+            'body' => 'Subukan ulit pagkalipas ng :seconds segundo.',
+        ],
+    ],
+    'actions' => [
+        'cancel' => [
+            'label' => 'Kanselahin',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/pages/email-verification/email-verification-prompt.php
+++ b/packages/panels/resources/lang/fil/auth/pages/email-verification/email-verification-prompt.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+    'title' => 'I-verify ang email address mo',
+    'heading' => 'I-verify ang email address mo',
+    'actions' => [
+        'resend_notification' => [
+            'label' => 'Ipadala ulit',
+        ],
+    ],
+    'messages' => [
+        'notification_not_received' => 'Hindi mo natanggap ang email na ipinadala namin?',
+        'notification_sent' => 'Nagpadala kami ng email sa :email na may mga tagubilin kung paano i-verify ang email address mo.',
+    ],
+    'notifications' => [
+        'notification_resent' => [
+            'title' => 'Ipinadala ulit namin ang email.',
+        ],
+        'notification_resend_throttled' => [
+            'title' => 'Masyadong maraming resend attempt',
+            'body' => 'Subukan ulit pagkalipas ng :seconds segundo.',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/pages/login.php
+++ b/packages/panels/resources/lang/fil/auth/pages/login.php
@@ -1,0 +1,54 @@
+<?php
+
+return [
+    'title' => 'Pag-login',
+    'heading' => 'Mag-sign in',
+    'actions' => [
+        'register' => [
+            'before' => 'o',
+            'label' => 'gumawa ng account',
+        ],
+        'request_password_reset' => [
+            'label' => 'Nakalimutan ang password?',
+        ],
+    ],
+    'form' => [
+        'email' => [
+            'label' => 'Address ng email',
+        ],
+        'password' => [
+            'label' => 'Password mo',
+        ],
+        'remember' => [
+            'label' => 'Tandaan ako',
+        ],
+        'actions' => [
+            'authenticate' => [
+                'label' => 'Mag-sign in',
+            ],
+        ],
+    ],
+    'multi_factor' => [
+        'heading' => 'I-verify ang pagkakakilanlan mo',
+        'subheading' => 'Para magpatuloy sa pag-sign in, kailangan mong i-verify ang pagkakakilanlan mo.',
+        'form' => [
+            'provider' => [
+                'label' => 'Paano mo gustong mag-verify?',
+            ],
+            'actions' => [
+                'authenticate' => [
+                    'label' => 'Kumpirmahin ang pag-sign in',
+                ],
+            ],
+        ],
+    ],
+    'messages' => [
+        'failed' => 'Hindi tugma ang mga credential na ito sa aming mga rekord.',
+    ],
+    'notifications' => [
+        'throttled' => [
+            'title' => 'Masyadong maraming login attempt',
+            'body' => 'Subukan ulit pagkalipas ng :seconds segundo.',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/pages/password-reset/request-password-reset.php
+++ b/packages/panels/resources/lang/fil/auth/pages/password-reset/request-password-reset.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+    'title' => 'I-reset ang password mo',
+    'heading' => 'Nakalimutan ang password?',
+    'actions' => [
+        'login' => [
+            'label' => 'bumalik sa login',
+        ],
+    ],
+    'form' => [
+        'email' => [
+            'label' => 'Address ng email',
+        ],
+        'actions' => [
+            'request' => [
+                'label' => 'Ipadala ang email',
+            ],
+        ],
+    ],
+    'notifications' => [
+        'sent' => [
+            'body' => 'Kung hindi umiiral ang account mo, hindi mo matatanggap ang email.',
+        ],
+        'throttled' => [
+            'title' => 'Masyadong maraming request',
+            'body' => 'Subukan ulit pagkalipas ng :seconds segundo.',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/pages/password-reset/reset-password.php
+++ b/packages/panels/resources/lang/fil/auth/pages/password-reset/reset-password.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+    'title' => 'I-reset ang password mo',
+    'heading' => 'I-reset ang password mo',
+    'form' => [
+        'email' => [
+            'label' => 'Address ng email',
+        ],
+        'password' => [
+            'label' => 'Password mo',
+            'validation_attribute' => 'password ng account',
+        ],
+        'password_confirmation' => [
+            'label' => 'Kumpirmahin ang password',
+        ],
+        'actions' => [
+            'reset' => [
+                'label' => 'I-reset ang password',
+            ],
+        ],
+    ],
+    'notifications' => [
+        'throttled' => [
+            'title' => 'Masyadong maraming reset attempt',
+            'body' => 'Subukan ulit pagkalipas ng :seconds segundo.',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/auth/pages/register.php
+++ b/packages/panels/resources/lang/fil/auth/pages/register.php
@@ -1,0 +1,38 @@
+<?php
+
+return [
+    'title' => 'Mag-register',
+    'heading' => 'Gumawa ng account',
+    'actions' => [
+        'login' => [
+            'before' => 'o',
+            'label' => 'mag-sign in sa account mo',
+        ],
+    ],
+    'form' => [
+        'email' => [
+            'label' => 'Address ng email',
+        ],
+        'name' => [
+            'label' => 'Pangalan',
+        ],
+        'password' => [
+            'label' => 'Password mo',
+            'validation_attribute' => 'password ng account',
+        ],
+        'password_confirmation' => [
+            'label' => 'Kumpirmahin ang password',
+        ],
+        'actions' => [
+            'register' => [
+                'label' => 'Gumawa ng account',
+            ],
+        ],
+    ],
+    'notifications' => [
+        'throttled' => [
+            'title' => 'Masyadong maraming registration attempt',
+            'body' => 'Subukan ulit pagkalipas ng :seconds segundo.',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/error-notifications.php
+++ b/packages/panels/resources/lang/fil/error-notifications.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'title' => 'Nagka-error habang nilo-load ang page',
+    'body' => 'Nagka-error habang sinusubukang i-load ang page na ito. Subukan ulit mamaya.',
+];

--- a/packages/panels/resources/lang/fil/global-search.php
+++ b/packages/panels/resources/lang/fil/global-search.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'field' => [
+        'label' => 'Pangkalahatang search',
+        'placeholder' => 'Maghanap',
+    ],
+    'no_results_message' => 'Walang nahanap na resulta.',
+];

--- a/packages/panels/resources/lang/fil/layout.php
+++ b/packages/panels/resources/lang/fil/layout.php
@@ -1,0 +1,61 @@
+<?php
+
+return [
+    'direction' => 'ltr',
+    'skip_to_content' => [
+        'label' => 'Pumunta sa content',
+    ],
+    'actions' => [
+        'billing' => [
+            'label' => 'I-manage ang subscription',
+        ],
+        'logout' => [
+            'label' => 'Mag-sign out',
+        ],
+        'open_database_notifications' => [
+            'label' => 'Mga notification',
+            'label_with_unread_count' => '{1} Mga notification, :count hindi pa nababasang notification|[2,*] Mga notification, :count hindi pa nababasang notification',
+        ],
+        'open_user_menu' => [
+            'label' => 'Menu ng user',
+        ],
+        'sidebar' => [
+            'collapse' => [
+                'label' => 'I-collapse ang sidebar',
+            ],
+            'expand' => [
+                'label' => 'I-expand ang sidebar',
+            ],
+        ],
+        'theme_switcher' => [
+            'label' => 'Display theme',
+            'dark' => [
+                'label' => 'I-enable ang dark theme',
+            ],
+            'light' => [
+                'label' => 'I-enable ang light theme',
+            ],
+            'system' => [
+                'label' => 'I-enable ang system theme',
+            ],
+        ],
+    ],
+    'navigation' => [
+        'label' => 'Navigation sa sidebar',
+    ],
+    'topbar' => [
+        'label' => 'Bar sa itaas',
+    ],
+    'avatar' => [
+        'alt' => 'Avatar ni :name',
+    ],
+    'logo' => [
+        'alt' => 'Logo ng :name',
+    ],
+    'tenant_menu' => [
+        'search_field' => [
+            'label' => 'Maghanap ng tenant',
+            'placeholder' => 'Maghanap',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/pages/dashboard.php
+++ b/packages/panels/resources/lang/fil/pages/dashboard.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'title' => 'Pangkalahatang dashboard',
+    'actions' => [
+        'filter' => [
+            'label' => 'I-filter',
+            'modal' => [
+                'heading' => 'Mga filter',
+                'actions' => [
+                    'apply' => [
+                        'label' => 'I-apply',
+                    ],
+                ],
+            ],
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/pages/tenancy/edit-tenant-profile.php
+++ b/packages/panels/resources/lang/fil/pages/tenancy/edit-tenant-profile.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'form' => [
+        'actions' => [
+            'save' => [
+                'label' => 'I-save ang mga pagbabago',
+            ],
+        ],
+    ],
+    'notifications' => [
+        'saved' => [
+            'title' => 'Na-save',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/resources/pages/create-record.php
+++ b/packages/panels/resources/lang/fil/resources/pages/create-record.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+    'title' => 'Gumawa ng :label',
+    'breadcrumb' => 'Gumawa',
+    'form' => [
+        'actions' => [
+            'cancel' => [
+                'label' => 'Kanselahin',
+            ],
+            'create' => [
+                'label' => 'Gumawa',
+            ],
+            'create_another' => [
+                'label' => 'Gumawa at gumawa pa ng isa',
+            ],
+        ],
+    ],
+    'notifications' => [
+        'created' => [
+            'title' => 'Nagawa na',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/resources/pages/edit-record.php
+++ b/packages/panels/resources/lang/fil/resources/pages/edit-record.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+    'title' => 'I-edit ang :label',
+    'breadcrumb' => 'I-edit',
+    'navigation_label' => 'I-edit',
+    'form' => [
+        'actions' => [
+            'cancel' => [
+                'label' => 'Kanselahin',
+            ],
+            'save' => [
+                'label' => 'I-save ang mga pagbabago',
+            ],
+        ],
+    ],
+    'content' => [
+        'tab' => [
+            'label' => 'I-edit',
+        ],
+    ],
+    'notifications' => [
+        'saved' => [
+            'title' => 'Na-save',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/resources/pages/list-records.php
+++ b/packages/panels/resources/lang/fil/resources/pages/list-records.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'breadcrumb' => 'Listahan',
+];

--- a/packages/panels/resources/lang/fil/resources/pages/manage-related-records.php
+++ b/packages/panels/resources/lang/fil/resources/pages/manage-related-records.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'title' => 'I-manage ang :label :relationship',
+];

--- a/packages/panels/resources/lang/fil/resources/pages/view-record.php
+++ b/packages/panels/resources/lang/fil/resources/pages/view-record.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'title' => 'Tingnan ang :label',
+    'breadcrumb' => 'Tingnan',
+    'navigation_label' => 'Tingnan',
+    'content' => [
+        'tab' => [
+            'label' => 'Tingnan',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fil/unsaved-changes-alert.php
+++ b/packages/panels/resources/lang/fil/unsaved-changes-alert.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'body' => 'May mga pagbabago kang hindi pa nai-save. Sigurado ka bang gusto mong umalis sa page na ito?',
+];

--- a/packages/panels/resources/lang/fil/widgets/account-widget.php
+++ b/packages/panels/resources/lang/fil/widgets/account-widget.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'actions' => [
+        'logout' => [
+            'label' => 'Mag-sign out',
+        ],
+    ],
+    'welcome' => 'Maligayang pagdating',
+];

--- a/packages/panels/resources/lang/fil/widgets/filament-info-widget.php
+++ b/packages/panels/resources/lang/fil/widgets/filament-info-widget.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'actions' => [
+        'open_documentation' => [
+            'label' => 'Mga dokumento',
+        ],
+        'open_github' => [
+            'label' => 'GitHub',
+        ],
+    ],
+];

--- a/packages/query-builder/resources/lang/fil/query-builder.php
+++ b/packages/query-builder/resources/lang/fil/query-builder.php
@@ -1,0 +1,402 @@
+<?php
+
+return [
+    'label' => 'Tagabuo ng query',
+    'form' => [
+        'operator' => [
+            'label' => 'Operador',
+        ],
+        'or_groups' => [
+            'label' => 'Mga Grupo',
+            'group' => [
+                'label' => 'Grupo',
+            ],
+            'block' => [
+                'label' => 'Kondisyong OR',
+                'or' => 'OR',
+            ],
+        ],
+        'rules' => [
+            'label' => 'Mga Rule',
+            'item' => [
+                'and' => 'AND',
+            ],
+        ],
+    ],
+    'no_rules' => '(Walang rule)',
+    'max_rules_reached_tooltip' => 'Naabot mo na ang maximum na :count rule.',
+    'item_separators' => [
+        'and' => 'AND',
+        'or' => 'OR',
+    ],
+    'operators' => [
+        'is_filled' => [
+            'label' => [
+                'direct' => 'May laman',
+                'inverse' => 'Blangko',
+            ],
+            'summary' => [
+                'direct' => 'May laman ang :attribute',
+                'inverse' => 'Blangko ang :attribute',
+            ],
+        ],
+        'boolean' => [
+            'is_true' => [
+                'label' => [
+                    'direct' => 'Tama',
+                    'inverse' => 'Mali',
+                ],
+                'summary' => [
+                    'direct' => 'Tama ang :attribute',
+                    'inverse' => 'Mali ang :attribute',
+                ],
+            ],
+        ],
+        'date' => [
+            'is_after' => [
+                'label' => [
+                    'direct' => 'Pagkatapos ng',
+                    'inverse' => 'Hindi pagkatapos ng',
+                ],
+                'summary' => [
+                    'direct' => 'Ang :attribute ay pagkatapos ng :date',
+                    'inverse' => 'Ang :attribute ay hindi pagkatapos ng :date',
+                ],
+            ],
+            'is_before' => [
+                'label' => [
+                    'direct' => 'Bago ang',
+                    'inverse' => 'Hindi bago ang',
+                ],
+                'summary' => [
+                    'direct' => 'Ang :attribute ay bago ang :date',
+                    'inverse' => 'Ang :attribute ay hindi bago ang :date',
+                ],
+            ],
+            'is_date' => [
+                'label' => [
+                    'direct' => 'Ang petsa ay',
+                    'inverse' => 'Ang petsa ay hindi',
+                ],
+                'summary' => [
+                    'direct' => 'Ang :attribute ay :date',
+                    'inverse' => 'Ang :attribute ay hindi :date',
+                ],
+            ],
+            'is_month' => [
+                'label' => [
+                    'direct' => 'Ang buwan ay',
+                    'inverse' => 'Ang buwan ay hindi',
+                ],
+                'summary' => [
+                    'direct' => 'Ang :attribute ay :month',
+                    'inverse' => 'Ang :attribute ay hindi :month',
+                ],
+            ],
+            'is_year' => [
+                'label' => [
+                    'direct' => 'Ang taon ay',
+                    'inverse' => 'Ang taon ay hindi',
+                ],
+                'summary' => [
+                    'direct' => 'Ang :attribute ay :year',
+                    'inverse' => 'Ang :attribute ay hindi :year',
+                ],
+            ],
+            'unit_labels' => [
+                'second' => 'Mga Segundo',
+                'minute' => 'Mga Minuto',
+                'hour' => 'Mga Oras',
+                'day' => 'Mga Araw',
+                'week' => 'Mga Linggo',
+                'month' => 'Mga Buwan',
+                'quarter' => 'Mga Quarter',
+                'year' => 'Mga Taon',
+            ],
+            'presets' => [
+                'past_decade' => 'Nakaraang dekada',
+                'past_5_years' => 'Nakaraang 5 taon',
+                'past_2_years' => 'Nakaraang 2 taon',
+                'past_year' => 'Nakaraang taon',
+                'past_6_months' => 'Nakaraang 6 na buwan',
+                'past_quarter' => 'Nakaraang quarter',
+                'past_month' => 'Nakaraang buwan',
+                'past_2_weeks' => 'Nakaraang 2 linggo',
+                'past_week' => 'Nakaraang linggo',
+                'past_hour' => 'Nakaraang oras',
+                'past_minute' => 'Nakaraang minuto',
+                'this_decade' => 'Dekadang ito',
+                'this_year' => 'Taong ito',
+                'this_quarter' => 'Quarter na ito',
+                'this_month' => 'Buwang ito',
+                'today' => 'Ngayon',
+                'this_hour' => 'Oras na ito',
+                'this_minute' => 'Minutong ito',
+                'next_minute' => 'Susunod na minuto',
+                'next_hour' => 'Susunod na oras',
+                'next_week' => 'Susunod na linggo',
+                'next_2_weeks' => 'Susunod na 2 linggo',
+                'next_month' => 'Susunod na buwan',
+                'next_quarter' => 'Susunod na quarter',
+                'next_6_months' => 'Susunod na 6 na buwan',
+                'next_year' => 'Susunod na taon',
+                'next_2_years' => 'Susunod na 2 taon',
+                'next_5_years' => 'Susunod na 5 taon',
+                'next_decade' => 'Susunod na dekada',
+                'custom' => 'Custom na panahon',
+            ],
+            'form' => [
+                'date' => [
+                    'label' => 'Petsa',
+                ],
+                'month' => [
+                    'label' => 'Buwan',
+                ],
+                'year' => [
+                    'label' => 'Taon',
+                ],
+                'mode' => [
+                    'label' => 'Uri ng petsa',
+                    'options' => [
+                        'absolute' => 'Partikular na petsa',
+                        'relative' => 'Gumagalaw na saklaw',
+                    ],
+                ],
+                'preset' => [
+                    'label' => 'Panahon',
+                ],
+                'relative_value' => [
+                    'label' => 'Ilan',
+                ],
+                'relative_unit' => [
+                    'label' => 'Yunit ng oras',
+                ],
+                'tense' => [
+                    'label' => 'Panahon ng pandiwa',
+                    'options' => [
+                        'past' => 'Nakaraan',
+                        'future' => 'Hinaharap',
+                    ],
+                ],
+            ],
+        ],
+        'number' => [
+            'equals' => [
+                'label' => [
+                    'direct' => 'Katumbas ng',
+                    'inverse' => 'Hindi katumbas ng',
+                ],
+                'summary' => [
+                    'direct' => 'Ang :attribute ay katumbas ng :number',
+                    'inverse' => 'Ang :attribute ay hindi katumbas ng :number',
+                ],
+            ],
+            'is_max' => [
+                'label' => [
+                    'direct' => 'Maximum na',
+                    'inverse' => 'Higit sa',
+                ],
+                'summary' => [
+                    'direct' => 'Ang maximum na :attribute ay :number',
+                    'inverse' => 'Ang :attribute ay higit sa :number',
+                ],
+            ],
+            'is_min' => [
+                'label' => [
+                    'direct' => 'Minimum na',
+                    'inverse' => 'Mas mababa sa',
+                ],
+                'summary' => [
+                    'direct' => 'Ang minimum na :attribute ay :number',
+                    'inverse' => 'Ang :attribute ay mas mababa sa :number',
+                ],
+            ],
+            'aggregates' => [
+                'average' => [
+                    'label' => 'Katamtaman',
+                    'summary' => 'Average ng :attribute',
+                ],
+                'max' => [
+                    'label' => 'Pinakamataas',
+                    'summary' => 'Pinakamataas na :attribute',
+                ],
+                'min' => [
+                    'label' => 'Pinakamababa',
+                    'summary' => 'Pinakamababang :attribute',
+                ],
+                'sum' => [
+                    'label' => 'Kabuuan',
+                    'summary' => 'Kabuuan ng :attribute',
+                ],
+            ],
+            'form' => [
+                'aggregate' => [
+                    'label' => 'Pinagsama-samang halaga',
+                ],
+                'number' => [
+                    'label' => 'Numero',
+                ],
+            ],
+        ],
+        'relationship' => [
+            'equals' => [
+                'label' => [
+                    'direct' => 'Mayroon',
+                    'inverse' => 'Wala',
+                ],
+                'summary' => [
+                    'direct' => 'May :count :relationship',
+                    'inverse' => 'Walang :count :relationship',
+                ],
+            ],
+            'has_max' => [
+                'label' => [
+                    'direct' => 'May maximum na',
+                    'inverse' => 'May higit sa',
+                ],
+                'summary' => [
+                    'direct' => 'May maximum na :count :relationship',
+                    'inverse' => 'May higit sa :count :relationship',
+                ],
+            ],
+            'has_min' => [
+                'label' => [
+                    'direct' => 'May minimum na',
+                    'inverse' => 'May mas kaunti sa',
+                ],
+                'summary' => [
+                    'direct' => 'May minimum na :count :relationship',
+                    'inverse' => 'May mas kaunti sa :count :relationship',
+                ],
+            ],
+            'is_empty' => [
+                'label' => [
+                    'direct' => 'Walang laman',
+                    'inverse' => 'May laman',
+                ],
+                'summary' => [
+                    'direct' => 'Walang laman ang :relationship',
+                    'inverse' => 'May laman ang :relationship',
+                ],
+            ],
+            'is_related_to' => [
+                'label' => [
+                    'single' => [
+                        'direct' => 'Ay',
+                        'inverse' => 'Ay hindi',
+                    ],
+                    'multiple' => [
+                        'direct' => 'Naglalaman ng',
+                        'inverse' => 'Hindi naglalaman ng',
+                    ],
+                ],
+                'summary' => [
+                    'single' => [
+                        'direct' => 'Ang :relationship ay :values',
+                        'inverse' => 'Ang :relationship ay hindi :values',
+                    ],
+                    'multiple' => [
+                        'direct' => 'Naglalaman ang :relationship ng :values',
+                        'inverse' => 'Hindi naglalaman ang :relationship ng :values',
+                    ],
+                    'values_glue' => [
+                        0 => ', ',
+                        'final' => ' o ',
+                    ],
+                ],
+                'form' => [
+                    'value' => [
+                        'label' => 'Halaga',
+                    ],
+                    'values' => [
+                        'label' => 'Mga Halaga',
+                    ],
+                ],
+            ],
+            'form' => [
+                'count' => [
+                    'label' => 'Bilang',
+                ],
+            ],
+        ],
+        'select' => [
+            'is' => [
+                'label' => [
+                    'direct' => 'Ay',
+                    'inverse' => 'Ay hindi',
+                ],
+                'summary' => [
+                    'direct' => 'Ang :attribute ay :values',
+                    'inverse' => 'Ang :attribute ay hindi :values',
+                    'values_glue' => [
+                        0 => ', ',
+                        'final' => ' o ',
+                    ],
+                ],
+                'form' => [
+                    'value' => [
+                        'label' => 'Halaga',
+                    ],
+                    'values' => [
+                        'label' => 'Mga Halaga',
+                    ],
+                ],
+            ],
+        ],
+        'text' => [
+            'contains' => [
+                'label' => [
+                    'direct' => 'Naglalaman ng',
+                    'inverse' => 'Hindi naglalaman ng',
+                ],
+                'summary' => [
+                    'direct' => 'Naglalaman ang :attribute ng :text',
+                    'inverse' => 'Hindi naglalaman ang :attribute ng :text',
+                ],
+            ],
+            'ends_with' => [
+                'label' => [
+                    'direct' => 'Nagtatapos sa',
+                    'inverse' => 'Hindi nagtatapos sa',
+                ],
+                'summary' => [
+                    'direct' => 'Nagtatapos ang :attribute sa :text',
+                    'inverse' => 'Hindi nagtatapos ang :attribute sa :text',
+                ],
+            ],
+            'equals' => [
+                'label' => [
+                    'direct' => 'Katumbas ng',
+                    'inverse' => 'Hindi katumbas ng',
+                ],
+                'summary' => [
+                    'direct' => 'Ang :attribute ay katumbas ng :text',
+                    'inverse' => 'Ang :attribute ay hindi katumbas ng :text',
+                ],
+            ],
+            'starts_with' => [
+                'label' => [
+                    'direct' => 'Nagsisimula sa',
+                    'inverse' => 'Hindi nagsisimula sa',
+                ],
+                'summary' => [
+                    'direct' => 'Nagsisimula ang :attribute sa :text',
+                    'inverse' => 'Hindi nagsisimula ang :attribute sa :text',
+                ],
+            ],
+            'form' => [
+                'text' => [
+                    'label' => 'Teksto',
+                ],
+            ],
+        ],
+    ],
+    'actions' => [
+        'add_rule' => [
+            'label' => 'Magdagdag ng rule',
+        ],
+        'add_rule_group' => [
+            'label' => 'Magdagdag ng OR',
+        ],
+    ],
+];

--- a/packages/schemas/resources/lang/fil/components.php
+++ b/packages/schemas/resources/lang/fil/components.php
@@ -1,0 +1,40 @@
+<?php
+
+return [
+    'callout' => [
+        'statuses' => [
+            'danger' => 'May error:',
+            'info' => 'Paalala:',
+            'success' => 'Tagumpay:',
+            'warning' => 'Babala:',
+        ],
+    ],
+    'section' => [
+        'actions' => [
+            'collapse' => [
+                'label' => 'I-collapse ang seksyon',
+            ],
+            'expand' => [
+                'label' => 'I-expand ang seksyon',
+            ],
+        ],
+    ],
+    'wizard' => [
+        'actions' => [
+            'previous_step' => [
+                'label' => 'Bumalik',
+            ],
+            'next_step' => [
+                'label' => 'Susunod',
+            ],
+        ],
+        'header' => [
+            'step' => [
+                'statuses' => [
+                    'completed' => 'Tapos na',
+                    'upcoming' => 'Hindi pa tapos',
+                ],
+            ],
+        ],
+    ],
+];

--- a/packages/spatie-laravel-settings-plugin/resources/lang/fil/pages/settings-page.php
+++ b/packages/spatie-laravel-settings-plugin/resources/lang/fil/pages/settings-page.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'form' => [
+        'actions' => [
+            'save' => [
+                'label' => 'I-save',
+            ],
+        ],
+    ],
+    'notifications' => [
+        'saved' => [
+            'title' => 'Na-save',
+        ],
+    ],
+];

--- a/packages/support/resources/lang/fil/components/badge.php
+++ b/packages/support/resources/lang/fil/components/badge.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'actions' => [
+        'delete' => [
+            'label' => 'Alisin',
+        ],
+    ],
+];

--- a/packages/support/resources/lang/fil/components/breadcrumbs.php
+++ b/packages/support/resources/lang/fil/components/breadcrumbs.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'label' => 'Daan ng pahina',
+];

--- a/packages/support/resources/lang/fil/components/button.php
+++ b/packages/support/resources/lang/fil/components/button.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'messages' => [
+        'uploading_file' => 'Ina-upload ang file...',
+    ],
+];

--- a/packages/support/resources/lang/fil/components/copyable.php
+++ b/packages/support/resources/lang/fil/components/copyable.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'messages' => [
+        'copied' => 'Nakopya na',
+    ],
+];

--- a/packages/support/resources/lang/fil/components/input/one-time-code.php
+++ b/packages/support/resources/lang/fil/components/input/one-time-code.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'aria_label' => 'Character :position sa :count',
+];

--- a/packages/support/resources/lang/fil/components/loading-section.php
+++ b/packages/support/resources/lang/fil/components/loading-section.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'label' => 'Naglo-load...',
+];

--- a/packages/support/resources/lang/fil/components/modal.php
+++ b/packages/support/resources/lang/fil/components/modal.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'actions' => [
+        'close' => [
+            'label' => 'Isara',
+        ],
+    ],
+];

--- a/packages/support/resources/lang/fil/components/pagination.php
+++ b/packages/support/resources/lang/fil/components/pagination.php
@@ -1,0 +1,31 @@
+<?php
+
+return [
+    'label' => 'Navigation ng mga pahina',
+    'overview' => '{1} Ipinapakita ang 1 resulta|[2,*] Ipinapakita ang :first hanggang :last sa :total resulta',
+    'fields' => [
+        'records_per_page' => [
+            'label' => 'Bawat pahina',
+            'options' => [
+                'all' => 'Lahat',
+            ],
+        ],
+    ],
+    'actions' => [
+        'first' => [
+            'label' => 'Una',
+        ],
+        'go_to_page' => [
+            'label' => 'Pumunta sa pahina :page',
+        ],
+        'last' => [
+            'label' => 'Huli',
+        ],
+        'next' => [
+            'label' => 'Susunod',
+        ],
+        'previous' => [
+            'label' => 'Nauna',
+        ],
+    ],
+];

--- a/packages/support/resources/lang/fil/components/section.php
+++ b/packages/support/resources/lang/fil/components/section.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'actions' => [
+        'collapse' => [
+            'label' => 'I-collapse ang seksyon',
+        ],
+        'expand' => [
+            'label' => 'I-expand ang seksyon',
+        ],
+    ],
+];

--- a/packages/support/resources/lang/fil/components/tabs.php
+++ b/packages/support/resources/lang/fil/components/tabs.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'label' => 'Mga Tab',
+];

--- a/packages/tables/resources/lang/fil/table.php
+++ b/packages/tables/resources/lang/fil/table.php
@@ -1,0 +1,186 @@
+<?php
+
+return [
+    'column_manager' => [
+        'heading' => 'Mga Column',
+        'actions' => [
+            'apply' => [
+                'label' => 'I-apply ang mga column',
+            ],
+            'reorder' => [
+                'label' => 'Ayusin muli ang column',
+            ],
+            'reset' => [
+                'label' => 'I-reset',
+            ],
+        ],
+    ],
+    'columns' => [
+        'actions' => [
+            'label' => 'Aksyon|Mga Aksyon',
+        ],
+        'icon' => [
+            'boolean' => [
+                'true' => 'Oo',
+                'false' => 'Hindi',
+            ],
+        ],
+        'select' => [
+            'loading_message' => 'Naglo-load...',
+            'no_options_message' => 'Walang available na opsyon.',
+            'no_search_results_message' => 'Walang opsyong tumutugma sa iyong hinahanap.',
+            'placeholder' => 'Pumili ng opsyon',
+            'searching_message' => 'Naghahanap...',
+            'search_prompt' => 'Magsimulang mag-type para maghanap...',
+        ],
+        'text' => [
+            'actions' => [
+                'collapse_list' => 'Magpakita ng mas kaunting :count',
+                'expand_list' => 'Magpakita ng :count pa',
+            ],
+            'more_list_items' => 'at :count pa',
+        ],
+    ],
+    'fields' => [
+        'bulk_select_page' => [
+            'label' => 'Piliin/alisin sa pagkakapili ang lahat ng item para sa bulk actions.',
+        ],
+        'bulk_select_record' => [
+            'label' => 'Piliin/alisin sa pagkakapili ang item na :key para sa bulk actions.',
+        ],
+        'bulk_select_group' => [
+            'label' => 'Piliin/alisin sa pagkakapili ang grupong :title para sa bulk actions.',
+        ],
+        'search' => [
+            'label' => 'Maghanap',
+            'placeholder' => 'Maghanap',
+            'indicator' => 'Maghanap',
+        ],
+    ],
+    'summary' => [
+        'heading' => 'Buod',
+        'subheadings' => [
+            'all' => 'Lahat ng :label',
+            'group' => 'Buod ng :group',
+            'page' => 'Pahinang ito',
+        ],
+        'summarizers' => [
+            'average' => [
+                'label' => 'Katamtaman',
+            ],
+            'count' => [
+                'label' => 'Bilang',
+            ],
+            'sum' => [
+                'label' => 'Kabuuan',
+            ],
+        ],
+    ],
+    'actions' => [
+        'disable_reordering' => [
+            'label' => 'Tapusin ang muling pag-aayos ng mga rekord',
+        ],
+        'enable_reordering' => [
+            'label' => 'Ayusin muli ang mga rekord',
+        ],
+        'reorder_record' => [
+            'label' => 'Ayusin muli ang item na :key',
+        ],
+        'filter' => [
+            'label' => 'I-filter',
+        ],
+        'group' => [
+            'label' => 'Grupo',
+        ],
+        'open_bulk_actions' => [
+            'label' => 'Mga bulk action',
+        ],
+        'column_manager' => [
+            'label' => 'Tagapamahala ng column',
+        ],
+        'toggle_record_content' => [
+            'label' => 'I-expand/i-collapse ang item na :key',
+        ],
+    ],
+    'empty' => [
+        'heading' => 'Walang :model',
+        'description' => 'Gumawa ng :model para makapagsimula.',
+    ],
+    'filters' => [
+        'actions' => [
+            'apply' => [
+                'label' => 'I-apply ang mga filter',
+            ],
+            'remove' => [
+                'label' => 'Alisin ang filter',
+            ],
+            'remove_all' => [
+                'label' => 'Alisin lahat ng filter',
+                'tooltip' => 'Alisin lahat ng filter',
+            ],
+            'reset' => [
+                'label' => 'I-reset',
+            ],
+        ],
+        'heading' => 'Mga Filter',
+        'indicator' => 'Mga aktibong filter',
+        'multi_select' => [
+            'placeholder' => 'Lahat',
+        ],
+        'select' => [
+            'placeholder' => 'Lahat',
+            'relationship' => [
+                'empty_option_label' => 'Wala',
+            ],
+        ],
+        'trashed' => [
+            'label' => 'Mga na-delete na rekord',
+            'only_trashed' => 'Mga na-delete na rekord lang',
+            'with_trashed' => 'Kasama ang mga na-delete na rekord',
+            'without_trashed' => 'Hindi kasama ang mga na-delete na rekord',
+        ],
+    ],
+    'grouping' => [
+        'fields' => [
+            'group' => [
+                'label' => 'I-grupo ayon sa',
+            ],
+            'direction' => [
+                'label' => 'Direksyon ng paggrupo',
+                'options' => [
+                    'asc' => 'Pataas',
+                    'desc' => 'Pababa',
+                ],
+            ],
+        ],
+    ],
+    'loading' => 'Naglo-load...',
+    'reorder_indicator' => 'I-drag at i-drop ang mga rekord sa tamang ayos.',
+    'result_count' => '{0} Walang resulta|{1} :count resulta|[2,*] :count resulta',
+    'selection_indicator' => [
+        'selected_count' => '1 rekord ang napili|:count rekord ang napili',
+        'actions' => [
+            'select_all' => [
+                'label' => 'Piliin lahat ng :count',
+            ],
+            'deselect_all' => [
+                'label' => 'Alisin sa pagkakapili ang lahat',
+            ],
+        ],
+    ],
+    'sorting' => [
+        'fields' => [
+            'column' => [
+                'label' => 'I-sort ayon sa',
+            ],
+            'direction' => [
+                'label' => 'Direksyon ng pag-sort',
+                'options' => [
+                    'asc' => 'Pataas',
+                    'desc' => 'Pababa',
+                ],
+            ],
+        ],
+    ],
+    'default_model_label' => 'rekord',
+];

--- a/packages/widgets/resources/lang/fil/chart.php
+++ b/packages/widgets/resources/lang/fil/chart.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+    'actions' => [
+        'filter' => [
+            'label' => 'I-filter',
+        ],
+    ],
+    'filter' => [
+        'label' => 'I-filter ang data ng chart',
+    ],
+    'filters' => [
+        'actions' => [
+            'apply' => [
+                'label' => 'I-apply',
+            ],
+            'reset' => [
+                'label' => 'I-reset',
+            ],
+        ],
+    ],
+    'empty' => [
+        'heading' => 'Walang data na maipapakita',
+    ],
+];


### PR DESCRIPTION
## Description

Adds a complete Filipino (`fil`) locale for every package that ships translations (68 files: actions, forms, infolists, notifications, panels, query-builder, schemas, settings plugin, support, tables, widgets). `bin/translation-tool.php` reports Filipino at 100% with 0 outdated keys.

Register is conversational Manila Filipino as used in everyday apps (`I-save`, `Mga rekord`, `Kanselahin`) rather than purist Tagalog. Placeholders and plural segments mirror the English files exactly.

These were produced by the Pixalink team for our own Filament app (Malaysia/SEA loyalty platform) with machine assistance and human review for word order and placeholders. Corrections from native speakers are very welcome — happy to adjust anything.

## Visual changes

None — translation files only.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date. (N/A — no documentation changes)