### PR TITLE
Fix `filament-query-builder::query-builder.operators.is_filled.summary` german translations

### DIFF
--- a/packages/query-builder/resources/lang/de/query-builder.php
+++ b/packages/query-builder/resources/lang/de/query-builder.php
@@ -56,8 +56,8 @@ return [
             ],
 
             'summary' => [
-                'direct' => ':Attribut ist vorhangen',
-                'inverse' => ':Attribut ist nicht vorhanden',
+                'direct' => ':attribute ist vorhanden',
+                'inverse' => ':attribute ist nicht vorhanden',
             ],
 
         ],


### PR DESCRIPTION
## Description

Small fix for some german query builder translations: there was a typo and the placeholder was translated.

## Visual changes

Before:
<img width="455" height="31" alt="grafik" src="https://github.com/user-attachments/assets/0d3357f5-b553-47dd-b1c9-223936f52538" />

After:
<img width="513" height="27" alt="grafik" src="https://github.com/user-attachments/assets/eb6ba707-0f6a-4277-8939-9a795f9a0515" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
