### PR TITLE
fix: restore badge delete button icon alias

### DIFF
--- a/packages/support/src/View/SupportIconAlias.php
+++ b/packages/support/src/View/SupportIconAlias.php
@@ -4,6 +4,11 @@ namespace Filament\Support\View;
 
 class SupportIconAlias
 {
+    /**
+     * @deprecated Customize the `.fi-badge-delete-btn-icon` CSS class instead.
+     */
+    const BADGE_DELETE_BUTTON = 'badge.delete-button';
+
     const BREADCRUMBS_SEPARATOR = 'breadcrumbs.separator';
 
     const BREADCRUMBS_SEPARATOR_RTL = 'breadcrumbs.separator.rtl';


### PR DESCRIPTION
## Description

Restores `SupportIconAlias::BADGE_DELETE_BUTTON` as a deprecated compatibility constant so icon packages that still register it do not fail after upgrading. The badge delete icon can now be customized using the `.fi-badge-delete-btn-icon` CSS class.

Fixes #20426.

## Visual changes

None.

## Functional changes

- [x] Code style has been checked with Pint.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
