### PR TITLE
Cache immutable trait discovery for lifecycle hook dispatch

### DIFF
--- a/packages/support/src/Concerns/CanCallHooks.php
+++ b/packages/support/src/Concerns/CanCallHooks.php
@@ -10,15 +10,19 @@ trait CanCallHooks
             $this->{$hook}();
         }
 
-        $calledTraitHooks = [];
+        /** @var array<class-string, array<string>> $traitHookSuffixes */
+        static $traitHookSuffixes = [];
 
-        foreach (class_uses_recursive($this) as $trait) {
-            $method = $hook . class_basename($trait);
+        $traitHookSuffixes[static::class] ??= array_unique(array_map(
+            class_basename(...),
+            class_uses_recursive(static::class),
+        ));
 
-            if (method_exists($this, $method) && (! in_array($method, $calledTraitHooks, strict: true))) {
+        foreach ($traitHookSuffixes[static::class] as $suffix) {
+            $method = $hook . $suffix;
+
+            if (method_exists($this, $method)) {
                 $this->{$method}();
-
-                $calledTraitHooks[] = $method;
             }
         }
     }

--- a/tests/src/Support/CanCallHooksTest.php
+++ b/tests/src/Support/CanCallHooksTest.php
@@ -91,6 +91,76 @@ it('calls duplicate trait hook methods once with `callHook()`', function (): voi
     ]);
 });
 
+it('keeps repeated `callHook()` invocations live across instances and hook names', function (): void {
+    $first = new HookCaller;
+    $second = new HookCaller;
+
+    $first->callHookByName('afterSave');
+    $first->callHookByName('beforeCreate');
+    $first->callHookByName('afterSave');
+    $second->callHookByName('beforeSave');
+
+    expect($first->lifecycleHookInvocations)->toBe([
+        'afterSave',
+        'afterSaveRecordsParentLifecycleHooks',
+        'afterSaveRecordsLifecycleHooks',
+        'afterSaveRecordsNestedLifecycleHooks',
+        'beforeCreateRecordsLifecycleHooks',
+        'afterSave',
+        'afterSaveRecordsParentLifecycleHooks',
+        'afterSaveRecordsLifecycleHooks',
+        'afterSaveRecordsNestedLifecycleHooks',
+    ])->and($second->lifecycleHookInvocations)->toBe([
+        'beforeSaveRecordsDuplicateLifecycleHooks',
+    ]);
+});
+
+it('isolates trait discovery by concrete class and keeps overrides live in `callHook()`', function (): void {
+    $parent = new ParentHookCaller;
+    $child = new HookCaller;
+    $overridden = new class extends HookCaller
+    {
+        protected function afterSaveRecordsNestedLifecycleHooks(): void
+        {
+            $this->lifecycleHookInvocations[] = 'overridden';
+        }
+    };
+
+    $child->callHookByName('afterSave');
+    $parent->callHookByName('afterSave');
+    $overridden->callHookByName('afterSave');
+
+    expect($parent->lifecycleHookInvocations)->toBe(['afterSaveRecordsParentLifecycleHooks'])
+        ->and($overridden->lifecycleHookInvocations)->toBe([
+            'afterSave',
+            'afterSaveRecordsParentLifecycleHooks',
+            'afterSaveRecordsLifecycleHooks',
+            'overridden',
+        ]);
+});
+
+it('does not retain hook caller instances after caching trait discovery in `callHook()`', function (): void {
+    $caller = new HookCaller;
+    $reference = \WeakReference::create($caller);
+    $caller->callHookByName('missing');
+    unset($caller);
+
+    expect($reference->get())->toBeNull();
+});
+
+it('propagates hook exceptions without suppressing later `callHook()` attempts', function (): void {
+    $caller = new class extends HookCaller
+    {
+        protected function beforeCreateRecordsLifecycleHooks(): void
+        {
+            throw new \RuntimeException('lifecycle failure');
+        }
+    };
+
+    expect(fn () => $caller->callHookByName('beforeCreate'))->toThrow(\RuntimeException::class, 'lifecycle failure')
+        ->and(fn () => $caller->callHookByName('beforeCreate'))->toThrow(\RuntimeException::class, 'lifecycle failure');
+});
+
 class ParentHookCaller
 {
     use CanCallHooks;


### PR DESCRIPTION
## Description

`CanCallHooks::callHook()` recursively discovers the same traits and computes their basenames every time a lifecycle hook runs, even though a loaded class cannot acquire new traits.

Cache the ordered, unique trait suffixes per concrete class. Keep method-existence checks and hook invocation live on every call, including the class hook, inherited/nested traits, duplicate basenames, and overridden methods. The cache contains class names and strings, never page instances or callback results.

### Measurements

PHP 8.4.24 CLI, Xdebug absent, CLI OPcache disabled, Laravel 13.15.0, comparing `5.x` at `02742899b97ec24e97ac5561832fe144ef6ed6f9` with this change. Three alternating baseline/candidate/candidate/baseline rounds, each sample in a fresh PHP process; table values are medians of six samples per version. Setup is outside the timed loops, and output hashes agree across versions.

| Scenario | Baseline µs/call | Proposed µs/call | Time reduction |
| --- | ---: | ---: | ---: |
| `missing` | 9.307 | 2.488 | 73.3% |
| `benchmark` | 9.570 | 2.638 | 72.4% |

Repeated dispatch on an `EditRecord` subclass with 35 recursive traits was 72–73% cheaper. These measurements describe warm repeated dispatch; the first call still discovers the traits.

These are isolated hot-path measurements, not whole-request speedup estimates. Benefits depend on how often an application exercises these paths. Laravel 11/12 and other PHP versions were not benchmarked locally.

<details>
<summary>Reproduction script</summary>

Save this outside the checkout as `benchmark.php`, run `php -d xdebug.mode=off /path/to/benchmark.php` from the repository root on the baseline and PR branch with the same Composer dependencies. Repeat in baseline/candidate/candidate/baseline order three times. Each script reports nanoseconds per call, iteration counts, and output hashes.

```php
<?php
require getcwd() . '/vendor/autoload.php';
class BenchmarkEditPage extends Filament\Resources\Pages\EditRecord
{
    public int $calls = 0;
    public function dispatchBenchmarkHook(string $hook): void { $this->callHook($hook); }
    protected function benchmark(): void { $this->calls++; }
}
$page = new BenchmarkEditPage;
$results = [];
foreach (['missing', 'benchmark'] as $hook) {
    $iterations = 100000;
    $page->calls = 0;
    $started = hrtime(true);
    for ($index = 0; $index < $iterations; $index++) { $page->dispatchBenchmarkHook($hook); }
    $results[$hook] = ['ns_per_call' => (hrtime(true) - $started) / $iterations, 'sha256' => hash('sha256', (string) $page->calls), 'iterations' => $iterations, 'trait_count' => count(class_uses_recursive($page))];
}
echo json_encode($results), "\n";
```

</details>

### Validation

- `vendor/bin/pest tests/src/Support/CanCallHooksTest.php --compact`: 7 tests, 12 assertions passed.
- Targeted PHPStan passed for changed production files.
- Pint and targeted Rector checks passed; no JavaScript or CSS changed.
- Compatibility review covered ordering, repeated calls, exceptions, and extension points relevant to this change.

## Visual changes

None intended. No public API or configuration changes are required.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command. (Targeted Pint and Rector passed; the full repository command was not run.)
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date. (Internal optimization; no documented behavior changes.)
