### PR TITLE
Reduce allocations and duplicate scans in render-hook dispatch

### DIFF
--- a/packages/support/src/View/ViewManager.php
+++ b/packages/support/src/View/ViewManager.php
@@ -73,40 +73,28 @@ class ViewManager
      */
     public function renderHook(string $name, string | array | null $scopes = null, array $data = []): Htmlable
     {
-        $renderedHooks = [];
-
-        $scopes = Arr::wrap($scopes);
-
-        $renderHook = function (callable $hook) use (&$renderedHooks, $scopes, $data): ?string {
-            $hookId = spl_object_id($hook);
-
-            if (in_array($hookId, $renderedHooks)) {
-                return null;
-            }
-
-            $renderedHooks[] = $hookId;
-
-            $result = app()->call($hook, ['data' => $data, 'scopes' => $scopes]);
-
-            return (string) $result;
-        };
-
-        $hooks = array_map(
-            $renderHook,
-            $this->renderHooks[$name][''] ?? [],
-        );
-
-        foreach ($scopes as $scopeName) {
-            $hooks = [
-                ...$hooks,
-                ...array_map(
-                    $renderHook,
-                    $this->renderHooks[$name][$scopeName] ?? [],
-                ),
-            ];
+        if (! isset($this->renderHooks[$name])) {
+            return new HtmlString('');
         }
 
-        return new HtmlString(implode('', $hooks));
+        $renderedHooks = [];
+        $scopes = Arr::wrap($scopes);
+        $html = '';
+
+        foreach (['', ...$scopes] as $scopeName) {
+            foreach ($this->renderHooks[$name][$scopeName] ?? [] as $hook) {
+                $hookId = spl_object_id($hook);
+
+                if (isset($renderedHooks[$hookId])) {
+                    continue;
+                }
+
+                $renderedHooks[$hookId] = true;
+                $html .= (string) app()->call($hook, ['data' => $data, 'scopes' => $scopes]);
+            }
+        }
+
+        return new HtmlString($html);
     }
 
     public function spa(bool $condition = true, bool $hasPrefetching = false): void

--- a/packages/support/src/View/ViewManager.php
+++ b/packages/support/src/View/ViewManager.php
@@ -79,22 +79,28 @@ class ViewManager
 
         $renderedHooks = [];
         $scopes = Arr::wrap($scopes);
-        $html = '';
+        $hooks = [];
 
         foreach (['', ...$scopes] as $scopeName) {
-            foreach ($this->renderHooks[$name][$scopeName] ?? [] as $hook) {
+            foreach ($this->renderHooks[$name][$scopeName] ?? [] as $key => $hook) {
                 $hookId = spl_object_id($hook);
 
-                if (isset($renderedHooks[$hookId])) {
-                    continue;
+                $result = null;
+
+                if (! isset($renderedHooks[$hookId])) {
+                    $renderedHooks[$hookId] = true;
+                    $result = (string) app()->call($hook, ['data' => $data, 'scopes' => $scopes]);
                 }
 
-                $renderedHooks[$hookId] = true;
-                $html .= (string) app()->call($hook, ['data' => $data, 'scopes' => $scopes]);
+                if (is_int($key)) {
+                    $hooks[] = $result;
+                } else {
+                    $hooks[$key] = $result;
+                }
             }
         }
 
-        return new HtmlString($html);
+        return new HtmlString(implode('', $hooks));
     }
 
     public function spa(bool $condition = true, bool $hasPrefetching = false): void

--- a/tests/src/Support/RenderHooksTest.php
+++ b/tests/src/Support/RenderHooksTest.php
@@ -83,3 +83,53 @@ test('render hooks can be passed data', function (): void {
         ->toBeInstanceOf(HtmlString::class)
         ->toHtml()->toBe('bar');
 });
+
+it('renders an empty string for unregistered names and unmatched scopes with `renderHook()`', function (): void {
+    FilamentView::registerRenderHook('registered', static fn (): string => 'scoped', 'matching');
+
+    expect(FilamentView::renderHook('missing', ['matching'])->toHtml())->toBe('')
+        ->and(FilamentView::renderHook('registered', ['different'])->toHtml())->toBe('');
+});
+
+it('preserves global and scope order while deduplicating closure identities with `renderHook()`', function (): void {
+    $calls = [];
+    $shared = static function (array $scopes, array $data) use (&$calls): string {
+        $calls[] = [$scopes, $data];
+
+        return 'shared';
+    };
+
+    FilamentView::registerRenderHook('ordered', $shared, ['', 'first', 'second']);
+    FilamentView::registerRenderHook('ordered', static fn (): string => 'global');
+    FilamentView::registerRenderHook('ordered', static fn (): string => 'first', 'first');
+    FilamentView::registerRenderHook('ordered', static fn (): string => 'second', 'second');
+
+    $scopes = ['second', 'first', 'second', ''];
+    expect(FilamentView::renderHook('ordered', $scopes, ['value' => 42])->toHtml())->toBe('sharedglobalsecondfirst')
+        ->and($calls)->toBe([[$scopes, ['value' => 42]]]);
+});
+
+it('observes registrations in later scopes without changing the current scope snapshot in `renderHook()`', function (): void {
+    FilamentView::registerRenderHook('changing', static function (): string {
+        FilamentView::registerRenderHook('changing', static fn (): string => 'new-global');
+        FilamentView::registerRenderHook('changing', static fn (): string => 'new-scoped', 'later');
+
+        return 'original';
+    });
+
+    expect(FilamentView::renderHook('changing', ['later'])->toHtml())->toBe('originalnew-scoped');
+});
+
+it('executes hooks again and propagates exceptions through `renderHook()`', function (): void {
+    $calls = 0;
+    FilamentView::registerRenderHook('live', static function () use (&$calls): string {
+        return (string) ++$calls;
+    });
+
+    expect(FilamentView::renderHook('live')->toHtml())->toBe('1')
+        ->and(FilamentView::renderHook('live')->toHtml())->toBe('2');
+
+    FilamentView::registerRenderHook('throwing', static fn () => throw new RuntimeException('hook failure'));
+
+    expect(static fn () => FilamentView::renderHook('throwing'))->toThrow(RuntimeException::class, 'hook failure');
+});

--- a/tests/src/Support/RenderHooksTest.php
+++ b/tests/src/Support/RenderHooksTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Filament\Support\Facades\FilamentView;
+use Filament\Support\View\ViewManager;
 use Filament\Tests\TestCase;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Blade;
@@ -132,4 +133,34 @@ it('executes hooks again and propagates exceptions through `renderHook()`', func
     FilamentView::registerRenderHook('throwing', static fn () => throw new RuntimeException('hook failure'));
 
     expect(static fn () => FilamentView::renderHook('throwing'))->toThrow(RuntimeException::class, 'hook failure');
+});
+
+it('preserves string-keyed hook replacement in `ViewManager` subclasses', function (): void {
+    $manager = new class extends ViewManager
+    {
+        public function registerNamedHook(string $scope, Closure $hook): void
+        {
+            $this->renderHooks['named'][$scope]['plugin'] = $hook;
+        }
+    };
+    $manager->registerNamedHook('', static fn (): string => 'global');
+    $manager->registerNamedHook('scope', static fn (): string => 'scoped');
+
+    expect($manager->renderHook('named', ['scope'])->toHtml())->toBe('scoped')
+        ->and($manager->renderHook('named', ['scope', 'scope'])->toHtml())->toBe('');
+});
+
+it('keeps duplicate tracking local to nested `renderHook()` invocations', function (): void {
+    $nested = false;
+    FilamentView::registerRenderHook('nested', static function () use (&$nested): string {
+        if ($nested) {
+            return 'inner';
+        }
+
+        $nested = true;
+
+        return 'outer[' . FilamentView::renderHook('nested')->toHtml() . ']';
+    });
+
+    expect(FilamentView::renderHook('nested')->toHtml())->toBe('outer[inner]');
 });


### PR DESCRIPTION
## Description

`ViewManager::renderHook()` constructs closures and intermediate arrays even when no callback is registered. Registered hooks also use a growing linear scan to detect duplicate closure identities across scopes.

Return an empty `HtmlString` immediately for unregistered names, use an identity set for duplicate detection, and collect results in one ordered pass. Preserve scope order, data injection, string-key overwrite semantics for subclasses, registration during rendering, reentrant calls, and per-call callback execution.

### Measurements

PHP 8.4.24 CLI, Xdebug absent, CLI OPcache disabled, Laravel 13.15.0, comparing `5.x` at `02742899b97ec24e97ac5561832fe144ef6ed6f9` with this change. Three alternating baseline/candidate/candidate/baseline rounds, each sample in a fresh PHP process; table values are medians of six samples per version. Setup is outside the timed loops, and output hashes agree across versions.

| Scenario | Baseline µs/call | Proposed µs/call | Time reduction |
| --- | ---: | ---: | ---: |
| `missing_name` | 0.365 | 0.090 | 75.3% |
| `one_global` | 1.398 | 1.254 | 10.3% |
| `100_hooks_3_scopes` | 84.060 | 71.672 | 14.7% |

Missing-hook calls were 75% cheaper in this microbenchmark; populated cases were 10–15% cheaper. Callback/container work is still performed on every applicable invocation.

These are isolated hot-path measurements, not whole-request speedup estimates. Benefits depend on how often an application exercises these paths. Laravel 11/12 and other PHP versions were not benchmarked locally.

<details>
<summary>Reproduction script</summary>

Save this outside the checkout as `benchmark.php`, run `php -d xdebug.mode=off /path/to/benchmark.php` from the repository root on the baseline and PR branch with the same Composer dependencies. Repeat in baseline/candidate/candidate/baseline order three times. Each script reports nanoseconds per call, iteration counts, and output hashes.

```php
<?php
require getcwd() . '/vendor/autoload.php';
Illuminate\Container\Container::setInstance(new Illuminate\Container\Container);
$manager = new Filament\Support\View\ViewManager;
$scopes = ['Page', 'Resource', 'Cluster'];
$benchmarks = [
    'missing_name' => static fn () => $manager->renderHook('missing', $scopes)->toHtml(),
];
$manager->registerRenderHook('one', static fn (array $data): string => $data['value']);
$benchmarks['one_global'] = static fn () => $manager->renderHook('one', $scopes, ['value' => 'content'])->toHtml();
for ($index = 0; $index < 100; $index++) {
    $manager->registerRenderHook('shared', static fn (): string => 'x', $scopes);
}
$benchmarks['100_hooks_3_scopes'] = static fn () => $manager->renderHook('shared', $scopes)->toHtml();
$results = [];
foreach ($benchmarks as $name => $benchmark) {
    $iterations = $name === '100_hooks_3_scopes' ? 1000 : 100000;
    $expected = $benchmark();
    for ($index = 0; $index < 100; $index++) { $benchmark(); }
    $started = hrtime(true);
    for ($index = 0; $index < $iterations; $index++) { $actual = $benchmark(); }
    if ($actual !== $expected) { throw new RuntimeException('Changed output'); }
    $results[$name] = ['ns_per_call' => (hrtime(true) - $started) / $iterations, 'sha256' => hash('sha256', $actual), 'iterations' => $iterations];
}
echo json_encode($results), "\n";
```

</details>

### Validation

- `vendor/bin/pest tests/src/Support/RenderHooksTest.php --compact`: 12 tests, 26 assertions passed.
- Targeted PHPStan passed for changed production files.
- Pint and targeted Rector checks passed; no JavaScript or CSS changed.
- Compatibility review covered ordering, repeated calls, exceptions, and extension points relevant to this change.

## Visual changes

None intended. No public API or configuration changes are required.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command. (Targeted Pint and Rector passed; the full repository command was not run.)
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date. (Internal optimization; no documented behavior changes.)
