### PR TITLE
feat(actions): add `enum()` to `ImportColumn`

### DIFF
--- a/packages/actions/docs/11-import.md
+++ b/packages/actions/docs/11-import.md
@@ -165,6 +165,28 @@ Any rows that do not pass validation will not be imported. Instead, they will be
 
 <UtilityInjection set="importColumns" version="4.x">As well as allowing a static value, the `rules()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
+### Validating a column against an enum
+
+If a column maps onto a [backed enum](https://www.php.net/manual/en/language.enumerations.backed.php), you can pass the enum class to the `enum()` method. Any row whose value is not a case of the enum will fail validation, instead of reaching the model's cast and throwing a `ValueError`:
+
+```php
+use App\Enums\Status;
+use Filament\Actions\Imports\ImportColumn;
+
+ImportColumn::make('status')
+    ->enum(Status::class)
+```
+
+The cases of the enum are also used as the [example CSV data](#providing-example-csv-data) for the column, so the user can see which values are accepted without you listing them by hand. Passing `examples()` yourself overrides this.
+
+Pure enums are supported too, in which case the case names are validated and used as the example data.
+
+<Aside variant="info">
+    If the column [handles multiple values](#handling-multiple-values-in-a-single-column), each item in the array is validated against the enum.
+</Aside>
+
+<UtilityInjection set="importColumns" version="4.x">As well as allowing a static value, the `enum()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+
 ### Casting state
 
 Before [validation](#validating-csv-data), data from the CSV can be cast. This is useful for converting strings into the correct data type, otherwise validation may fail. For example, if you have a `price` column in your CSV, you may want to cast it to a float:

--- a/packages/actions/src/Imports/ImportColumn.php
+++ b/packages/actions/src/Imports/ImportColumn.php
@@ -2,7 +2,9 @@
 
 namespace Filament\Actions\Imports;
 
+use BackedEnum;
 use Closure;
+use Filament\Forms\Components\Concerns\HasEnum;
 use Filament\Forms\Components\Select;
 use Filament\Support\Components\Component;
 use Filament\Support\Services\RelationshipJoiner;
@@ -14,10 +16,14 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 use InvalidArgumentException;
+use UnitEnum;
 
 class ImportColumn extends Component
 {
+    use HasEnum;
+
     protected string $name;
 
     protected string | Closure | null $label = null;
@@ -430,6 +436,10 @@ class ImportColumn extends Component
             };
         }
 
+        if (filled($enum = $this->getEnum()) && (! $this->isMultiple())) {
+            $rules[] = Rule::enum($enum);
+        }
+
         return $rules;
     }
 
@@ -543,7 +553,13 @@ class ImportColumn extends Component
      */
     public function getNestedRecursiveDataValidationRules(): array
     {
-        return $this->evaluate($this->nestedRecursiveDataValidationRules);
+        $rules = $this->evaluate($this->nestedRecursiveDataValidationRules);
+
+        if (filled($enum = $this->getEnum()) && $this->isMultiple()) {
+            $rules[] = Rule::enum($enum);
+        }
+
+        return $rules;
     }
 
     public function isNumeric(): bool
@@ -594,7 +610,24 @@ class ImportColumn extends Component
      */
     public function getExamples(): array
     {
-        return Arr::wrap($this->evaluate($this->examples));
+        $examples = Arr::wrap($this->evaluate($this->examples));
+
+        if (filled($examples)) {
+            return $examples;
+        }
+
+        $enum = $this->getEnum();
+
+        if (blank($enum)) {
+            return $examples;
+        }
+
+        return array_map(
+            fn (BackedEnum | UnitEnum $case): string | int => ($case instanceof BackedEnum)
+                ? $case->value
+                : $case->name,
+            $enum::cases(),
+        );
     }
 
     /**

--- a/tests/src/Actions/Imports/ImportColumnEnumTest.php
+++ b/tests/src/Actions/Imports/ImportColumnEnumTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use Filament\Actions\Imports\ImportColumn;
+use Filament\Tests\TestCase;
+use Illuminate\Support\Facades\Validator;
+
+uses(TestCase::class);
+
+enum ImportColumnEnumTestStatus: string
+{
+    case Draft = 'draft';
+
+    case Published = 'published';
+}
+
+enum ImportColumnEnumTestPriority
+{
+    case Low;
+
+    case High;
+}
+
+it('uses the cases of the enum as examples when none are set', function (): void {
+    $column = ImportColumn::make('status')
+        ->enum(ImportColumnEnumTestStatus::class);
+
+    expect($column->getExamples())->toBe(['draft', 'published']);
+});
+
+it('uses the case names as examples for a pure enum', function (): void {
+    $column = ImportColumn::make('priority')
+        ->enum(ImportColumnEnumTestPriority::class);
+
+    expect($column->getExamples())->toBe(['Low', 'High']);
+});
+
+it('keeps `examples()` when they are set alongside `enum()`', function (): void {
+    $column = ImportColumn::make('status')
+        ->enum(ImportColumnEnumTestStatus::class)
+        ->examples(['draft']);
+
+    expect($column->getExamples())->toBe(['draft']);
+});
+
+it('returns examples that can be cast to a string for the example CSV', function (): void {
+    $column = ImportColumn::make('status')
+        ->enum(ImportColumnEnumTestStatus::class);
+
+    foreach ($column->getExamples() as $example) {
+        expect($example)->not->toBeObject();
+    }
+});
+
+it('validates the state against the enum', function (): void {
+    $column = ImportColumn::make('status')
+        ->enum(ImportColumnEnumTestStatus::class);
+
+    $rules = ['status' => $column->getDataValidationRules()];
+
+    expect(Validator::make(['status' => 'draft'], $rules)->fails())->toBeFalse();
+    expect(Validator::make(['status' => 'unknown'], $rules)->fails())->toBeTrue();
+});
+
+it('does not validate against the enum when `enum()` is not used', function (): void {
+    $column = ImportColumn::make('status');
+
+    expect($column->getDataValidationRules())->toBe([]);
+});
+
+it('accepts a `Closure` for `enum()`', function (): void {
+    $column = ImportColumn::make('status')
+        ->enum(fn (): string => ImportColumnEnumTestStatus::class);
+
+    expect($column->getEnum())->toBe(ImportColumnEnumTestStatus::class)
+        ->and($column->getExamples())->toBe(['draft', 'published']);
+});
+
+it('returns `null` for `getEnum()` by default', function (): void {
+    expect(ImportColumn::make('status')->getEnum())->toBeNull();
+});
+
+it('validates each item of a `multiple()` column against the enum', function (): void {
+    $column = ImportColumn::make('statuses')
+        ->multiple()
+        ->enum(ImportColumnEnumTestStatus::class);
+
+    expect($column->getDataValidationRules())->toBe([]);
+
+    $rules = ['statuses.*' => $column->getNestedRecursiveDataValidationRules()];
+
+    expect(Validator::make(['statuses' => ['draft', 'published']], $rules)->fails())->toBeFalse();
+    expect(Validator::make(['statuses' => ['draft', 'unknown']], $rules)->fails())->toBeTrue();
+});


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Mapping an import column onto an enum currently takes two manual steps, and getting either one wrong fails at runtime.

**1. The example CSV.** To show the user which values are accepted, the cases have to be listed by hand. Passing the cases themselves reads naturally:

```php
ImportColumn::make('status')
    ->examples(Status::cases())
```

…but it breaks the `downloadExample` modal action. `getExamples()` is handed straight to the `league/csv` writer, which casts every value to a string, so an enum instance throws `Object of class App\Enums\Status could not be converted to string` and the download responds with a 500. Nothing in the signature of `examples(mixed $examples)` hints at that.

**2. Validation.** Without an explicit `Rule::enum()`, an unknown value in the CSV reaches the model's cast and throws a `ValueError: "..." is not a valid backing value for enum`, rather than being reported as a failed row the user can read and correct.

This PR adds `enum()`, which covers both:

```php
use App\Enums\Status;
use Filament\Actions\Imports\ImportColumn;

ImportColumn::make('status')
    ->enum(Status::class)
```

- The cases become the example data for the column, unless `examples()` is set, in which case that still wins.
- The state is validated against the enum.
- Pure enums are supported, using their case names.
- A `multiple()` column validates each item, through the nested recursive rules the importer already applies to array columns.

It reuses the existing `HasEnum` concern, so the method has the same name and signature as the `enum()` that `SelectColumn` already exposes.

Nothing changes for a column that does not call `enum()`.

## Visual changes

None — this affects the contents of the example CSV and the validation rules of an import column, not the UI.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
