### PR TITLE
chore: run `composer run pint`

### DIFF
--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -15,6 +15,7 @@ use Filament\Support\Concerns\HasPlaceholder;
 use Filament\Support\Concerns\HasVerticalAlignment;
 use Filament\Support\Concerns\HasWidth;
 use Filament\Support\Enums\Alignment;
+use Filament\Support\Enums\VerticalAlignment;
 use Filament\Support\View\ComponentAttributeBag as FilamentComponentAttributeBag;
 use Filament\Tables\Columns\Concerns\HasTooltip;
 use Filament\Tables\Table;
@@ -200,7 +201,7 @@ class Column extends ViewComponent
             'fi-ta-cell',
             'fi-ta-cell-' . str($this->getName())->camel()->kebab(),
             (($columnAlignment instanceof Alignment) ? "fi-align-{$columnAlignment->value}" : (is_string($columnAlignment) ? $columnAlignment : '')),
-            (($columnVerticalAlignment instanceof \Filament\Support\Enums\VerticalAlignment) ? "fi-vertical-align-{$columnVerticalAlignment->value}" : (is_string($columnVerticalAlignment) ? $columnVerticalAlignment : '')),
+            (($columnVerticalAlignment instanceof VerticalAlignment) ? "fi-vertical-align-{$columnVerticalAlignment->value}" : (is_string($columnVerticalAlignment) ? $columnVerticalAlignment : '')),
             (filled($columnHiddenFrom = $this->getHiddenFrom()) ? "{$columnHiddenFrom}:fi-hidden" : ''),
             (filled($columnVisibleFrom = $this->getVisibleFrom()) ? "{$columnVisibleFrom}:fi-visible" : ''),
         ])->toHtml();

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -10,6 +10,8 @@ use Filament\Notifications\Notification;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Support\Colors\Color;
+use Filament\Support\Enums\IconPosition;
+use Filament\Support\Enums\IconSize;
 use Filament\Support\Enums\Size;
 use Filament\Support\Enums\Width;
 use Filament\Support\Facades\FilamentView;
@@ -1945,7 +1947,7 @@ describe('rendering', function (): void {
     it('renders an `iconPosition(After)` icon after the label', function (): void {
         $html = Action::make('test')
             ->icon('heroicon-o-arrow-right')
-            ->iconPosition(\Filament\Support\Enums\IconPosition::After)
+            ->iconPosition(IconPosition::After)
             ->label('Next')
             ->toHtml();
 
@@ -1979,7 +1981,7 @@ describe('rendering', function (): void {
     it('renders an `iconSize()` as a `fi-size-*` class on the icon', function (): void {
         $html = Action::make('test')
             ->icon('heroicon-o-trash')
-            ->iconSize(\Filament\Support\Enums\IconSize::Large)
+            ->iconSize(IconSize::Large)
             ->toHtml();
 
         expect($html)->toContain('fi-size-lg');

--- a/tests/src/Forms/Components/ToggleButtonsTest.php
+++ b/tests/src/Forms/Components/ToggleButtonsTest.php
@@ -8,6 +8,7 @@ use Filament\Tests\Fixtures\Livewire\Livewire;
 use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\HtmlString;
 
 use function Filament\Tests\livewire;
 
@@ -377,7 +378,7 @@ describe('rendering', function (): void {
             ->components([
                 $field = ToggleButtons::make('status')
                     ->options(['active' => 'Active'])
-                    ->tooltips(['active' => new \Illuminate\Support\HtmlString('<strong>Tip</strong>')]),
+                    ->tooltips(['active' => new HtmlString('<strong>Tip</strong>')]),
             ])
             ->fill();
 

--- a/tests/src/Notifications/NotificationTest.php
+++ b/tests/src/Notifications/NotificationTest.php
@@ -14,6 +14,7 @@ use Filament\Tests\Fixtures\Notifications\CustomNotification;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use PHPUnit\Framework\AssertionFailedError;
 
 use function Filament\Tests\livewire;
 
@@ -190,7 +191,7 @@ it('fails `assertNotified()` when no sent notification matches the given instanc
 
     expect(fn () => Notification::assertNotified(
         Notification::make()->title('Third')->body('Third body'),
-    ))->toThrow(PHPUnit\Framework\AssertionFailedError::class);
+    ))->toThrow(AssertionFailedError::class);
 });
 
 it('fails `assertNotNotified()` when a matching notification was sent but was not first', function (): void {
@@ -200,7 +201,7 @@ it('fails `assertNotNotified()` when a matching notification was sent but was no
     // `Second` WAS sent (just not first), so asserting it was not notified must fail.
     expect(fn () => Notification::assertNotNotified(
         Notification::make()->title('Second')->body('Second body'),
-    ))->toThrow(PHPUnit\Framework\AssertionFailedError::class);
+    ))->toThrow(AssertionFailedError::class);
 });
 
 it('passes `assertNotNotified()` when the given instance was genuinely not sent', function (): void {


### PR DESCRIPTION
## Description

IT IS I, I AM FINALLY HERE

This runs `composer run pint` 

There are two separate pint scripts
1) The cs script 
2) The pint script  

One has strict imports, the other doesnt.

Perhaps there's a reason for the two being diff?  Anyway, I ran the strict one seeing as everything else adheres to it

Could we just copy the strict json into the pint.json? That way, free strictness? (unless theres a reason theres 2 idk)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
