### PR TITLE
translation: add the missing Danish (da) boolean labels

### DIFF
--- a/packages/infolists/resources/lang/da/components.php
+++ b/packages/infolists/resources/lang/da/components.php
@@ -15,6 +15,11 @@ return [
 
         ],
 
+        'icon' => [
+            'true' => 'Ja',
+            'false' => 'Nej',
+        ],
+
         'key_value' => [
 
             'columns' => [

--- a/packages/tables/resources/lang/da/table.php
+++ b/packages/tables/resources/lang/da/table.php
@@ -26,6 +26,15 @@ return [
             'label' => 'Handling|Handlinger',
         ],
 
+        'icon' => [
+
+            'boolean' => [
+                'true' => 'Ja',
+                'false' => 'Nej',
+            ],
+
+        ],
+
         'select' => [
 
             'loading_message' => 'Indlæser...',


### PR DESCRIPTION
The Danish translations for `tables` and `infolists` translate nearly every key in their file and omit the boolean labels, so `columns.icon.boolean` and `entries.icon` fall through to `fallback_locale`. On an otherwise fully Danish panel, a boolean icon column and a boolean icon entry announce **`Yes`** / **`No`**.

It is invisible to sighted review, which is why it lasted: the value renders as a check or a cross, and the word ships as the icon's screen-reader label.

```html
<div class="fi-ta-icon">
  <svg … aria-hidden="true">…</svg>
  <span class="fi-sr-only">Yes</span>
</div>
```

So the only people who meet it are the ones using a screen reader — on a panel that is otherwise entirely in their language.

| file | had | this adds |
| --- | --- | --- |
| `packages/tables/resources/lang/da/table.php` | `columns.actions`, `columns.select`, `columns.text` | `columns.icon.boolean.{true,false}` |
| `packages/infolists/resources/lang/da/components.php` | `entries.text`, `entries.key_value` | `entries.icon.{true,false}` |

Both are defined in the English files (`lang/en/table.php` `columns.icon.boolean`, `lang/en/components.php` `entries.icon`). The additions sit in the same position and use the same spacing as their English counterparts.

`Ja` and `Nej` are the ordinary Danish affirmative and negative, and match the register the rest of this locale already uses.

Two files, fourteen added lines, nothing removed and no behaviour changed — a key that previously resolved through the English fallback now resolves in Danish.

Found in a production Filament 5 panel (v5.7.6); the same keys are missing on `5.x`, so this wants forward-merging. I originally opened this as #20417, which closed for want of a reproduction repository — fair enough, and a PR is what CONTRIBUTING points translations at anyway.