### PR TITLE
docs: Improve documentation section ordering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,8 @@ Hook class naming:
 
 - **Tone**: Direct, second person ("You may set...", "You can do this using...")
 - **Structure**: Start with `## Introduction`, show simplest code first
+- **Section order**: Review the full page and analogous pages, then place sections by reader importance and logical flow, not by when they were added. Do not default new sections to the top.
+- **Hierarchy**: Keep foundational and common workflows before specialized content, and nest narrower topics under their parent section.
 - **Headings**: Use gerunds ("Setting the type" not "Type settings", "Enabling search" not "Search")
 - **Formatting**: Backticks for code (`method()`, `ClassName`), include `use` statements
 - **Asides**: `<Aside variant="tip|info|danger">...</Aside>`

--- a/docs/03-resources/01-overview.md
+++ b/docs/03-resources/01-overview.md
@@ -653,7 +653,7 @@ Deleting a page will not delete any actions that link to that page. Any actions 
 
 ## Security
 
-## Authorization
+### Authorization
 
 For authorization, Filament will observe any [model policies](https://laravel.com/docs/authorization#creating-policies) that are registered in your app. The following methods are used:
 
@@ -666,7 +666,7 @@ For authorization, Filament will observe any [model policies](https://laravel.co
 - `restore()` is used to prevent a single soft-deleted record from being restored. `restoreAny()` is used to prevent records from being bulk restored. Filament uses the `restoreAny()` method because iterating through multiple records and checking the `restore()` policy is not very performant. When using a `RestoreBulkAction`, if you want to call the `restore()` method for each record anyway, you should use the `RestoreBulkAction::make()->authorizeIndividualRecords()` method. Any records that fail the authorization check will not be processed.
 - `reorder()` is used to control [reordering records in a table](listing-records#reordering-records).
 
-### Skipping authorization
+#### Skipping authorization
 
 If you'd like to skip authorization for a resource, you may set the `$shouldSkipAuthorization` property to `true`:
 

--- a/docs/03-resources/06-deleting-records.md
+++ b/docs/03-resources/06-deleting-records.md
@@ -9,7 +9,7 @@ import AutoScreenshot from "@components/AutoScreenshot.astro"
 
 <AutoScreenshot name="panels/resources/trashed" alt="A resource listing with the trashed filter" version="4.x" />
 
-## Creating a resource with soft-delete
+### Creating a resource with soft-delete
 
 By default, you will not be able to interact with deleted records in the app. If you'd like to add functionality to restore, force-delete and filter trashed records in your resource, use the `--soft-deletes` flag when generating the resource:
 
@@ -17,7 +17,7 @@ By default, you will not be able to interact with deleted records in the app. If
 php artisan make:filament-resource Customer --soft-deletes
 ```
 
-## Adding soft-deletes to an existing resource
+### Adding soft-deletes to an existing resource
 
 Alternatively, you may add soft-deleting functionality to an existing resource.
 

--- a/docs/03-resources/10-global-search.md
+++ b/docs/03-resources/10-global-search.md
@@ -136,24 +136,6 @@ By default, global search will return up to 50 results per resource. You can cus
 protected static int $globalSearchResultsLimit = 20;
 ```
 
-## Moving the global search to the sidebar
-
-By default, the global search field is positioned in the topbar. If the topbar is disabled, it is added to the sidebar.
-
-You can choose to always move it to the sidebar by passing a `position` argument to the `globalSearch()` method in the [configuration](../panel-configuration):
-
-```php
-use Filament\Enums\GlobalSearchPosition;
-use Filament\Panel;
-
-public function panel(Panel $panel): Panel
-{
-    return $panel
-        // ...
-        ->globalSearch(position: GlobalSearchPosition::Sidebar);
-}
-```
-
 ## Sorting global search results
 
 By default, global search results are ordered alphabetically by resource name. You can customize this order by setting the `$globalSearchSort` property on your resource:
@@ -203,6 +185,24 @@ protected static bool $isGloballySearchable = true;
 ```
 
 Resources that do not declare this property will be excluded from global search, even if they have a title attribute set.
+
+## Moving the global search to the sidebar
+
+By default, the global search field is positioned in the topbar. If the topbar is disabled, it is added to the sidebar.
+
+You can choose to always move it to the sidebar by passing a `position` argument to the `globalSearch()` method in the [configuration](../panel-configuration):
+
+```php
+use Filament\Enums\GlobalSearchPosition;
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->globalSearch(position: GlobalSearchPosition::Sidebar);
+}
+```
 
 ## Registering global search key bindings
 

--- a/docs/07-users/02-multi-factor-authentication.md
+++ b/docs/07-users/02-multi-factor-authentication.md
@@ -291,6 +291,26 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+## Requiring multi-factor authentication
+
+By default, users are not required to set up multi-factor authentication. You can require users to configure it by passing `isRequired: true` as a parameter to the `multiFactorAuthentication()` method in the [configuration](../panel-configuration):
+
+```php
+use Filament\Auth\MultiFactor\App\AppAuthentication;
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->multiFactorAuthentication([
+            AppAuthentication::make(),
+        ], isRequired: true);
+}
+```
+
+When this is enabled, users will be prompted to set up multi-factor authentication after they sign in, if they have not already done so.
+
 ## Creating a custom multi-factor authentication provider
 
 You can add another MFA method by creating an object that implements the `MultiFactorAuthenticationProvider` interface. The provider tells Filament how to identify the method, determine whether it is enabled for a user, manage it, and validate its login challenge.
@@ -469,26 +489,6 @@ public function panel(Panel $panel): Panel
         ]);
 }
 ```
-
-## Requiring multi-factor authentication
-
-By default, users are not required to set up multi-factor authentication. You can require users to configure it by passing `isRequired: true` as a parameter to the `multiFactorAuthentication()` method in the [configuration](../panel-configuration):
-
-```php
-use Filament\Auth\MultiFactor\App\AppAuthentication;
-use Filament\Panel;
-
-public function panel(Panel $panel): Panel
-{
-    return $panel
-        // ...
-        ->multiFactorAuthentication([
-            AppAuthentication::make(),
-        ], isRequired: true);
-}
-```
-
-When this is enabled, users will be prompted to set up multi-factor authentication after they sign in, if they have not already done so.
 
 ## Security notes about multi-factor authentication
 

--- a/packages/actions/docs/01-overview.md
+++ b/packages/actions/docs/01-overview.md
@@ -398,116 +398,6 @@ Action::make('edit')
     By default, calling `extraAttributes()` multiple times will overwrite the previous attributes. If you wish to merge the attributes instead, you can pass `merge: true` to the method.
 </Aside>
 
-## Rate limiting actions
-
-You can rate limit actions by using the `rateLimit()` method. This method accepts the number of attempts per minute that a user IP address can make. If the user exceeds this limit, the action will not run and a notification will be shown:
-
-```php
-use Filament\Actions\Action;
-
-Action::make('delete')
-    ->rateLimit(5)
-```
-
-If the action opens a modal, the rate limit will be applied when the modal is submitted.
-
-If an action is opened with arguments or for a specific Eloquent record, the rate limit will apply to each unique combination of arguments or record for each action. The rate limit is also unique to the current Livewire component / page in a panel.
-
-<UtilityInjection set="actions" version="4.x">As well as allowing a static value, the `rateLimit()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
-
-## Customizing the rate limited notification
-
-When an action is rate limited, a notification is dispatched to the user, which indicates the rate limit.
-
-To customize the title of this notification, use the `rateLimitedNotificationTitle()` method:
-
-```php
-use Filament\Actions\DeleteAction;
-
-DeleteAction::make()
-    ->rateLimit(5)
-    ->rateLimitedNotificationTitle('Slow down!')
-```
-
-<UtilityInjection set="actions" version="4.x">As well as allowing a static value, the `rateLimitedNotificationTitle()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
-
-You may customize the entire notification using the `rateLimitedNotification()` method:
-
-```php
-use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
-use Filament\Actions\DeleteAction;
-use Filament\Notifications\Notification;
-
-DeleteAction::make()
-    ->rateLimit(5)
-    ->rateLimitedNotification(
-       fn (TooManyRequestsException $exception): Notification => Notification::make()
-            ->warning()
-            ->title('Slow down!')
-            ->body("You can try deleting again in {$exception->secondsUntilAvailable} seconds."),
-    )
-```
-
-<UtilityInjection set="actions" version="4.x" extras="Exception;;DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;;$exception;;The exception encountered when the rate limit was hit.||Minutes until available;;int;;$minutes;;The number of minutes until the rate limit will pass.||Seconds until available;;int;;$seconds;;The number of seconds until the rate limit will pass.||Notification;;Filament\Notifications\Notification;;$notification;;The default notification object for the rate limit, which could be a useful starting point for customization.">As well as allowing a static value, the `rateLimitedNotification()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
-
-### Customizing the rate limit behavior
-
-If you wish to customize the rate limit behavior, you can use Laravel's [rate limiting](https://laravel.com/docs/rate-limiting#basic-usage) features and Filament's [flash notifications](../notifications/overview) together in the action.
-
-If you want to rate limit immediately when an action modal is opened, you can do so in the `mountUsing()` method:
-
-```php
-use Filament\Actions\Action;
-use Filament\Notifications\Notification;
-use Illuminate\Support\Facades\RateLimiter;
-
-Action::make('delete')
-    ->mountUsing(function () {
-        if (RateLimiter::tooManyAttempts(
-            $rateLimitKey = 'delete:' . auth()->id(),
-            maxAttempts: 5,
-        )) {
-            Notification::make()
-                ->title('Too many attempts')
-                ->body('Please try again in ' . RateLimiter::availableIn($rateLimitKey) . ' seconds.')
-                ->danger()
-                ->send();
-                
-            return;
-        }
-        
-         RateLimiter::hit($rateLimitKey);
-    })
-```
-
-If you want to rate limit when an action is run, you can do so in the `action()` method:
-
-```php
-use Filament\Actions\Action;
-use Filament\Notifications\Notification;
-use Illuminate\Support\Facades\RateLimiter;
-
-Action::make('delete')
-    ->action(function () {
-        if (RateLimiter::tooManyAttempts(
-            $rateLimitKey = 'delete:' . auth()->id(),
-            maxAttempts: 5,
-        )) {
-            Notification::make()
-                ->title('Too many attempts')
-                ->body('Please try again in ' . RateLimiter::availableIn($rateLimitKey) . ' seconds.')
-                ->danger()
-                ->send();
-                
-            return;
-        }
-        
-         RateLimiter::hit($rateLimitKey);
-        
-        // ...
-    })
-```
-
 ## Using actions in schemas
 
 Action objects can be inserted anywhere in a [schema](../schemas/overview), such as in [form field slots](../forms/overview#adding-extra-content-to-a-field), [section headers and footers](../schemas/sections), or alongside [prime components](../schemas/primes). When an action is used in a schema, it has access to the schema's state via [utility injection](#injecting-utilities-from-a-schema) - you can use `$schemaGet` and `$schemaSet` in closures to read and modify form field values.
@@ -743,4 +633,114 @@ use Illuminate\Http\Request;
 function (Request $request, array $arguments) {
     // ...
 }
+```
+
+## Rate limiting actions
+
+You can rate limit actions by using the `rateLimit()` method. This method accepts the number of attempts per minute that a user IP address can make. If the user exceeds this limit, the action will not run and a notification will be shown:
+
+```php
+use Filament\Actions\Action;
+
+Action::make('delete')
+    ->rateLimit(5)
+```
+
+If the action opens a modal, the rate limit will be applied when the modal is submitted.
+
+If an action is opened with arguments or for a specific Eloquent record, the rate limit will apply to each unique combination of arguments or record for each action. The rate limit is also unique to the current Livewire component / page in a panel.
+
+<UtilityInjection set="actions" version="4.x">As well as allowing a static value, the `rateLimit()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+
+### Customizing the rate limited notification
+
+When an action is rate limited, a notification is dispatched to the user, which indicates the rate limit.
+
+To customize the title of this notification, use the `rateLimitedNotificationTitle()` method:
+
+```php
+use Filament\Actions\DeleteAction;
+
+DeleteAction::make()
+    ->rateLimit(5)
+    ->rateLimitedNotificationTitle('Slow down!')
+```
+
+<UtilityInjection set="actions" version="4.x">As well as allowing a static value, the `rateLimitedNotificationTitle()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+
+You may customize the entire notification using the `rateLimitedNotification()` method:
+
+```php
+use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
+use Filament\Actions\DeleteAction;
+use Filament\Notifications\Notification;
+
+DeleteAction::make()
+    ->rateLimit(5)
+    ->rateLimitedNotification(
+       fn (TooManyRequestsException $exception): Notification => Notification::make()
+            ->warning()
+            ->title('Slow down!')
+            ->body("You can try deleting again in {$exception->secondsUntilAvailable} seconds."),
+    )
+```
+
+<UtilityInjection set="actions" version="4.x" extras="Exception;;DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;;$exception;;The exception encountered when the rate limit was hit.||Minutes until available;;int;;$minutes;;The number of minutes until the rate limit will pass.||Seconds until available;;int;;$seconds;;The number of seconds until the rate limit will pass.||Notification;;Filament\Notifications\Notification;;$notification;;The default notification object for the rate limit, which could be a useful starting point for customization.">As well as allowing a static value, the `rateLimitedNotification()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+
+### Customizing the rate limit behavior
+
+If you wish to customize the rate limit behavior, you can use Laravel's [rate limiting](https://laravel.com/docs/rate-limiting#basic-usage) features and Filament's [flash notifications](../notifications/overview) together in the action.
+
+If you want to rate limit immediately when an action modal is opened, you can do so in the `mountUsing()` method:
+
+```php
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\RateLimiter;
+
+Action::make('delete')
+    ->mountUsing(function () {
+        if (RateLimiter::tooManyAttempts(
+            $rateLimitKey = 'delete:' . auth()->id(),
+            maxAttempts: 5,
+        )) {
+            Notification::make()
+                ->title('Too many attempts')
+                ->body('Please try again in ' . RateLimiter::availableIn($rateLimitKey) . ' seconds.')
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+         RateLimiter::hit($rateLimitKey);
+    })
+```
+
+If you want to rate limit when an action is run, you can do so in the `action()` method:
+
+```php
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\RateLimiter;
+
+Action::make('delete')
+    ->action(function () {
+        if (RateLimiter::tooManyAttempts(
+            $rateLimitKey = 'delete:' . auth()->id(),
+            maxAttempts: 5,
+        )) {
+            Notification::make()
+                ->title('Too many attempts')
+                ->body('Please try again in ' . RateLimiter::availableIn($rateLimitKey) . ' seconds.')
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+         RateLimiter::hit($rateLimitKey);
+
+        // ...
+    })
 ```

--- a/packages/forms/docs/22-custom-fields.md
+++ b/packages/forms/docs/22-custom-fields.md
@@ -45,7 +45,7 @@ This is the basis of how fields work in Filament. Each field is assigned to a pu
 
 If your component heavily relies on third party libraries, we advise that you asynchronously load the Alpine.js component using the Filament asset system. This ensures that the Alpine.js component is only loaded when it's needed, and not on every page load. To find out how to do this, check out our [Assets documentation](../advanced/assets#asynchronous-alpinejs-components).
 
-### Custom field classes
+## Custom field classes
 
 You may create your own custom field classes and views, which you can reuse across your project, and even release as a plugin to the community.
 

--- a/packages/schemas/docs/02-layouts.md
+++ b/packages/schemas/docs/02-layouts.md
@@ -280,6 +280,40 @@ Fieldset::make('Label')
 
 <AutoScreenshot name="schemas/layout/fieldset/not-contained" alt="Fieldset without a container border" version="4.x" />
 
+## Controlling spacing between components
+
+### Reducing space between components
+
+The `dense()` method creates a more compact layout by reducing the spacing between components by 50%:
+
+```php
+use Filament\Schemas\Components\Fieldset;
+
+Fieldset::make('Dense')
+    ->dense()
+    ->schema([
+        // ...
+    ])
+```
+
+<AutoScreenshot name="schemas/layout/dense" alt="A layout with dense spacing" version="4.x" />
+
+### Removing space between components
+
+The `gap(false)` method removes space between components:
+
+```php
+use Filament\Schemas\Components\Fieldset;
+
+Fieldset::make('No gap')
+    ->gap(false)
+    ->schema([
+        // ...
+    ])
+```
+
+<AutoScreenshot name="schemas/layout/no-gap" alt="A layout with no gap" version="4.x" />
+
 ## Using container queries
 
 In addition to traditional breakpoints based on the size of the viewport, you can also use [container queries](https://tailwindcss.com/docs/responsive-design#container-queries) to create responsive layouts based on the size of a parent container. This is particularly useful when the size of the parent container is not directly tied to the size of the viewport. For example, when using a collapsible sidebar alongside the content, the content area dynamically adjusts its size depending on the collapse state of the sidebar.
@@ -412,40 +446,6 @@ Grid::make()
 ```
 
 In this example, the fallback breakpoints ensure that even in browsers that don't support container queries, the layout will still respond to viewport size changes, with the name field appearing first and the email field second on larger screens.
-
-## Controlling spacing between components
-
-### Reducing space between components
-
-The `dense()` method creates a more compact layout by reducing the spacing between components by 50%:
-
-```php
-use Filament\Schemas\Components\Fieldset;
-
-Fieldset::make('Dense')
-    ->dense()
-    ->schema([
-        // ...
-    ])
-```
-
-<AutoScreenshot name="schemas/layout/dense" alt="A layout with dense spacing" version="4.x" />
-
-### Removing space between components
-
-The `gap(false)` method removes space between components:
-
-```php
-use Filament\Schemas\Components\Fieldset;
-
-Fieldset::make('No gap')
-    ->gap(false)
-    ->schema([
-        // ...
-    ])
-```
-
-<AutoScreenshot name="schemas/layout/no-gap" alt="A layout with no gap" version="4.x" />
 
 ## Adding extra HTML attributes to a layout component
 

--- a/packages/schemas/docs/04-tabs.md
+++ b/packages/schemas/docs/04-tabs.md
@@ -331,7 +331,7 @@ Tabs::make('Tabs')
 
 <UtilityInjection set="schemaComponents" version="4.x">As well as allowing static values, the `persistTab()` and `id()` methods also accept functions to dynamically calculate them. You can inject various utilities into the function as parameters.</UtilityInjection>
 
-### Persisting the current tab in the URL's query string
+## Persisting the current tab in the URL's query string
 
 By default, the current tab is not persisted in the URL's query string. You can change this behavior using the `persistTabInQueryString()` method:
 

--- a/packages/tables/docs/02-columns/08-text-input.md
+++ b/packages/tables/docs/02-columns/08-text-input.md
@@ -62,20 +62,6 @@ TextInputColumn::make('quantity')
     ->step('1')
 ```
 
-## Lifecycle hooks
-
-Hooks may be used to execute code at various points within the input's lifecycle:
-
-```php
-TextInputColumn::make()
-    ->beforeStateUpdated(function ($record, $state) {
-        // Runs before the state is saved to the database.
-    })
-    ->afterStateUpdated(function ($record, $state) {
-        // Runs after the state is saved to the database.
-    })
-```
-
 ## Adding affix text aside the field
 
 You may place text before and after the input using the `prefix()` and `suffix()` methods:
@@ -125,6 +111,20 @@ TextInputColumn::make('status')
 <UtilityInjection set="tableColumns" version="4.x">As well as allowing static values, the `prefixIconColor()` and `suffixIconColor()` methods also accept a function to dynamically calculate them. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 <AutoScreenshot name="tables/columns/text-input/suffix-icon-color" alt="Text input column with suffix icon in color" version="4.x" />
+
+## Lifecycle hooks
+
+Hooks may be used to execute code at various points within the input's lifecycle:
+
+```php
+TextInputColumn::make()
+    ->beforeStateUpdated(function ($record, $state) {
+        // Runs before the state is saved to the database.
+    })
+    ->afterStateUpdated(function ($record, $state) {
+        // Runs after the state is saved to the database.
+    })
+```
 
 ## Security
 

--- a/packages/tables/docs/03-filters/04-query-builder.md
+++ b/packages/tables/docs/03-filters/04-query-builder.md
@@ -69,53 +69,6 @@ public function table(Table $table): Table
 }
 ```
 
-## Limiting the size of the rule tree
-
-The set of rules a user builds is stored in the Livewire component's state and submitted with each request. To protect against a request that contains an excessively large or deeply-nested set of rules consuming too much server memory or CPU, you can limit how many rules and how deeply nested they can be.
-
-By default, no limits are applied. You can set them using the `maxRules()` and `maxNestingDepth()` methods:
-
-```php
-use Filament\Tables\Filters\QueryBuilder;
-
-QueryBuilder::make()
-    ->maxRules(100)
-    ->maxNestingDepth(10)
-    ->constraints([
-        // ...
-    ])
-```
-
-Both methods also accept a function to compute the value dynamically:
-
-```php
-use Filament\Tables\Filters\QueryBuilder;
-
-QueryBuilder::make()
-    ->maxRules(fn (): int => auth()->user()->isAdmin() ? 200 : 50)
-    ->constraints([
-        // ...
-    ])
-```
-
-The `maxRules()` limit counts individual conditions only. "OR" groups are structural containers, so they do not count towards the limit themselves — nesting is bounded separately by `maxNestingDepth()`.
-
-When a limit is set, the UI enforces it: once the maximum number of rules is reached, the "add rule" and clone buttons are disabled with a tooltip explaining why, and the "OR" grouping option is hidden once the maximum nesting depth is reached. As a safeguard against a tampered request that bypasses the UI, a submitted rule tree that still exceeds either limit is safely ignored, applying no constraints instead of filtering the table.
-
-<Aside variant="tip">
-    Since these limits are the same for every query builder, you will usually want to apply them globally rather than repeating them on each filter. You can do this using `configureUsing()` in the `boot()` method of a service provider, so that every query builder in your app is bounded:
-
-    ```php
-    use Filament\Tables\Filters\QueryBuilder;
-
-    QueryBuilder::configureUsing(function (QueryBuilder $queryBuilder): void {
-        $queryBuilder
-            ->maxRules(100)
-            ->maxNestingDepth(10);
-    });
-    ```
-</Aside>
-
 ## Available constraints
 
 Filament ships with many different constraints that you can use out of the box. You can also [create your own custom constraints](#creating-custom-constraints):
@@ -380,6 +333,53 @@ Now, the following operators are also available:
 
 - Is filled - filters a column to not be empty
 - Is blank - filters a column to be empty
+
+## Limiting the size of the rule tree
+
+The set of rules a user builds is stored in the Livewire component's state and submitted with each request. To protect against a request that contains an excessively large or deeply-nested set of rules consuming too much server memory or CPU, you can limit how many rules and how deeply nested they can be.
+
+By default, no limits are applied. You can set them using the `maxRules()` and `maxNestingDepth()` methods:
+
+```php
+use Filament\Tables\Filters\QueryBuilder;
+
+QueryBuilder::make()
+    ->maxRules(100)
+    ->maxNestingDepth(10)
+    ->constraints([
+        // ...
+    ])
+```
+
+Both methods also accept a function to compute the value dynamically:
+
+```php
+use Filament\Tables\Filters\QueryBuilder;
+
+QueryBuilder::make()
+    ->maxRules(fn (): int => auth()->user()->isAdmin() ? 200 : 50)
+    ->constraints([
+        // ...
+    ])
+```
+
+The `maxRules()` limit counts individual conditions only. "OR" groups are structural containers, so they do not count towards the limit themselves — nesting is bounded separately by `maxNestingDepth()`.
+
+When a limit is set, the UI enforces it: once the maximum number of rules is reached, the "add rule" and clone buttons are disabled with a tooltip explaining why, and the "OR" grouping option is hidden once the maximum nesting depth is reached. As a safeguard against a tampered request that bypasses the UI, a submitted rule tree that still exceeds either limit is safely ignored, applying no constraints instead of filtering the table.
+
+<Aside variant="tip">
+    Since these limits are the same for every query builder, you will usually want to apply them globally rather than repeating them on each filter. You can do this using `configureUsing()` in the `boot()` method of a service provider, so that every query builder in your app is bounded:
+
+    ```php
+    use Filament\Tables\Filters\QueryBuilder;
+
+    QueryBuilder::configureUsing(function (QueryBuilder $queryBuilder): void {
+        $queryBuilder
+            ->maxRules(100)
+            ->maxNestingDepth(10);
+    });
+    ```
+</Aside>
 
 ## Scoping relationships
 

--- a/packages/tables/docs/04-actions.md
+++ b/packages/tables/docs/04-actions.md
@@ -82,6 +82,8 @@ public function table(Table $table): Table
 }
 ```
 
+<AutoScreenshot name="tables/actions/before-cells" alt="Table with actions before cells" version="4.x" />
+
 ### Global record action settings
 
 To customize the default configuration used for ungrouped record actions, you can use `modifyUngroupedRecordActionsUsing()` from a [`Table::configureUsing()` function](overview#global-settings) in the `boot()` method of a service provider:
@@ -95,8 +97,6 @@ Table::configureUsing(function (Table $table): void {
         ->modifyUngroupedRecordActionsUsing(fn (Action $action) => $action->iconButton());
 });
 ```
-
-<AutoScreenshot name="tables/actions/before-cells" alt="Table with actions before cells" version="4.x" />
 
 ### Accessing the selected table rows
 


### PR DESCRIPTION
## Description

Reorders documentation sections identified during audits of 2025 and 2026 Markdown changes so foundational and common material precedes specialized content. Corrects related heading hierarchy and adds concise section-order guidance for future documentation updates.

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.