### PR TITLE
fix: guard enum state casts against non-scalar values

### DIFF
--- a/packages/schemas/src/Components/StateCasts/EnumArrayStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/EnumArrayStateCast.php
@@ -49,6 +49,10 @@ class EnumArrayStateCast implements StateCast
                     return $carry;
                 }
 
+                if ($stateItem instanceof Stringable) {
+                    $stateItem = (string) $stateItem;
+                }
+
                 $carry[] = $this->enum::tryFrom($stateItem);
 
                 return $carry;

--- a/packages/schemas/src/Components/StateCasts/EnumArrayStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/EnumArrayStateCast.php
@@ -5,6 +5,7 @@ namespace Filament\Schemas\Components\StateCasts;
 use BackedEnum;
 use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
 use Illuminate\Support\Arr;
+use Stringable;
 
 class EnumArrayStateCast implements StateCast
 {
@@ -41,6 +42,10 @@ class EnumArrayStateCast implements StateCast
                 if ($stateItem instanceof BackedEnum) {
                     $carry[] = $stateItem;
 
+                    return $carry;
+                }
+
+                if ((! is_scalar($stateItem)) && (! $stateItem instanceof Stringable)) {
                     return $carry;
                 }
 

--- a/packages/schemas/src/Components/StateCasts/EnumArrayStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/EnumArrayStateCast.php
@@ -45,12 +45,12 @@ class EnumArrayStateCast implements StateCast
                     return $carry;
                 }
 
-                if ((! is_scalar($stateItem)) && (! $stateItem instanceof Stringable)) {
-                    return $carry;
-                }
-
                 if ($stateItem instanceof Stringable) {
                     $stateItem = (string) $stateItem;
+                }
+
+                if (! is_scalar($stateItem)) {
+                    return $carry;
                 }
 
                 $carry[] = $this->enum::tryFrom($stateItem);

--- a/packages/schemas/src/Components/StateCasts/EnumStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/EnumStateCast.php
@@ -29,6 +29,10 @@ class EnumStateCast implements StateCast
             return null;
         }
 
+        if ($state instanceof Stringable) {
+            $state = (string) $state;
+        }
+
         return $this->enum::tryFrom($state);
     }
 

--- a/packages/schemas/src/Components/StateCasts/EnumStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/EnumStateCast.php
@@ -4,6 +4,7 @@ namespace Filament\Schemas\Components\StateCasts;
 
 use BackedEnum;
 use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
+use Stringable;
 
 class EnumStateCast implements StateCast
 {
@@ -22,6 +23,10 @@ class EnumStateCast implements StateCast
 
         if ($state instanceof $this->enum) {
             return $state;
+        }
+
+        if ((! is_scalar($state)) && (! $state instanceof Stringable)) {
+            return null;
         }
 
         return $this->enum::tryFrom($state);

--- a/packages/schemas/src/Components/StateCasts/EnumStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/EnumStateCast.php
@@ -25,12 +25,12 @@ class EnumStateCast implements StateCast
             return $state;
         }
 
-        if ((! is_scalar($state)) && (! $state instanceof Stringable)) {
-            return null;
-        }
-
         if ($state instanceof Stringable) {
             $state = (string) $state;
+        }
+
+        if (! is_scalar($state)) {
+            return null;
         }
 
         return $this->enum::tryFrom($state);

--- a/tests/src/Schemas/Components/StateCasts/EnumArrayStateCastTest.php
+++ b/tests/src/Schemas/Components/StateCasts/EnumArrayStateCastTest.php
@@ -28,6 +28,13 @@ it('can ignore if an array of enums is passed to the getter already', function (
         ->toBe([StringBackedEnum::One, StringBackedEnum::Two, StringBackedEnum::Three]);
 });
 
+it('can get an array of enums from `Stringable` values', function (): void {
+    $cast = app(EnumArrayStateCast::class, ['enum' => StringBackedEnum::class]);
+
+    expect($cast->get([str('one'), str('two')]))
+        ->toBe([StringBackedEnum::One, StringBackedEnum::Two]);
+});
+
 it('can return an empty array if blank values are passed to the getter', function (): void {
     $cast = app(EnumArrayStateCast::class, ['enum' => StringBackedEnum::class]);
 
@@ -41,6 +48,13 @@ it('can filter out blank values from the array of enums in the getter', function
 
     expect($cast->get(['one', null, 'two', '', 'three']))
         ->toBe([StringBackedEnum::One, StringBackedEnum::Two, StringBackedEnum::Three]);
+});
+
+it('can filter out tampered non-scalar values from the array of enums in the getter', function (): void {
+    $cast = app(EnumArrayStateCast::class, ['enum' => StringBackedEnum::class]);
+
+    expect($cast->get(['one', ['tampered'], 'two']))
+        ->toBe([StringBackedEnum::One, StringBackedEnum::Two]);
 });
 
 it('can decode a JSON array of enum from strings', function (): void {

--- a/tests/src/Schemas/Components/StateCasts/EnumStateCastTest.php
+++ b/tests/src/Schemas/Components/StateCasts/EnumStateCastTest.php
@@ -40,6 +40,13 @@ it('can ignore if an enum is passed to the getter already', function (StringBack
     StringBackedEnum::Three,
 ]);
 
+it('can get an enum from a `Stringable` value', function (): void {
+    $cast = app(EnumStateCast::class, ['enum' => StringBackedEnum::class]);
+
+    expect($cast->get(str('one')))
+        ->toBe(StringBackedEnum::One);
+});
+
 it('can return null if a blank value is passed to the getter', function ($value): void {
     $cast = app(EnumStateCast::class, ['enum' => StringBackedEnum::class]);
 
@@ -49,6 +56,12 @@ it('can return null if a blank value is passed to the getter', function ($value)
     null,
     '',
 ]);
+
+it('can return null if a tampered non-scalar value is passed to the getter', function (): void {
+    $cast = app(EnumStateCast::class, ['enum' => StringBackedEnum::class]);
+
+    expect($cast->get(['tampered']))->toBeNull();
+});
 
 it('can get the value from a string backed enum in the setter', function (StringBackedEnum $enum, string $string): void {
     $cast = app(EnumStateCast::class, ['enum' => StringBackedEnum::class]);


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Non-scalar enum field state can reach `BackedEnum::tryFrom()`, causing a `TypeError`.

Return `null` for single-value casts and skip non-scalar items in array casts, while preserving `Stringable` values.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
