### PR TITLE
fix: validate Livewire temp uploads from sidecar metadata

### DIFF
--- a/packages/forms/resources/lang/en/validation.php
+++ b/packages/forms/resources/lang/en/validation.php
@@ -9,4 +9,6 @@ return [
 
     'tampered_file_path' => 'The :attribute field contains a file path that is not permitted.',
 
+    'temporary_upload_missing' => 'The :attribute is no longer available. Please upload the file again.',
+
 ];

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -3,6 +3,7 @@
 namespace Filament\Forms\Components;
 
 use Closure;
+use Filament\Forms\Support\TemporaryUploadedFileMetadata;
 use Filament\Schemas\Components\StateCasts\FileUploadStateCast;
 use Filament\Support\Components\Attributes\ExposedLivewireMethod;
 use Illuminate\Contracts\Filesystem\Filesystem;
@@ -259,10 +260,45 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
     {
         $this->acceptedFileTypes = $types;
 
-        $this->rule(static function (BaseFileUpload $component) {
-            $types = implode(',', ($component->getAcceptedFileTypes() ?? []));
+        $this->rule(static function (BaseFileUpload $component): Closure {
+            /** @var list<string> $allowed */
+            $allowed = $component->getAcceptedFileTypes() ?? [];
 
-            return "mimetypes:{$types}";
+            $extensionMimeMap = $component instanceof FileUpload
+                ? $component->getMimeTypeMap()
+                : [];
+
+            return static function (string $attribute, mixed $value, Closure $fail) use ($allowed, $component, $extensionMimeMap): void {
+                if (! $value instanceof TemporaryUploadedFile) {
+                    return;
+                }
+
+                if ($allowed === []) {
+                    return;
+                }
+
+                $metadata = app(TemporaryUploadedFileMetadata::class);
+
+                if ($metadata->hasBlockedPhpExtension($value, $allowed)) {
+                    static::failFileUploadRule($component, $fail, 'mimetypes', 'validation.mimetypes', [
+                        'values' => implode(', ', $allowed),
+                    ]);
+
+                    return;
+                }
+
+                if (! $metadata->exists($value)) {
+                    static::failFileUploadRule($component, $fail, 'temporary_upload_missing', 'filament-forms::validation.temporary_upload_missing');
+
+                    return;
+                }
+
+                if (! $metadata->mimeMatches($value, $allowed, $extensionMimeMap)) {
+                    static::failFileUploadRule($component, $fail, 'mimetypes', 'validation.mimetypes', [
+                        'values' => implode(', ', $allowed),
+                    ]);
+                }
+            };
         });
 
         return $this;
@@ -414,10 +450,36 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
     {
         $this->maxSize = $size;
 
-        $this->rule(static function (BaseFileUpload $component): string {
-            $size = $component->getMaxSize();
+        $this->rule(static function (BaseFileUpload $component): Closure {
+            $maxKb = $component->getMaxSize();
 
-            return "max:{$size}";
+            return static function (string $attribute, mixed $value, Closure $fail) use ($component, $maxKb): void {
+                if (! $value instanceof TemporaryUploadedFile || $maxKb === null) {
+                    return;
+                }
+
+                $metadata = app(TemporaryUploadedFileMetadata::class);
+
+                if (! $metadata->exists($value)) {
+                    static::failFileUploadRule($component, $fail, 'temporary_upload_missing', 'filament-forms::validation.temporary_upload_missing');
+
+                    return;
+                }
+
+                $bytes = $metadata->sizeBytes($value);
+
+                if ($bytes === null) {
+                    static::failFileUploadRule($component, $fail, 'temporary_upload_missing', 'filament-forms::validation.temporary_upload_missing');
+
+                    return;
+                }
+
+                if ($bytes > $maxKb * 1024) {
+                    static::failFileUploadRule($component, $fail, 'max', 'validation.max.file', [
+                        'max' => $maxKb,
+                    ]);
+                }
+            };
         });
 
         return $this;
@@ -427,10 +489,36 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
     {
         $this->minSize = $size;
 
-        $this->rule(static function (BaseFileUpload $component): string {
-            $size = $component->getMinSize();
+        $this->rule(static function (BaseFileUpload $component): Closure {
+            $minKb = $component->getMinSize();
 
-            return "min:{$size}";
+            return static function (string $attribute, mixed $value, Closure $fail) use ($component, $minKb): void {
+                if (! $value instanceof TemporaryUploadedFile || $minKb === null) {
+                    return;
+                }
+
+                $metadata = app(TemporaryUploadedFileMetadata::class);
+
+                if (! $metadata->exists($value)) {
+                    static::failFileUploadRule($component, $fail, 'temporary_upload_missing', 'filament-forms::validation.temporary_upload_missing');
+
+                    return;
+                }
+
+                $bytes = $metadata->sizeBytes($value);
+
+                if ($bytes === null) {
+                    static::failFileUploadRule($component, $fail, 'temporary_upload_missing', 'filament-forms::validation.temporary_upload_missing');
+
+                    return;
+                }
+
+                if ($bytes < $minKb * 1024) {
+                    static::failFileUploadRule($component, $fail, 'min', 'validation.min.file', [
+                        'min' => $minKb,
+                    ]);
+                }
+            };
         });
 
         return $this;
@@ -782,6 +870,22 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
         $ruleName = strtolower(explode(':', $rule)[0]);
 
         return in_array($ruleName, static::ARRAY_VALIDATION_RULES, strict: true);
+    }
+
+    /**
+     * @param  array<string, mixed>  $replace
+     */
+    protected static function failFileUploadRule(BaseFileUpload $component, Closure $fail, string $rule, string $translationKey, array $replace = []): void
+    {
+        $message = $component->getValidationMessages()[$rule] ?? null;
+
+        if (filled($message)) {
+            $fail($message);
+
+            return;
+        }
+
+        $fail($translationKey)->translate($replace);
     }
 
     #[ExposedLivewireMethod]

--- a/packages/forms/src/Components/Concerns/HasFileAttachments.php
+++ b/packages/forms/src/Components/Concerns/HasFileAttachments.php
@@ -3,13 +3,12 @@
 namespace Filament\Forms\Components\Concerns;
 
 use Closure;
+use Filament\Forms\Support\TemporaryUploadedFileMetadata;
 use Filament\Support\Components\Attributes\ExposedLivewireMethod;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Facades\Validator;
-use Illuminate\Validation\ValidationException;
 use League\Flysystem\UnableToCheckFileExistence;
 use Livewire\Attributes\Renderless;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
@@ -66,21 +65,15 @@ trait HasFileAttachments
         }
 
         if ($attachment instanceof TemporaryUploadedFile) {
-            $maxSize = $this->getFileAttachmentsMaxSize();
-            $acceptedFileTypes = $this->getFileAttachmentsAcceptedFileTypes();
-
             try {
-                Validator::validate(
-                    ['file' => $attachment],
-                    rules: [
-                        'file' => [
-                            'file',
-                            ...($maxSize ? ["max:{$maxSize}"] : []),
-                            ...($acceptedFileTypes ? ['mimetypes:' . implode(',', $acceptedFileTypes)] : []),
-                        ],
-                    ],
-                );
-            } catch (ValidationException $exception) {
+                if (! app(TemporaryUploadedFileMetadata::class)->isValid(
+                    $attachment,
+                    $this->getFileAttachmentsAcceptedFileTypes(),
+                    $this->getFileAttachmentsMaxSize(),
+                )) {
+                    return null;
+                }
+            } catch (Throwable) {
                 return null;
             }
         }

--- a/packages/forms/src/Support/TemporaryUploadedFileMetadata.php
+++ b/packages/forms/src/Support/TemporaryUploadedFileMetadata.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace Filament\Forms\Support;
+
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+use Symfony\Component\Mime\MimeTypes;
+use Throwable;
+
+/**
+ * Reads MIME type and size for a Livewire temp upload from sidecar metadata when possible.
+ *
+ * `TemporaryUploadedFile::getMimeType()` and `TemporaryUploadedFile::getSize()` call Flysystem,
+ * which can report a generic Content-Type or throw `UnableToRetrieveMetadata` when `file_size`
+ * is missing. Livewire already stores `name` / `type` / `size` in `{path}.json` next to the file.
+ */
+class TemporaryUploadedFileMetadata
+{
+    /**
+     * @var list<string>
+     */
+    protected const BLOCKED_PHP_EXTENSIONS = [
+        'php', 'php3', 'php4', 'php5', 'php7', 'php8', 'phtml', 'phar',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    protected const GENERIC_MIME_TYPES = [
+        'application/octet-stream',
+        'application/x-empty',
+        'inode/x-empty',
+    ];
+
+    /**
+     * @var array<string, list<string>>
+     */
+    protected const MIME_ALIASES = [
+        'application/zip' => ['application/x-zip-compressed', 'application/x-zip'],
+        'application/x-zip-compressed' => ['application/zip', 'application/x-zip'],
+        'application/x-zip' => ['application/zip', 'application/x-zip-compressed'],
+        'image/jpeg' => ['image/jpg', 'image/pjpeg'],
+        'image/jpg' => ['image/jpeg', 'image/pjpeg'],
+        'image/pjpeg' => ['image/jpeg', 'image/jpg'],
+    ];
+
+    public function exists(TemporaryUploadedFile $file): bool
+    {
+        try {
+            return $file->exists();
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * @param  array<string, string>  $extensionMimeMap
+     */
+    public function mimeType(TemporaryUploadedFile $file, array $extensionMimeMap = []): ?string
+    {
+        $fromMeta = $this->metaString($file, 'type');
+
+        if ($this->isUsableMime($fromMeta)) {
+            return $fromMeta;
+        }
+
+        $fromFilename = $this->mimeFromFilename($this->clientOriginalName($file) ?? '', $extensionMimeMap)
+            ?? $this->mimeFromFilename($this->storedFilename($file) ?? '', $extensionMimeMap);
+
+        if ($fromFilename !== null) {
+            return $fromFilename;
+        }
+
+        try {
+            $fromDisk = $file->getMimeType();
+        } catch (Throwable) {
+            return null;
+        }
+
+        return $this->isUsableMime($fromDisk) ? $fromDisk : null;
+    }
+
+    public function sizeBytes(TemporaryUploadedFile $file): ?int
+    {
+        $fromMeta = $this->meta($file)['size'] ?? null;
+
+        if (is_int($fromMeta) && $fromMeta >= 0) {
+            return $fromMeta;
+        }
+
+        if (is_numeric($fromMeta) && (int) $fromMeta >= 0) {
+            return (int) $fromMeta;
+        }
+
+        try {
+            return $file->getSize();
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * @param  list<string>  $allowed
+     * @param  array<string, string>  $extensionMimeMap
+     */
+    public function mimeMatches(TemporaryUploadedFile $file, array $allowed, array $extensionMimeMap = []): bool
+    {
+        $mime = $this->mimeType($file, $extensionMimeMap);
+
+        if ($mime === null) {
+            return false;
+        }
+
+        return $this->mimeIsAllowed($mime, $allowed);
+    }
+
+    /**
+     * @param  list<string>  $allowed
+     */
+    public function hasBlockedPhpExtension(TemporaryUploadedFile $file, array $allowed): bool
+    {
+        if (in_array('php', $allowed, true)) {
+            return false;
+        }
+
+        $extension = strtolower($this->clientOriginalExtension($file) ?? '');
+
+        return in_array($extension, self::BLOCKED_PHP_EXTENSIONS, true);
+    }
+
+    /**
+     * @param  list<string> | null  $allowedMimeTypes
+     * @param  array<string, string>  $extensionMimeMap
+     */
+    public function isValid(TemporaryUploadedFile $file, ?array $allowedMimeTypes, ?int $maxSizeKb, array $extensionMimeMap = []): bool
+    {
+        if (
+            is_array($allowedMimeTypes) &&
+            ($allowedMimeTypes !== []) &&
+            $this->hasBlockedPhpExtension($file, $allowedMimeTypes)
+        ) {
+            return false;
+        }
+
+        if (! $this->exists($file)) {
+            return false;
+        }
+
+        if (
+            is_array($allowedMimeTypes) &&
+            ($allowedMimeTypes !== []) &&
+            (! $this->mimeMatches($file, $allowedMimeTypes, $extensionMimeMap))
+        ) {
+            return false;
+        }
+
+        if ($maxSizeKb !== null) {
+            $bytes = $this->sizeBytes($file);
+
+            if ($bytes === null || $bytes > $maxSizeKb * 1024) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<string, string>  $extensionMimeMap
+     */
+    public function mimeFromFilename(string $filename, array $extensionMimeMap = []): ?string
+    {
+        $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+
+        if ($extension === '') {
+            return null;
+        }
+
+        if (isset($extensionMimeMap[$extension])) {
+            return $extensionMimeMap[$extension];
+        }
+
+        $mimeTypes = MimeTypes::getDefault()->getMimeTypes($extension);
+
+        return $mimeTypes[0] ?? null;
+    }
+
+    /**
+     * @param  list<string>  $allowed
+     */
+    protected function mimeIsAllowed(string $mime, array $allowed): bool
+    {
+        foreach ($allowed as $allowedMime) {
+            if ($allowedMime === $mime) {
+                return true;
+            }
+
+            if (str_ends_with($allowedMime, '/*')) {
+                $prefix = substr($allowedMime, 0, -1);
+
+                if (str_starts_with($mime, $prefix)) {
+                    return true;
+                }
+            }
+
+            foreach (self::MIME_ALIASES[$allowedMime] ?? [] as $alias) {
+                if ($alias === $mime) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function meta(TemporaryUploadedFile $file): array
+    {
+        try {
+            $meta = $file->metaFileData();
+        } catch (Throwable) {
+            return [];
+        }
+
+        return is_array($meta) ? $meta : [];
+    }
+
+    protected function metaString(TemporaryUploadedFile $file, string $key): ?string
+    {
+        $value = $this->meta($file)[$key] ?? null;
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    protected function isUsableMime(?string $mime): bool
+    {
+        if ($mime === null) {
+            return false;
+        }
+
+        return ! in_array($mime, self::GENERIC_MIME_TYPES, true);
+    }
+
+    protected function clientOriginalName(TemporaryUploadedFile $file): ?string
+    {
+        try {
+            $name = $file->getClientOriginalName();
+        } catch (Throwable) {
+            return null;
+        }
+
+        return filled($name) ? $name : null;
+    }
+
+    protected function storedFilename(TemporaryUploadedFile $file): ?string
+    {
+        try {
+            $filename = $file->getFilename();
+        } catch (Throwable) {
+            return null;
+        }
+
+        return filled($filename) ? $filename : null;
+    }
+
+    protected function clientOriginalExtension(TemporaryUploadedFile $file): ?string
+    {
+        try {
+            $extension = $file->getClientOriginalExtension();
+        } catch (Throwable) {
+            return null;
+        }
+
+        return filled($extension) ? $extension : null;
+    }
+}

--- a/tests/src/Forms/Components/FileUploadTest.php
+++ b/tests/src/Forms/Components/FileUploadTest.php
@@ -299,6 +299,65 @@ describe('validation', function (): void {
             ->call('save')
             ->assertHasFormErrors(['avatar']);
     });
+
+    it('accepts a jpeg against `image()` when the temp upload sidecar type is generic', function (): void {
+        Storage::fake('tmp-for-tests');
+
+        $filename = 'avatar.jpeg';
+        Storage::disk('tmp-for-tests')->put('livewire-tmp/' . $filename, 'dummy-image');
+        Storage::disk('tmp-for-tests')->put('livewire-tmp/' . $filename . '.json', json_encode([
+            'name' => 'avatar.jpeg',
+            'type' => 'application/octet-stream',
+            'size' => 4096,
+            'hash' => $filename,
+        ]));
+
+        $file = TemporaryUploadedFile::createFromLivewire($filename);
+
+        $validationPassed = false;
+
+        try {
+            Schema::make(Livewire::make())
+                ->statePath('data')
+                ->components([
+                    FileUpload::make('photo')
+                        ->image()
+                        ->maxSize(1024),
+                ])
+                ->fill(['photo' => [$file]])
+                ->validate();
+
+            $validationPassed = true;
+        } catch (ValidationException) {
+            $validationPassed = false;
+        }
+
+        expect($validationPassed)->toBeTrue();
+    });
+
+    it('fails `maxSize()` without throwing when the temp upload object is missing', function (): void {
+        Storage::fake('tmp-for-tests');
+
+        $file = TemporaryUploadedFile::createFromLivewire('absent.jpeg');
+
+        $field = FileUpload::make('document')
+            ->maxSize(100)
+            ->container(Schema::make(Livewire::make())->statePath('data'));
+
+        $validationFailed = false;
+
+        foreach ($field->getValidationRules() as $rule) {
+            if (! $rule instanceof Closure) {
+                continue;
+            }
+
+            $rule('document', [$file], function () use (&$validationFailed): void {
+                $validationFailed = true;
+            });
+        }
+
+        expect($validationFailed)->toBeTrue();
+    });
 });
 
 describe('preventing existing file path tampering', function (): void {

--- a/tests/src/Forms/Support/TemporaryUploadedFileMetadataTest.php
+++ b/tests/src/Forms/Support/TemporaryUploadedFileMetadataTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use Filament\Forms\Support\TemporaryUploadedFileMetadata;
+use Filament\Tests\TestCase;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+
+uses(TestCase::class);
+
+/**
+ * @param  array{name?: string, type?: string, size?: int|string, hash?: string}  $meta
+ */
+function createLivewireTemporaryUpload(string $filename, ?string $contents, array $meta): TemporaryUploadedFile
+{
+    Storage::fake('tmp-for-tests');
+
+    $path = 'livewire-tmp/' . $filename;
+
+    if (is_string($contents)) {
+        Storage::disk('tmp-for-tests')->put($path, $contents);
+    }
+
+    Storage::disk('tmp-for-tests')->put($path . '.json', json_encode($meta));
+
+    return TemporaryUploadedFile::createFromLivewire($filename);
+}
+
+describe('TemporaryUploadedFileMetadata', function (): void {
+    it('treats a jpeg as `image/*` from the original filename when the sidecar type is generic', function (): void {
+        $file = createLivewireTemporaryUpload('avatar.jpeg', 'dummy-image', [
+            'name' => 'avatar.jpeg',
+            'type' => 'application/octet-stream',
+            'size' => 4096,
+            'hash' => 'avatar.jpeg',
+        ]);
+
+        $metadata = app(TemporaryUploadedFileMetadata::class);
+
+        expect($metadata->exists($file))->toBeTrue()
+            ->and($metadata->mimeType($file))->toBe('image/jpeg')
+            ->and($metadata->mimeMatches($file, ['image/*']))->toBeTrue()
+            ->and($metadata->sizeBytes($file))->toBe(4096);
+    });
+
+    it('accepts zip uploads from a zip alias in the sidecar type', function (): void {
+        $file = createLivewireTemporaryUpload('archive.zip', 'dummy-zip', [
+            'name' => 'archive.zip',
+            'type' => 'application/x-zip-compressed',
+            'size' => 512,
+            'hash' => 'archive.zip',
+        ]);
+
+        expect(app(TemporaryUploadedFileMetadata::class)->mimeMatches($file, ['application/zip']))->toBeTrue();
+    });
+
+    it('rejects a zip against `image/*`', function (): void {
+        $file = createLivewireTemporaryUpload('archive.zip', 'dummy-zip', [
+            'name' => 'archive.zip',
+            'type' => 'application/zip',
+            'size' => 512,
+            'hash' => 'archive.zip',
+        ]);
+
+        expect(app(TemporaryUploadedFileMetadata::class)->mimeMatches($file, ['image/*']))->toBeFalse();
+    });
+
+    it('reads size from the sidecar without calling Flysystem `file_size`', function (): void {
+        Storage::fake('tmp-for-tests');
+
+        $filename = 'stale-upload.jpeg';
+        Storage::disk('tmp-for-tests')->put('livewire-tmp/' . $filename . '.json', json_encode([
+            'name' => 'stale-upload.jpeg',
+            'type' => 'image/jpeg',
+            'size' => 15360,
+            'hash' => $filename,
+        ]));
+
+        $file = TemporaryUploadedFile::createFromLivewire($filename);
+        $metadata = app(TemporaryUploadedFileMetadata::class);
+
+        expect($metadata->sizeBytes($file))->toBe(15360)
+            ->and($metadata->mimeType($file))->toBe('image/jpeg');
+    });
+
+    it('uses `mimeTypeMap()` when the filename extension is not a well-known MIME type', function (): void {
+        $file = createLivewireTemporaryUpload('floorplan.3dm', 'dummy-3dm', [
+            'name' => 'floorplan.3dm',
+            'type' => 'application/octet-stream',
+            'size' => 1024,
+            'hash' => 'floorplan.3dm',
+        ]);
+
+        expect(app(TemporaryUploadedFileMetadata::class)->mimeMatches(
+            $file,
+            ['x-world/x-3dmf'],
+            ['3dm' => 'x-world/x-3dmf'],
+        ))->toBeTrue();
+    });
+
+    it('blocks a `.php` client filename unless `php` is an accepted type', function (): void {
+        $file = createLivewireTemporaryUpload('upload.php', '<?php', [
+            'name' => 'upload.php',
+            'type' => 'image/png',
+            'size' => 32,
+            'hash' => 'upload.php',
+        ]);
+
+        $metadata = app(TemporaryUploadedFileMetadata::class);
+
+        expect($metadata->hasBlockedPhpExtension($file, ['image/png']))->toBeTrue()
+            ->and($metadata->hasBlockedPhpExtension($file, ['php']))->toBeFalse()
+            ->and($metadata->isValid($file, ['image/png'], null))->toBeFalse();
+    });
+
+    it('returns `null` for size when the object and sidecar size are both missing', function (): void {
+        Storage::fake('tmp-for-tests');
+
+        $file = TemporaryUploadedFile::createFromLivewire('absent.jpeg');
+        $metadata = app(TemporaryUploadedFileMetadata::class);
+
+        expect($metadata->exists($file))->toBeFalse()
+            ->and($metadata->sizeBytes($file))->toBeNull()
+            ->and($metadata->isValid($file, ['image/*'], 1024))->toBeFalse();
+    });
+});


### PR DESCRIPTION
## Description

`FileUpload` validated new uploads with Laravel's `mimetypes`, `max`, and `min` rules. Those call `TemporaryUploadedFile::getMimeType()` and `getSize()`, which in production read Flysystem metadata instead of the JSON sidecar Livewire already writes next to the temp file.

That causes two failures:

- Real images are rejected against `image()` / `image/*` when the disk reports a generic Content-Type such as `application/octet-stream`.
- A missing `file_size` throws `UnableToRetrieveMetadata` (HTTP 500) instead of a validation error.

This change reads `name` / `type` / `size` from the sidecar first, then the original filename and `mimeTypeMap()`, and only then Flysystem inside a try/catch. Missing temp files fail validation. PHP-family extensions (`.php`, `.phtml`, `.phar`, and similar) are still blocked, matching Laravel's `mimetypes` rule.

The same metadata helper is used for rich editor file attachments. There is no API change.

## Visual changes

None. Validation behavior only; FilePond UI is unchanged.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.


Made with [Cursor](https://cursor.com)