### PR TITLE
feat: Add relationship support to `ColumnGroup`

### DIFF
--- a/packages/tables/docs/02-columns/01-overview.md
+++ b/packages/tables/docs/02-columns/01-overview.md
@@ -827,6 +827,30 @@ ColumnGroup::make('Website visibility')
     ->wrapHeader()
 ```
 
+If all the columns in a group belong to the same relationship, you can use the `relationship()` method to prefix each child column's name with the relationship name, instead of having to do it manually for each column:
+
+```php
+use Filament\Tables\Columns\ColumnGroup;
+use Filament\Tables\Columns\TextColumn;
+
+ColumnGroup::make('Author', [
+    TextColumn::make('name'),
+    TextColumn::make('email'),
+])->relationship('author')
+```
+
+This is the equivalent of writing:
+
+```php
+use Filament\Tables\Columns\ColumnGroup;
+use Filament\Tables\Columns\TextColumn;
+
+ColumnGroup::make('Author', [
+    TextColumn::make('author.name'),
+    TextColumn::make('author.email'),
+])
+```
+
 ## Hiding columns
 
 You may hide a column by using the `hidden()` or `visible()` method:

--- a/packages/tables/src/Columns/ColumnGroup.php
+++ b/packages/tables/src/Columns/ColumnGroup.php
@@ -22,6 +22,8 @@ class ColumnGroup extends Component
 
     protected bool $shouldTranslateLabel = false;
 
+    protected string | Closure | null $relationship = null;
+
     /**
      * @var array<Column> | Closure
      */
@@ -78,12 +80,30 @@ class ColumnGroup extends Component
         return $this;
     }
 
+    public function relationship(string | Closure | null $name): static
+    {
+        $this->relationship = $name;
+
+        return $this;
+    }
+
+    public function getRelationshipName(): ?string
+    {
+        return $this->evaluate($this->relationship);
+    }
+
     /**
      * @return array<string, Column>
      */
     public function getColumns(): array
     {
-        return array_reduce($this->evaluate($this->columns) ?? [], function (array $result, Column $column): array {
+        $relationshipName = $this->getRelationshipName();
+
+        return array_reduce($this->evaluate($this->columns) ?? [], function (array $result, Column $column) use ($relationshipName): array {
+            if (filled($relationshipName) && (! str($column->getName())->startsWith("{$relationshipName}."))) {
+                $column->name("{$relationshipName}.{$column->getName()}");
+            }
+
             $result[$column->getName()] = $column->group($this);
 
             return $result;

--- a/tests/src/Tables/Columns/ColumnGroupTest.php
+++ b/tests/src/Tables/Columns/ColumnGroupTest.php
@@ -48,7 +48,8 @@ it('can define a relationship for grouped columns', function (): void {
     livewire(TestTableWithColumnGroupWithRelationship::class)
         ->assertSuccessful()
         ->assertCanRenderTableColumn('author.name')
-        ->assertCanRenderTableColumn('author.email');
+        ->assertCanRenderTableColumn('author.email')
+        ->assertCanRenderTableColumn('author.company.name');
 });
 
 class TestTableWithColumnGroup extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
@@ -116,31 +117,8 @@ class TestTableWithColumnGroupWithRelationship extends Component implements HasA
                 Tables\Columns\ColumnGroup::make('Author', [
                     Tables\Columns\TextColumn::make('name'),
                     Tables\Columns\TextColumn::make('email'),
+                    Tables\Columns\TextColumn::make('company.name'),
                 ])->relationship('author'),
-            ]);
-    }
-
-    public function render(): View
-    {
-        return view('livewire.table');
-    }
-}
-
-class TestTableWithColumnGroupWithNestedRelationship extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
-{
-    use InteractsWithActions;
-    use InteractsWithSchemas;
-    use Tables\Concerns\InteractsWithTable;
-
-    public function table(Table $table): Table
-    {
-        return $table
-            ->query(Post::query())
-            ->columns([
-                Tables\Columns\TextColumn::make('title'),
-                Tables\Columns\ColumnGroup::make('Author Team', [
-                    Tables\Columns\TextColumn::make('name'),
-                ])->relationship('author.team'),
             ]);
     }
 

--- a/tests/src/Tables/Columns/ColumnGroupTest.php
+++ b/tests/src/Tables/Columns/ColumnGroupTest.php
@@ -42,6 +42,15 @@ it('can use `HtmlString` as label', function (): void {
         ->assertCanRenderTableColumn('author.email');
 });
 
+it('can define a relationship for grouped columns', function (): void {
+    Post::factory()->count(5)->create();
+
+    livewire(TestTableWithColumnGroupWithRelationship::class)
+        ->assertSuccessful()
+        ->assertCanRenderTableColumn('author.name')
+        ->assertCanRenderTableColumn('author.email');
+});
+
 class TestTableWithColumnGroup extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
 {
     use InteractsWithActions;
@@ -83,6 +92,55 @@ class TestTableWithColumnGroupWithHtmlStringLabel extends Component implements H
                     Tables\Columns\TextColumn::make('author.name'),
                     Tables\Columns\TextColumn::make('author.email'),
                 ]),
+            ]);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.table');
+    }
+}
+
+class TestTableWithColumnGroupWithRelationship extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use Tables\Concerns\InteractsWithTable;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(Post::query())
+            ->columns([
+                Tables\Columns\TextColumn::make('title'),
+                Tables\Columns\ColumnGroup::make('Author', [
+                    Tables\Columns\TextColumn::make('name'),
+                    Tables\Columns\TextColumn::make('email'),
+                ])->relationship('author'),
+            ]);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.table');
+    }
+}
+
+class TestTableWithColumnGroupWithNestedRelationship extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use Tables\Concerns\InteractsWithTable;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(Post::query())
+            ->columns([
+                Tables\Columns\TextColumn::make('title'),
+                Tables\Columns\ColumnGroup::make('Author Team', [
+                    Tables\Columns\TextColumn::make('name'),
+                ])->relationship('author.team'),
             ]);
     }
 


### PR DESCRIPTION
## Description

This allows a relationship to be defined on a column group so that child columns are resolved relative to that relationship.

For example:

```php
ColumnGroup::make('Author', [
    TextColumn::make('name'),
    TextColumn::make('email'),
    TextColumn::make('company.name'),
])
->relationship('author')
```

The columns will resolve as:

```php
author.name
author.email
author.company.name
```

Columns that are already prefixed with the configured relationship are left unchanged.

This makes `ColumnGroup` more useful for defining reusable groups of columns that may be used directly on a model or through a relationship.

Related discussion:
#20445 

## Visual changes

No visual changes.

This is an API/functional change to `ColumnGroup`.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
