### PR TITLE
fix: replace missing `scrollbar-gutter-stable` utility with raw CSS

### DIFF
--- a/packages/forms/resources/css/components/markdown-editor.css
+++ b/packages/forms/resources/css/components/markdown-editor.css
@@ -32,7 +32,8 @@
         }
 
         &[style*='--max-height'] {
-            @apply focus-visible:ring-primary-600 dark:focus-visible:ring-primary-500 scrollbar-gutter-stable overflow-y-auto outline-none focus-visible:ring-2 focus-visible:ring-inset;
+            @apply focus-visible:ring-primary-600 dark:focus-visible:ring-primary-500 overflow-y-auto outline-none focus-visible:ring-2 focus-visible:ring-inset;
+            scrollbar-gutter: stable;
             max-height: var(--max-height);
         }
     }

--- a/packages/forms/resources/css/components/rich-editor.css
+++ b/packages/forms/resources/css/components/rich-editor.css
@@ -94,7 +94,8 @@
     }
 
     &[style*='--max-height'] .fi-fo-rich-editor-content {
-        @apply scrollbar-gutter-stable overflow-y-auto;
+        @apply overflow-y-auto;
+        scrollbar-gutter: stable;
         max-height: var(--max-height);
     }
 


### PR DESCRIPTION
## Problem

The rich editor and markdown editor `max-height` styles `@apply` a `scrollbar-gutter-stable` utility that is **not declared anywhere in Filament's CSS**. As soon as a panel theme imports `vendor/filament/filament/resources/css/theme.css`, Vite fails to build:

```
[@tailwindcss/vite:generate:build] Cannot apply unknown utility class `scrollbar-gutter-stable`
file: /project/resources/css/filament/<panel>/theme.css
```

Reported (and closed for lack of a repro repo) in #20463. The affected lines were introduced in #20258 (`RichEditor` `minHeight()`/`maxHeight()` support):

- `packages/forms/resources/css/components/markdown-editor.css:35`
- `packages/forms/resources/css/components/rich-editor.css:97`

Elsewhere in the codebase (`packages/panels/resources/css/components/sidebar.css:144`) the same behaviour is expressed as the raw property `scrollbar-gutter: stable;`, which works fine.

## Fix

Drop `scrollbar-gutter-stable` from the `@apply` list and add the raw `scrollbar-gutter: stable;` declaration next to `max-height`, matching the sidebar's existing pattern. Two-line change, no new utility to maintain.

## Test plan

- [x] `npm run build` no longer errors on a fresh panel with a custom theme
- [x] Verified the resulting CSS still emits `scrollbar-gutter: stable` for the two selectors

Closes #20463.