### PR TITLE
refactor: define search configuration directly on CheckboxList

### DIFF
--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -91,9 +91,9 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
         return (bool) $this->evaluate($this->isSearchable);
     }
 
-    public function searchPrompt(string | Htmlable | Closure | null $prompt): static
+    public function searchPrompt(string | Htmlable | Closure | null $message): static
     {
-        $this->searchPrompt = $prompt;
+        $this->searchPrompt = $message;
 
         return $this;
     }

--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -31,7 +31,6 @@ use function Filament\Support\generate_icon_html;
 class CheckboxList extends Field implements Contracts\CanDisableOptions, Contracts\HasNestedRecursiveValidationRules, HasEmbeddedView
 {
     use Concerns\CanAllowHtml;
-    use Concerns\CanBeSearchable;
     use Concerns\CanDisableOptions;
     use Concerns\CanDisableOptionsWhenSelectedInSiblingRepeaterItems;
     use Concerns\CanFixIndistinctState;
@@ -45,6 +44,14 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
     use HasExtraAlpineAttributes;
 
     protected ?string $publishedViewOverrideCheckPath = 'filament-forms::components.checkbox-list';
+
+    protected bool | Closure | null $isSearchable = false;
+
+    protected string | Htmlable | Closure | null $searchPrompt = null;
+
+    protected string | Htmlable | Closure | null $noSearchResultsMessage = null;
+
+    protected int | Closure $searchDebounce = 0;
 
     protected string | Closure | null $relationshipTitleAttribute = null;
 
@@ -66,12 +73,58 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
     {
         parent::setUp();
 
-        $this->searchDebounce(0);
-
         $this->registerActions([
             fn (CheckboxList $component): Action => $component->getSelectAllAction(),
             fn (CheckboxList $component): Action => $component->getDeselectAllAction(),
         ]);
+    }
+
+    public function searchable(bool | Closure | null $condition = true): static
+    {
+        $this->isSearchable = $condition;
+
+        return $this;
+    }
+
+    public function isSearchable(): bool
+    {
+        return (bool) $this->evaluate($this->isSearchable);
+    }
+
+    public function searchPrompt(string | Htmlable | Closure | null $prompt): static
+    {
+        $this->searchPrompt = $prompt;
+
+        return $this;
+    }
+
+    public function getSearchPrompt(): string | Htmlable
+    {
+        return $this->evaluate($this->searchPrompt) ?? __('filament-forms::components.select.search_prompt');
+    }
+
+    public function noSearchResultsMessage(string | Htmlable | Closure | null $message): static
+    {
+        $this->noSearchResultsMessage = $message;
+
+        return $this;
+    }
+
+    public function getNoSearchResultsMessage(): string | Htmlable
+    {
+        return $this->evaluate($this->noSearchResultsMessage) ?? __('filament-forms::components.select.no_search_results_message');
+    }
+
+    public function searchDebounce(int | Closure $debounce): static
+    {
+        $this->searchDebounce = $debounce;
+
+        return $this;
+    }
+
+    public function getSearchDebounce(): int
+    {
+        return $this->evaluate($this->searchDebounce);
     }
 
     public function getSelectAllAction(): Action

--- a/tests/src/Forms/Components/CheckboxListTest.php
+++ b/tests/src/Forms/Components/CheckboxListTest.php
@@ -1007,7 +1007,7 @@ describe('pivot data', function (): void {
 });
 
 describe('search configuration', function (): void {
-    it('has `getSearchDebounce()` of `0` (set in `setUp()`)', function (): void {
+    it('returns `0` from `getSearchDebounce()` by default', function (): void {
         $checkboxList = CheckboxList::make('options')
             ->options(['a' => 'A']);
 

--- a/tests/src/Forms/Components/CheckboxListTest.php
+++ b/tests/src/Forms/Components/CheckboxListTest.php
@@ -1062,59 +1062,6 @@ describe('search configuration', function (): void {
         expect($checkboxList->getSearchPrompt())->toBe('Type to search...');
     });
 
-    it('defaults `shouldSearchLabels()` to `true`', function (): void {
-        $checkboxList = CheckboxList::make('options')
-            ->options(['a' => 'A']);
-
-        expect($checkboxList->shouldSearchLabels())->toBeTrue();
-    });
-
-    it('can set `searchLabels()` to `false`', function (): void {
-        $checkboxList = CheckboxList::make('options')
-            ->options(['a' => 'A'])
-            ->searchLabels(false);
-
-        expect($checkboxList->shouldSearchLabels())->toBeFalse();
-    });
-
-    it('defaults `shouldSearchValues()` to `false`', function (): void {
-        $checkboxList = CheckboxList::make('options')
-            ->options(['a' => 'A']);
-
-        expect($checkboxList->shouldSearchValues())->toBeFalse();
-    });
-
-    it('can set `searchValues()`', function (): void {
-        $checkboxList = CheckboxList::make('options')
-            ->options(['a' => 'A'])
-            ->searchValues();
-
-        expect($checkboxList->shouldSearchValues())->toBeTrue();
-    });
-
-    it('returns `[label]` from `getSearchableOptionFields()` by default', function (): void {
-        $checkboxList = CheckboxList::make('options')
-            ->options(['a' => 'A']);
-
-        expect($checkboxList->getSearchableOptionFields())->toBe(['label']);
-    });
-
-    it('returns `[value]` from `getSearchableOptionFields()` when only values searchable', function (): void {
-        $checkboxList = CheckboxList::make('options')
-            ->options(['a' => 'A'])
-            ->searchLabels(false)
-            ->searchValues();
-
-        expect($checkboxList->getSearchableOptionFields())->toBe(['value']);
-    });
-
-    it('returns `[label, value]` from `getSearchableOptionFields()` when both searchable', function (): void {
-        $checkboxList = CheckboxList::make('options')
-            ->options(['a' => 'A'])
-            ->searchValues();
-
-        expect($checkboxList->getSearchableOptionFields())->toBe(['label', 'value']);
-    });
 });
 
 describe('relationship name inference', function (): void {


### PR DESCRIPTION
## Description

Follow-up to the Builder block picker search PR (https://github.com/filamentphp/filament/pull/20469): `CheckboxList` used the `CanBeSearchable` concern but only reads `searchable()`, `searchPrompt()`, `noSearchResultsMessage()` and `searchDebounce()`. Those are now defined directly on the component with unchanged behavior, so the concern's methods that had no effect there (`searchingMessage()`, `noOptionsMessage()`, `searchLabels()`, `searchValues()`) are no longer exposed. The concern itself is unchanged and still used by `Select` and `MorphToSelect`, where all of its methods work.

**Note:** the four removed methods were silent no-ops, but any code chaining them on a `CheckboxList` will now throw. Let me know if this needs an upgrade guide note.

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
