### PR TITLE
docs: Update Blueprint Boost skill workflow

### DIFF
--- a/docs/01-introduction/03-ai.md
+++ b/docs/01-introduction/03-ai.md
@@ -67,13 +67,13 @@ composer config --auth http-basic.packages.filamentphp.com "YOUR_EMAIL_ADDRESS" 
 composer require filament/blueprint --dev
 ```
 
-Then run the Boost installer and select the **Guidelines** and **Skills** for both **Filament** and **Filament Blueprint** when prompted:
+Then run the Boost installer, enable **Agent Skills**, and select **filament/blueprint** when prompted:
 
 ```bash
 php artisan boost:install
 ```
 
-To verify installation, check your `AGENTS.md`, `CLAUDE.md`, or similar file for a new **Filament Blueprint** section.
+To verify installation, check your agent's skills directory for `planning-filament/SKILL.md` and `filament-security-audit/SKILL.md`.
 
 <Aside variant="info">
     To access your purchased license, sign in to [Filament Packages](https://packages.filamentphp.com) with the email address used to purchase your Blueprint license.
@@ -81,10 +81,10 @@ To verify installation, check your `AGENTS.md`, `CLAUDE.md`, or similar file for
 
 ### Using Blueprint
 
-To create a blueprint, enable **planning mode** in your AI agent and ask it to create a Filament Blueprint for your feature:
+To create a blueprint, enable **planning mode** in your AI agent and ask it to use the `planning-filament` skill:
 
 ```
-Create a Filament Blueprint for an order management system.
+Using the planning-filament skill, create a Filament Blueprint for an order management system.
 
 Orders belong to customers and have many order items. Each order has a status
 (pending, confirmed, shipped, delivered, cancelled), shipping address, and
@@ -124,7 +124,7 @@ The plan should:
 You can read a plan written for this prompt [**without Blueprint**](https://filamentphp.com/blueprint/examples/invoicing/before.md) vs. [**with Blueprint**](https://filamentphp.com/blueprint/examples/invoicing/after.md), and compare the level of detail and thoughtfulness. You could have a go at passing these plans to your AI agent of choice in implementation mode to see how they perform!
 
 <Aside variant="info">
-    When using Blueprint, `Using Filament Blueprint` was added at the start of the prompt.
+    When using Blueprint, the `planning-filament` skill was explicitly named at the start of the prompt.
 </Aside>
 
 ### Running a security audit


### PR DESCRIPTION
## Description

Updates Filament v4's AI-assisted development documentation to match Blueprint 1.x's Laravel Boost Agent Skill workflow. Users now enable Agent Skills, select `filament/blueprint`, and explicitly invoke `planning-filament` when creating a Filament Blueprint.

Removes the obsolete instruction to look for always-on Blueprint guidelines in `AGENTS.md` or `CLAUDE.md`.

## Visual changes

None.

## Functional changes

- [x] Code style has been checked with Prettier.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
