### PR TITLE
Add missing pt_BR translations for select actions

### DIFF
--- a/packages/forms/resources/lang/pt_BR/components.php
+++ b/packages/forms/resources/lang/pt_BR/components.php
@@ -736,6 +736,10 @@ return [
 
         'actions' => [
 
+            'clear' => [
+                'label' => 'Limpar seleção',
+            ],
+
             'create_option' => [
 
                 'label' => 'Criar',
@@ -780,6 +784,10 @@ return [
 
             ],
 
+            'remove_option' => [
+                'label' => 'Remover :label',
+            ],
+
         ],
 
         'boolean' => [
@@ -798,6 +806,8 @@ return [
         'placeholder' => 'Selecione uma opção',
 
         'searching_message' => 'Pesquisando...',
+
+        'search_label' => 'Pesquisar',
 
         'search_prompt' => 'Comece a digitar para pesquisar...',
 


### PR DESCRIPTION
## Summary
- Add 3 missing `pt_BR` translation keys in `packages/forms/resources/lang/pt_BR/components.php` that already existed in `en/components.php`:
  - `select.actions.clear.label`
  - `select.actions.remove_option.label`
  - `select.search_label`

## Test plan
- [x] `vendor/bin/pint --dirty` (clean, no content changes)
- [x] `php -l` on the changed file
- [x] Diffed every `pt_BR` lang file against its `en` counterpart across all packages — no other missing/stale keys found