### PR TITLE
Strip scheme when checking if panel root route is taken

### DIFF
--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -187,7 +187,7 @@ Route::name('filament.')
 
                                         if (version_compare(Application::VERSION, '13.0.0', '>=')) { /** @phpstan-ignore if.alwaysTrue, if.alwaysFalse */
                                             $groupStack = Route::getGroupStack();
-                                            $rootDomain = RouteUri::parse(end($groupStack)['domain'] ?? '')->uri;
+                                            $rootDomain = RouteUri::parse(str_replace(['http://', 'https://'], '', end($groupStack)['domain'] ?? ''))->uri;
                                             $rootUri = RouteUri::parse(trim(Route::getLastGroupPrefix(), '/') ?: '/')->uri;
                                             $rootKey = $rootDomain . $rootUri;
 

--- a/tests/src/Fixtures/Providers/Fixtures/Providers/SingleDomainPanel.php
+++ b/tests/src/Fixtures/Providers/Fixtures/Providers/SingleDomainPanel.php
@@ -29,7 +29,7 @@ class SingleDomainPanel extends PanelProvider
     {
         return $panel
             ->id('single-domain')
-            ->domain('example3.com')
+            ->domain('https://example3.com')
             ->login()
             ->registration()
             ->passwordReset()

--- a/tests/src/Panels/Routes/SingleAndMultiDomainTest.php
+++ b/tests/src/Panels/Routes/SingleAndMultiDomainTest.php
@@ -35,7 +35,7 @@ it('panels with multiple domains should use the domain in names of all routes', 
     expect($route)->not->toBeEmpty();
 });
 
-it('does not register the home route when a page already owns the root path', function (): void {
+it('does not register the home route when a page already owns the root path and `domain()` contains a scheme', function (): void {
     expect(Route::getRoutes()->getByName('filament.single-domain.home'))->toBeNull()
         ->and(Route::getRoutes()->getByName('filament.single-domain.pages.dashboard'))->not->toBeNull();
 });


### PR DESCRIPTION
On Laravel 13, panels using `->domain()` lose their Dashboard route and throw `Route [filament.{panel}.pages.dashboard] not defined`.

The root-path check builds `$rootKey` from the raw group domain, which keeps the scheme when the domain is configured as a full URL. Laravel stores routes under a domain with the scheme stripped (`Route::getDomain()`), so the lookup never matches, the home route is registered at `/` anyway, and it replaces the Dashboard route already registered there.

This applies the same `str_replace` Laravel uses, so the key is built the same way it was stored.

Same symptom as #19549, which was fixed on 4.x in #19562. That code path no longer exists on 5.x, so the bug is still present here.
