### PR TITLE
Add `--parallel` to pint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
     "scripts": {
         "cs": [
             "rector",
-            "pint --cache-file=.pint.cache",
+            "pint --parallel --cache-file=.pint.cache",
             "npm run prettier"
         ],
         "pint": "pint --config pint-strict-imports.json --cache-file=.pint.cache",


### PR DESCRIPTION
## Description

This just makes it faster when we / CI run `composer run cs` this got introduced in https://github.com/laravel/pint/releases/tag/v1.23.0 

Ie [before the what filament asks for](https://github.com/search?q=repo%3Afilamentphp%2Ffilament+%22laravel%2Fpint&type=code)

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date. 


If you want to use strict mode, parallel wont work, soooo will see the outcome of that 1 first
