### PR TITLE
chore: use parallel and bump pint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "danharrin/date-format-converter": "^0.3.1",
         "filament/support": "*",
         "larastan/larastan": "^3.0",
-        "laravel/pint": "1.25.1",
+        "laravel/pint": "1.29.2",
         "laravel/prompts": "^0.3.5",
         "league/csv": "^9.27",
         "league/flysystem-aws-s3-v3": "^3.0",
@@ -83,7 +83,7 @@
             "@pint",
             "npm run prettier"
         ],
-        "pint": "pint --config pint-strict-imports.json --cache-file=.pint.cache",
+        "pint": "pint --parallel --config pint-strict-imports.json --cache-file=.pint.cache",
         "rector": "rector",
         "test:pest": "pest --parallel --exclude-group=serial",
         "test:sqlite": "pest --configuration=phpunit.sqlite.xml --parallel --exclude-group=serial",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0905dfacfe4d97043d5e781a703e47fb",
+    "content-hash": "113a644b17645c5d9993bf46e8041470",
     "packages": [],
     "packages-dev": [
         {
@@ -2905,7 +2905,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/support",
-                "reference": "29d6fbba7e13027d1cb215346ef9ab06cd78e69a"
+                "reference": "bf931e86fdf79045443b590ad3df1074ffaa67c4"
             },
             "require": {
                 "blade-ui-kit/blade-heroicons": "^2.5",
@@ -4245,16 +4245,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.25.1",
+            "version": "v1.29.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "5016e263f95d97670d71b9a987bd8996ade6d8d9"
+                "reference": "88493e9b15581b73db00fcc3cedfec07bcc52cf5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/5016e263f95d97670d71b9a987bd8996ade6d8d9",
-                "reference": "5016e263f95d97670d71b9a987bd8996ade6d8d9",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/88493e9b15581b73db00fcc3cedfec07bcc52cf5",
+                "reference": "88493e9b15581b73db00fcc3cedfec07bcc52cf5",
                 "shasum": ""
             },
             "require": {
@@ -4265,13 +4265,14 @@
                 "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.87.2",
-                "illuminate/view": "^11.46.0",
-                "larastan/larastan": "^3.7.1",
-                "laravel-zero/framework": "^11.45.0",
+                "friendsofphp/php-cs-fixer": "^3.95.8",
+                "illuminate/view": "^12.62.0",
+                "larastan/larastan": "^3.10.0",
+                "laravel-zero/framework": "^12.1.0",
+                "laravel/agent-detector": "^2.0.2",
                 "mockery/mockery": "^1.6.12",
-                "nunomaduro/termwind": "^2.3.1",
-                "pestphp/pest": "^2.36.0"
+                "nunomaduro/termwind": "^2.4.0",
+                "pestphp/pest": "^3.8.6"
             },
             "bin": [
                 "builds/pint"
@@ -4297,6 +4298,7 @@
             "description": "An opinionated code formatter for PHP.",
             "homepage": "https://laravel.com",
             "keywords": [
+                "dev",
                 "format",
                 "formatter",
                 "lint",
@@ -4307,7 +4309,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2025-09-19T02:57:12+00:00"
+            "time": "2026-06-16T12:31:41+00:00"
         },
         {
             "name": "laravel/prompts",


### PR DESCRIPTION
## Description

This bumps pint to the latest sem ver version and uses the --parallel flag meaning CI will be much faster  which means happy life.

laravel/pint v1.27.1 had the fix to support the parallel flag when using the config flag, but thought I'd just update it the latest sem ver.

Can't update to 1.3x cause they bumped the php version

Tested locally and all gucci. (probably worth running CI workflow too maybe)

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

