### PR TITLE
Fix the Czech translations

### DIFF
--- a/packages/actions/resources/lang/cs/associate.php
+++ b/packages/actions/resources/lang/cs/associate.php
@@ -25,7 +25,7 @@ return [
                 ],
 
                 'associate_another' => [
-                    'label' => 'Připojit & připojit další',
+                    'label' => 'Připojit a připojit další',
                 ],
 
             ],

--- a/packages/actions/resources/lang/cs/attach.php
+++ b/packages/actions/resources/lang/cs/attach.php
@@ -25,7 +25,7 @@ return [
                 ],
 
                 'attach_another' => [
-                    'label' => 'Přidat & přidat další',
+                    'label' => 'Přidat a přidat další',
                 ],
 
             ],

--- a/packages/actions/resources/lang/cs/create.php
+++ b/packages/actions/resources/lang/cs/create.php
@@ -17,7 +17,7 @@ return [
                 ],
 
                 'create_another' => [
-                    'label' => 'Vytvořit & vytvořit další',
+                    'label' => 'Vytvořit a vytvořit další',
                 ],
 
             ],

--- a/packages/actions/resources/lang/cs/export.php
+++ b/packages/actions/resources/lang/cs/export.php
@@ -29,11 +29,11 @@ return [
                 'form' => [
 
                     'is_enabled' => [
-                        'label' => ':column povoleno',
+                        'label' => 'Povolit sloupec :column',
                     ],
 
                     'label' => [
-                        'label' => ':column popisek',
+                        'label' => 'Popisek sloupce :column',
                     ],
 
                 ],
@@ -74,17 +74,17 @@ return [
 
         'max_rows' => [
             'title' => 'Export překračuje povolenou velikost',
-            'body' => 'Není možné exportovat více než 1 řádek najednou.|Není možné exportovat více než :count řádků najednou.',
+            'body' => 'Není možné exportovat více než 1 řádek najednou.|Není možné exportovat více než :count řádky najednou.|Není možné exportovat více než :count řádků najednou.',
         ],
 
         'no_columns' => [
             'title' => 'Nejsou vybrány žádné sloupce',
-            'body' => 'Prosím vyberte alespoň jeden sloupec k exportu.',
+            'body' => 'Vyberte prosím alespoň jeden sloupec k exportu.',
         ],
 
         'started' => [
             'title' => 'Export byl zahájen',
-            'body' => 'Export byl zahájen a 1 řádek bude zpracován na pozadí.|Váš export byl zahájen a :count řádků bude zpracováno na pozadí.',
+            'body' => 'Export byl zahájen a na pozadí bude zpracován 1 řádek.|Export byl zahájen a na pozadí budou zpracovány :count řádky.|Export byl zahájen a na pozadí bude zpracováno :count řádků.',
         ],
 
     ],

--- a/packages/actions/resources/lang/cs/import.php
+++ b/packages/actions/resources/lang/cs/import.php
@@ -12,7 +12,7 @@ return [
 
             'file' => [
                 'label' => 'Soubor',
-                'placeholder' => 'Nahrát CSV soubor',
+                'placeholder' => 'Nahrát soubor CSV',
                 'rules' => [
                     'duplicate_columns' => '{0} Soubor nesmí obsahovat více než jednu prázdnou hlavičku sloupce.|{1,*} Soubor nesmí obsahovat duplicitní hlavičky sloupců: :columns.',
                 ],
@@ -48,7 +48,7 @@ return [
             'actions' => [
 
                 'download_failed_rows_csv' => [
-                    'label' => 'Stáhnout informace o chybném řádku|Stáhnout informace o chybných řádcích',
+                    'label' => '{1} Stáhnout informace o chybném řádku|[0,*] Stáhnout informace o chybných řádcích',
                 ],
 
             ],
@@ -56,13 +56,13 @@ return [
         ],
 
         'max_rows' => [
-            'title' => 'Nahraný CSV soubor je příliš velký',
-            'body' => 'Nelze importovat více než 1 řádek najednou.|Nelze importovat více než :count řádků najednou.',
+            'title' => 'Nahraný soubor CSV je příliš velký',
+            'body' => 'Nelze importovat více než 1 řádek najednou.|Nelze importovat více než :count řádky najednou.|Nelze importovat více než :count řádků najednou.',
         ],
 
         'started' => [
             'title' => 'Zahájení importu',
-            'body' => 'Váš import byl zahájen a na pozadí bude zpracován 1 řádek.|Váš import byl zahájen a na pozadí budou zpracovány řádky :count.',
+            'body' => 'Import byl zahájen a na pozadí bude zpracován 1 řádek.|Import byl zahájen a na pozadí budou zpracovány :count řádky.|Import byl zahájen a na pozadí bude zpracováno :count řádků.',
         ],
 
     ],
@@ -75,7 +75,7 @@ return [
         'file_name' => 'import-:import_id-:csv_name-failed-rows',
         'error_header' => 'chyba',
         'system_error' => 'Chyba systému, kontaktujte prosím podporu.',
-        'column_mapping_required_for_new_record' => 'Sloupec :attribute nebyl přiřazen k žádnému sloupci ve souboru, ale je vyžadován pro vytvoření nových záznamů.',
+        'column_mapping_required_for_new_record' => 'Sloupec :attribute nebyl přiřazen k žádnému sloupci v souboru, ale je vyžadován pro vytvoření nových záznamů.',
     ],
 
 ];

--- a/packages/actions/resources/lang/cs/notifications.php
+++ b/packages/actions/resources/lang/cs/notifications.php
@@ -3,6 +3,6 @@
 return [
     'throttled' => [
         'title' => 'Příliš mnoho pokusů',
-        'body' => 'Zkuste to prosím znovu za :seconds sekund.',
+        'body' => 'Zkuste to prosím znovu za :seconds s.',
     ],
 ];

--- a/packages/forms/resources/lang/cs/components.php
+++ b/packages/forms/resources/lang/cs/components.php
@@ -342,7 +342,7 @@ return [
 
         'file_attachments_accepted_file_types_message' => 'Nahrané soubory musí být typu: :values.',
 
-        'file_attachments_max_size_message' => 'Nahrané soubory nesmí být větší než :max kilobajtů.',
+        'file_attachments_max_size_message' => 'Nahrané soubory nesmí být větší než :max kB.',
 
         'tools' => [
             'attach_files' => 'Přidat soubory',
@@ -532,14 +532,14 @@ return [
                             'placeholder' => 'Žádné',
 
                             'options' => [
-                                'two' => 'Dvě',
+                                'two' => 'Dva',
                                 'three' => 'Tři',
                                 'four' => 'Čtyři',
                                 'five' => 'Pět',
-                                'two_start_third' => 'Dvě (Začátek třetí)',
-                                'two_end_third' => 'Dvě (Konec třetí)',
-                                'two_start_fourth' => 'Dvě (Začátek čtvrté)',
-                                'two_end_fourth' => 'Dvě (Konec čtvrté)',
+                                'two_start_third' => 'Dva (první zabírá třetinu)',
+                                'two_end_third' => 'Dva (druhý zabírá třetinu)',
+                                'two_start_fourth' => 'Dva (první zabírá čtvrtinu)',
+                                'two_end_fourth' => 'Dva (druhý zabírá čtvrtinu)',
                             ],
                         ],
 
@@ -661,14 +661,14 @@ return [
 
         'file_attachments_accepted_file_types_message' => 'Nahrané soubory musí být typu: :values.',
 
-        'file_attachments_max_size_message' => 'Nahrané soubory nesmí být větší než :max kilobajtů.',
+        'file_attachments_max_size_message' => 'Nahrané soubory nesmí být větší než :max kB.',
 
         'no_merge_tag_search_results_message' => 'Žádné výsledky pro značky slučování.',
 
         'mentions' => [
             'no_options_message' => 'Nejsou dostupné žádné možnosti.',
             'no_search_results_message' => 'Žádné výsledky neodpovídají vašemu hledání.',
-            'search_prompt' => 'Začněte psát na vyhledávání...',
+            'search_prompt' => 'Zadejte hledaný výraz...',
             'searching_message' => 'Hledám...',
         ],
 
@@ -789,7 +789,7 @@ return [
 
         'loading_message' => 'Načítání...',
 
-        'max_items_message' => 'Lze vybrat pouze 1 položka.|Lze vybrat pouze :count položky.|Lze vybrat pouze :count položek.',
+        'max_items_message' => 'Lze vybrat pouze 1 položku.|Lze vybrat pouze :count položky.|Lze vybrat pouze :count položek.',
 
         'no_options_message' => 'Nejsou dostupné žádné možnosti.',
 

--- a/packages/infolists/resources/lang/cs/components.php
+++ b/packages/infolists/resources/lang/cs/components.php
@@ -11,7 +11,7 @@ return [
                 'expand_list' => 'Zobrazit o :count více',
             ],
 
-            'more_list_items' => 'a 1 další|a :count další| a :count dalších',
+            'more_list_items' => 'a 1 další|a :count další|a :count dalších',
 
         ],
 

--- a/packages/panels/resources/lang/cs/auth/http/controllers/block-email-change-verification-controller.php
+++ b/packages/panels/resources/lang/cs/auth/http/controllers/block-email-change-verification-controller.php
@@ -9,7 +9,7 @@ return [
 
         'failed' => [
             'title' => 'Nepodařilo se zablokovat změnu e-mailové adresy',
-            'body' => 'Bohužel se Vám nepodařilo zabránit změně e-mailové adresy na :email, protože již byla ověřena před zablokováním. Pokud jste o změnu nežádali, kontaktujte nás prosím ihned.',
+            'body' => 'Bohužel se vám nepodařilo zabránit změně e-mailové adresy na :email, protože již byla ověřena před zablokováním. Pokud jste o změnu nežádali, kontaktujte nás prosím ihned.',
         ],
     ],
 ];

--- a/packages/panels/resources/lang/cs/auth/multi-factor/app/actions/disable.php
+++ b/packages/panels/resources/lang/cs/auth/multi-factor/app/actions/disable.php
@@ -6,11 +6,11 @@ return [
     'modal' => [
         'heading' => 'Vypnout ověřovací aplikaci',
 
-        'description' => 'Opravdu chcete přestat používat ověřovací aplikaci? Vypnutím odstraníte další vrstvu zabezpečení Vašeho účtu.',
+        'description' => 'Opravdu chcete přestat používat ověřovací aplikaci? Vypnutím odstraníte další vrstvu zabezpečení vašeho účtu.',
 
         'form' => [
             'code' => [
-                'label' => 'Zadejte 6-místný kód z ověřovací aplikace',
+                'label' => 'Zadejte šestimístný kód z ověřovací aplikace',
 
                 'validation_attribute' => 'kód',
 

--- a/packages/panels/resources/lang/cs/auth/multi-factor/app/actions/regenerate-recovery-codes.php
+++ b/packages/panels/resources/lang/cs/auth/multi-factor/app/actions/regenerate-recovery-codes.php
@@ -14,7 +14,7 @@ return [
 
             'code' => [
 
-                'label' => 'Zadejte 6-místný kód z ověřovací aplikace',
+                'label' => 'Zadejte šestimístný kód z ověřovací aplikace',
 
                 'validation_attribute' => 'kód',
 

--- a/packages/panels/resources/lang/cs/auth/multi-factor/app/actions/set-up.php
+++ b/packages/panels/resources/lang/cs/auth/multi-factor/app/actions/set-up.php
@@ -34,7 +34,7 @@ return [
 
             'recovery_codes' => [
 
-                'instruction' => 'Uložte si prosím následující záložní kódy na bezpečné místo. Budou zobrazeny pouze jednou, ale budete je potřebovat, pokud ztratíte přístup k ověřovací aplikaci:',
+                'instruction' => 'Uložte si prosím následující obnovovací kódy na bezpečné místo. Budou zobrazeny pouze jednou, ale budete je potřebovat, pokud ztratíte přístup k ověřovací aplikaci:',
 
             ],
 
@@ -44,11 +44,11 @@ return [
 
             'code' => [
 
-                'label' => 'Zadejte 6-místný kód z ověřovací aplikace',
+                'label' => 'Zadejte šestimístný kód z ověřovací aplikace',
 
-                'validation_attribute' => 'code',
+                'validation_attribute' => 'kód',
 
-                'below_content' => 'Při každém přihlášení nebo provádění citlivých akcí budete muset zadat 6-místný kód z ověřovací aplikace.',
+                'below_content' => 'Při každém přihlášení nebo provádění citlivých akcí budete muset zadat šestimístný kód z ověřovací aplikace.',
 
                 'messages' => [
 

--- a/packages/panels/resources/lang/cs/auth/multi-factor/app/provider.php
+++ b/packages/panels/resources/lang/cs/auth/multi-factor/app/provider.php
@@ -21,11 +21,11 @@ return [
 
     'login_form' => [
 
-        'label' => 'Použijte kód z Vaší ověřovací aplikace',
+        'label' => 'Použijte kód z vaší ověřovací aplikace',
 
         'code' => [
 
-            'label' => 'Zadejte 6-místný kód z ověřovací aplikace',
+            'label' => 'Zadejte šestimístný kód z ověřovací aplikace',
 
             'validation_attribute' => 'kód',
 

--- a/packages/panels/resources/lang/cs/auth/multi-factor/email/actions/disable.php
+++ b/packages/panels/resources/lang/cs/auth/multi-factor/email/actions/disable.php
@@ -8,13 +8,13 @@ return [
 
         'heading' => 'Vypnout e-mailové ověřovací kódy',
 
-        'description' => 'Opravdu chcete přestat dostávat e-mailové ověřovací kódy? Vypnutím odstraníte další vrstvu zabezpečení Vašeho účtu.',
+        'description' => 'Opravdu chcete přestat dostávat e-mailové ověřovací kódy? Vypnutím odstraníte další vrstvu zabezpečení vašeho účtu.',
 
         'form' => [
 
             'code' => [
 
-                'label' => 'Zadejte 6-místný kód, který jsme Vám poslali e-mailem',
+                'label' => 'Zadejte šestimístný kód, který jsme vám poslali e-mailem',
 
                 'validation_attribute' => 'kód',
 
@@ -27,7 +27,7 @@ return [
                         'notifications' => [
 
                             'resent' => [
-                                'title' => 'Nový kód byl odeslán na Váš e-mail',
+                                'title' => 'Nový kód byl odeslán na váš e-mail',
                             ],
 
                             'throttled' => [

--- a/packages/panels/resources/lang/cs/auth/multi-factor/email/actions/set-up.php
+++ b/packages/panels/resources/lang/cs/auth/multi-factor/email/actions/set-up.php
@@ -8,13 +8,13 @@ return [
 
         'heading' => 'Nastavit e-mailové ověřovací kódy',
 
-        'description' => 'Při každém přihlášení nebo provádění citlivých akcí budete muset zadat 6-místný kód, který Vám zašleme e-mailem. Zkontrolujte svůj e-mail a zadejte 6-místný kód pro dokončení nastavení.',
+        'description' => 'Při každém přihlášení nebo provádění citlivých akcí budete muset zadat šestimístný kód, který vám zašleme e-mailem. Zkontrolujte svůj e-mail a zadejte šestimístný kód pro dokončení nastavení.',
 
         'form' => [
 
             'code' => [
 
-                'label' => 'Zadejte 6-místný kód, který jsme Vám poslali e-mailem',
+                'label' => 'Zadejte šestimístný kód, který jsme vám poslali e-mailem',
 
                 'validation_attribute' => 'kód',
 
@@ -27,7 +27,7 @@ return [
                         'notifications' => [
 
                             'resent' => [
-                                'title' => 'Nový kód byl odeslán na Váš e-mail',
+                                'title' => 'Nový kód byl odeslán na váš e-mail',
                             ],
 
                             'throttled' => [

--- a/packages/panels/resources/lang/cs/auth/multi-factor/email/notifications/verify-email-authentication.php
+++ b/packages/panels/resources/lang/cs/auth/multi-factor/email/notifications/verify-email-authentication.php
@@ -1,10 +1,10 @@
 <?php
 
 return [
-    'subject' => 'Zde je Váš přihlašovací kód',
+    'subject' => 'Zde je váš přihlašovací kód',
 
     'lines' => [
         'Váš přihlašovací kód je: :code',
-        'Tento kód vyprší za minutu.|Tento kód vyprší za :minutes minúty.|Tento kód vyprší za :minutes minut.',
+        'Tento kód vyprší za minutu.|Tento kód vyprší za :minutes minuty.|Tento kód vyprší za :minutes minut.',
     ],
 ];

--- a/packages/panels/resources/lang/cs/auth/multi-factor/email/provider.php
+++ b/packages/panels/resources/lang/cs/auth/multi-factor/email/provider.php
@@ -4,7 +4,7 @@ return [
     'management_schema' => [
         'actions' => [
             'label' => 'E-mailové ověřovací kódy',
-            'below_content' => 'Při přihlášení obdržíte dočasný kód na svou e-mailovou adresu pro ověření Vaší identity.',
+            'below_content' => 'Při přihlášení obdržíte dočasný kód na svou e-mailovou adresu pro ověření vaší identity.',
             'messages' => [
                 'enabled' => 'Povoleno',
                 'disabled' => 'Zakázáno',
@@ -12,16 +12,16 @@ return [
         ],
     ],
     'login_form' => [
-        'label' => 'Odeslat kód na Váš e-mail',
+        'label' => 'Odeslat kód na váš e-mail',
         'code' => [
-            'label' => 'Zadejte 6-místný kód, který jsme Vám poslali e-mailem',
+            'label' => 'Zadejte šestimístný kód, který jsme vám poslali e-mailem',
             'validation_attribute' => 'kód',
             'actions' => [
                 'resend' => [
                     'label' => 'Odeslat nový kód e-mailem',
                     'notifications' => [
                         'resent' => [
-                            'title' => 'Poslali jsme Vám nový kód e-mailem',
+                            'title' => 'Poslali jsme vám nový kód e-mailem',
                         ],
                         'throttled' => [
                             'title' => 'Příliš mnoho pokusů o opětovné odeslání. Počkejte prosím, než požádáte o další kód.',

--- a/packages/panels/resources/lang/cs/auth/multi-factor/pages/set-up-required-multi-factor-authentication.php
+++ b/packages/panels/resources/lang/cs/auth/multi-factor/pages/set-up-required-multi-factor-authentication.php
@@ -5,7 +5,7 @@ return [
 
     'heading' => 'Nastavte dvoufázové ověření',
 
-    'subheading' => '2FA přidává další úroveň zabezpečení Vašeho účtu tím, že při přihlášení vyžaduje druhou formu ověření.',
+    'subheading' => '2FA přidává další úroveň zabezpečení vašeho účtu tím, že při přihlášení vyžaduje druhou formu ověření.',
 
     'actions' => [
         'continue' => [

--- a/packages/panels/resources/lang/cs/auth/notifications/notice-of-email-change-request.php
+++ b/packages/panels/resources/lang/cs/auth/notifications/notice-of-email-change-request.php
@@ -4,10 +4,10 @@ return [
     'subject' => 'Vaše e-mailová adresa se mění',
 
     'lines' => [
-        'Obdrželi jsme žádost o změnu e-mailové adresy přiřazené k Vašemu účtu. Vaše heslo bylo použito k potvrzení této změny.',
+        'Obdrželi jsme žádost o změnu e-mailové adresy přiřazené k vašemu účtu. Vaše heslo bylo použito k potvrzení této změny.',
         'Po ověření bude nová e-mailová adresa vašeho účtu: :email.',
         'Změnu můžete zablokovat před jejím ověřením kliknutím na tlačítko níže.',
-        'Pokud jste tuto žádost neodeslali Vy, kontaktujte nás prosím ihned.',
+        'Pokud jste tuto žádost neodeslali vy, kontaktujte nás prosím ihned.',
     ],
 
     'action' => 'Zablokovat změnu e-mailu',

--- a/packages/panels/resources/lang/cs/auth/pages/edit-profile.php
+++ b/packages/panels/resources/lang/cs/auth/pages/edit-profile.php
@@ -48,7 +48,7 @@ return [
 
         'email_change_verification_sent' => [
             'title' => 'Požadavek na změnu e-mailové adresy byl odeslán',
-            'body' => 'Požadavek na změnu Vaší e-mailové adresy byl odeslán na :email. Zkontrolujte si e-mail a potvrďte změnu.',
+            'body' => 'Požadavek na změnu vaší e-mailové adresy byl odeslán na :email. Zkontrolujte si e-mail a potvrďte změnu.',
         ],
 
         'saved' => [
@@ -56,8 +56,8 @@ return [
         ],
 
         'throttled' => [
-            'title' => 'Příliš mnoho požadavků. Zkuste to znovu za :seconds sekund.',
-            'body' => 'Zkuste to znovu za :seconds sekund.',
+            'title' => 'Příliš mnoho požadavků. Zkuste to znovu za :seconds s.',
+            'body' => 'Zkuste to znovu za :seconds s.',
         ],
     ],
 

--- a/packages/panels/resources/lang/cs/auth/pages/email-verification/email-verification-prompt.php
+++ b/packages/panels/resources/lang/cs/auth/pages/email-verification/email-verification-prompt.php
@@ -16,7 +16,7 @@ return [
 
     'messages' => [
         'notification_not_received' => 'Neobdrželi jste e-mail, který jsme poslali?',
-        'notification_sent' => 'Na Vaši e-mailovou adresu :email jsme zaslali zprávu s pokyny pro ověření této adresy.',
+        'notification_sent' => 'Na vaši e-mailovou adresu :email jsme zaslali zprávu s pokyny pro ověření této adresy.',
     ],
 
     'notifications' => [
@@ -27,7 +27,7 @@ return [
 
         'notification_resend_throttled' => [
             'title' => 'Příliš mnoho požadavků',
-            'body' => 'Zkuste to prosím znovu za :seconds sekund.',
+            'body' => 'Zkuste to prosím znovu za :seconds s.',
         ],
 
     ],

--- a/packages/panels/resources/lang/cs/auth/pages/login.php
+++ b/packages/panels/resources/lang/cs/auth/pages/login.php
@@ -77,7 +77,7 @@ return [
 
         'throttled' => [
             'title' => 'Příliš mnoho pokusů o přihlášení.',
-            'body' => 'Zkuste to znovu za :seconds vteřin.',
+            'body' => 'Zkuste to znovu za :seconds s.',
         ],
 
     ],

--- a/packages/panels/resources/lang/cs/auth/pages/login.php
+++ b/packages/panels/resources/lang/cs/auth/pages/login.php
@@ -4,7 +4,7 @@ return [
 
     'title' => 'Přihlášení',
 
-    'heading' => 'Přihlašte se k Vašemu účtu',
+    'heading' => 'Přihlaste se ke svému účtu',
 
     'actions' => [
 
@@ -22,7 +22,7 @@ return [
     'form' => [
 
         'email' => [
-            'label' => 'Emailová adresa',
+            'label' => 'E-mailová adresa',
         ],
 
         'password' => [
@@ -47,7 +47,7 @@ return [
 
         'heading' => 'Ověřte svou identitu',
 
-        'subheading' => 'Pro pokračování přihlášení musíte ověřit svou identitu.',
+        'subheading' => 'Pro pokračování v přihlášení musíte ověřit svou identitu.',
 
         'form' => [
 

--- a/packages/panels/resources/lang/cs/auth/pages/password-reset/request-password-reset.php
+++ b/packages/panels/resources/lang/cs/auth/pages/password-reset/request-password-reset.php
@@ -33,12 +33,12 @@ return [
     'notifications' => [
 
         'sent' => [
-            'body' => 'Pokud Váš účet neexistuje, e-mail neobdržíte.',
+            'body' => 'Pokud váš účet neexistuje, e-mail neobdržíte.',
         ],
 
         'throttled' => [
             'title' => 'Příliš mnoho požadavků',
-            'body' => 'Zkuste to prosím znovu za :seconds sekund.',
+            'body' => 'Zkuste to prosím znovu za :seconds s.',
         ],
 
     ],

--- a/packages/panels/resources/lang/cs/auth/pages/password-reset/reset-password.php
+++ b/packages/panels/resources/lang/cs/auth/pages/password-reset/reset-password.php
@@ -35,7 +35,7 @@ return [
 
         'throttled' => [
             'title' => 'Příliš mnoho požadavků',
-            'body' => 'Zkuste to prosím znovu za :seconds sekund.',
+            'body' => 'Zkuste to prosím znovu za :seconds s.',
         ],
 
     ],

--- a/packages/panels/resources/lang/cs/auth/pages/register.php
+++ b/packages/panels/resources/lang/cs/auth/pages/register.php
@@ -48,7 +48,7 @@ return [
 
         'throttled' => [
             'title' => 'Příliš mnoho požadavků',
-            'body' => 'Zkuste to prosím znovu za :seconds sekund.',
+            'body' => 'Zkuste to prosím znovu za :seconds s.',
         ],
 
     ],

--- a/packages/panels/resources/lang/cs/layout.php
+++ b/packages/panels/resources/lang/cs/layout.php
@@ -20,7 +20,7 @@ return [
 
         'open_database_notifications' => [
             'label' => 'Zobrazit notifikace',
-            'label_with_unread_count' => '{1} Oznámení, :count nepřečtené oznámení|[2,*] Oznámení, :count nepřečtená oznámení',
+            'label_with_unread_count' => '{1} Oznámení, :count nepřečtené oznámení|[2,4] Oznámení, :count nepřečtená oznámení|[0,*] Oznámení, :count nepřečtených oznámení',
         ],
 
         'open_user_menu' => [
@@ -72,7 +72,7 @@ return [
     ],
 
     'logo' => [
-        'alt' => ':name logo',
+        'alt' => 'Logo :name',
     ],
 
     'tenant_menu' => [

--- a/packages/panels/resources/lang/cs/resources/pages/create-record.php
+++ b/packages/panels/resources/lang/cs/resources/pages/create-record.php
@@ -19,7 +19,7 @@ return [
             ],
 
             'create_another' => [
-                'label' => 'Vytvořit & vytvořit další',
+                'label' => 'Vytvořit a vytvořit další',
             ],
 
         ],

--- a/packages/query-builder/resources/lang/cs/query-builder.php
+++ b/packages/query-builder/resources/lang/cs/query-builder.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'label' => 'Query builder',
+    'label' => 'Tvůrce dotazů',
 
     'form' => [
 
@@ -39,7 +39,7 @@ return [
 
     'no_rules' => '(Žádná pravidla)',
 
-    'max_rules_reached_tooltip' => 'Dosáhli jste maxima :count pravidel.',
+    'max_rules_reached_tooltip' => 'Dosáhli jste maximálního počtu pravidel (:count).',
 
     'item_separators' => [
         'and' => 'A',
@@ -166,16 +166,16 @@ return [
             'presets' => [
                 'past_decade' => 'Posledních 10 let',
                 'past_5_years' => 'Posledních 5 let',
-                'past_2_years' => 'Posledních 2 let',
+                'past_2_years' => 'Poslední 2 roky',
                 'past_year' => 'Poslední rok',
                 'past_6_months' => 'Posledních 6 měsíců',
                 'past_quarter' => 'Poslední čtvrtletí',
                 'past_month' => 'Poslední měsíc',
-                'past_2_weeks' => 'Posledních 2 týdnů',
+                'past_2_weeks' => 'Poslední 2 týdny',
                 'past_week' => 'Poslední týden',
                 'past_hour' => 'Poslední hodina',
                 'past_minute' => 'Poslední minuta',
-                'this_decade' => 'Toto desítletí',
+                'this_decade' => 'Toto desetiletí',
                 'this_year' => 'Tento rok',
                 'this_quarter' => 'Toto čtvrtletí',
                 'this_month' => 'Tento měsíc',
@@ -185,12 +185,12 @@ return [
                 'next_minute' => 'Příští minuta',
                 'next_hour' => 'Příští hodina',
                 'next_week' => 'Příští týden',
-                'next_2_weeks' => 'Příštích 2 týdny',
+                'next_2_weeks' => 'Příští 2 týdny',
                 'next_month' => 'Příští měsíc',
                 'next_quarter' => 'Příští čtvrtletí',
                 'next_6_months' => 'Příštích 6 měsíců',
                 'next_year' => 'Příští rok',
-                'next_2_years' => 'Příštích 2 let',
+                'next_2_years' => 'Příští 2 roky',
                 'next_5_years' => 'Příštích 5 let',
                 'next_decade' => 'Příštích 10 let',
                 'custom' => 'Vlastní',
@@ -261,7 +261,7 @@ return [
             'is_max' => [
 
                 'label' => [
-                    'direct' => 'Je maximální',
+                    'direct' => 'Je nejvýše',
                     'inverse' => 'Je větší než',
                 ],
 
@@ -275,7 +275,7 @@ return [
             'is_min' => [
 
                 'label' => [
-                    'direct' => 'Je minimální',
+                    'direct' => 'Je nejméně',
                     'inverse' => 'Je menší než',
                 ],
 

--- a/packages/support/resources/lang/cs/components/loading-section.php
+++ b/packages/support/resources/lang/cs/components/loading-section.php
@@ -2,6 +2,6 @@
 
 return [
 
-    'label' => 'Načítává se...',
+    'label' => 'Načítá se...',
 
 ];

--- a/packages/support/resources/lang/cs/components/pagination.php
+++ b/packages/support/resources/lang/cs/components/pagination.php
@@ -4,7 +4,7 @@ return [
 
     'label' => 'Stránkování',
 
-    'overview' => '{1} Zobrazuji 1 výsledek|[2,*] Zobrazuji :first až :last z :total výsledků',
+    'overview' => '{0} Žádné výsledky|{1} Zobrazuji 1 výsledek|[2,*] Zobrazuji :first až :last z :total výsledků',
 
     'fields' => [
 

--- a/packages/tables/resources/lang/cs/table.php
+++ b/packages/tables/resources/lang/cs/table.php
@@ -41,7 +41,7 @@ return [
 
         'select' => [
 
-            'loading_message' => 'Načítává se...',
+            'loading_message' => 'Načítá se...',
 
             'no_options_message' => 'Nejsou dostupné žádné možnosti.',
 
@@ -62,7 +62,7 @@ return [
                 'expand_list' => 'Zobrazit o :count více',
             ],
 
-            'more_list_items' => 'a 1 další|a :count další| a :count dalších',
+            'more_list_items' => 'a 1 další|a :count další|a :count dalších',
         ],
 
     ],
@@ -95,7 +95,7 @@ return [
 
         'subheadings' => [
             'all' => 'Všechny :label',
-            'group' => ':group shrnutí',
+            'group' => 'Shrnutí: :group',
             'page' => 'Tato stránka',
         ],
 
@@ -157,7 +157,7 @@ return [
 
         'heading' => 'Žádné záznamy nenalezeny',
 
-        'description' => 'Začněte vytvořením :modelu.',
+        'description' => 'Začněte vytvořením záznamu (:model).',
 
     ],
 
@@ -239,7 +239,7 @@ return [
 
     ],
 
-    'loading' => 'Načítává se...',
+    'loading' => 'Načítá se...',
 
     'reorder_indicator' => 'Vyberte a přesuňte položky.',
 
@@ -252,7 +252,7 @@ return [
         'actions' => [
 
             'select_all' => [
-                'label' => 'Označit všechny :count',
+                'label' => 'Vybrat vše (:count)',
             ],
 
             'deselect_all' => [


### PR DESCRIPTION
## Description

Corrected the Czech translation throughout the app. This includes:

* Incorrect translations of individual words, such as `"minúty"` → `"minuty"` and `"Načítává se"` → `"Načítá se"`.
* Grammatically incorrect phrases, such as `"Přihlašte se"` → `"Přihlaste se"`.
* Incorrect or unnatural sentence structure and word order.
* Standardized spelling of certain words, such as `"Email"` → `"E-mail"`.

The changes follow the recommendations of the Czech Language Institute and can be verified using the Czech Language Reference Book: https://prirucka.ujc.cas.cz/.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.