### PR TITLE
chore: prepare orb for docs screenshots

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -274,6 +274,27 @@ initialize_demo_application() {
     printf '%s\n' "${current_demo_branch:-detached HEAD}" > "$demo_state_branch_file"
 }
 
+initialize_docs_screenshot_application() {
+    local docs_application_root="$repository_root/docs-assets/app"
+
+    if [[ ! -f "$docs_application_root/.env" ]]; then
+        cp "$docs_application_root/.env.example" "$docs_application_root/.env"
+    fi
+
+    mkdir -p "$docs_application_root/database"
+
+    if [[ ! -f "$docs_application_root/database/database.sqlite" ]]; then
+        touch "$docs_application_root/database/database.sqlite"
+    fi
+
+    if ! grep -Eq '^APP_KEY=base64:.+' "$docs_application_root/.env"; then
+        php "$docs_application_root/artisan" key:generate --force
+    fi
+
+    php "$docs_application_root/artisan" migrate:fresh --seed --force
+    php "$docs_application_root/artisan" storage:link --force
+}
+
 cd "$repository_root"
 
 run_step 'Installing PHP 8.4 and extensions' install_php
@@ -281,9 +302,16 @@ run_step 'Installing Composer' install_composer
 run_step 'Installing Filament Composer dependencies' composer install --prefer-dist --no-interaction --no-scripts
 run_step 'Installing Filament Node.js dependencies' npm ci --ignore-scripts
 run_step 'Installing Playwright Chromium' npx playwright install --with-deps chromium
+run_step 'Building Filament assets' npm run build
+run_step 'Installing docs screenshot application Composer dependencies' composer --working-dir="$repository_root/docs-assets/app" install --prefer-dist --no-interaction
+run_step 'Installing docs screenshot application Node.js dependencies' npm --prefix "$repository_root/docs-assets/app" ci --ignore-scripts
+run_step 'Installing docs screenshot generator dependencies' npm --prefix "$repository_root/docs-assets/screenshots" ci
+run_step 'Initializing the docs screenshot application' initialize_docs_screenshot_application
+run_step 'Building the docs screenshot application assets' npm --prefix "$repository_root/docs-assets/app" run build
 run_step 'Preparing the matching Filament demo checkout' prepare_demo_checkout
 run_step 'Configuring the demo portal proxy' write_demo_proxy_configuration
 run_step 'Installing locally linked demo dependencies' install_demo_dependencies
 run_step 'Initializing the demo Laravel application' initialize_demo_application
 
 printf '\nOrb setup complete. The demo checkout is at %s.\n' "$demo_root"
+printf 'Docs screenshot generation is ready in %s.\n' "$repository_root/docs-assets/screenshots"


### PR DESCRIPTION
## Description

Prepare Amp orbs to regenerate docs screenshots by installing and initializing the docs asset application and screenshot generator during setup.

## Visual changes

None.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
