### PR TITLE
Support Widget::configureUsing() for global polling config

### DIFF
--- a/packages/support/src/Components/ComponentManager.php
+++ b/packages/support/src/Components/ComponentManager.php
@@ -98,7 +98,7 @@ class ComponentManager implements ScopedComponentManager
         }
     }
 
-    public function configure(Component $component, Closure $setUp): void
+    public function configure(object $component, Closure $setUp): void
     {
         $componentClass = $component::class;
 

--- a/packages/support/src/Components/Contracts/ScopedComponentManager.php
+++ b/packages/support/src/Components/Contracts/ScopedComponentManager.php
@@ -9,7 +9,7 @@ interface ScopedComponentManager
 {
     public function configureUsing(string $component, Closure $modifyUsing, ?Closure $during = null, bool $isImportant = false): mixed;
 
-    public function configure(Component $component, Closure $setUp): void;
+    public function configure(object $component, Closure $setUp): void;
 
     /**
      * @return array<string, Closure>

--- a/packages/widgets/docs/02-stats-overview.md
+++ b/packages/widgets/docs/02-stats-overview.md
@@ -222,6 +222,30 @@ Alternatively, you may disable polling altogether:
 protected ?string $pollingInterval = null;
 ```
 
+### Globally changing the polling interval of all stats overview widgets
+
+If you wish to change the polling behavior of all stats overview widgets globally, then you can call the static `StatsOverviewWidget::configureUsing()` method inside a service provider's `boot()` method or a middleware. Pass a closure which is able to modify the widget, using the `poll()` method:
+
+```php
+use Filament\Widgets\StatsOverviewWidget;
+
+StatsOverviewWidget::configureUsing(function (StatsOverviewWidget $widget): void {
+    $widget->poll('30s');
+});
+```
+
+To disable polling for all stats overview widgets, pass `null` to `poll()`:
+
+```php
+use Filament\Widgets\StatsOverviewWidget;
+
+StatsOverviewWidget::configureUsing(function (StatsOverviewWidget $widget): void {
+    $widget->poll(null);
+});
+```
+
+Of course, you are still able to overwrite this behavior on each widget individually, either by overriding the `$pollingInterval` property or by calling `poll()` in the widget's `setUp()` method.
+
 ## Disabling lazy loading
 
 By default, widgets are lazy-loaded. This means that they will only be loaded when they are visible on the page.

--- a/packages/widgets/docs/03-charts.md
+++ b/packages/widgets/docs/03-charts.md
@@ -420,6 +420,30 @@ Alternatively, you may disable polling altogether:
 protected ?string $pollingInterval = null;
 ```
 
+### Globally changing the polling interval of all chart widgets
+
+If you wish to change the polling behavior of all chart widgets globally, then you can call the static `ChartWidget::configureUsing()` method inside a service provider's `boot()` method or a middleware. Pass a closure which is able to modify the widget, using the `poll()` method:
+
+```php
+use Filament\Widgets\ChartWidget;
+
+ChartWidget::configureUsing(function (ChartWidget $widget): void {
+    $widget->poll('30s');
+});
+```
+
+To disable polling for all chart widgets, pass `null` to `poll()`:
+
+```php
+use Filament\Widgets\ChartWidget;
+
+ChartWidget::configureUsing(function (ChartWidget $widget): void {
+    $widget->poll(null);
+});
+```
+
+Of course, you are still able to overwrite this behavior on each widget individually, either by overriding the `$pollingInterval` property or by calling `poll()` in the widget's `setUp()` method.
+
 ## Setting a maximum chart height
 
 You may place a maximum height on the chart to ensure that it doesn't get too big, using the `$maxHeight` property:

--- a/packages/widgets/src/Concerns/CanPoll.php
+++ b/packages/widgets/src/Concerns/CanPoll.php
@@ -2,12 +2,21 @@
 
 namespace Filament\Widgets\Concerns;
 
+use Closure;
+
 trait CanPoll
 {
-    protected ?string $pollingInterval = '5s';
+    protected string | Closure | null $pollingInterval = '5s';
 
-    protected function getPollingInterval(): ?string
+    public function poll(string | Closure | null $interval = '5s'): static
     {
-        return $this->pollingInterval;
+        $this->pollingInterval = $interval;
+
+        return $this;
+    }
+
+    public function getPollingInterval(): ?string
+    {
+        return $this->evaluate($this->pollingInterval);
     }
 }

--- a/packages/widgets/src/Widget.php
+++ b/packages/widgets/src/Widget.php
@@ -3,6 +3,8 @@
 namespace Filament\Widgets;
 
 use Filament\Support\Concerns\CanBeLazy;
+use Filament\Support\Concerns\Configurable;
+use Filament\Support\Concerns\EvaluatesClosures;
 use Filament\Widgets\Concerns\CanAuthorizeAccess;
 use Illuminate\Contracts\View\View;
 use Livewire\Component;
@@ -11,6 +13,8 @@ abstract class Widget extends Component
 {
     use CanAuthorizeAccess;
     use CanBeLazy;
+    use Configurable;
+    use EvaluatesClosures;
 
     protected static bool $isDiscovered = true;
 
@@ -30,6 +34,11 @@ abstract class Widget extends Component
      * @var int | string | array<string, int | null>
      */
     protected int | string | array $columnStart = [];
+
+    public function boot(): void
+    {
+        $this->configure();
+    }
 
     public static function canView(): bool
     {

--- a/tests/src/Widgets/ChartWidgetTest.php
+++ b/tests/src/Widgets/ChartWidgetTest.php
@@ -133,6 +133,32 @@ it('returns `null` from `getDescription()` by default', function (): void {
     expect($widget->instance()->getDescription())->toBeNull();
 });
 
+it('returns `5s` from `getPollingInterval()` by default', function (): void {
+    $widget = Livewire::test(TestChartWidgetDefault::class);
+
+    expect($widget->instance()->getPollingInterval())->toBe('5s');
+});
+
+it('can override `getPollingInterval()` via `poll()`', function (): void {
+    $widget = Livewire::test(TestChartWidgetWithCustomPolling::class);
+
+    expect($widget->instance()->getPollingInterval())->toBe('30s');
+});
+
+it('can disable or alter polling for all widgets via `Widget::configureUsing()`', function (): void {
+    $undo = ChartWidget::configureUsing(fn (ChartWidget $chartWidget) => $chartWidget->poll(null));
+
+    $widget = Livewire::test(TestChartWidgetDefault::class);
+
+    expect($widget->instance()->getPollingInterval())->toBeNull();
+
+    $undo();
+
+    $widget = Livewire::test(TestChartWidgetDefault::class);
+
+    expect($widget->instance()->getPollingInterval())->toBe('5s');
+});
+
 class TestChartWidgetDefault extends ChartWidget
 {
     use ChartWidget\Concerns\HasFiltersSchema;
@@ -241,6 +267,26 @@ class TestChartWidgetWithDynamicDeferredFilters extends ChartWidget
             ->components([
                 Select::make('year')->options(['2024' => '2024', '2023' => '2023'])->default('2024'),
             ]);
+    }
+}
+
+class TestChartWidgetWithCustomPolling extends ChartWidget
+{
+    protected function getType(): string
+    {
+        return 'bar';
+    }
+
+    protected function getData(): array
+    {
+        return ['datasets' => [], 'labels' => []];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->poll('30s');
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `Configurable` (and `EvaluatesClosures`) to `Widget`, so `Widget::configureUsing()` — and subclass-scoped variants like `ChartWidget::configureUsing()` / `StatsOverviewWidget::configureUsing()` — can globally disable or change polling across every widget.
- `CanPoll` now exposes a fluent `poll()` setter with `Closure` support, matching the existing `CanPoll` trait in the `schemas` and `tables` packages.
- `ComponentManager::configure()` now accepts `object` instead of the concrete `Filament\Support\Components\Component` class, since `Widget` extends `Livewire\Component` rather than that base class.
- Documented the new global config option in `packages/widgets/docs/02-stats-overview.md` and `packages/widgets/docs/03-charts.md`.

## Test plan
- [x] `vendor/bin/pest tests/src/Widgets` (94 passed, excluding pre-existing browser accessibility test infra failures)
- [x] `vendor/bin/pest tests/src/Support` (727 passed)
- [x] `vendor/bin/phpstan analyse` (no errors)
- [x] `vendor/bin/pint --dirty` (clean)