### PR TITLE
fix: scope table session state to the table configuration of a `TableSelect`

### DIFF
--- a/packages/forms/src/Components/TableSelect/Livewire/TableSelectLivewireComponent.php
+++ b/packages/forms/src/Components/TableSelect/Livewire/TableSelectLivewireComponent.php
@@ -139,6 +139,11 @@ class TableSelectLivewireComponent extends Component implements HasActions, HasF
         return $table;
     }
 
+    public function getTableSessionKeyNamespace(): string
+    {
+        return $this::class . '|' . base64_decode($this->tableConfiguration);
+    }
+
     /**
      * @return array<mixed>
      */

--- a/packages/tables/src/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Concerns/CanGroupRecords.php
@@ -83,7 +83,7 @@ trait CanGroupRecords
 
     public function getTableGroupingSessionKey(): string
     {
-        $table = md5($this::class);
+        $table = md5($this->getTableSessionKeyNamespace());
 
         return "tables.{$table}_grouping";
     }

--- a/packages/tables/src/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Concerns/CanPaginateRecords.php
@@ -93,7 +93,7 @@ trait CanPaginateRecords
 
     public function getTablePerPageSessionKey(): string
     {
-        $table = md5($this::class);
+        $table = md5($this->getTableSessionKeyNamespace());
 
         return "tables.{$table}_per_page";
     }

--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -362,14 +362,14 @@ trait CanSearchRecords
 
     public function getTableSearchSessionKey(): string
     {
-        $table = md5($this::class);
+        $table = md5($this->getTableSessionKeyNamespace());
 
         return "tables.{$table}_search";
     }
 
     public function getTableColumnSearchesSessionKey(): string
     {
-        $table = md5($this::class);
+        $table = md5($this->getTableSessionKeyNamespace());
 
         return "tables.{$table}_column_search";
     }

--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -158,7 +158,7 @@ trait CanSortRecords
 
     public function getTableSortSessionKey(): string
     {
-        $table = md5($this::class);
+        $table = md5($this->getTableSessionKeyNamespace());
 
         return "tables.{$table}_sort";
     }

--- a/packages/tables/src/Concerns/HasColumnManager.php
+++ b/packages/tables/src/Concerns/HasColumnManager.php
@@ -159,14 +159,14 @@ trait HasColumnManager
 
     public function getTableColumnsSessionKey(): string
     {
-        $table = md5($this::class);
+        $table = md5($this->getTableSessionKeyNamespace());
 
         return "tables.{$table}_columns";
     }
 
     public function getHasReorderedTableColumnsSessionKey(): string
     {
-        $table = md5($this::class);
+        $table = md5($this->getTableSessionKeyNamespace());
 
         return "tables.{$table}_has_reordered_columns";
     }

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -232,7 +232,7 @@ trait HasFilters
 
     public function getTableFiltersSessionKey(): string
     {
-        $namespace = $this::class;
+        $namespace = $this->getTableSessionKeyNamespace();
 
         $tenantKey = null;
 

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -195,6 +195,11 @@ trait InteractsWithTable
         return $this->table;
     }
 
+    public function getTableSessionKeyNamespace(): string
+    {
+        return $this::class;
+    }
+
     protected function makeTable(): Table
     {
         return Table::make($this)

--- a/tests/src/Forms/Components/TableSelect/Livewire/TableSelectLivewireComponentTest.php
+++ b/tests/src/Forms/Components/TableSelect/Livewire/TableSelectLivewireComponentTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Filament\Forms\Components\TableSelect\Livewire\TableSelectLivewireComponent;
+use Filament\Tests\Fixtures\Tables\PostsTable;
+use Filament\Tests\Fixtures\Tables\UsersTable;
 use Filament\Tests\TestCase;
 
 uses(TestCase::class);
@@ -22,4 +24,17 @@ it('renders a blade string', function (): void {
     $component = new TableSelectLivewireComponent;
 
     expect($component->render())->toBe('{{ $this->table }}');
+});
+
+it('scopes the table session keys to the `tableConfiguration`', function (): void {
+    $component = new TableSelectLivewireComponent;
+    $component->tableConfiguration = base64_encode(PostsTable::class);
+
+    $anotherComponent = new TableSelectLivewireComponent;
+    $anotherComponent->tableConfiguration = base64_encode(UsersTable::class);
+
+    expect($component->getTableFiltersSessionKey())->not->toBe($anotherComponent->getTableFiltersSessionKey());
+    expect($component->getTableColumnsSessionKey())->not->toBe($anotherComponent->getTableColumnsSessionKey());
+    expect($component->getTableSortSessionKey())->not->toBe($anotherComponent->getTableSortSessionKey());
+    expect($component->getTableSearchSessionKey())->not->toBe($anotherComponent->getTableSearchSessionKey());
 });

--- a/tests/src/Forms/Components/TableSelect/Livewire/TableSelectLivewireComponentTest.php
+++ b/tests/src/Forms/Components/TableSelect/Livewire/TableSelectLivewireComponentTest.php
@@ -26,6 +26,14 @@ it('renders a blade string', function (): void {
     expect($component->render())->toBe('{{ $this->table }}');
 });
 
+it('scopes `getTableSessionKeyNamespace()` to the `tableConfiguration`', function (): void {
+    $component = new TableSelectLivewireComponent;
+    $component->tableConfiguration = base64_encode(PostsTable::class);
+
+    expect($component->getTableSessionKeyNamespace())
+        ->toBe(TableSelectLivewireComponent::class . '|' . PostsTable::class);
+});
+
 it('scopes the table session keys to the `tableConfiguration`', function (): void {
     $component = new TableSelectLivewireComponent;
     $component->tableConfiguration = base64_encode(PostsTable::class);
@@ -33,8 +41,19 @@ it('scopes the table session keys to the `tableConfiguration`', function (): voi
     $anotherComponent = new TableSelectLivewireComponent;
     $anotherComponent->tableConfiguration = base64_encode(UsersTable::class);
 
+    $table = md5(TableSelectLivewireComponent::class . '|' . PostsTable::class);
+
+    expect($component->getTableFiltersSessionKey())->toBe("tables.{$table}_filters");
+    expect($component->getTableColumnsSessionKey())->toBe("tables.{$table}_columns");
+    expect($component->getTableSortSessionKey())->toBe("tables.{$table}_sort");
+    expect($component->getTableSearchSessionKey())->toBe("tables.{$table}_search");
+
     expect($component->getTableFiltersSessionKey())->not->toBe($anotherComponent->getTableFiltersSessionKey());
     expect($component->getTableColumnsSessionKey())->not->toBe($anotherComponent->getTableColumnsSessionKey());
     expect($component->getTableSortSessionKey())->not->toBe($anotherComponent->getTableSortSessionKey());
     expect($component->getTableSearchSessionKey())->not->toBe($anotherComponent->getTableSearchSessionKey());
+    expect($component->getTableGroupingSessionKey())->not->toBe($anotherComponent->getTableGroupingSessionKey());
+    expect($component->getTablePerPageSessionKey())->not->toBe($anotherComponent->getTablePerPageSessionKey());
+    expect($component->getTableColumnSearchesSessionKey())->not->toBe($anotherComponent->getTableColumnSearchesSessionKey());
+    expect($component->getHasReorderedTableColumnsSessionKey())->not->toBe($anotherComponent->getHasReorderedTableColumnsSessionKey());
 });


### PR DESCRIPTION
## Description

Every `TableSelect` picker mounts through the same `TableSelectLivewireComponent`, and the table session keys are built from the Livewire component class. Two pickers with different `tableConfiguration()` classes therefore share one set of persisted filters, columns, sort and search. Applying a filter in one picker changes the other, and a stored query builder rule that has no matching block in the other table throws `LogicException: No query builder block found for [...]`, which returns a 500 on every visit until the session is cleared.

The session keys now come from a `getTableSessionKeyNamespace()` method, which `TableSelectLivewireComponent` overrides to include its table configuration class.

Only `TableSelect` keys change. For every other component the namespace is still the Livewire component class, so existing persisted state keeps working.

Making `QueryBuilder` tolerant of stale persisted rules in general is left out of scope here, since that is a separate behavioural decision rather than part of this bug.

Fixes #20468

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
