### PR TITLE
Avoid filtered attribute-bag allocations when resolving loading targets

### DIFF
--- a/packages/support/src/View/Concerns/CanGenerateBadgeHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateBadgeHtml.php
@@ -15,6 +15,7 @@ use Illuminate\View\ComponentAttributeBag;
 use function Filament\Support\generate_href_html;
 use function Filament\Support\generate_icon_html;
 use function Filament\Support\generate_loading_indicator_html;
+use function Filament\Support\get_loading_indicator_target;
 
 trait CanGenerateBadgeHtml
 {
@@ -59,7 +60,7 @@ trait CanGenerateBadgeHtml
             $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
         }
 
-        $wireTarget = $hasLoadingIndicator ? $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first() : null;
+        $wireTarget = $hasLoadingIndicator ? get_loading_indicator_target($attributes) : null;
 
         $hasLoadingIndicator = filled($wireTarget) || ($type === 'submit' && filled($form));
 

--- a/packages/support/src/View/Concerns/CanGenerateButtonHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateButtonHtml.php
@@ -16,6 +16,7 @@ use Illuminate\View\ComponentAttributeBag;
 use function Filament\Support\generate_href_html;
 use function Filament\Support\generate_icon_html;
 use function Filament\Support\generate_loading_indicator_html;
+use function Filament\Support\get_loading_indicator_target;
 
 trait CanGenerateButtonHtml
 {
@@ -77,7 +78,7 @@ trait CanGenerateButtonHtml
             default => null,
         };
 
-        $wireTarget = $hasLoadingIndicator ? $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first() : null;
+        $wireTarget = $hasLoadingIndicator ? get_loading_indicator_target($attributes) : null;
 
         $hasFormProcessingLoadingIndicator = $type === 'submit' && filled($form);
         $hasLoadingIndicator = filled($wireTarget) || $hasFormProcessingLoadingIndicator;

--- a/packages/support/src/View/Concerns/CanGenerateDropdownItemHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateDropdownItemHtml.php
@@ -15,6 +15,7 @@ use Illuminate\View\ComponentAttributeBag;
 use function Filament\Support\generate_href_html;
 use function Filament\Support\generate_icon_html;
 use function Filament\Support\generate_loading_indicator_html;
+use function Filament\Support\get_loading_indicator_target;
 
 trait CanGenerateDropdownItemHtml
 {
@@ -55,7 +56,7 @@ trait CanGenerateDropdownItemHtml
 
         $iconColor ??= $color;
 
-        $wireTarget = $hasLoadingIndicator ? $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first() : null;
+        $wireTarget = $hasLoadingIndicator ? get_loading_indicator_target($attributes) : null;
 
         $hasLoadingIndicator = filled($wireTarget);
 

--- a/packages/support/src/View/Concerns/CanGenerateIconButtonHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateIconButtonHtml.php
@@ -15,6 +15,7 @@ use Illuminate\View\ComponentAttributeBag;
 use function Filament\Support\generate_href_html;
 use function Filament\Support\generate_icon_html;
 use function Filament\Support\generate_loading_indicator_html;
+use function Filament\Support\get_loading_indicator_target;
 
 trait CanGenerateIconButtonHtml
 {
@@ -69,7 +70,7 @@ trait CanGenerateIconButtonHtml
             default => null,
         };
 
-        $wireTarget = $hasLoadingIndicator ? $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first() : null;
+        $wireTarget = $hasLoadingIndicator ? get_loading_indicator_target($attributes) : null;
 
         $hasLoadingIndicator = filled($wireTarget) || ($type === 'submit' && filled($form));
 

--- a/packages/support/src/View/Concerns/CanGenerateLinkHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateLinkHtml.php
@@ -17,6 +17,7 @@ use Illuminate\View\ComponentAttributeBag;
 use function Filament\Support\generate_href_html;
 use function Filament\Support\generate_icon_html;
 use function Filament\Support\generate_loading_indicator_html;
+use function Filament\Support\get_loading_indicator_target;
 
 trait CanGenerateLinkHtml
 {
@@ -81,7 +82,7 @@ trait CanGenerateLinkHtml
             $weight = filled($weight) ? (FontWeight::tryFrom($weight) ?? $weight) : null;
         }
 
-        $wireTarget = $hasLoadingIndicator ? $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first() : null;
+        $wireTarget = $hasLoadingIndicator ? get_loading_indicator_target($attributes) : null;
 
         $hasLoadingIndicator = filled($wireTarget) || ($type === 'submit' && filled($form));
 

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -232,6 +232,28 @@ if (! function_exists('Filament\Support\generate_icon_html')) {
     }
 }
 
+if (! function_exists('Filament\Support\get_loading_indicator_target')) {
+    /**
+     * @internal
+     */
+    function get_loading_indicator_target(ComponentAttributeBag $attributes): mixed
+    {
+        if (($attributes::class !== ComponentAttributeBag::class) && ($attributes::class !== FilamentComponentAttributeBag::class)) {
+            return $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(static fn ($value): bool => filled($value))->first();
+        }
+
+        $target = null;
+
+        foreach ($attributes->getAttributes() as $name => $value) {
+            if ((str_starts_with($name, 'wire:target') || str_starts_with($name, 'wire:click')) && filled($value)) {
+                $target ??= $value;
+            }
+        }
+
+        return $target;
+    }
+}
+
 if (! function_exists('Filament\Support\generate_loading_indicator_html')) {
     function generate_loading_indicator_html(?ComponentAttributeBag $attributes = null, ?IconSize $size = null): Htmlable
     {

--- a/tests/src/Support/BladeComponentsTest.php
+++ b/tests/src/Support/BladeComponentsTest.php
@@ -1,9 +1,13 @@
 <?php
 
+use Filament\Support\View\Concerns\CanGenerateBadgeHtml;
 use Filament\Support\View\Concerns\CanGenerateButtonHtml;
+use Filament\Support\View\Concerns\CanGenerateDropdownItemHtml;
 use Filament\Support\View\Concerns\CanGenerateIconButtonHtml;
 use Filament\Support\View\Concerns\CanGenerateLinkHtml;
+use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\TestCase;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
@@ -15,7 +19,9 @@ function embeddedHtmlGenerator(): object
 {
     return new class
     {
+        use CanGenerateBadgeHtml;
         use CanGenerateButtonHtml;
+        use CanGenerateDropdownItemHtml;
         use CanGenerateIconButtonHtml;
         use CanGenerateLinkHtml;
     };
@@ -153,4 +159,48 @@ it('binds `aria-controls` on the collapse button when a collapsible section has 
 
     expect($html)
         ->toContain('x-bind:aria-controls');
+});
+
+it('preserves loading targets in shared embedded component rendering', function (string $method): void {
+    $generator = embeddedHtmlGenerator();
+    $attributes = new ComponentAttributeBag(['wire:target' => ' ', 'wire:click.prevent' => 'save', 'title' => 'Save']);
+    $html = $generator->{$method}($attributes, label: 'Save');
+
+    expect($html)->toContain('wire:target="save"')
+        ->toContain('fi-loading-indicator');
+
+    $withoutIndicator = $generator->{$method}($attributes, label: 'Save', hasLoadingIndicator: false);
+    expect($withoutIndicator)->not->toContain('fi-loading-indicator');
+})->with([
+    'button' => 'generateButtonHtml',
+    'badge' => 'generateBadgeHtml',
+    'icon button' => 'generateIconButtonHtml',
+    'link' => 'generateLinkHtml',
+    'dropdown item' => 'generateDropdownItemHtml',
+]);
+
+it('preserves submit-form loading fallback in shared embedded component rendering', function (string $method): void {
+    $html = embeddedHtmlGenerator()->{$method}(new ComponentAttributeBag, label: 'Save', type: 'submit', form: 'save');
+
+    expect($html)->toContain('fi-loading-indicator');
+})->with(['generateButtonHtml', 'generateBadgeHtml', 'generateIconButtonHtml', 'generateLinkHtml']);
+
+it('keeps form submission and loading controls accessible in the browser', function (): void {
+    $this->actingAs(User::factory()->create());
+    Artisan::call('filament:assets');
+
+    visit('/text-input-test')
+        ->type('[data-testid="text-input"] input', 'Ada Lovelace')
+        ->click('Save')
+        ->assertSee('Name')
+        ->assertNoSmoke()
+        ->assertNoAccessibilityIssues();
+
+    visit('/text-input-test')
+        ->inDarkMode()
+        ->type('[data-testid="text-input"] input', 'Ada Lovelace')
+        ->click('Save')
+        ->assertSee('Name')
+        ->assertNoSmoke()
+        ->assertNoAccessibilityIssues();
 });

--- a/tests/src/Support/helpersTest.php
+++ b/tests/src/Support/helpersTest.php
@@ -339,3 +339,61 @@ it('will generate a JSON search column expression for Postgres with explicit ->>
     expect($expression->getValue($grammar))
         ->toBe("lower(\"name\"->>'en'::text)");
 });
+
+it('preserves attribute order and filled-value semantics in `get_loading_indicator_target()`', function (array $values): void {
+    $attributes = new ComponentAttributeBag($values);
+    $expected = $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(static fn ($value): bool => filled($value))->first();
+
+    expect(\Filament\Support\get_loading_indicator_target($attributes))->toBe($expected)
+        ->and($attributes->getAttributes())->toBe($values);
+})->with([
+    'missing' => [[]],
+    'unrelated' => [['class' => 'button', 'data-wire:target' => 'ignored']],
+    'target first' => [['wire:target' => 'save', 'wire:click' => 'delete']],
+    'click first' => [['wire:click' => 'delete', 'wire:target' => 'save']],
+    'modifiers' => [['wire:click.prevent' => 'save']],
+    'prefix without separator' => [['wire:targeted' => 'save']],
+    'blank first' => [['wire:target' => ' ', 'wire:click' => 'save']],
+    'null first' => [['wire:target' => null, 'wire:click' => 'save']],
+    'false first' => [['wire:target' => false, 'wire:click' => 'save']],
+    'zero' => [['wire:target' => 0, 'wire:click' => 'save']],
+    'zero string' => [['wire:target' => '0']],
+    'empty array' => [['wire:target' => [], 'wire:click' => 'save']],
+    'numeric attribute key' => [[0 => 'ignored', 'wire:click' => 'save']],
+    'encoded quotes' => [['wire:target' => 'save(&quot;value&quot;)']],
+]);
+
+it('reads updated attributes on subsequent `get_loading_indicator_target()` calls', function (): void {
+    $attributes = new ComponentAttributeBag(['wire:click' => 'before']);
+    expect(\Filament\Support\get_loading_indicator_target($attributes))->toBe('before');
+    $attributes->setAttributes(['wire:target' => 'after']);
+    expect(\Filament\Support\get_loading_indicator_target($attributes))->toBe('after');
+});
+
+it('preserves custom attribute bag filtering in `get_loading_indicator_target()`', function (): void {
+    $attributes = new class(['wire:click' => 'save']) extends ComponentAttributeBag
+    {
+        public function whereStartsWith($needles): static
+        {
+            return new self(['wire:target' => 'custom']);
+        }
+    };
+
+    expect(\Filament\Support\get_loading_indicator_target($attributes))->toBe('custom');
+});
+
+it('evaluates later matching values in `get_loading_indicator_target()`', function (): void {
+    $attributes = new ComponentAttributeBag([
+        'wire:target' => 'save',
+        'wire:click' => new class implements Stringable
+        {
+            public function __toString(): string
+            {
+                throw new RuntimeException('Invalid target');
+            }
+        },
+    ]);
+
+    expect(fn () => \Filament\Support\get_loading_indicator_target($attributes))
+        ->toThrow(RuntimeException::class, 'Invalid target');
+});


### PR DESCRIPTION
## Description

The shared button, badge, icon-button, link, and dropdown-item HTML generators each allocate two filtered attribute bags to select a single loading target.

Use an internal direct scan for the standard Laravel and Filament attribute bags. Preserve first-filled attribute ordering, prefix/modifier matching, false/zero values, and evaluation of later matching object values. Custom attribute-bag subclasses retain the existing virtual filtering chain. Loading-indicator disabling, quote decoding and submit-form fallback remain in their existing renderer paths.

### Measurements

PHP 8.4.24 CLI, Xdebug absent, CLI OPcache disabled, Laravel 13.15.0, comparing `5.x` at `02742899b97ec24e97ac5561832fe144ef6ed6f9` with this change. Three alternating baseline/candidate/candidate/baseline rounds, each sample in a fresh PHP process; table values are medians of six samples per version. Setup is outside the timed loops, and output hashes agree across versions.

| Scenario | Baseline µs/call | Proposed µs/call | Time reduction |
| --- | ---: | ---: | ---: |
| `lookup_early` | 1.566 | 0.233 | 85.1% |
| `lookup_late` | 1.587 | 0.235 | 85.2% |
| `lookup_missing` | 1.375 | 0.152 | 89.0% |
| `render_Button` | 9.933 | 8.387 | 15.6% |
| `render_Badge` | 8.819 | 7.195 | 18.4% |
| `render_IconButton` | 10.476 | 8.925 | 14.8% |
| `render_Link` | 9.290 | 7.739 | 16.7% |
| `render_DropdownItem` | 8.892 | 7.310 | 17.8% |

Complete generator calls were 15–18% cheaper for these fixtures. Lookup alone was 85–89% cheaper. Complete rendered HTML hashes matched the baseline across all runs; this is not a claim about complete Blade/page rendering time.

These are isolated hot-path measurements, not whole-request speedup estimates. Benefits depend on how often an application exercises these paths. Laravel 11/12 and other PHP versions were not benchmarked locally.

<details>
<summary>Reproduction script</summary>

Save this outside the checkout as `benchmark.php`, run `php -d xdebug.mode=off /path/to/benchmark.php` from the repository root on the baseline and PR branch with the same Composer dependencies. Repeat in baseline/candidate/candidate/baseline order three times. Each script reports nanoseconds per call, iteration counts, and output hashes.

```php
<?php
require getcwd() . '/vendor/autoload.php';
$test = new class('benchmark') extends Filament\Tests\TestCase
{
    public function bootBenchmark(): void { parent::setUp(); }
    public function benchmark(): void {}
};
$test->bootBenchmark();
$generator = new class {
 use Filament\Support\View\Concerns\CanGenerateButtonHtml;
 use Filament\Support\View\Concerns\CanGenerateBadgeHtml;
 use Filament\Support\View\Concerns\CanGenerateIconButtonHtml;
 use Filament\Support\View\Concerns\CanGenerateLinkHtml;
 use Filament\Support\View\Concerns\CanGenerateDropdownItemHtml;
};
$lookup = function_exists('Filament\Support\get_loading_indicator_target') ? Filament\Support\get_loading_indicator_target(...) : static fn ($attributes) => $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(static fn ($value): bool => filled($value))->first();
$benchmarks = [];
foreach (['early' => ['wire:click' => 'save', 'class' => 'example', 'title' => 'Save', 'data-value' => 'value'], 'late' => ['class' => 'example', 'title' => 'Save', 'data-value' => 'value', 'wire:click' => 'save'], 'missing' => ['class' => 'example', 'title' => 'Save', 'data-value' => 'value']] as $name => $values) {
 $attributes = new Filament\Support\View\ComponentAttributeBag($values);
 $benchmarks['lookup_'.$name] = [100000, static fn () => $lookup($attributes)];
}
foreach (['Button', 'Badge', 'IconButton', 'Link', 'DropdownItem'] as $kind) {
 $attributes = new Filament\Support\View\ComponentAttributeBag(['wire:click' => 'save', 'class' => 'example', 'title' => 'Save', 'data-value' => 'value']);
 $method = 'generate'.$kind.'Html';
 $benchmarks['render_'.$kind] = [5000, static fn () => $generator->$method($attributes, label: 'Save')];
}
$results = [];
foreach ($benchmarks as $name => [$iterations, $benchmark]) {
 for ($index = 0; $index < 20; $index++) { $benchmark(); }
 $started = hrtime(true);
 for ($index = 0; $index < $iterations; $index++) { $result = $benchmark(); }
 $results[$name] = ['ns_per_call' => (hrtime(true) - $started) / $iterations, 'sha256' => hash('sha256', (string) $result), 'iterations' => $iterations];
}
echo json_encode($results), "\n";
```

</details>

### Validation

- `TMPDIR=/private/tmp vendor/bin/pest tests/src/Support/helpersTest.php tests/src/Support/BladeComponentsTest.php tests/src/Support/LoadingIndicatorTest.php --compact`: 64 tests, 110 assertions passed. This includes browser submission and accessibility checks in light and dark modes. The canonical temporary path avoids an existing macOS symlink-path issue in the Composer class-discovery fixture.
- Targeted PHPStan passed for changed production files.
- Pint and targeted Rector checks passed; no JavaScript or CSS changed.
- Compatibility review covered ordering, repeated calls, exceptions, and extension points relevant to this change.

## Visual changes

None intended. No public API or configuration changes are required.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command. (Targeted Pint and Rector passed; the full repository command was not run.)
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date. (Internal optimization; no documented behavior changes.)
