### PR TITLE
docs: document shared Blueprint workflow and Astra comparison

### DIFF
--- a/docs/01-introduction/03-ai.md
+++ b/docs/01-introduction/03-ai.md
@@ -57,11 +57,11 @@ The planning skill covers details that agents commonly get wrong, like namespace
 
 The planning skill is designed for planning agents only, so it shouldn't consume the implementing agent's context window. The planning agent copies all necessary details (namespaces, documentation URLs to fetch, exact method syntax) into the blueprint itself, so the implementing agent has everything it needs without loading the planning skill.
 
-If you're interested in an example of a plan that Claude Opus 4.5 can write with and without Blueprint, visit the [Blueprint Plan Example](#blueprint-plan-example) section.
+If you're interested in an example of a plan that GPT-6 Astra can write with and without Blueprint, visit the [Blueprint Plan Example](#blueprint-plan-example) section.
 
 ### Installing Blueprint
 
-Blueprint is compatible with Filament v4 and above.
+Use Blueprint 1.x with Filament v4, or Blueprint 2.x with Filament v5. The skills and workflow below apply to both versions.
 
 Once you have [purchased a license for Blueprint](https://packages.filamentphp.com/portal/blueprint/checkout), install it via Composer:
 
@@ -77,7 +77,7 @@ Then run the Boost installer. Select **Agent Skills**, followed by **filament/bl
 php artisan boost:install
 ```
 
-To verify installation, check your agent's skills directory for `planning-filament/SKILL.md` and `filament-security-audit/SKILL.md`.
+To verify installation, check your agent's skills directory for `planning-filament/SKILL.md`, `reviewing-filament-plans/SKILL.md`, and `filament-security-audit/SKILL.md`.
 
 <Aside variant="info">
     To access your purchased license, sign in to [Filament Packages](https://packages.filamentphp.com) with the email address used to purchase your Blueprint license.
@@ -85,28 +85,52 @@ To verify installation, check your agent's skills directory for `planning-filame
 
 ### Using Blueprint
 
-To create a blueprint, enable **planning mode** in your AI agent and ask it to use the `planning-filament` skill:
+#### Writing a blueprint
+
+To create a blueprint, enable **planning mode** in your AI agent, ask it to use the `planning-filament` skill, and specify a Markdown file for the plan:
 
 ```
-Using the planning-filament skill, create a Filament Blueprint for an order management system.
+Using the planning-filament skill, create a Filament Blueprint for a SaaS invoicing
+system using this application's Filament version. Write the plan as Markdown to
+blueprints/invoicing.md.
 
-Orders belong to customers and have many order items. Each order has a status
-(pending, confirmed, shipped, delivered, cancelled), shipping address, and
-optional notes. Order items reference products with quantity and unit price.
-
-I need to search orders by customer name and filter by status and date range.
-The order form should calculate line totals automatically as items are added.
-Only admins can delete orders, and orders can only be cancelled if not yet shipped.
+Include managing customers and products, creating and editing invoices with line
+items, sending invoices, and recording and tracking payments. Describe the user
+flows, Filament components, and state transitions. Flag unresolved business choices.
 ```
 
-The agent will produce a detailed specification document ready for direct implementation.
+#### Implementing a blueprint
+
+Read the saved plan and resolve its outstanding business choices. Then switch out of planning mode and give the implementing agent the saved blueprint and access to your application checkout:
+
+```
+Implement blueprints/invoicing.md in this application checkout. Follow the plan
+and run the relevant tests. Report what was implemented and any checks that
+could not be completed.
+```
+
+#### Reviewing an implementation against a blueprint
+
+After implementation, use Blueprint's `reviewing-filament-plans` skill with the same saved blueprint and application checkout to check whether the implementation satisfies the plan:
+
+```
+Using the reviewing-filament-plans skill, review the implementation in
+this checkout against blueprints/invoicing.md, including the current uncommitted
+changes.
+Report requirement traceability, confirmed deviations, and anything blocked
+or not verified. Do not change application code.
+```
+
+The report traces plan requirements to code and test evidence using **Conforms**, **Deviates**, **Blocked**, and **Not verified**. It distinguishes inspected code and test assertions from executed tests or browser checks, and recommends the smallest correction and verification for each confirmed deviation. Existing focused tests run only when an isolated, safe harness is established.
+
+This is a plan-conformance review, not a second planning pass or a general security audit. It does not invent requirements omitted from the blueprint or treat omissions in an update plan as deletions.
 
 ### Blueprint Plan Example
 
-The following prompt was used with Claude Opus 4.5 in planning mode using Claude Code CLI:
+The following Filament v5 prompt was used with GPT-6 Astra in Amp's standard `astra` mode, in independent threads with and without the `planning-filament` skill:
 
 ```markdown
-Produce an implementation plan for a Filament v4 application. The application is
+Produce an implementation plan for a Filament v5 application. The application is
 a SaaS invoicing system with the following capabilities:
 
 - Manage customers
@@ -125,10 +149,10 @@ The plan should:
   trigger them.
 ```
 
-You can read a plan written for this prompt [**without Blueprint**](https://filamentphp.com/blueprint/examples/invoicing/before.md) vs. [**with Blueprint**](https://filamentphp.com/blueprint/examples/invoicing/after.md), and compare the level of detail and thoughtfulness. You could have a go at passing these plans to your AI agent of choice in implementation mode to see how they perform!
+You can read the plans written for this prompt [**without Blueprint**](https://filamentphp.com/blueprint/examples/invoicing/gpt-6-astra/before.md) and [**with Blueprint**](https://filamentphp.com/blueprint/examples/invoicing/gpt-6-astra/after.md), and compare their proposed implementation details. These are planning outputs, not implemented applications or verified test results. Review their assumptions and resolve the outstanding business choices before passing either plan to an implementing agent.
 
 <Aside variant="info">
-    When using Blueprint, the `planning-filament` skill was explicitly named at the start of the prompt.
+    The Blueprint run additionally requested: "Use the planning-filament skill." The `blueprints/invoicing.md` output path in the workflow above is a suggested addition, not part of this recorded comparison prompt.
 </Aside>
 
 ### Running a security audit


### PR DESCRIPTION
## Description

Document the shared Blueprint workflow for Filament v4 / Blueprint 1.x and Filament v5 / Blueprint 2.x: save a Markdown plan, implement it, and review the implementation with `reviewing-filament-plans`. Explain review evidence and safe test execution, and replace the main plan comparison with the recorded GPT-6 Astra example.

The recorded Filament v5 prompt is preserved exactly; the reusable save-file instruction is identified separately. This targets `4.x` for the normal forward-merge workflow.

Publication dependencies: the two new Astra example URLs currently return HTTP 404. Coordinate publication with the site examples and the Blueprint 1.x review-skill port before shipping these docs.

## Visual changes

Documentation content only; no application UI changes.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

Validation: `git diff --check` passed; assertions verified the exact archived prompt, all three skills, workflow and evidence semantics, version mappings, comparison URLs, and preservation of existing sections. The patch applies cleanly to the identical current `5.x` page in a temporary index. Markdown is intentionally ignored by Prettier; `composer cs` and application tests were not run for this documentation-only change.
